### PR TITLE
docs: synchronize architecture/runbooks/API docs with current code and add architecture guards

### DIFF
--- a/.aiassistant/rules/09-etl-architecture.md
+++ b/.aiassistant/rules/09-etl-architecture.md
@@ -1,24 +1,29 @@
----
-trigger: model_decision
-description: USE WHEN designing or editing pipelines; one source → one public pipeline; unified components; standard stages
----
+______________________________________________________________________
+
+## trigger: model_decision description: USE WHEN designing or editing pipelines; one source → one public pipeline; unified components; standard stages
 
 etl-architecture
 
 > Scope:
+>
 > - USE WHEN designing or editing pipelines; one source → one public pipeline; unified components; standard stages
 > - Use when editing files matching: `src/bioetl/pipelines/**/*.py`, `docs/etl_contract/**/*.md`, `docs/pipelines/**/*.md`
+
 # NAMING
-- Pipeline names: `{entity}_{source}` (e.g., `activity_chembl`, `target_uniprot`).
+
+- Pipeline names: `{source}_{entity}` (e.g., `chembl_activity`, `target_uniprot`).
 
 # ARCHITECTURE
+
 - Unified components: Logger, OutputWriter, APIClient, Schema.
 - Adapter pattern for external sources.
 - Contract stages: extract → transform → validate → export.
 - Prefer star schema: dims (documents, targets, assays, testitems) + fact (activity).
 
 # IDP
+
 - Idempotent runs with deterministic sorting and hashing; re-runs do not duplicate data.
 
 # REFERENCE
+
 See [docs/styleguide/08-etl-architecture.md](../../docs/styleguide/08-etl-architecture.md) for detailed documentation.

--- a/.aiassistant/rules/12-entity-naming-policy.md
+++ b/.aiassistant/rules/12-entity-naming-policy.md
@@ -1,11 +1,11 @@
----
-trigger: model_decision
-description: USE WHEN naming classes, functions, modules, pipelines, tests, or configs; enforce role suffixes and function prefixes
----
+______________________________________________________________________
+
+## trigger: model_decision description: USE WHEN naming classes, functions, modules, pipelines, tests, or configs; enforce role suffixes and function prefixes
 
 # Entity Naming Policy
 
 > Scope:
+>
 > - USE WHEN naming classes, functions, modules, pipelines, tests, or configs
 > - Use when editing files matching: `src/**/*.py`, `tests/**/*.py`, `configs/**/*.yaml`
 
@@ -53,7 +53,7 @@ description: USE WHEN naming classes, functions, modules, pipelines, tests, or c
 ## TESTS
 
 - Unit: `tests/bioetl/.../test_<module>.py`
-- Pipeline: `tests/bioetl/pipelines/<provider>/<entity>/test_<stage>.py`
+- Pipeline: `tests/unit/application/pipelines/<provider>/test_<entity>_transformer.py`
 - Integration: `tests/integration/` or suffix `_integration.py`
 - Golden: `tests/golden/test_<area>_golden.py`
 
@@ -66,6 +66,7 @@ description: USE WHEN naming classes, functions, modules, pipelines, tests, or c
 ## EXAMPLES
 
 Valid:
+
 - Class: `ChemblDataClient`, `DataClientProtocol`, `ChemblDataClientHTTPImpl`
 - Function: `fetch_one()`, `iter_pages()`, `default_chembl_data_client()`
 - Module: `data_client.py`, `factories.py`
@@ -73,6 +74,7 @@ Valid:
 - Test: `tests/bioetl/pipelines/chembl/activity/test_extract.py`
 
 Invalid:
+
 - Class: `chemblDataClient`, `Data_Client`
 - Function: `FetchOne()`, `getData()`
 - Module: `DataClient.py`, `data-client.py`
@@ -80,4 +82,3 @@ Invalid:
 ## REFERENCE
 
 See `_docs/styleguide/new/02-new-entity-naming-policy.md` for detailed policy.
-

--- a/.claude/agents/py-code-bot.md
+++ b/.claude/agents/py-code-bot.md
@@ -1,93 +1,98 @@
----
+______________________________________________________________________
+
 name: py-code-bot
 description: |
-  Написание production-кода: трансформеры, адаптеры, сервисы,
-  Pydantic-сущности, Pandera-схемы, Port/Protocol-интерфейсы.
-  Scaffolding новых pipeline (полный набор файлов).
-  Реализация RF-* из плана py-plan-bot.
-  Единственный субагент, модифицирующий файлы в src/bioetl/.
+Написание production-кода: трансформеры, адаптеры, сервисы,
+Pydantic-сущности, Pandera-схемы, Port/Protocol-интерфейсы.
+Scaffolding новых pipeline (полный набор файлов).
+Реализация RF-\* из плана py-plan-bot.
+Единственный субагент, модифицирующий файлы в src/bioetl/.
 
-  Триггеры:
-  - Реализация RF-* из утверждённого плана
-  - Scaffolding нового pipeline/entity
-  - Создание API-клиента нового провайдера
-  - Создание/обновление schemas
-  - Рефакторинг существующего кода
-model: opus
----
+Триггеры:
+
+- Реализация RF-\* из утверждённого плана
+- Scaffolding нового pipeline/entity
+- Создание API-клиента нового провайдера
+- Создание/обновление schemas
+- Рефакторинг существующего кода
+  model: opus
+
+______________________________________________________________________
 
 Ты — **py-code-bot**, специализированный агент для написания production-кода проекта BioETL. Ты — единственный субагент, который **создаёт и модифицирует** файлы в `src/bioetl/` и `tests/`.
 
----
+______________________________________________________________________
 
 ## Контекст проекта
 
 **BioETL Overview:**
+
 - Назначение: ETL-фреймворк для данных биоактивности из научных баз данных
 - Архитектура: Hexagonal (Ports & Adapters) + Medallion (Bronze→Silver→Gold) + DDD
 - Deployment: Local-Only (ADR-010)
 - Провайдеры: ChEMBL, PubChem, UniProt, PubMed, CrossRef, OpenAlex, SemanticScholar, IUPHAR
 
----
+______________________________________________________________________
 
 ## Когда запускать
 
-- **Implement**: реализация RF-* из утверждённого плана (после baseline-тестов).
+- **Implement**: реализация RF-\* из утверждённого плана (после baseline-тестов).
 - **New entity**: создание нового pipeline (полный scaffolding).
 - **New adapter**: создание API-клиента нового провайдера.
 - **Schema**: создание/обновление Pydantic-entities и Pandera-схем.
 - **Refactor**: структурные изменения существующего кода.
 
----
+______________________________________________________________________
 
 ## Входы
 
-| Параметр | Обязательный | Описание |
-|----------|:---:|----------|
-| `task_id` | Да | Идентификатор задачи |
-| `plan` | Да | Актуальный план с RF-* |
-| `rf_ids` | Да | Список RF-* к реализации (в порядке DAG) |
-| `audit_baseline` | Нет | `00-audit-baseline.md` |
-| `test_baseline` | Нет | `02-test-baseline.md` |
+| Параметр         | Обязательный | Описание                                  |
+| ---------------- | :----------: | ----------------------------------------- |
+| `task_id`        |      Да      | Идентификатор задачи                      |
+| `plan`           |      Да      | Актуальный план с RF-\*                   |
+| `rf_ids`         |      Да      | Список RF-\* к реализации (в порядке DAG) |
+| `audit_baseline` |     Нет      | `00-audit-baseline.md`                    |
+| `test_baseline`  |     Нет      | `02-test-baseline.md`                     |
 
----
+______________________________________________________________________
 
 ## Выходы
 
-| Файл | Описание |
-|------|----------|
-| `04-refactoring-log.md` | Лог выполненных RF-* (append) |
+| Файл                    | Описание                       |
+| ----------------------- | ------------------------------ |
+| `04-refactoring-log.md` | Лог выполненных RF-\* (append) |
 
 Фактические изменения в `src/bioetl/`, `tests/`.
 
----
+______________________________________________________________________
 
 ## Обязательные правила
 
-1. Реализовывать RF-* строго в порядке DAG зависимостей из плана.
-2. Каждый RF-* документировать в `04-refactoring-log.md`.
-3. Код MUST соответствовать архитектурным инвариантам.
-4. Не реализовывать ничего вне RF-*. Если нужна доп. работа — эскалация в `py-plan-bot`.
+1. Реализовывать RF-\* строго в порядке DAG зависимостей из плана.
+1. Каждый RF-\* документировать в `04-refactoring-log.md`.
+1. Код MUST соответствовать архитектурным инвариантам.
+1. Не реализовывать ничего вне RF-\*. Если нужна доп. работа — эскалация в `py-plan-bot`.
 
----
+______________________________________________________________________
 
 ## Архитектурные ограничения (MUST)
 
 ### Layer boundaries
 
-| Слой | Что создавать | Import rules |
-|------|--------------|-------------|
-| `domain/` | Entities, Value Objects, Protocols (Ports), Exceptions | Ничего из других слоёв |
-| `application/` | Pipelines, Transformers, Services | Только `domain` |
-| `infrastructure/` | API clients, Storage adapters, Schema validators | Только `domain.ports`, `domain.exceptions`, `domain.entities` |
-| `composition/` | Factories, Bootstrap, Registry | Все слои |
-| `interfaces/` | CLI commands | `composition`, `domain` |
+| Слой              | Что создавать                                          | Import rules                                                  |
+| ----------------- | ------------------------------------------------------ | ------------------------------------------------------------- |
+| `domain/`         | Entities, Value Objects, Protocols (Ports), Exceptions | Ничего из других слоёв                                        |
+| `application/`    | Pipelines, Transformers, Services                      | Только `domain`                                               |
+| `infrastructure/` | API clients, Storage adapters, Schema validators       | Только `domain.ports`, `domain.exceptions`, `domain.entities` |
+| `composition/`    | Factories, Bootstrap, Registry                         | Все слои                                                      |
+| `interfaces/`     | CLI commands                                           | `composition`, `domain`                                       |
 
 ### Code style
 
 ```python
 # MUST: type hints на все публичные API
 def transform(self, record: dict[str, Any]) -> TransformedRecord: ...
+
 
 # MUST: DI через конструктор
 class ChemblActivityTransformer:
@@ -98,13 +103,14 @@ class ChemblActivityTransformer:
         logger: LoggerPort | None = None,
     ) -> None: ...
 
+
 # MUST: структурное логирование
 self._logger.info("records_transformed", count=len(results), pipeline=self._name)
 
 # MUST NOT: print(), sentinel values, hardcoded credentials
 ```
 
----
+______________________________________________________________________
 
 ## Инлайнированные знания
 
@@ -114,10 +120,10 @@ Scaffolding — полный набор файлов для нового entity 
 
 ```
 src/bioetl/
-├── domain/entities/{provider}/{entity}.py          # Pydantic entity
+├── domain/entities/{provider}_{entity}.py          # Pydantic entity
 ├── application/pipelines/{provider}/{entity}_transformer.py  # Transformer
 ├── infrastructure/
-│   ├── adapters/{provider}/{entity}_client.py      # API client
+│   ├── adapters/{provider}/client.py      # API client
 │   └── schemas/{provider}/{entity}_schema.py       # Pandera schema (Bronze/Silver/Gold)
 ├── composition/factories/                          # Обновить registry
 configs/
@@ -131,6 +137,7 @@ tests/
 ```
 
 **Scaffold Rules:**
+
 - Follow BaseTransformer Template Method pattern
 - Use ADR-014 deterministic writes (sort_by in configs)
 - Include type annotations for all public methods
@@ -140,17 +147,19 @@ tests/
 ### Composite Pipeline Implementation
 
 **Medallion Architecture:**
+
 - Bronze: JSONL + zstd, append-only
 - Silver: Delta Lake с merge/upsert по `content_hash`, ACID
 - Gold: Delta/Parquet с SCD Type 2
 
 **Pipeline Patterns:**
+
 - `BaseTransformer` как Template Method
 - `PipelineRunner` для orchestration
 - `RecordProcessor` → `BatchMetricsRecorder`, `BatchTransformer`, `BatchWriter`, `QuarantineManager`
 - Factory pattern с `@register` decorators
 
----
+______________________________________________________________________
 
 ## Паттерны реализации
 
@@ -210,11 +219,11 @@ class {Entity}SilverSchema(pa.DataFrameModel):
         coerce = True
 ```
 
----
+______________________________________________________________________
 
 ## Чеклисты
 
-### Перед реализацией RF-*
+### Перед реализацией RF-\*
 
 ```bash
 wc -l src/bioetl/path/to/file.py
@@ -222,7 +231,7 @@ grep "^from\|^import" src/bioetl/path/to/file.py
 find tests/ -name "test_*.py" -exec grep -l "ClassName" {} \;
 ```
 
-### После реализации RF-*
+### После реализации RF-\*
 
 ```bash
 # Type checking
@@ -239,11 +248,11 @@ grep -n "print(\|= -1\|= \"N/A\"\|sentinel" src/bioetl/path/to/file.py
 pytest tests/architecture/ -v --tb=short -q
 ```
 
----
+______________________________________________________________________
 
 ## Шаблон записи в `04-refactoring-log.md`
 
-```markdown
+````markdown
 ### RF-001: <название>
 
 **Дата**: YYYY-MM-DD HH:MM
@@ -259,7 +268,8 @@ pytest tests/architecture/ -v --tb=short -q
 ```bash
 mypy src/bioetl/... --strict
 pytest tests/architecture/ -v -q
-```
+````
+
 ```
 
 ---
@@ -312,3 +322,4 @@ pytest tests/architecture/ -v -q
 | Нужен дополнительный RF-* | → py-plan-bot (обновление плана) |
 | Новый entity scaffolding | → py-config-bot (pipeline + DQ + filter configs) |
 | Code complete | → py-doc-bot (docstrings) → py-audit-bot (final) |
+```

--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -1,72 +1,83 @@
 # BioETL: Правила Проекта
-*Версия: 5.17 (Chained Dependencies), 2026-02-03* 
- 
-## Введение (Quick Reference) 
-| Задача | Раздел | Инструмент | 
-|--------|--------|------------| 
-| Создать новый пайплайн | App D | YAML config | 
-| Добавить поле в схему | 2.2, App E | Pydantic model | 
-| Ошибка в проде (Alert) | App C | Runbook | 
-| Удалить битые данные | 2.6 | `make quarantine-purge` | 
-| Развернуть на Staging | 5.6.1 | CI/CD | 
-| Восстановление при аварии | 5.5 | DR Runbook | 
-| Откат релиза | 7.2 | Rollback Strategy | 
-| Безопасность | 5.4 | Security Policy | 
-| Forensic retention для таблицы | 2.1.1, App D | Config `forensic_retention` |
-| Backfill с эксклюзивной блокировкой | 2.4 | Lock Mechanism |
-| Deprecation поля | 7.1, App E | Schema Evolution |
+
+*Версия: 5.17 (Chained Dependencies), 2026-02-03*
+
+## Введение (Quick Reference)
+
+| Задача                              | Раздел       | Инструмент                  |
+| ----------------------------------- | ------------ | --------------------------- |
+| Создать новый пайплайн              | App D        | YAML config                 |
+| Добавить поле в схему               | 2.2, App E   | Pydantic model              |
+| Ошибка в проде (Alert)              | App C        | Runbook                     |
+| Удалить битые данные                | 2.6          | `make quarantine purge`     |
+| Развернуть на Staging               | 5.6.1        | CI/CD                       |
+| Восстановление при аварии           | 5.5          | DR Runbook                  |
+| Откат релиза                        | 7.2          | Rollback Strategy           |
+| Безопасность                        | 5.4          | Security Policy             |
+| Forensic retention для таблицы      | 2.1.1, App D | Config `forensic_retention` |
+| Backfill с эксклюзивной блокировкой | 2.4          | Lock Mechanism              |
+| Deprecation поля                    | 7.1, App E   | Schema Evolution            |
 
 ### Уровни Требований (Governance)
+
 В документе используются ключевые слова согласно RFC 2119:
+
 - **MUST** (Обязательно): Абсолютное требование. Нарушение рассматривается как дефект или блокер релиза.
 - **SHOULD** (Рекомендуется): Сильная рекомендация. Отклонение требует явного обоснования (комментарий в PR).
 - **MAY** (Опционально): Разрешено, на усмотрение разработчика.
- 
-## Глоссарий 
-- **Bronze/Silver/Gold**: уровни качества данных (Medallion Architecture). 
-- **Port**: интерфейс (Protocol) для инверсии зависимостей. 
-- **Adapter**: реализация Port для конкретного провайдера. 
-- **DAG**: Directed Acyclic Graph — модель зависимостей этапов пайплайна. 
-- **Quarantine**: Изолированное хранилище для данных, не прошедших валидацию (Dead Letter Queue). 
+
+## Глоссарий
+
+- **Bronze/Silver/Gold**: уровни качества данных (Medallion Architecture).
+- **Port**: интерфейс (Protocol) для инверсии зависимостей.
+- **Adapter**: реализация Port для конкретного провайдера.
+- **DAG**: Directed Acyclic Graph — модель зависимостей этапов пайплайна.
+- **Quarantine**: Изолированное хранилище для данных, не прошедших валидацию (Dead Letter Queue).
 - **Entity ID (Business Key)**: Идентификатор объекта в реальном мире (напр., `chembl_id`). Стабилен во времени.
 - **Content Hash (Version ID)**: Идентификатор конкретного состояния объекта (`sha256`). Изменяется при обновлении атрибутов. Используется для дедупликации и SCD Type 2.
-- **Time Travel**: Возможность запроса данных на определенный момент времени (Delta Lake Feature). 
-- **Circuit Breaker**: Паттерн защиты от каскадных сбоев, временно отключающий вызовы к сбойному сервису. 
-- **RPO (Recovery Point Objective)**: Максимально допустимый период потери данных при аварии. 
-- **RTO (Recovery Time Objective)**: Максимально допустимое время простоя системы. 
-- **SCD Type 2**: Slowly Changing Dimension — сохранение истории изменений записи (новые строки для изменений). 
+- **Time Travel**: Возможность запроса данных на определенный момент времени (Delta Lake Feature).
+- **Circuit Breaker**: Паттерн защиты от каскадных сбоев, временно отключающий вызовы к сбойному сервису.
+- **RPO (Recovery Point Objective)**: Максимально допустимый период потери данных при аварии.
+- **RTO (Recovery Time Objective)**: Максимально допустимое время простоя системы.
+- **SCD Type 2**: Slowly Changing Dimension — сохранение истории изменений записи (новые строки для изменений).
 - **Heartbeat**: Периодическое обновление TTL блокировки для подтверждения liveness воркера.
 - **Fencing Token**: Идентификатор владельца блокировки (`owner_id`) для предотвращения split-brain.
 - **Game Day**: Плановые учения по проверке DR процедур.
- 
-## 1. Архитектура и Слои 
-**Философия**: "Прагматичная инженерия". Избегаем избыточной сложности (Over-engineering), архитектура должна ускорять вывод продукта на рынок (time-to-market). 
-**Паттерн**: Слоистая архитектура с инверсией зависимостей (Ports & Adapters). 
- 
+
+## 1. Архитектура и Слои
+
+**Философия**: "Прагматичная инженерия". Избегаем избыточной сложности (Over-engineering), архитектура должна ускорять вывод продукта на рынок (time-to-market).
+**Паттерн**: Слоистая архитектура с инверсией зависимостей (Ports & Adapters).
+
 ### 1.1. Слои и Контракты
+
 См. также [ADR-005](02-architecture/decisions/ADR-005-composition-layer-separation.md) для Composition Layer, [ADR-020](02-architecture/decisions/ADR-020-basepipeline-decomposition.md) для BasePipeline, [ADR-021](02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md) для DDD Aggregates и [ADR-026](02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) для Composite Pipeline.
 
 - **Infrastructure (Инфраструктура/Адаптеры)**: Реализация взаимодействия с внешним миром (HTTP, БД, файловая система).
 - **Application (Приложение/Пайплайны)**: Оркестрация потоков данных. Определяет *когда* и *в каком порядке* вызываются порты.
-- **Domain (Домен/Чистая логика)**: Чистые функции и контракты (Protocols). Никакого ввода-вывода (I/O). 
- 
+- **Domain (Домен/Чистая логика)**: Чистые функции и контракты (Protocols). Никакого ввода-вывода (I/O).
+
 ### 1.1.1. Обеспечение Контрактов (Enforcement)
+
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
+
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
 - **Runtime Boundary**: Опционально использовать `@runtime_checkable` только для критичных адаптеров (boundary validation). Семантика поведения в runtime не проверяется типами.
-- **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом. 
- 
-```python 
-class DataSourcePort(Protocol): 
-    def fetch(self, query: Query) -> Iterator[RawRecord]: ... 
-    async def health_check(self) -> HealthStatus: ... 
+- **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
+
+```python
+class DataSourcePort(Protocol):
+    def fetch(self, query: Query) -> Iterator[RawRecord]: ...
+    async def health_check(self) -> HealthStatus: ...
 ```
 
 ### 1.1.2. Health Check Protocol
+
 Все адаптеры **MUST** реализовывать асинхронный метод `health_check()` возвращающий `HealthStatus` enum:
 
 ```python
 from bioetl.domain.types import HealthStatus
+
 
 class MyAdapter:
     async def health_check(self) -> HealthStatus:
@@ -80,6 +91,7 @@ class MyAdapter:
 ```
 
 **Контракт:**
+
 - **MUST** быть `async def` (асинхронный)
 - **MUST** возвращать `HealthStatus` enum, не `bool`
 - **MUST** использовать lightweight probe (не тяжёлые запросы)
@@ -89,81 +101,98 @@ class MyAdapter:
 **Проверка:** Архитектурный тест `tests/architecture/` валидирует сигнатуры.
 
 ## 2. Поток Данных и Стратегия Medallion
+
 Пайплайны реализуются как направленные ациклические графы (**DAG**).
 
 См. [ADR-002](02-architecture/decisions/ADR-002-medallion-architecture.md).
 
-### 2.1. Архитектура Medallion 
-| Уровень | Формат | Валидация | Хранение (Retention) | Идемпотентность | 
-|---------|--------|-----------|----------------------|-----------------| 
-| **Bronze** (Сырые) | **JSONL + zstd** | Мин./Нет | 90 дней hot -> Archive (local archive policy) | Path: `bronze/{provider}/{entity}/{date}/`. Append-only. | 
-| **Silver** (Норм.) | **Delta Lake / Iceberg** | Мягкая (учет дрейфа схемы) | Постоянно | **Merge/Upsert**. Raw Parquet в Silver **MUST NOT** использоваться. Обязателен ACID. Time Travel — для Ops, не для DR. | 
-| **Gold** (Витрины) | Delta/Iceberg/Parquet | Строгая (`strict=True`) | Постоянно | Версионированные снимки (SCD Type 2) или партиционирование по дате. |
+### 2.1. Архитектура Medallion
+
+| Уровень            | Формат           | Валидация                  | Хранение (Retention)                          | Идемпотентность                                                                                                        |
+| ------------------ | ---------------- | -------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Bronze** (Сырые) | **JSONL + zstd** | Мин./Нет                   | 90 дней hot -> Archive (local archive policy) | Path: `bronze/{provider}/{entity}/{date}/`. Append-only.                                                               |
+| **Silver** (Норм.) | **Delta Lake**   | Мягкая (учет дрейфа схемы) | Постоянно                                     | **Merge/Upsert**. Raw Parquet в Silver **MUST NOT** использоваться. Обязателен ACID. Time Travel — для Ops, не для DR. |
+| **Gold** (Витрины) | Delta Lake       | Строгая (`strict=True`)    | Постоянно                                     | Версионированные снимки (SCD Type 2) или партиционирование по дате.                                                    |
 
 #### 2.1.1. Silver Write Modes (Режимы Записи)
+
 Режимы записи для Silver слоя строго типизированы (`SilverWriteMode` enum):
+
 - **MERGE**: Upsert по первичным ключам. Стратегия по умолчанию для incremental updates.
 - **APPEND**: Вставка новых записей без проверки дубликатов.
 - **DELETE**: Полная перезапись таблицы (удаление и вставка).
 
 **Валидация**:
+
 - Попытка использовать режим `OVERWRITE` (не `DELETE`) вызовет ошибку.
 - Нарушение инвариантов Medallion (например, Append для данных требующих идемпотентности) логируется как `PolicyViolation`.
 
 #### 2.1.2. Gold Write Modes (Режимы Записи)
+
 Режимы записи для Gold слоя строго типизированы (`GoldWriteMode` enum):
+
 - **OVERWRITE**: Полная перезапись витрины. Стандарт для агрегатов.
 - **APPEND**: Добавление новых партиций (для timeseries данных).
 - **SCD2**: Slowly Changing Dimensions Type 2 (историчность). Требует `scd_config` (ключи, valid_from/to).
 
 ### 2.1.3. Инфраструктура Delta Lake
+
 См. [ADR-001](02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md).
 
-- **Engine**: Использовать `delta-rs` (Rust core) для Python-воркеров для производительности. 
-- **Protocol**: Writer Version 2 (поддержка Column Mapping), Reader Version 1. 
+- **Engine**: Использовать `delta-rs` (Rust core) для Python-воркеров для производительности.
+- **Protocol**: Writer Version 2 (поддержка Column Mapping), Reader Version 1.
 - **Maintenance**: Обязательный запуск `VACUUM` с `retention_period=7 days` еженедельно для очистки старых файлов и уменьшения стоимости хранения. **VACUUM MUST** запускаться еженедельно.
 - **Forensic Retention**: По умолчанию 7 дней. Для таблиц класса critical (Core Data) допустимо увеличение до 30 дней через конфиг (`forensic_retention: true`), если позволяет бюджет.
- 
-### 2.2. Политика Дрейфа Схемы (Schema Drift) 
-- **Info**: Появление новых опциональных полей. Логируется. 
-- **Warn**: Появление >3 новых полей. Требует ревью. 
-- **Critical**: Исчезновение обязательного поля (ID). Блокирует пайплайн. 
+
+### 2.2. Политика Дрейфа Схемы (Schema Drift)
+
+- **Info**: Появление новых опциональных полей. Логируется.
+- **Warn**: Появление >3 новых полей. Требует ревью.
+- **Critical**: Исчезновение обязательного поля (ID). Блокирует пайплайн.
 - **Drift SLA**: Для событий WARN (дрейф схемы) назначается Owner. SLA на реакцию — 48 часов. Нерешенный дрейф блокирует следующий релиз.
- 
-### 2.3. Data Lineage (Происхождение Данных) 
-Оптимизированная схема lineage: 
-- **Silver Record**: Содержит `_source_batch_id` (FK). 
-- **Lineage Log**: Таблица `sys.lineage_log` хранит маппинг `_source_batch_id` -> список файлов Bronze (local paths), версия трансформации, параметры запуска. 
-Полные пути к файлам в каждой строке данных хранить запрещено (избыточность). 
- 
-### 2.4. Политика Backfill / Replay 
-- **Metadata**: Обязательные поля `_run_id` (UUID), `_run_type` (`incremental` | `backfill` | `rebuild`). 
-- **Merge Priority**: `rebuild` > `backfill` > `incremental`. При конфликте версий побеждает более "полный" тип запуска. 
+
+### 2.3. Data Lineage (Происхождение Данных)
+
+Оптимизированная схема lineage:
+
+- **Silver Record**: Содержит `_source_batch_id` (FK).
+- **Lineage Log**: Таблица `sys.lineage_log` хранит маппинг `_source_batch_id` -> список файлов Bronze (local paths), версия трансформации, параметры запуска.
+  Полные пути к файлам в каждой строке данных хранить запрещено (избыточность).
+
+### 2.4. Политика Backfill / Replay
+
+- **Metadata**: Обязательные поля `_run_id` (UUID), `_run_type` (`incremental` | `backfill` | `rebuild`).
+- **Merge Priority**: `rebuild` > `backfill` > `incremental`. При конфликте версий побеждает более "полный" тип запуска.
 - **Concurrency Constraint**: В один момент времени для одной сущности допустим только один процесс записи типа `rebuild` или `backfill`. Параллельный запуск запрещен (Lock должен это гарантировать).
 
 #### 2.4.1. Backfill Lock Enforcement
+
 Lock key включает тип запуска:
+
 - `incremental`: `lock:{provider}_{entity}`
 - `backfill`/`rebuild`: `lock:{provider}_{entity}:exclusive`
 
 При наличии активного `incremental` lock попытка взять `:exclusive`:
+
 - **Default**: Fail immediately (configurable).
 - **Wait mode**: `--wait-for-lock TIMEOUT_SEC`. Timeout по умолчанию: 300 секунд.
 
 #### 2.4.2. Medallion Clear Policy by Run Type
+
 См. [ADR-012](02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) и [ADR-013](02-architecture/decisions/ADR-013-async-storage-cleanup.md).
 
-| Run Type | Clear Silver | Clear Gold | Rationale |
-|----------|--------------|------------|-----------|
-| `REBUILD` | ✅ MUST | ✅ MUST | Полная перестройка данных |
-| `BACKFILL` | ✅ MUST | ✅ MUST | Историческая загрузка заново |
-| `INCREMENTAL` | ❌ MUST NOT | ❌ MUST NOT | Merge/Upsert, сохранение данных |
+| Run Type      | Clear Silver | Clear Gold  | Rationale                       |
+| ------------- | ------------ | ----------- | ------------------------------- |
+| `REBUILD`     | ✅ MUST      | ✅ MUST     | Полная перестройка данных       |
+| `BACKFILL`    | ✅ MUST      | ✅ MUST     | Историческая загрузка заново    |
+| `INCREMENTAL` | ❌ MUST NOT  | ❌ MUST NOT | Merge/Upsert, сохранение данных |
 
 **Инвариант Medallion**: Incremental runs **MUST NOT** вызывать `clear_silver()` или `clear_gold()`. Нарушение этого правила приводит к потере данных.
 
 **Реализация:**
+
 ```python
-# В PipelineRunner._clear_exports()
+# В MedallionLifecycleService.clear()
 if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
     await self.services.storage.clear_silver(self.config.silver_table)
     if self.config.gold_table:
@@ -172,35 +201,46 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 **Проверка:** Интеграционный тест `tests/integration/test_runner_lifecycle.py::test_incremental_skips_clear`.
 
-### 2.5. Стратегия Партиционирования 
-| Уровень | Стратегия партиционирования | Пример | 
-|---------|----------------------------|--------| 
-| **Bronze** | По `ingestion_date` (YYYY-MM-DD) | `bronze/chembl/activity/2025-05-20/` | 
-| **Silver** | По `source_date` или `entity_type` | `silver/chembl/activity/year=2025/month=05/` | 
-| **Gold** | По use-case (часто по `target_id` или `date`) | `gold/activity_by_target/target_id=CHEMBL123/` | 
- 
-- **Soft Limits**: Warning при >10,000 партиций или >100 файлов в партиции. 
+### 2.5. Стратегия Партиционирования
+
+| Уровень    | Стратегия партиционирования                   | Пример                                         |
+| ---------- | --------------------------------------------- | ---------------------------------------------- |
+| **Bronze** | По `ingestion_date` (YYYY-MM-DD)              | `bronze/chembl/activity/2025-05-20/`           |
+| **Silver** | По `source_date` или `entity_type`            | `silver/chembl/activity/year=2025/month=05/`   |
+| **Gold**   | По use-case (часто по `target_id` или `date`) | `gold/activity_by_target/target_id=CHEMBL123/` |
+
+- **Soft Limits**: Warning при >10,000 партиций или >100 файлов в партиции.
 - **Hard Limits**: 50,000 партиций -> Pipeline Fail. Запрещены ключи партиционирования: UUID, Hash, Free-text (высокая кардинальность убивает Delta Log).
-- **Z-ORDER**: Рекомендуется для полей с высокой кардинальностью в Gold слое (вместо глубокого партиционирования). 
- 
-### 2.6. Политика NULL и Пропущенных Значений 
-| Состояние | Действие | Куда попадает | 
-|-----------|----------|---------------| 
-| Значение отсутствует в источнике | Замена на NULL | Таблица Silver | 
-| Некритичная ошибка DQ (warning) | Замена на NULL | Таблица Silver (с флагом `_dq_warn=true`) | 
-| Критичная ошибка DQ (error) | Исключение из основного потока | **Таблица Quarantine (Unified)** | 
- 
-#### Спецификация Unified Quarantine 
-Единая таблица `common.quarantine` для всех сущностей. 
-- `ingestion_ts` (Timestamp): Время инцидента. 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). 
-- `payload_hash` (String): Для дедупликации ошибок. 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. 
-- `dq_status` (String): `NEW` | `IGNORED` | `REPROCESSED`. 
- 
+- **Z-ORDER**: Рекомендуется для полей с высокой кардинальностью в Gold слое (вместо глубокого партиционирования).
+
+### 2.6. Политика NULL и Пропущенных Значений
+
+| Состояние                        | Действие                       | Куда попадает                             |
+| -------------------------------- | ------------------------------ | ----------------------------------------- |
+| Значение отсутствует в источнике | Замена на NULL                 | Таблица Silver                            |
+| Некритичная ошибка DQ (warning)  | Замена на NULL                 | Таблица Silver (с флагом `_dq_warn=true`) |
+| Критичная ошибка DQ (error)      | Исключение из основного потока | **Таблица Quarantine (Unified)**          |
+
+#### Спецификация Unified Quarantine
+
+Единая таблица `common.quarantine` для всех сущностей.
+
+- `ingestion_ts` (Timestamp): Время инцидента.
+
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`).
+
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`).
+
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**).
+
+- `payload_hash` (String): Для дедупликации ошибок.
+
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных.
+
+- `dq_status` (String): `NEW` | `IGNORED` | `REPROCESSED`.
+
 - **Запрещено**: Sentinel values (-1, "N/A", 9999) **MUST NOT** использоваться.
+
 - **Pandera**: Поля, допускающие NULL, явно маркируются `nullable=True`.
 
 #### Int→Float Coercion для Nullable Integers
@@ -211,91 +251,102 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 **Затронутые поля (34 occurrences)**:
 
-| Сущность | Поля |
-|----------|------|
+| Сущность        | Поля                                                                                   |
+| --------------- | -------------------------------------------------------------------------------------- |
 | ChEMBL Activity | `record_id`, `src_id`, `standard_flag`, `potential_duplicate`, `toid`, `document_year` |
-| ChEMBL Molecule | `first_approval`, `black_box_warning`, `max_phase`, `chirality`, `usan_year` и др. |
-| ChEMBL Assay | `src_id`, `assay_taxonomy_id`, `confidence_score`, `dap_id` |
-| ChEMBL Target | `taxonomy_id` |
-| UniProt Protein | `organism_id`, `sequence_length` |
-| Publications | `year`, `publication_year` |
+| ChEMBL Molecule | `first_approval`, `black_box_warning`, `max_phase`, `chirality`, `usan_year` и др.     |
+| ChEMBL Assay    | `src_id`, `assay_taxonomy_id`, `confidence_score`, `dap_id`                            |
+| ChEMBL Target   | `taxonomy_id`                                                                          |
+| UniProt Protein | `organism_id`, `sequence_length`                                                       |
+| Publications    | `year`, `publication_year`                                                             |
 
 **Слои типизации**:
 
-| Слой | Тип | Пример |
-|------|-----|--------|
-| Domain | `Series[int]` или `Series[int] \| None` | Строгая типизация |
-| Silver | `pa.int64()` | Реальный формат хранения |
-| Gold | `Series[float]` + `coerce=True` | Nullable через NaN |
+| Слой   | Тип                                     | Пример                   |
+| ------ | --------------------------------------- | ------------------------ |
+| Domain | `Series[int]` или `Series[int] \| None` | Строгая типизация        |
+| Silver | `pa.int64()`                            | Реальный формат хранения |
+| Gold   | `Series[float]` + `coerce=True`         | Nullable через NaN       |
 
 **Требования к downstream-потребителям**:
+
 - **SHOULD** обрабатывать `NaN` как отсутствующее значение
 - **MAY** конвертировать `float → int` после проверки на `NaN` (если бизнес-логика требует)
 - **MUST NOT** предполагать, что все значения — целые числа
 
 **Реализация**: `src/bioetl/infrastructure/schemas/gold.py`
 
-#### Жизненный цикл Карантина 
-- **Retention**: 30 дней. Старые записи удаляются автоматически (local archive policy). 
-- **Triage**: Еженедельный пересмотр (Triage) ошибок аналитиками. Если ошибка системная — правим адаптер, если разовая — игнорируем. 
+#### Жизненный цикл Карантина
+
+- **Retention**: 30 дней. Старые записи удаляются автоматически (local archive policy).
+- **Triage**: Еженедельный пересмотр (Triage) ошибок аналитиками. Если ошибка системная — правим адаптер, если разовая — игнорируем.
 - **Source of Truth**: Карантин — это инструмент триажа, а не источник истины. Данные в карантине считаются "отсутствующими" в аналитическом слое.
 - **Linkage**: Обязательна ссылка на Bronze-файл (`bronze_file_uri` или `batch_id`) для возможности перепарсить исходник, если payload был обрезан.
- 
-#### Операции с карантином 
-Для управления "мусорными" данными использовать make-команды: 
-- `make quarantine-inspect PIPELINE=...`: Выгрузка сэмпла ошибок для анализа. 
-- `make quarantine-replay PIPELINE=...`: Повторная отправка исправленных записей в пайплайн. 
-- `make quarantine-purge PIPELINE=...`: Принудительная очистка карантина. 
- 
-### 2.7. Стратегия Загрузки (Load Strategy) 
-| Критерий | Incremental | Full Load | 
-|----------|-------------|-----------| 
-| Источник поддерживает `updated_since` | ✅ Предпочтительно | — | 
-| Объём данных > 1M записей | ✅ Обязательно | Только при rebuild | 
-| Источник не гарантирует immutability | — | ✅ Периодически (weekly) | 
-| Первичная загрузка | — | ✅ | 
- 
-- **Watermark**: Для инкрементальной загрузки хранить `last_successful_watermark` (timestamp или ID). 
-- **Конфигурация**: `load_strategy: incremental | full` в YAML пайплайна. 
-- **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности. 
- 
+
+#### Операции с карантином
+
+Для управления "мусорными" данными использовать make-команды:
+
+- `make quarantine-inspect PIPELINE=...`: Выгрузка сэмпла ошибок для анализа.
+- `make quarantine-replay PIPELINE=...`: Повторная отправка исправленных записей в пайплайн.
+- `make quarantine purge PIPELINE=...`: Принудительная очистка карантина.
+
+### 2.7. Стратегия Загрузки (Load Strategy)
+
+| Критерий                              | Incremental        | Full Load                |
+| ------------------------------------- | ------------------ | ------------------------ |
+| Источник поддерживает `updated_since` | ✅ Предпочтительно | —                        |
+| Объём данных > 1M записей             | ✅ Обязательно     | Только при rebuild       |
+| Источник не гарантирует immutability  | —                  | ✅ Периодически (weekly) |
+| Первичная загрузка                    | —                  | ✅                       |
+
+- **Watermark**: Для инкрементальной загрузки хранить `last_successful_watermark` (timestamp или ID).
+- **Конфигурация**: `load_strategy: incremental | full` в YAML пайплайна.
+- **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
+
 ### 2.8. Генерация ID Сущности (Entity ID)
+
 См. [ADR-023](02-architecture/decisions/ADR-023-entity-type-patterns.md) и [ADR-024](02-architecture/decisions/ADR-024-entity-naming-unification.md) для паттернов типов и именования сущностей.
 
-| Сценарий | Стратегия ID |
-|----------|--------------|
-| Источник предоставляет стабильный ID | Использовать как есть (`chembl_id`, `pubchem_cid`) |
-| ID отсутствует | **Content Hash**: `sha256(provider + canonical_json_dumps(record))` | 
- 
-- **Алгоритм**: `sha256(provider + canonical_json_dumps(record))` 
-- **Canonical JSON**: `json.dumps(obj, sort_keys=True, separators=(',', ':'), ensure_ascii=True)`. 
-  - **Float Precision**: Все значения типа float принудительно округляются: `round(val, 10)` для нивелирования различий архитектур процессоров. 
- 
-### 2.8.1. Robust Content Hash 
-Для обеспечения стабильности хэша перед генерацией ID данные должны быть нормализованы: 
-- **NaN/Inf**: Заменяются на `null` (None). 
-- **Floats**: Округляются до 10 знаков после запятой. 
-- **Dates**: Приводятся к единому ISO-формату `YYYY-MM-DD`. 
-- **Strings**: Удаление пробелов по краям (`strip()`). 
- 
-**Исключения**: Из расчета хэша исключаются технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`. 
- 
+| Сценарий                             | Стратегия ID                                                        |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| Источник предоставляет стабильный ID | Использовать как есть (`chembl_id`, `pubchem_cid`)                  |
+| ID отсутствует                       | **Content Hash**: `sha256(provider + canonical_json_dumps(record))` |
+
+- **Алгоритм**: `sha256(provider + canonical_json_dumps(record))`
+- **Canonical JSON**: `json.dumps(obj, sort_keys=True, separators=(',', ':'), ensure_ascii=True)`.
+  - **Float Precision**: Все значения типа float принудительно округляются: `round(val, 10)` для нивелирования различий архитектур процессоров.
+
+### 2.8.1. Robust Content Hash
+
+Для обеспечения стабильности хэша перед генерацией ID данные должны быть нормализованы:
+
+- **NaN/Inf**: Заменяются на `null` (None).
+- **Floats**: Округляются до 10 знаков после запятой.
+- **Dates**: Приводятся к единому ISO-формату `YYYY-MM-DD`.
+- **Strings**: Удаление пробелов по краям (`strip()`).
+
+**Исключения**: Из расчета хэша исключаются технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`.
+
 - **Детекция Коллизий**: При upsert проверять `_source_record_id`; если отличается — конфликт, логировать обе записи.
 
 ### 2.9. Composite Pipelines
+
 См. [ADR-026](02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) для архитектуры композитных пайплайнов.
 
 Composite Pipeline объединяет данные из нескольких источников в единую обогащённую сущность:
+
 1. **Seed Pipeline** — извлекает первичные сущности (напр., публикации из ChEMBL)
-2. **Dependency Pipelines** — заполняют Silver-таблицы перед обогащением (опционально)
-3. **Enricher Pipelines** — обогащают данными из других источников (CrossRef, OpenAlex, PubMed)
-4. **Merge Step** — объединяет все обогащения в единую Gold-сущность
+1. **Dependency Pipelines** — заполняют Silver-таблицы перед обогащением (опционально)
+1. **Enricher Pipelines** — обогащают данными из других источников (CrossRef, OpenAlex, PubMed)
+1. **Merge Step** — объединяет все обогащения в единую Gold-сущность
 
 #### 2.9.1. Dependency Pipelines (Chained Dependencies)
 
 Dependencies — пайплайны, которые запускаются **после seed, но до enrichers**. В отличие от enrichers (читают из Silver), dependencies выполняют полный цикл API→Bronze→Silver.
 
 **Конфигурация dependency:**
+
 ```yaml
 dependencies:
   - pipeline: chembl_target_component
@@ -324,39 +375,41 @@ dependencies:
 
 **Поля DependencyConfig:**
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `pipeline` | string | Имя пайплайна |
-| `join_keys` | list | Колонки для извлечения ключей |
-| `key_source` | string? | `null`/`"seed"` = seed, иначе имя dependency |
-| `filter_field` | string? | Поле API для фильтрации (если ≠ join_key) |
-| `required` | bool | При `true` — ошибка останавливает composite |
-| `timeout_seconds` | int | Таймаут выполнения |
-| `silver_table` | string? | Путь к Silver-таблице |
+| Поле              | Тип     | Описание                                     |
+| ----------------- | ------- | -------------------------------------------- |
+| `pipeline`        | string  | Имя пайплайна                                |
+| `join_keys`       | list    | Колонки для извлечения ключей                |
+| `key_source`      | string? | `null`/`"seed"` = seed, иначе имя dependency |
+| `filter_field`    | string? | Поле API для фильтрации (если ≠ join_key)    |
+| `required`        | bool    | При `true` — ошибка останавливает composite  |
+| `timeout_seconds` | int     | Таймаут выполнения                           |
+| `silver_table`    | string? | Путь к Silver-таблице                        |
 
 #### 2.9.2. Merge Configuration
 
-| Параметр | Описание | Значения |
-|----------|----------|----------|
-| `strategy` | Стратегия объединения | `left_outer`, `inner`, `union` |
-| `conflict_resolution` | Разрешение конфликтов полей | `seed_priority`, `enricher_priority`, `coalesce`, `explicit_rules` |
-| `preserve_all_sources` | Сохранение всех колонок провайдеров | `true` / `false` (default) |
+| Параметр               | Описание                            | Значения                                                           |
+| ---------------------- | ----------------------------------- | ------------------------------------------------------------------ |
+| `strategy`             | Стратегия объединения               | `left_outer`, `inner`, `union`                                     |
+| `conflict_resolution`  | Разрешение конфликтов полей         | `seed_priority`, `enricher_priority`, `coalesce`, `explicit_rules` |
+| `preserve_all_sources` | Сохранение всех колонок провайдеров | `true` / `false` (default)                                         |
 
 #### 2.9.3. preserve_all_sources Feature
 
 Опция `preserve_all_sources` в `MergeConfig` контролирует обработку колонок при слиянии:
 
-| Режим | Поведение | Используется когда |
-|-------|-----------|-------------------|
-| `preserve_all_sources: false` (default) | Колонки из разных источников **сливаются** (coalesce) в единую колонку по приоритету | Нужна единая "лучшая" версия поля |
-| `preserve_all_sources: true` | **Все** квалифицированные колонки сохраняются | Нужны данные из всех источников для анализа |
+| Режим                                   | Поведение                                                                            | Используется когда                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------- |
+| `preserve_all_sources: false` (default) | Колонки из разных источников **сливаются** (coalesce) в единую колонку по приоритету | Нужна единая "лучшая" версия поля           |
+| `preserve_all_sources: true`            | **Все** квалифицированные колонки сохраняются                                        | Нужны данные из всех источников для анализа |
 
 **Формат колонок при `preserve_all_sources: true`:**
+
 ```
 {provider}.{entity}.{field}
 ```
 
 **Пример:**
+
 ```yaml
 # configs/pipelines/composite/publication.yaml
 merge:
@@ -366,6 +419,7 @@ merge:
 ```
 
 **Результирующие колонки:**
+
 ```
 # При preserve_all_sources: false (coalesce)
 title                           # Единственная колонка title
@@ -378,6 +432,7 @@ pubmed.publication.title        # Значение из PubMed
 ```
 
 **Когда использовать:**
+
 - **`preserve_all_sources: true`**: Анализ качества данных, сравнение источников, ML-фичи из нескольких провайдеров
 - **`preserve_all_sources: false`**: Продакшн-витрины с единственной "лучшей" версией каждого поля
 
@@ -399,26 +454,28 @@ merge:
 #### 2.9.5. Field Group Registry
 
 `FieldGroupRegistry` обеспечивает семантическую группировку полей для:
+
 - **Упорядочивание колонок** в merged output (группы отсортированы по приоритету enum)
 - **Фильтрация Gold-слоя** — группа `TRASH` автоматически исключается из Gold output
 - **Валидация** — отслеживание mapped/unmapped/system колонок
 
 **8 семантических групп** (`PublicationFieldGroup` enum):
 
-| Группа | Описание | Включается в Gold |
-|--------|----------|-------------------|
-| `ID_AND_STATUS` | Идентификаторы, DOI, PMID, статусы | Да |
-| `BIBLIOGRAPHY` | Title, abstract, journal, volume, pages | Да |
-| `AUTHOR_AND_AFFILIATIONS` | Авторы, аффилиации, ORCID | Да |
-| `TERMS_AND_KEYWORDS_AND_TOPICS` | Keywords, MeSH, topics | Да |
-| `CITATIONS_AND_REFERENCE` | Счётчики цитирований, ссылки | Да |
-| `DATE_AND_PLACES` | Даты публикации, страны | Да |
-| `PUBLICATION_TYPES` | Типы документов | Да |
-| `TRASH` | Внутренние, избыточные, low-value | **Нет** |
+| Группа                          | Описание                                | Включается в Gold |
+| ------------------------------- | --------------------------------------- | ----------------- |
+| `ID_AND_STATUS`                 | Идентификаторы, DOI, PMID, статусы      | Да                |
+| `BIBLIOGRAPHY`                  | Title, abstract, journal, volume, pages | Да                |
+| `AUTHOR_AND_AFFILIATIONS`       | Авторы, аффилиации, ORCID               | Да                |
+| `TERMS_AND_KEYWORDS_AND_TOPICS` | Keywords, MeSH, topics                  | Да                |
+| `CITATIONS_AND_REFERENCE`       | Счётчики цитирований, ссылки            | Да                |
+| `DATE_AND_PLACES`               | Даты публикации, страны                 | Да                |
+| `PUBLICATION_TYPES`             | Типы документов                         | Да                |
+| `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 94 базовых поля, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
+
 - `FieldMapping` — маппинг `base_name → provider_columns + group`
 - `FieldGroupDefinition` — определение группы с её полями
 - `FieldGroupRegistry` — центральный реестр для lookup, фильтрации, сортировки
@@ -429,10 +486,11 @@ merge:
 
 `rename_fields` в `data_schema` конфигурации позволяет переименовывать колонки на уровне Silver и Gold слоёв.
 
-**ВАЖНО**: `gold.rename_fields` **MUST** использовать имена колонок **ПОСЛЕ** `silver.rename_fields`.  
+**ВАЖНО**: `gold.rename_fields` **MUST** использовать имена колонок **ПОСЛЕ** `silver.rename_fields`.
 Gold читает из Silver (Medallion flow), поэтому видит Silver output schema, а не оригинальные имена.
 
 **Формат конфигурации:**
+
 ```yaml
 # configs/data_schema/{provider}/{entity}.yaml
 column_groups: [...]  # Shared groups
@@ -454,6 +512,7 @@ gold:
 ```
 
 **Rename Chain:**
+
 ```
 Original → Silver → Gold
 ---------------------------------
@@ -463,85 +522,97 @@ _run_id → _run_id → pipeline_run_id
 ```
 
 **Когда использовать:**
+
 - **Silver**: Редко. Только для стандартизации внутренних имён между провайдерами
 - **Gold**: Часто. Для user-friendly имён в аналитических витринах
 
 **Best Practice:**
+
 - Сохранять оригинальные имена в Silver (упрощает отладку)
 - Применять бизнес-имена только в Gold (`_run_id` → `pipeline_run_id`, `pmid` → `pubmed_id`)
 
 ## 3. Обработка Ошибок и Наблюдаемость
 
 ### 3.1. Стратегия Обработки Ошибок
+
 См. [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md).
 
 Вместо тотального подхода "Fail Fast" используем дифференцированный подход.
 
-### 3.1.1. Классификация Ошибок 
-| Тип Ошибки | Поведение | Пример | 
-|------------|-----------|--------| 
-| **Критическая** (Critical) | Падение пайплайна | Ошибка авторизации, несовпадение схемы в Gold, БД недоступна. | 
-| **Восстановимая** (Recoverable) | Повтор N раз (Backoff) | 429 Rate Limit, 502/504 Timeout, сетевой сбой. | 
-| **Качество данных** (Data Quality) | Лог + Пропуск записи | Невалидный SMILES, отсутствует необязательное поле. Не роняет батч. | 
+### 3.1.1. Классификация Ошибок
 
-### 3.1.2. Пороги Ошибок Батча (Thresholds) 
-- **Soft Threshold**: >5% ошибок качества данных -> Warning. 
-- **Hard Threshold**: >20% ошибок -> Fail Batch. 
-- **Metric Scope**: Отслеживать как `record_error_rate` (доля битых строк), так и `entity_error_rate` (доля битых уникальных сущностей). 
- 
+| Тип Ошибки                         | Поведение              | Пример                                                              |
+| ---------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| **Критическая** (Critical)         | Падение пайплайна      | Ошибка авторизации, несовпадение схемы в Gold, БД недоступна.       |
+| **Восстановимая** (Recoverable)    | Повтор N раз (Backoff) | 429 Rate Limit, 502/504 Timeout, сетевой сбой.                      |
+| **Качество данных** (Data Quality) | Лог + Пропуск записи   | Невалидный SMILES, отсутствует необязательное поле. Не роняет батч. |
+
+### 3.1.2. Пороги Ошибок Батча (Thresholds)
+
+- **Soft Threshold**: >5% ошибок качества данных -> Warning.
+- **Hard Threshold**: >20% ошибок -> Fail Batch.
+- **Metric Scope**: Отслеживать как `record_error_rate` (доля битых строк), так и `entity_error_rate` (доля битых уникальных сущностей).
+
 ### 3.1.3. Параметры Retry (Backoff)
+
 Для типа ошибок **Recoverable** применять стратегию Exponential Backoff:
+
 - **Max Attempts**: 3
 - **Multiplier**: 2.0 (wait 1s, 2s, 4s...)
 - **Jitter**: Random(0.1s, 0.5s). Jitter **SHOULD** применяться для избежания thundering herd.
 - **Deterministic Mode**: При `RetryConfig(deterministic=True)` jitter **MUST** вычисляться через hash вместо random для воспроизводимости. См. [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md).
- 
+
 ### 3.1.4. Circuit Breaker (Размыкатель цепи)
+
 Паттерн защиты от каскадных сбоев. См. [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md).
+
 - **Trigger**: 5 последовательных ошибок соединения/таймаута.
 - **Open Duration**: 5 минут (configurable: `circuit_breaker.recovery_timeout`).
 - **Recovery**: Half-Open → 1 пробный запрос. Success → Closed, Failure → Open +5 мин.
-- **Observability**: Метрики `circuit_breaker_state` (0=Closed, 1=Half-Open, 2=Open), `trips_total`. Алерт при зависании в Open > 10 мин. 
- 
+- **Observability**: Метрики `circuit_breaker_state` (0=Closed, 1=Half-Open, 2=Open), `trips_total`. Алерт при зависании в Open > 10 мин.
+
 ### 3.2. Наблюдаемость (Observability)
+
 См. [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md) и [ADR-022](02-architecture/decisions/ADR-022-tracing-noop.md) для NoOp Tracing.
 
-- **Correlation ID**: `run_id` обязателен во всех логах, метриках и блокировках. 
-- **Retention**: Логи хранятся 30 дней, метрики — 90 дней. 
-- **Логи**: Структурированный JSON. 
-- **Dataset ID**: В логи и метрики добавляется лейбл `dataset` (логическое имя таблицы, напр. `chembl.activity`), так как pipeline может писать в несколько таблиц.
+- **Correlation ID**: `run_id` обязателен во всех логах, метриках и блокировках.
+- **Retention**: Логи хранятся 30 дней, метрики — 90 дней.
+- **Логи**: Структурированный JSON.
+- **Dataset ID**: В логи и метрики добавляется лейбл `dataset` (логическое имя таблицы, напр. `chembl/activity`), так как pipeline может писать в несколько таблиц.
 
 ### 3.2.1. Log Schema
-| Поле | Обязательность | Пример |
-|------|----------------|--------|
-| ts | MUST | `2025-12-15T10:00:00Z` |
-| level | MUST | `INFO`, `ERROR` |
-| run_id | MUST | UUID |
-| pipeline | MUST | `chembl_activity` |
-| stage | MUST | `extract`, `transform`, `load` |
-| dataset | SHOULD | `chembl.activity` |
-| record_count | SHOULD | 1000 |
-| error_type | При ошибках | `SCHEMA_VIOLATION` |
+
+| Поле         | Обязательность | Пример                         |
+| ------------ | -------------- | ------------------------------ |
+| timestamp    | MUST           | `2025-12-15T10:00:00Z`         |
+| level        | MUST           | `INFO`, `ERROR`                |
+| run_id       | MUST           | UUID                           |
+| pipeline     | MUST           | `chembl_activity`              |
+| stage        | MUST           | `extract`, `transform`, `load` |
+| dataset      | SHOULD         | `chembl/activity`              |
+| record_count | SHOULD         | 1000                           |
+| error_type   | При ошибках    | `SCHEMA_VIOLATION`             |
 
 ### 3.2.2. Prometheus Metrics
 
 **Endpoint:** `http://localhost:{BIOETL_METRICS_PORT}/metrics` (default port: 8000)
 
 **Запуск метрик:**
+
 - Автоматически в `bootstrap_pipeline()` (Composition Root)
 - Идемпотентный: повторный вызов безопасен (Double-Check Locking)
 - Graceful degradation: ошибки метрик не блокируют пайплайн
 
 **Pipeline Metrics (prefix: `bioetl_`):**
 
-| Метрика | Тип | Labels | Описание |
-|---------|-----|--------|----------|
-| `pipeline_duration_seconds` | Histogram | pipeline, stage, status, run_type | Длительность выполнения этапов |
-| `records_processed_total` | Counter | pipeline, stage, run_type | Количество обработанных записей |
-| `errors_total` | Counter | pipeline, stage, error_code | Количество ошибок по типам |
-| `batch_size_records` | Histogram | pipeline, stage | Распределение размеров батчей |
-| `filter_ids_loaded_total` | Counter | pipeline | Загружено ID для фильтрации |
-| `filter_ids_duplicates_total` | Counter | pipeline | Дубликаты в файле фильтрации |
+| Метрика                       | Тип       | Labels                            | Описание                        |
+| ----------------------------- | --------- | --------------------------------- | ------------------------------- |
+| `pipeline_duration_seconds`   | Histogram | pipeline, stage, status, run_type | Длительность выполнения этапов  |
+| `records_processed_total`     | Counter   | pipeline, stage, run_type         | Количество обработанных записей |
+| `errors_total`                | Counter   | pipeline, stage, error_code       | Количество ошибок по типам      |
+| `batch_size_records`          | Histogram | pipeline, stage                   | Распределение размеров батчей   |
+| `filter_ids_loaded_total`     | Counter   | pipeline                          | Загружено ID для фильтрации     |
+| `filter_ids_duplicates_total` | Counter   | pipeline                          | Дубликаты в файле фильтрации    |
 
 **Реализация:** См. `src/bioetl/infrastructure/observability/metrics.py` и `prometheus_metrics.py`.
 
@@ -551,6 +622,7 @@ _run_id → _run_id → pipeline_run_id
 > См. [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md)
 
 #### Strict Single Instance Policy (Local-Only)
+
 **ЗАПРЕЩЕНО** запускать несколько экземпляров одного пайплайна. Система разработана как **Single Instance Application**.
 
 - **Constraint**: `MemoryLock` работает только внутри одного процесса. Межпроцессные блокировки отсутствуют.
@@ -558,6 +630,7 @@ _run_id → _run_id → pipeline_run_id
 - **Horizontal Scaling**: **FORBIDDEN**. Масштабирование только вертикальное.
 
 #### Текущая реализация
+
 - **Механизм**: In-memory блокировки (`MemoryLock`)
 - **Scope**: Один процесс Python
 - **Pipeline Lock**: Один активный инстанс `{provider}_{entity}`
@@ -574,65 +647,72 @@ _run_id → _run_id → pipeline_run_id
 будут отклонены как нарушение архитектурного стандарта (ADR-010).
 
 **Invariant** (применимо ко всем вариантам развёртывания):
+
 - Потеря блокировки = Потеря права на запись.
 - Если Heartbeat не прошел, воркер **MUST** аварийно завершиться до попытки коммита данных.
 - **Safety Guard**: Адаптер **MUST** валидировать наличие блокировки перед записью данных.
- 
-### 3.4. Метрики Качества Данных (DQ Metrics) 
+
+### 3.4. Метрики Качества Данных (DQ Metrics)
+
 Метрики экспортируются в формате Prometheus с использованием лейблов для агрегации (`pipeline`, `entity`, `column`, `check`):
+
 - `dq_validation_score{check="null_rate", column="..."}`: % NULL значений.
 - `dq_validation_score{check="unique_count", column="..."}`: кардинальность.
 - `dq_validation_score{check="schema_violations", column="all"}`: кол-во невалидных записей.
 - `data_freshness_seconds`: разница между `now()` и `max(updated_at)`.
- 
-### 3.4.1. Детекция Аномалий DQ 
-- **Baseline (Базовая линия)**: Скользящее среднее за последние 30 дней. 
-- **Пороги Алертинга**: 
-  | Метрика | Warning | Critical | 
-  |---------|---------|----------| 
-  | Рост `null_rate` | >2x baseline | >5x baseline | 
-  | Падение `record_count` | <70% baseline | <50% baseline | 
-  | `freshness_lag_hours` | >24h | >72h | 
-- **Автоматизация**: CI-джоб `dq-check` сравнивает текущий запуск с базовой линией. 
-- **Cold Start**: 
-  - Days 1-7: Silence (обучение). 
-  - Days 8-30: Warning only. 
-  - Days 30+: Full Alerting. 
- 
-### 3.5. Provider Health Monitoring 
-| Status | Условие | Действие |
-|--------|---------|----------|
-| Healthy | 0 errors за 5 мин | Normal operation |
-| Degraded | 1-2 consecutive errors | Timeout ×2, batch_size ÷2 |
-| Unhealthy | ≥3 errors или health_check fail | Pause pipeline, Alert P2 |
+
+### 3.4.1. Детекция Аномалий DQ
+
+- **Baseline (Базовая линия)**: Скользящее среднее за последние 30 дней.
+- **Пороги Алертинга**:
+  | Метрика                | Warning        | Critical       |
+  | ---------------------- | -------------- | -------------- |
+  | Рост `null_rate`       | >2x baseline   | >5x baseline   |
+  | Падение `record_count` | \<70% baseline | \<50% baseline |
+  | `freshness_lag_hours`  | >24h           | >72h           |
+- **Автоматизация**: CI-джоб `dq-check` сравнивает текущий запуск с базовой линией.
+- **Cold Start**:
+  - Days 1-7: Silence (обучение).
+  - Days 8-30: Warning only.
+  - Days 30+: Full Alerting.
+
+### 3.5. Provider Health Monitoring
+
+| Status    | Условие                         | Действие                  |
+| --------- | ------------------------------- | ------------------------- |
+| Healthy   | 0 errors за 5 мин               | Normal operation          |
+| Degraded  | 1-2 consecutive errors          | Timeout ×2, batch_size ÷2 |
+| Unhealthy | ≥3 errors или health_check fail | Pause pipeline, Alert P2  |
 
 **Recovery**: Unhealthy → Degraded после 1 успешного health_check.
 **Metric**: `provider_health_status{provider}` (0=Unhealthy, 1=Degraded, 2=Healthy).
- 
-## 4. Стандарты Кода и Тестирование 
- 
+
+## 4. Стандарты Кода и Тестирование
+
 ### 4.1. Стек и Матрица Решений
+
 См. также [ADR-004](02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md) для решения Pydantic vs Dataclasses.
 
-| Задача | Инструмент | Альтернатива | Критерий выбора |
-|--------|------------|--------------|-----------------|
-| **Оркестрация** | **PipelineRunner** | Prefect/Airflow | Используем собственный легковесный Runner. Внешние фреймворки при >5 DAG-ов. |
-| **Валидация** | **Pandera** | Great Expectations | Pandera нативна для DataFrames, легче интегрируется в CI. | 
-| **HTTP Клиент** | **httpx** via `UnifiedHTTPClient` | requests | Поддержка `async`. Все адаптеры **MUST** использовать `UnifiedHTTPClient` (см. §4.1.1). **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy) — `BaseSyncAdapter` с `ThreadPoolExecutor`. | 
-| **Линтер** | **Ruff** | Flake8/Black | Скорость и решение "все-в-одном". |
+| Задача          | Инструмент                        | Альтернатива       | Критерий выбора                                                                                                                                                                                        |
+| --------------- | --------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Оркестрация** | **PipelineRunner**                | Prefect/Airflow    | Используем собственный легковесный Runner. Внешние фреймворки при >5 DAG-ов.                                                                                                                           |
+| **Валидация**   | **Pandera**                       | Great Expectations | Pandera нативна для DataFrames, легче интегрируется в CI.                                                                                                                                              |
+| **HTTP Клиент** | **httpx** via `UnifiedHTTPClient` | requests           | Поддержка `async`. Все адаптеры **MUST** использовать `UnifiedHTTPClient` (см. §4.1.1). **Legacy Wrappers**: Для библиотек без async поддержки (pubchempy) — `BaseSyncAdapter` с `ThreadPoolExecutor`. |
+| **Линтер**      | **Ruff**                          | Flake8/Black       | Скорость и решение "все-в-одном".                                                                                                                                                                      |
 
 ### 4.1.1. Унифицированный HTTP-клиент (UnifiedHTTPClient)
 
 **Все HTTP-адаптеры используют единую инфраструктуру для HTTP-запросов.**
 
-| Адаптер | Базовый класс | HTTP-клиент | Статус |
-|---------|---------------|-------------|--------|
-| `ChemblAdapter` | `BaseHttpAdapter` | `UnifiedHTTPClient` | ✅ Унифицирован |
-| `UniProtAdapter` | `BaseHttpAdapter` | `UnifiedHTTPClient` | ✅ Унифицирован |
-| `PubMedAdapter` | `@dataclass` | `UnifiedHTTPClient` | ✅ Унифицирован |
+| Адаптер          | Базовый класс     | HTTP-клиент              | Статус            |
+| ---------------- | ----------------- | ------------------------ | ----------------- |
+| `ChemblAdapter`  | `BaseHttpAdapter` | `UnifiedHTTPClient`      | ✅ Унифицирован   |
+| `UniProtAdapter` | `BaseHttpAdapter` | `UnifiedHTTPClient`      | ✅ Унифицирован   |
+| `PubMedAdapter`  | `@dataclass`      | `UnifiedHTTPClient`      | ✅ Унифицирован   |
 | `PubChemAdapter` | `BaseSyncAdapter` | `pubchempy` + ThreadPool | ✅ Legacy-обёртка |
 
 **Компоненты `UnifiedHTTPClient`:**
+
 - **Rate Limiter** (`TokenBucket`): Ограничение частоты запросов по провайдеру
 - **Circuit Breaker**: Защита от каскадных отказов (см. [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md))
 - **Retry Logic**: Exponential backoff с configurable jitter
@@ -641,9 +721,11 @@ _run_id → _run_id → pipeline_run_id
 **Расположение:** `src/bioetl/infrastructure/adapters/http/client.py`
 
 **Создание нового адаптера:**
+
 ```python
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
 from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
 
 class NewProviderAdapter(BaseHttpAdapter):
     def __init__(
@@ -656,6 +738,7 @@ class NewProviderAdapter(BaseHttpAdapter):
 ```
 
 **Для sync-библиотек** используйте `BaseSyncAdapter` с DI:
+
 ```python
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
 
@@ -678,32 +761,34 @@ class LegacyAdapter(BaseSyncAdapter):
 ```
 
 ### 4.2. Политика Тестирования
+
 **Цель покрытия:** ≥85% line coverage (проверяется в CI через `--cov-fail-under=85`).
 
 - **Unit**: Только доменная логика. In-memory fakes предпочтительны, MagicMock допустим.
 - **Integration**:
-    - **VCR.py**: Запись ответов API в кассеты (`tests/fixtures/vcr/`).
-    - **Санитизация**: Обязательная очистка секретов (`Authorization`, `X-API-Key`) и PII в хуке `before_record`.
-    - **CI**: Падать, если кассета отсутствует (`pytest --vcr-record=none`), чтобы гарантировать отсутствие сетевых вызовов в CI.
+  - **VCR.py**: Запись ответов API в кассеты (`tests/fixtures/vcr/`).
+  - **Санитизация**: Обязательная очистка секретов (`Authorization`, `X-API-Key`) и PII в хуке `before_record`.
+  - **CI**: Падать, если кассета отсутствует (`pytest --vcr-record=none`), чтобы гарантировать отсутствие сетевых вызовов в CI.
 - **E2E (End-to-End)**: Полный цикл пайплайна от fetch до Gold (`tests/e2e/`).
-    - **Архитектура**: Local-Only (файловая система, MemoryLock, LocalCheckpoint).
-    - **Helpers**: `create_test_context()`, `assert_bronze_files_exist()`, `assert_silver_table_has_records()`.
-    - **Маркер**: `@pytest.mark.e2e` для селективного запуска.
-    - **Запуск**: `pytest tests/e2e/ -v -m e2e`.
+  - **Архитектура**: Local-Only (файловая система, MemoryLock, LocalCheckpoint).
+  - **Helpers**: `create_test_context()`, `assert_bronze_files_exist()`, `assert_silver_table_has_records()`.
+  - **Маркер**: `@pytest.mark.e2e` для селективного запуска.
+  - **Запуск**: `pytest tests/e2e/ -v -m e2e`.
 - **Contract Tests**: Ежемесячный запуск против *реальных* API (Live) в отдельном CI workflow для обнаружения нарушения контрактов.
 
 #### 4.2.1. Тестовые Зависимости и Установка
 
 Проект использует optional dependency группы в `pyproject.toml`:
 
-| Группа | Установка | Назначение |
-|--------|-----------|------------|
-| `tests` | `pip install .[tests]` | Минимальный набор для запуска тестов |
-| `dev` | `pip install .[dev]` | Полный набор для разработки (включает tests + linting + security) |
-| `tracing` | `pip install .[tracing]` | OpenTelemetry для production tracing |
-| `docs` | `pip install .[docs]` | MkDocs для генерации документации |
+| Группа    | Установка                | Назначение                                                        |
+| --------- | ------------------------ | ----------------------------------------------------------------- |
+| `tests`   | `pip install .[tests]`   | Минимальный набор для запуска тестов                              |
+| `dev`     | `pip install .[dev]`     | Полный набор для разработки (включает tests + linting + security) |
+| `tracing` | `pip install .[tracing]` | OpenTelemetry для production tracing                              |
+| `docs`    | `pip install .[docs]`    | MkDocs для генерации документации                                 |
 
 **Группа `tests` включает:**
+
 - `pytest>=8.0`, `pytest-cov>=4.0`, `pytest-asyncio>=0.23`, `pytest-xdist>=3.5` — основа тестирования
 - `respx>=0.21` — HTTP-мокирование для тестов адаптеров
 - `hypothesis>=6.100` — property-based тестирование
@@ -711,6 +796,7 @@ class LegacyAdapter(BaseSyncAdapter):
 - `syrupy>=4.0` — snapshot-тестирование
 
 **Рекомендуемый способ установки:**
+
 ```bash
 # Для разработки (полный набор)
 make install  # Эквивалент: pip install -e ".[dev]"
@@ -722,40 +808,46 @@ pip install -e ".[tests]"
 **ВАЖНО**: При использовании `pip install .[tests]` убедитесь, что все тестовые зависимости доступны. Если тесты падают с `ModuleNotFoundError`, проверьте версию `pyproject.toml` и выполните `pip install -e ".[tests]"` заново.
 
 ### 4.3. Детерминизм и Воспроизводимость
+
 См. [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md).
 
 #### MUST (Обязательно)
+
 1. Storage writers **MUST NOT** использовать модуль `random`
-2. Timestamps **MUST** передаваться из application слоя, не создаваться в infrastructure
-3. Retry jitter **MUST** быть детерминистичным при `deterministic=True`
-4. `PipelineContext.started_at` — единственный источник времени для batch
-5. Application и Interfaces слои **MUST NOT** импортировать `structlog` напрямую — использовать `LoggerPort` (см. ADR-019)
+1. Timestamps **MUST** передаваться из application слоя, не создаваться в infrastructure
+1. Retry jitter **MUST** быть детерминистичным при `deterministic=True`
+1. `PipelineContext.started_at` — единственный источник времени для batch
+1. Application и Interfaces слои **MUST NOT** импортировать `structlog` напрямую — использовать `LoggerPort` (см. ADR-019)
 
 #### Архитектурные Тесты (REQ-ARCH-030)
-| Тест | Цель | Проверки |
-|------|------|----------|
-| `test_no_random_in_writers` | Блокирует `random` в storage writers | `import random`, `from random import`, `random.uniform()`, `random.choice()` |
-| `test_no_datetime_now_in_infrastructure` | Блокирует `datetime.now()` в infra | `datetime.now()`, `datetime.datetime.now()` |
-| `test_no_structlog_in_application_interfaces` | Блокирует прямой импорт `structlog` | `import structlog`, `from structlog import` |
+
+| Тест                                          | Цель                                 | Проверки                                                                     |
+| --------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `test_no_random_in_writers`                   | Блокирует `random` в storage writers | `import random`, `from random import`, `random.uniform()`, `random.choice()` |
+| `test_no_datetime_now_in_infrastructure`      | Блокирует `datetime.now()` в infra   | `datetime.now()`, `datetime.datetime.now()`                                  |
+| `test_no_structlog_in_application_interfaces` | Блокирует прямой импорт `structlog`  | `import structlog`, `from structlog import`                                  |
 
 **Путь:** `tests/architecture/test_no_random_in_writers.py`, `tests/architecture/test_no_datetime_now_in_infrastructure.py`, `tests/architecture/test_no_structlog_in_application_interfaces.py`
 
 #### Детерминистичный Jitter
+
 ```python
 # RetryConfig (src/bioetl/infrastructure/adapters/http/client.py)
 RetryConfig(
     deterministic=True,  # Hash-based jitter
-    jitter_seed=42,      # Reproducible seed
+    jitter_seed=42,  # Reproducible seed
 )
 ```
 
 При `deterministic=True` jitter вычисляется как:
+
 ```python
 hash_input = f"{attempt}:{url}:{seed}"
 jitter_factor = (hash(hash_input) % 1000) / 1000.0
 ```
 
 #### Единый Источник Времени
+
 ```python
 # Application layer создаёт timestamp
 context = PipelineContext.create(run_id, run_type, logger)
@@ -769,6 +861,7 @@ await quarantine.write(..., ingestion_ts=context.started_at)
 ### 4.4. Python Standards
 
 #### 4.4.1. Future Annotations (PEP 563)
+
 Все Python-файлы **MUST** начинаться с:
 
 ```python
@@ -776,6 +869,7 @@ from __future__ import annotations
 ```
 
 **Причины:**
+
 - Отложенная evaluation типов (производительность)
 - Поддержка forward references без кавычек
 - Совместимость с Python 3.10+ стилем типизации
@@ -783,49 +877,58 @@ from __future__ import annotations
 **Проверка:** `ruff check --select FA` (Future Annotations rules).
 
 **Расположение в файле:**
+
 1. Shebang (если есть): `#!/usr/bin/env python`
-2. Encoding declaration (если есть): `# -*- coding: utf-8 -*-`
-3. Module docstring
-4. `from __future__ import annotations`  ← сразу после docstring
-5. Другие импорты
+1. Encoding declaration (если есть): `# -*- coding: utf-8 -*-`
+1. Module docstring
+1. `from __future__ import annotations` ← сразу после docstring
+1. Другие импорты
 
 #### 4.4.2. Type Hints
+
 - **MUST** использовать новый стиль типов: `list[str]` вместо `List[str]`
 - **MUST** использовать `X | None` вместо `Optional[X]`
 - **SHOULD** использовать `X | Y` вместо `Union[X, Y]`
 
-## 5. Операции (Лимиты, Секреты, Shutdown) 
- 
-### 5.1. Ограничение скорости (Rate Limiting) 
-Каждый адаптер обязан реализовать `TokenBucket` или аналог, соблюдающий лимиты провайдера. 
-**Обратное давление (Backpressure)**: Если внутренняя очередь заполнена >80%, адаптер должен замедлить чтение (дросселировать источник). 
- 
-### 5.2. Управление Секретами 
-- **Источник**: Переменные окружения (`os.environ`). 
-- **Формат**: `BIOETL_{PROVIDER}_{KEY}` (например, `BIOETL_PUBCHEM_API_KEY`). 
-- **Запрещено**: Хардкод секретов **MUST NOT**. Файлы `.env` в git **MUST NOT**. 
- 
+## 5. Операции (Лимиты, Секреты, Shutdown)
+
+### 5.1. Ограничение скорости (Rate Limiting)
+
+Каждый адаптер обязан реализовать `TokenBucket` или аналог, соблюдающий лимиты провайдера.
+**Обратное давление (Backpressure)**: Если внутренняя очередь заполнена >80%, адаптер должен замедлить чтение (дросселировать источник).
+
+### 5.2. Управление Секретами
+
+- **Источник**: Переменные окружения (`os.environ`).
+- **Формат**: `BIOETL_{PROVIDER}_{KEY}` (например, `BIOETL_PUBCHEM_API_KEY`).
+- **Запрещено**: Хардкод секретов **MUST NOT**. Файлы `.env` в git **MUST NOT**.
+
 ### 5.3. Graceful Shutdown (Штатное завершение)
+
 См. [ADR-008](02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md).
-При получении SIGTERM/SIGINT: 
-1. Прекратить извлечение (fetch) новых записей. 
-2. Дождаться завершения записи текущего батча. 
-3. Сохранить чекпоинт в **local storage** с использованием **If-Match / ETag** для обеспечения атомарности и предотвращения Lost Updates. 
-4. Выйти с кодом 0. 
+При получении SIGTERM/SIGINT:
+
+1. Прекратить извлечение (fetch) новых записей.
+1. Дождаться завершения записи текущего батча.
+1. Сохранить чекпоинт в **local storage** с использованием **If-Match / ETag** для обеспечения атомарности и предотвращения Lost Updates.
+1. Выйти с кодом 0.
 
 - **Guarantees**: Система гарантирует At-Least-Once доставку + Дедупликацию в Silver (через Content Hash). Гарантия Exactly-Once на уровне транспорта не требуется.
- 
-### 5.3.1. Восстановление из Чекпоинта (Checkpoint Recovery) 
-При запуске пайплайн: 
-1. Проверяет наличие чекпоинта в локальном хранилище (`data/output/checkpoints`). 
-2. Если найден и передан флаг `--resume`: 
-   - Начинает с `last_processed_id + 1`. 
-   - Логирует: `Resuming from checkpoint: {id}`. 
-3. Если найден без флага: 
-   - Warning: "Stale checkpoint detected. Use --resume or --ignore-checkpoint." 
-4. После успешного завершения: удалить локальный файл чекпоинта.
+
+### 5.3.1. Восстановление из Чекпоинта (Checkpoint Recovery)
+
+При запуске пайплайн:
+
+1. Проверяет наличие чекпоинта в локальном хранилище (`data/output/checkpoints`).
+1. Если найден и передан флаг `--resume`:
+   - Начинает с `last_processed_id + 1`.
+   - Логирует: `Resuming from checkpoint: {id}`.
+1. Если найден без флага:
+   - Warning: "Stale checkpoint detected. Use --resume or --ignore-checkpoint."
+1. После успешного завершения: удалить локальный файл чекпоинта.
 
 ### 5.3.2. Async Resource Cleanup
+
 См. [ADR-013](02-architecture/decisions/ADR-013-async-storage-cleanup.md) и [ADR-015](02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md).
 
 **Контракт `aclose()`:**
@@ -844,58 +947,67 @@ class MyAdapter:
 ```
 
 **Требования:**
+
 - **MUST** быть `async def` (асинхронный)
 - **MUST** быть идемпотентным (безопасен для повторных вызовов)
 - **MUST NOT** выбрасывать исключения
 - **SHOULD** обнулять ссылки после закрытия (`self._client = None`)
 
 **PipelineServices Lifecycle:**
+
 ```python
 async with services:  # __aenter__ инициализирует ресурсы
     await runner.run()
 # __aexit__ вызывает aclose() для всех компонентов
 ```
 
-### 5.4. Политика Чувствительных Данных (Sensitive Data) 
-- **Classification**: Public / Internal / Restricted. 
-- **IAM**: Принцип Least Privilege. Разделение ролей `writer` (пайплайн) и `reader` (аналитик). 
-- **Bronze**: Хранить как есть (Internal). 
+### 5.4. Политика Чувствительных Данных (Sensitive Data)
+
+- **Classification**: Public / Internal / Restricted.
+- **IAM**: Принцип Least Privilege. Разделение ролей `writer` (пайплайн) и `reader` (аналитик).
+- **Bronze**: Хранить как есть (Internal).
 - **Silver**: Хэшировать PII поля: `sha256(lowercase(value) + SALT)` (Restricted). **PII fields MUST be salted.**
 - **Gold**: PII исключается или агрегируется (Public/Internal).
 
 **Threat Model Scope**:
+
 - В фокусе: Утечка PII через логи, SQL-инъекции, несанкционированный доступ к локальным данным.
 - Out of Scope: Физический доступ к серверам, компрометация AWS Root Account (управляемый сервис).
- 
-### 5.5. Disaster Recovery (DR) 
-- **RPO**: 24 часа. 
-- **RTO**: 4 часа. 
-- **Game Days**: Game Days **SHOULD** проводиться ежегодно. Обязательные учения по восстановлению. Success criteria: данные идентичны, время < RTO. 
- 
-#### 5.5.1. Detailed DR Procedures (Runbook) 
-| Сценарий | Действие | 
-|----------|----------| 
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--full-rebuild` (если затронут Silver). | 
-| **Потеря чекпоинта** | Запуск с `--ignore-checkpoint` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). | 
-| **Отказ региона AWS** | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе. | 
- 
-### 5.6. Среды (Environments) 
-- **Dev**: Локальная разработка (Docker Compose). Данные: фикстуры или сэмпл Bronze. 
-- **Staging**: Полная копия архитектуры. Данные: Prod-like (обфусцированные). Тест деплоя. 
-- **Prod**: Боевая среда. Доступ на запись только у CI/CD. 
- 
+
+### 5.5. Disaster Recovery (DR)
+
+- **RPO**: 24 часа.
+- **RTO**: 4 часа.
+- **Game Days**: Game Days **SHOULD** проводиться ежегодно. Обязательные учения по восстановлению. Success criteria: данные идентичны, время < RTO.
+
+#### 5.5.1. Detailed DR Procedures (Runbook)
+
+| Сценарий                      | Действие                                                                                                                                                                         |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| **Потеря чекпоинта**          | Запуск с `--ignore-checkpoint` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это).                                                                          |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+
+### 5.6. Среды (Environments)
+
+- **Dev**: Локальная разработка (Docker Compose). Данные: фикстуры или сэмпл Bronze.
+- **Staging**: Полная копия архитектуры. Данные: Prod-like (обфусцированные). Тест деплоя.
+- **Prod**: Боевая среда. Доступ на запись только у CI/CD.
+
 ### 5.6.1. Environment Isolation
+
 Изоляция ресурсов для предотвращения "Cross-Env Pollution".
 
 > **Note**: Текущая архитектура — Local-Only (см. [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md)).
 > Нижеследующие примеры относятся к будущему распределённому развёртыванию.
 
 - **Storage**: Разные директории или бакеты (`data/dev`, `data/staging`, `data/prod` или `bioetl-dev`, `bioetl-staging`, `bioetl-prod`).
-- **Configs**: Строгое разделение переменных окружения. Доступ к Prod-секретам только у CI Runner. 
- 
-## 6. Документация (Автоматизация — приоритет) 
-- **Карта и Схемы**: Генерируются скриптами в CI (pydantic-to-json-schema, eralchemy2, mkdocs). 
-- **Именование**: Зеркальное (`src/bioetl/.../{provider}/` <-> `docs/providers/{provider}/`). 
+- **Configs**: Строгое разделение переменных окружения. Доступ к Prod-секретам только у CI Runner.
+
+## 6. Документация (Автоматизация — приоритет)
+
+- **Карта и Схемы**: Генерируются скриптами в CI (pydantic-to-json-schema, eralchemy2, mkdocs).
+- **Именование**: Зеркальное (`src/bioetl/.../{provider}/` \<-> `docs/providers/{provider}/`).
 
 ## 6.1. Детерминизм и Воспроизводимость
 
@@ -904,21 +1016,22 @@ async with services:  # __aenter__ инициализирует ресурсы
 **Детерминизм** — это гарантия того, что при одинаковых входных данных (source data, config) пайплайн всегда произведет идентичные выходные данные и побочные эффекты.
 
 #### MUST (Обязательно)
+
 1. **Randomness**: Модуль `random` **MUST NOT** использоваться в `infrastructure/storage` и других критических узлах записи. Используйте хэш-функции от входных данных или фиксированные константы.
-2. **Time Source**: `datetime.now()` **MUST NOT** вызываться в `infrastructure` слое (за исключением мониторинга реального времени). Все временные метки (`ingestion_ts`, `processing_ts`) **MUST** генерироваться в `Application` слое (`PipelineContext.started_at`) и передаваться вниз.
-3. **Retry Jitter**: При `deterministic=True`, jitter **MUST** вычисляться детерминистично (на основе хэша попытки и URL). Реализация: `domain/resilience.py:RetryPolicy.calculate_delay()` использует MD5-based jitter.
-4. **Ordering**: Запись в Delta Lake **MUST** происходить после сортировки данных по Primary Keys (Silver) или Business Keys (Gold).
-5. **Content Hash**: Исключать из расчёта хэша технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`. Реализация: `domain/transformations.py:META_FIELDS`.
+1. **Time Source**: `datetime.now()` **MUST NOT** вызываться в `infrastructure` слое (за исключением мониторинга реального времени). Все временные метки (`ingestion_ts`, `processing_ts`) **MUST** генерироваться в `Application` слое (`PipelineContext.started_at`) и передаваться вниз.
+1. **Retry Jitter**: При `deterministic=True`, jitter **MUST** вычисляться детерминистично (на основе хэша попытки и URL). Реализация: `domain/resilience.py:RetryPolicy.calculate_delay()` использует MD5-based jitter.
+1. **Ordering**: Запись в Delta Lake **MUST** происходить после сортировки данных по Primary Keys (Silver) или Business Keys (Gold).
+1. **Content Hash**: Исключать из расчёта хэша технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`. Реализация: `domain/transformations.py:META_FIELDS`.
 
 #### Архитектурные Тесты Детерминизма
 
-| Тест | REQ | Проверка | Файл |
-|------|-----|----------|------|
-| `test_no_random_import_in_storage_writers` | REQ-ARCH-030 | Запрет `import random` | `test_no_random_in_writers.py` |
-| `test_no_random_uniform_calls_in_storage` | REQ-ARCH-030 | Запрет `random.uniform()` | `test_no_random_in_writers.py` |
-| `test_no_random_choice_calls_in_storage` | REQ-ARCH-030 | Запрет `random.choice()` | `test_no_random_in_writers.py` |
-| `test_no_datetime_now_in_infrastructure` | REQ-ARCH-031 | Запрет `datetime.now()` | `test_no_datetime_now_in_infrastructure.py` |
-| `test_allowed_files_still_exist` | REQ-ARCH-031 | Валидация исключений | `test_no_datetime_now_in_infrastructure.py` |
+| Тест                                       | REQ          | Проверка                  | Файл                                        |
+| ------------------------------------------ | ------------ | ------------------------- | ------------------------------------------- |
+| `test_no_random_import_in_storage_writers` | REQ-ARCH-030 | Запрет `import random`    | `test_no_random_in_writers.py`              |
+| `test_no_random_uniform_calls_in_storage`  | REQ-ARCH-030 | Запрет `random.uniform()` | `test_no_random_in_writers.py`              |
+| `test_no_random_choice_calls_in_storage`   | REQ-ARCH-030 | Запрет `random.choice()`  | `test_no_random_in_writers.py`              |
+| `test_no_datetime_now_in_infrastructure`   | REQ-ARCH-031 | Запрет `datetime.now()`   | `test_no_datetime_now_in_infrastructure.py` |
+| `test_allowed_files_still_exist`           | REQ-ARCH-031 | Валидация исключений      | `test_no_datetime_now_in_infrastructure.py` |
 
 #### Детерминистичный Retry Jitter
 
@@ -930,7 +1043,7 @@ jitter_factor = int(digest[:8], 16) / 0xFFFFFFFF
 ```
 
 При `RetryPolicy(deterministic=False)` выдаётся `DeprecationWarning` — рекомендуется переход на детерминистичный режим.
- 
+
 ## 7. Протокол Архитектурных Обзоров
 
 ### 7.1. Обязательная Двойная Верификация (REQ-ARCH-040)
@@ -963,6 +1076,7 @@ grep -r "class ClassName\|def method_name" src/bioetl/
 ```
 
 **Критерии подтверждения проблемы:**
+
 - [ ] Файл прочитан полностью (не только упоминания)
 - [ ] Размер компонента измерен (LOC, количество методов)
 - [ ] Делегирование проанализировано
@@ -975,13 +1089,13 @@ grep -r "class ClassName\|def method_name" src/bioetl/
 
 Каждое утверждение о проблеме **MUST** содержать:
 
-| Поле | Требование |
-|------|------------|
-| **Файл:строки** | Точная ссылка на код (`runner.py:116-123`) |
-| **Размер** | LOC и количество методов |
-| **Структура** | Описание публичных методов и делегирования |
-| **Дата верификации** | Дата проверки кода |
-| **Проверено** | "Нет в refactoring-plan.md:ЛОЖНЫЕ УТВЕРЖДЕНИЯ ✅" |
+| Поле                 | Требование                                        |
+| -------------------- | ------------------------------------------------- |
+| **Файл:строки**      | Точная ссылка на код (`runner.py:116-123`)        |
+| **Размер**           | LOC и количество методов                          |
+| **Структура**        | Описание публичных методов и делегирования        |
+| **Дата верификации** | Дата проверки кода                                |
+| **Проверено**        | "Нет в refactoring-plan.md:ЛОЖНЫЕ УТВЕРЖДЕНИЯ ✅" |
 
 **Пример верифицированного утверждения:**
 
@@ -1005,34 +1119,34 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 **MUST NOT** делать утверждения без верификации:
 
-| ❌ Неверно | ✅ Верно |
-|-----------|----------|
+| ❌ Неверно                      | ✅ Верно                                                                                                           |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 527 LOC, 8 методов) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен" | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам" |
-| "Нет валидации X" | "Валидация X отсутствует в `file.py` (проверено grep по 'X')" |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
 
 #### 7.1.4. Типичные Ложные Выводы
 
-| Паттерн | Почему ошибочен | Пример из кодовой базы |
-|---------|-----------------|------------------------|
-| "500+ LOC = god object" | Размер ≠ сложность. Когезивный сервис с единой ответственностью валиден | `ChemblAdapter` (517 LOC) делегирует через `EntityMapper`, `ErrorClassifier`, `AdapterMetrics` |
-| "Монолит требует декомпозиции" | Файл с делегированием — НЕ монолит | `GoldWriter` (593 LOC) делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны |
-| "NoOp default = нарушение DI" | Null Object Pattern валиден для опциональных зависимостей | `NoOpMetrics`, `NoOpTracing` |
-| "Optional parameter = нарушение DI" | `policy: Policy | None = None` — допустимый паттерн для value objects | `timeout: float = 30.0` |
-| "click.echo в CLI = нарушение" | User-facing output — законная ответственность interfaces слоя | `cli.py` confirmation prompts |
-| "Shim file = дублирование" | Re-export для backward compatibility валиден | `medallion_policy.py` (19 LOC) |
-| "Нет автоматизации X" | Часто уже реализовано, но не проверено | `MedallionPolicy`, `DQConfig` существуют |
+| Паттерн                             | Почему ошибочен                                                         | Пример из кодовой базы                                                                         |
+| ----------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| "500+ LOC = god object"             | Размер ≠ сложность. Когезивный сервис с единой ответственностью валиден | `ChemblAdapter` (517 LOC) делегирует через `EntityMapper`, `ErrorClassifier`, `AdapterMetrics` |
+| "Монолит требует декомпозиции"      | Файл с делегированием — НЕ монолит                                      | `GoldWriter` (593 LOC) делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны          |
+| "NoOp default = нарушение DI"       | Null Object Pattern валиден для опциональных зависимостей               | `NoOpMetrics`, `NoOpTracing`                                                                   |
+| "Optional parameter = нарушение DI" | \`policy: Policy                                                        | None = None\` — допустимый паттерн для value objects                                           |
+| "click.echo в CLI = нарушение"      | User-facing output — законная ответственность interfaces слоя           | `cli.py` confirmation prompts                                                                  |
+| "Shim file = дублирование"          | Re-export для backward compatibility валиден                            | `medallion_policy.py` (19 LOC)                                                                 |
+| "Нет автоматизации X"               | Часто уже реализовано, но не проверено                                  | `MedallionPolicy`, `DQConfig` существуют                                                       |
 
 #### 7.1.5. Причины Ложных Утверждений (REQ-ARCH-041)
 
 > **Статистика**: Анализ 2025-12-27 выявил ~50% ложных утверждений в планах рефакторинга.
 
-| Причина | Описание | Митигация |
-|---------|----------|-----------|
-| **Отсутствие верификации кодом** | Утверждения без проверки фактического состояния | `grep`, `wc -l`, чтение файла |
-| **Ложная корреляция размер → сложность** | 500+ LOC автоматически считается "монолитом" | Анализ делегирования (см. 7.1.6) |
-| **Неверная интерпретация паттернов** | NoOp как нарушение DI, shim как дублирование | Знание Null Object Pattern, backward-compat |
-| **Устаревшие знания** | Задача уже реализована, но это не проверено | Сверка с `archived/refactoring-plan.md` |
+| Причина                                  | Описание                                        | Митигация                                   |
+| ---------------------------------------- | ----------------------------------------------- | ------------------------------------------- |
+| **Отсутствие верификации кодом**         | Утверждения без проверки фактического состояния | `grep`, `wc -l`, чтение файла               |
+| **Ложная корреляция размер → сложность** | 500+ LOC автоматически считается "монолитом"    | Анализ делегирования (см. 7.1.6)            |
+| **Неверная интерпретация паттернов**     | NoOp как нарушение DI, shim как дублирование    | Знание Null Object Pattern, backward-compat |
+| **Устаревшие знания**                    | Задача уже реализована, но это не проверено     | Сверка с `archived/refactoring-plan.md`     |
 
 #### 7.1.6. Анализ Делегирования (MUST перед "god object")
 
@@ -1053,12 +1167,14 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 ```
 
 **Критерии "монолита" (ВСЕ должны выполняться):**
+
 - [ ] 500+ строк кода
 - [ ] Мало делегирования (< 3 уникальных `self._component`)
 - [ ] Много публичных методов с разной ответственностью
 - [ ] Отсутствие injection через конструктор
 
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
+
 - `ChemblAdapter` (517 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (593 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (527 LOC): 8 методов с единой ответственностью (preflight validation)
@@ -1068,15 +1184,15 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 При обнаружении ложного утверждения **MUST**:
 
 1. Добавить в `docs/archived/refactoring-plan.md` → секция "❌ ЛОЖНЫЕ УТВЕРЖДЕНИЯ"
-2. Указать причину, почему утверждение ложно
-3. Добавить ссылку на код (`файл:строка`)
-4. Закоммитить изменения
+1. Указать причину, почему утверждение ложно
+1. Добавить ссылку на код (`файл:строка`)
+1. Закоммитить изменения
 
 При реализации задачи **MUST**:
 
 1. Переместить в `docs/archived/refactoring-plan.md` → секция "✅ УЖЕ РЕАЛИЗОВАНО"
-2. Добавить ссылку на коммит или файл
-3. Указать дату реализации
+1. Добавить ссылку на коммит или файл
+1. Указать дату реализации
 
 ### 7.3. Команды Быстрой Верификации
 
@@ -1098,68 +1214,79 @@ find tests -name "*.py" -exec grep -l "ClassName" {} \;
 grep -B2 -A2 "ComponentName" docs/archived/refactoring-plan.md
 ```
 
----
+______________________________________________________________________
 
 ## 8. Управление Изменениями
 
-### 8.1. Контракты Данных (Data Contracts) 
-- **Реестр Схем**: Gold-схемы публикуются в `docs/contracts/gold/{entity}.json` (JSON Schema). 
-- **Версионирование**: Семантическое версионирование схем: `{entity}_v{major}.{minor}`. 
-  - Minor: добавление nullable полей. 
-  - Major: удаление/переименование полей, изменение типов. 
-- **Уведомление о Breaking Change**: 
-  1. PR с изменением Gold-схемы **MUST** иметь лейбл `breaking-change`. 
-  2. CI генерирует diff схемы и постит в Slack-канал `#bioetl-contracts`. 
-  3. Период депрекации: 2 недели до удаления поля. 
-- **Consumer Tests**: Потребители могут подписаться на `contracts/` и запускать свои тесты при изменениях. 
- 
-### 8.2. Rollback Strategy 
-- **Scope**: 
-  - **Infrastructure/Code**: Auto Rollback при Error Rate > 10%. 
-  - **Data DQ**: Ручной анализ и replay. Ошибки качества данных не должны триггерить автоматический откат версии приложения. 
-- **Manual Rollback**: `make rollback VERSION=...`. 
- 
+### 8.1. Контракты Данных (Data Contracts)
+
+- **Реестр Схем**: Gold-схемы публикуются в `docs/contracts/gold/{entity}.json` (JSON Schema).
+- **Версионирование**: Семантическое версионирование схем: `{entity}_v{major}.{minor}`.
+  - Minor: добавление nullable полей.
+  - Major: удаление/переименование полей, изменение типов.
+- **Уведомление о Breaking Change**:
+  1. PR с изменением Gold-схемы **MUST** иметь лейбл `breaking-change`.
+  1. CI генерирует diff схемы и постит в Slack-канал `#bioetl-contracts`.
+  1. Период депрекации: 2 недели до удаления поля.
+- **Consumer Tests**: Потребители могут подписаться на `contracts/` и запускать свои тесты при изменениях.
+
+### 8.2. Rollback Strategy
+
+- **Scope**:
+  - **Infrastructure/Code**: Auto Rollback при Error Rate > 10%.
+  - **Data DQ**: Ручной анализ и replay. Ошибки качества данных не должны триггерить автоматический откат версии приложения.
+- **Manual Rollback**: `make rollback VERSION=...`.
+
 ## 9. Опыт Разработчика (Developer Experience)
-### 9.1. Локальная настройка 
-```bash 
-make install      # создание venv, установка зависимостей 
-make test         # unit + integration (на кассетах) 
-make lint         # ruff + mypy 
-make run-local    # запуск сэмплового пайплайна на фикстурах 
-``` 
+
+### 9.1. Локальная настройка
+
+```bash
+make install      # создание venv, установка зависимостей
+make test         # unit + integration (на кассетах)
+make lint         # ruff + mypy
+make run-local    # запуск сэмплового пайплайна на фикстурах
+```
+
 ### 9.2. Окружение
 
 > **Note: Local-Only Deployment** (см. [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md))
 
 **Текущая реализация (Local-Only):**
+
 - **Storage**: Локальная файловая система (`data/output/bronze`, `data/output/silver`, `data/output/gold`)
 - **Locking**: In-memory (`MemoryLock`)
 - **Checkpoints**: Локальные файлы (`data/output/checkpoints`)
 - **Зависимости**: Только Python 3.11+ и pip
 
 **Для распределённого развёртывания (будущее):**
+
 - Docker Compose (legacy, unsupported): Postgres, Redis, MinIO
+
 - Volumes: `./docker-data/`
+
 - Reset: `make docker-reset`
 
 - **Seed Data**: `make seed-local` — загрузка сэмпловых фикстур.
-- **.env.example**: Шаблон переменных окружения (без секретов). 
- 
---- 
-## Приложение А: Источники и Библиотеки 
- 
-**Структура папок:** `src/bioetl/infrastructure/adapters/{provider}/` 
- 
-| Источник | Библиотека | Rate Limit | Retry Strategy | Auth Type | Health Check |
-|----------|------------|------------|----------------|-----------|--------------|
-| **ChEMBL** | `chembl_webresource_client` | Нет явного лимита | Exponential backoff | Public | `GET /chembl/api/data/status.json` |
-| **PubChem** | `pubchempy` | 5 req/sec | 429 -> wait Retry-After | Public | Lightweight: `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
-| **UniProt** | `unipressed` | 100 req/sec (c API key) | Exponential backoff | API Key | Lightweight Search Probe |
-| **OpenAlex** | `pyalex` | 10 req/sec (polite pool) | 429 -> backoff | API Key (Email) | Generic Probe* |
-| **Semantic** | `semanticscholar` | 100 req/5min | Sliding window | API Key | Generic Probe* |
-| **PubMed** | `biopython` | 3 req/sec (10 c key) | 429 -> backoff | API Key | Generic Probe* |
-| **Crossref** | `habanero` | 50 req/sec (polite pool) | Exponential backoff | Email | Generic Probe* |
-| **GtoP** | `pyGtoP` (deprecated) | - | - | None | - |
+
+- **.env.example**: Шаблон переменных окружения (без секретов).
+
+______________________________________________________________________
+
+## Приложение А: Источники и Библиотеки
+
+**Структура папок:** `src/bioetl/infrastructure/adapters/{provider}/`
+
+| Источник     | Библиотека                  | Rate Limit               | Retry Strategy          | Auth Type       | Health Check                                                                  |
+| ------------ | --------------------------- | ------------------------ | ----------------------- | --------------- | ----------------------------------------------------------------------------- |
+| **ChEMBL**   | `chembl_webresource_client` | Нет явного лимита        | Exponential backoff     | Public          | `GET /chembl/api/data/status`                                                 |
+| **PubChem**  | `pubchempy`                 | 5 req/sec                | 429 -> wait Retry-After | Public          | Lightweight: `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
+| **UniProt**  | `unipressed`                | 100 req/sec (c API key)  | Exponential backoff     | API Key         | Lightweight Search Probe                                                      |
+| **OpenAlex** | `pyalex`                    | 10 req/sec (polite pool) | 429 -> backoff          | API Key (Email) | Generic Probe\*                                                               |
+| **Semantic** | `semanticscholar`           | 100 req/5min             | Sliding window          | API Key         | Generic Probe\*                                                               |
+| **PubMed**   | `biopython`                 | 3 req/sec (10 c key)     | 429 -> backoff          | API Key         | Generic Probe\*                                                               |
+| **Crossref** | `habanero`                  | 50 req/sec (polite pool) | Exponential backoff     | Email           | Generic Probe\*                                                               |
+| **GtoP**     | `pyGtoP` (deprecated)       | -                        | -                       | None            | -                                                                             |
 
 \* **Generic Probe**: Lightweight GET-запрос к базовому endpoint API (e.g., root или `/status`). Если API не предоставляет dedicated health endpoint, использовать минимальный запрос данных с timeout 5 секунд.
 
@@ -1167,135 +1294,146 @@ make run-local    # запуск сэмплового пайплайна на ф
 
 URL-адреса для ChEMBL формируются в `infrastructure/adapters/chembl/entity_mapper.py`:
 
-| Компонент | Константа/Метод | Значение |
-|-----------|-----------------|----------|
-| **Base URL** | `CHEMBL_API_BASE` | `https://www.ebi.ac.uk/chembl/api/data` |
-| **Status URL** | `CHEMBL_STATUS_URL` | `{BASE}/status` |
-| **Resource URL** | `ChemblEntityMapper.get_resource_url()` | `{BASE}/{resource}` |
-| **Direct record** | `ChemblEntityMapper.get_direct_record_url()` | `{BASE}/{resource}/{id}` |
+| Компонент         | Константа/Метод                              | Значение                                |
+| ----------------- | -------------------------------------------- | --------------------------------------- |
+| **Base URL**      | `CHEMBL_API_BASE`                            | `https://www.ebi.ac.uk/chembl/api/data` |
+| **Status URL**    | `CHEMBL_STATUS_URL`                          | `{BASE}/status`                         |
+| **Resource URL**  | `ChemblEntityMapper.get_resource_url()`      | `{BASE}/{resource}`                     |
+| **Direct record** | `ChemblEntityMapper.get_direct_record_url()` | `{BASE}/{resource}/{id}`                |
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type | API Resource | Primary Key |
-|-------------|--------------|-------------|
-| `activity` | `activity` | `activity_id` |
-| `assay` | `assay` | `assay_chembl_id` |
-| `molecule` | `molecule` | `molecule_chembl_id` |
-| `target` | `target` | `target_chembl_id` |
-| `protein_class` | `protein_classification` | `protein_class_id` |
-| `publication` | `document` | `document_chembl_id` |
+| Entity Type     | API Resource             | Primary Key          |
+| --------------- | ------------------------ | -------------------- |
+| `activity`      | `activity`               | `activity_id`        |
+| `assay`         | `assay`                  | `assay_chembl_id`    |
+| `molecule`      | `molecule`               | `molecule_chembl_id` |
+| `target`        | `target`                 | `target_chembl_id`   |
+| `protein_class` | `protein_classification` | `protein_class_id`   |
+| `publication`   | `document`               | `document_chembl_id` |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
+
 - `format=json` — обязательный (ChEMBL не поддерживает `.json` extension)
 - `limit`, `offset` — пагинация (health-aware: уменьшается при деградации)
 - `{field}__in=ID1,ID2,...` — фильтрация по списку ID
 
 **Конфигурация**: `configs/sources/chembl.yaml`
- 
-**Health Check Endpoints**: 
-- `GET /health` (Liveness) 
-- `GET /ready` (Readiness: local storage/lock health) 
- 
-## Приложение B: Политика Зависимостей 
-- **Pinning**: Точные версии в `requirements.txt` / `pyproject.toml`. 
-- **Обновления**: Ежемесячные PR от Dependabot + ручное ревью. 
-- **Безопасность**: `pip-audit` в CI. Блокировка мержа при CVE severity >= HIGH. 
- 
-## Приложение C: Error Recovery Playbook (Runbook) 
- 
-### Уровни Серьезности (Severity Levels) 
-| Level | Описание | SLA реакции | SLA восстановления | 
-|-------|----------|-------------|--------------------| 
-| **P0** | Система недоступна или критичные данные потеряны | 15 мин | 1 час | 
-| **P1** | Падение критичного пайплайна (Core Data) | 1 час | 4 часа | 
-| **P2** | Падение второстепенного пайплайна | 8 часов | 24 часа | 
-| **P3** | Warning / DQ аномалии | 24 часа | Next Sprint | 
- 
-| Ошибка | Симптом | Действие | 
-|--------|---------|----------| 
-| Auth failure | `401 Unauthorized` в логах | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY` | 
-| Rate limit exhausted | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге | 
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0 | Проверить изменения API; обновить Gold-схему через ADR | 
-| Stale checkpoint | Warning при старте | `--resume` для продолжения или `--ignore-checkpoint` для рестарта | 
-| >20% DQ errors | Batch fail | Проверить источник; возможно API вернул ошибку в теле ответа | 
-| Lock timeout | Alert "Lock expired" | Проверить зомби-процессы; `make release-lock PIPELINE=...` | 
- 
+
+**Health Check Endpoints**:
+
+- `GET /health` (Liveness)
+- `GET /ready` (Readiness: local storage/lock health)
+
+## Приложение B: Политика Зависимостей
+
+- **Pinning**: Точные версии в `requirements.txt` / `pyproject.toml`.
+- **Обновления**: Ежемесячные PR от Dependabot + ручное ревью.
+- **Безопасность**: `pip-audit` в CI. Блокировка мержа при CVE severity >= HIGH.
+
+## Приложение C: Error Recovery Playbook (Runbook)
+
+### Уровни Серьезности (Severity Levels)
+
+| Level  | Описание                                         | SLA реакции | SLA восстановления |
+| ------ | ------------------------------------------------ | ----------- | ------------------ |
+| **P0** | Система недоступна или критичные данные потеряны | 15 мин      | 1 час              |
+| **P1** | Падение критичного пайплайна (Core Data)         | 1 час       | 4 часа             |
+| **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
+| **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
+
+| Ошибка                 | Симптом                                        | Действие                                                          |
+| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или `--ignore-checkpoint` для рестарта |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+
 ## Приложение D: Схема Конфигурации Пайплайна
+
 См. [ADR-025](02-architecture/decisions/ADR-025-pipeline-config-unification.md) для унификации конфигурации, [ADR-027](02-architecture/decisions/ADR-027-dq-rules-externalization.md) для DQ rules и [ADR-028](02-architecture/decisions/ADR-028-filter-rules-externalization.md) для filter rules.
 
 ```yaml
-# configs/pipelines/chembl_activity.yaml 
-pipeline: 
-  name: chembl_activity 
-  provider: chembl 
-  entity: activity 
- 
-source: 
-  type: api  # api | csv | parquet 
-  load_strategy: incremental  # incremental | full 
-  watermark_field: updated_at 
- 
-transform: 
-  version: "1.2.0" 
-  steps: 
-    - normalize_units 
-    - validate_smiles 
-    - deduplicate 
- 
-sink: 
-  silver: 
-    path: data/output/silver/chembl/activity 
-    format: delta          # Использовать Delta Lake 
-    mode: merge            # Стратегия Upsert 
-    primary_key: [id]      # Ключ для merge 
-    partition_by: [year, month] 
-    classification: public 
+# configs/pipelines/chembl_activity.yaml
+pipeline:
+  name: chembl_activity
+  provider: chembl
+  entity: activity
+
+source:
+  type: api  # api | csv | parquet
+  load_strategy: incremental  # incremental | full
+  watermark_field: updated_at
+
+transform:
+  version: "1.2.0"
+  steps:
+    - normalize_units
+    - validate_smiles
+    - deduplicate
+
+sink:
+  silver:
+    path: data/output/silver/chembl/activity
+    format: delta          # Использовать Delta Lake
+    mode: merge            # Стратегия Upsert
+    primary_key: [id]      # Ключ для merge
+    partition_by: [year, month]
+    classification: public
     forensic_retention: false  # true = 30 days for Critical tables
     # Example for Critical table (Core Data):
-    # forensic_retention: true 
- 
-  gold: 
-    path: data/output/gold/chembl/activity_aggregated 
-    format: delta 
-    mode: overwrite        # Витрины часто перезаписываются целиком или партициями 
- 
-dq_rules: 
-  soft_fail_threshold: 0.05  # 5% 
-  hard_fail_threshold: 0.20  # 20% (Strict) 
- 
-circuit_breaker: 
-  failure_threshold: 5 
-  recovery_timeout: 300      # 5 min 
- 
-rate_limit: 
-  requests_per_second: 5 
-  burst: 10 
-``` 
- 
-## Приложение E: Примеры Schema Evolution 
- 
-### Minor Change (Обратная совместимость) 
-Добавление необязательного поля. Не требует пересчета истории. 
-```json 
-// Old Schema 
-{"id": "CHEMBL1", "score": 0.9} 
- 
-// New Schema 
-{"id": "CHEMBL1", "score": 0.9, "source": "manual"} 
-``` 
- 
-### Major Change (Breaking) 
-Переименование или изменение типа. Требует миграции данных или новой версии таблицы (v2). 
-```json 
-// Old Schema 
-{"id": 123}  // int 
- 
-// New Schema 
-{"id": "123"} // string 
-``` 
+    # forensic_retention: true
+
+  gold:
+    path: data/output/gold/chembl/activity_aggregated
+    format: delta
+    mode: overwrite        # Витрины часто перезаписываются целиком или партициями
+
+dq_rules:
+  soft_fail_threshold: 0.05  # 5%
+  hard_fail_threshold: 0.20  # 20% (Strict)
+
+circuit_breaker:
+  failure_threshold: 5
+  recovery_timeout: 300      # 5 min
+
+rate_limit:
+  requests_per_second: 5
+  burst: 10
+```
+
+## Приложение E: Примеры Schema Evolution
+
+### Minor Change (Обратная совместимость)
+
+Добавление необязательного поля. Не требует пересчета истории.
+
+```json
+// Old Schema
+{"id": "CHEMBL1", "score": 0.9}
+
+// New Schema
+{"id": "CHEMBL1", "score": 0.9, "source": "manual"}
+```
+
+### Major Change (Breaking)
+
+Переименование или изменение типа. Требует миграции данных или новой версии таблицы (v2).
+
+```json
+// Old Schema
+{"id": 123}  // int
+
+// New Schema
+{"id": "123"} // string
+```
 
 ### E.3. Field Deprecation Workflow
+
 **Day 0**: Пометить поле deprecated в схеме
+
 ```yaml
 fields:
   old_field:
@@ -1304,52 +1442,55 @@ fields:
 ```
 
 **Days 1-14**: Dual-write период
+
 - Писать оба поля: `old_field` и `new_field`
 - Потребители мигрируют чтение на `new_field`
 
 **Day 15** (после 14-дневного периода): Удаление `old_field`
+
 - Bump major version схемы
 - ADR с обоснованием изменения
- 
+
 ## Приложение F: Реестр Architecture Decision Records (ADR)
 
-| ADR | Название | Статус | Дата |
-|-----|----------|--------|------|
-| [ADR-001](02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md) | Delta Lake vs Parquet | Accepted | 2025-05 |
-| [ADR-002](02-architecture/decisions/ADR-002-medallion-architecture.md) | Medallion Architecture | Accepted | 2025-05 |
-| [ADR-003](02-architecture/decisions/ADR-003-in-memory-locking-strategy.md) | In-Memory Locking (MemoryLock) | Accepted (Revised) | 2025-12 |
-| [ADR-004](02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses | Accepted | 2025-05 |
-| [ADR-005](02-architecture/decisions/ADR-005-composition-layer-separation.md) | Composition Layer Separation | Accepted | 2025-12 |
-| [ADR-006](02-architecture/decisions/ADR-006-logger-metrics-ports.md) | Logger and Metrics Ports | Accepted | 2025-12-18 |
-| [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) | Circuit Breaker Implementation | Accepted | 2025-12-22 |
-| [ADR-008](02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy | Accepted | 2025-12-22 |
-| [ADR-009](02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md) | PaginatedFetcherMixin Design | Accepted | 2025-12-22 |
-| [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md) | Local-Only Deployment | Accepted | 2025-12-23 |
-| [ADR-011](02-architecture/decisions/ADR-011-remove-watermark-mechanism.md) | Remove Watermark Mechanism | Accepted | 2025-12-23 |
-| [ADR-012](02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID | Accepted | 2025-12-23 |
-| [ADR-013](02-architecture/decisions/ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | Accepted | 2025-12-24 |
-| [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md) | Deterministic Writes and Retries | Accepted | 2025-12-24 |
-| [ADR-015](02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | 2025-12-24 |
-| [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md) | Error Handling Strategy | Accepted | 2025-12-26 |
-| [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md) | Observability Architecture | Accepted | 2025-12-26 |
-| [ADR-018](02-architecture/decisions/ADR-018-gold-strict-validation.md) | Gold Strict Validation | Accepted | 2025-12-28 |
-| [ADR-019](02-architecture/decisions/ADR-019-observability-port-enforcement.md) | Observability Port Enforcement | Accepted | 2025-12-26 |
-| [ADR-020](02-architecture/decisions/ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition | Accepted | 2025-12-16 |
-| [ADR-021](02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates Adoption | Accepted | 2025-12-29 |
-| [ADR-022](02-architecture/decisions/ADR-022-tracing-noop.md) | NoOp Tracing for Local-Only | Accepted | 2025-12-30 |
-| [ADR-023](02-architecture/decisions/ADR-023-entity-type-patterns.md) | Entity Type Patterns | Accepted | 2026-01-06 |
-| [ADR-024](02-architecture/decisions/ADR-024-entity-naming-unification.md) | Entity Naming Unification | Accepted | 2026-01-06 |
-| [ADR-025](02-architecture/decisions/ADR-025-pipeline-config-unification.md) | Pipeline Config Unification | Accepted | 2026-01-19 |
-| [ADR-026](02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern | Accepted | 2026-01-15 |
-| [ADR-027](02-architecture/decisions/ADR-027-dq-rules-externalization.md) | DQ Rules Externalization | Accepted | 2026-01-19 |
-| [ADR-028](02-architecture/decisions/ADR-028-filter-rules-externalization.md) | Filter Rules Externalization | Accepted | 2026-01-20 |
-| [ADR-029](02-architecture/decisions/ADR-029-output-metadata-unification.md) | Output Metadata Unification | Accepted | 2026-01-23 |
-| [ADR-030](02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication Pagination Strategy | Accepted | 2026-01-26 |
-| [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md) | Loading Strategy Formalization | Accepted | 2026-01-26 |
-| [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md) | Unified HTTP Client Pattern | Accepted | 2026-01-28 |
-| [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md) | Publication Metadata Validation Strategy | Accepted | 2026-02 |
+| ADR                                                                               | Название                                 | Статус             | Дата       |
+| --------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ | ---------- |
+| [ADR-001](02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | 2025-05    |
+| [ADR-002](02-architecture/decisions/ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | 2025-05    |
+| [ADR-003](02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | 2025-12    |
+| [ADR-004](02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | Accepted           | 2025-05    |
+| [ADR-005](02-architecture/decisions/ADR-005-composition-layer-separation.md)      | Composition Layer Separation             | Accepted           | 2025-12    |
+| [ADR-006](02-architecture/decisions/ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                 | Accepted           | 2025-12-18 |
+| [ADR-007](02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation           | Accepted           | 2025-12-22 |
+| [ADR-008](02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy               | Accepted           | 2025-12-22 |
+| [ADR-009](02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design             | Accepted           | 2025-12-22 |
+| [ADR-010](02-architecture/decisions/ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | Accepted           | 2025-12-23 |
+| [ADR-011](02-architecture/decisions/ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism               | Accepted           | 2025-12-23 |
+| [ADR-012](02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID        | Accepted           | 2025-12-23 |
+| [ADR-013](02-architecture/decisions/ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | Accepted           | 2025-12-24 |
+| [ADR-014](02-architecture/decisions/ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries         | Accepted           | 2025-12-24 |
+| [ADR-015](02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | Accepted           | 2025-12-24 |
+| [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | 2025-12-26 |
+| [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | 2025-12-26 |
+| [ADR-018](02-architecture/decisions/ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | 2025-12-28 |
+| [ADR-019](02-architecture/decisions/ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | 2025-12-26 |
+| [ADR-020](02-architecture/decisions/ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | 2025-12-16 |
+| [ADR-021](02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | 2025-12-29 |
+| [ADR-022](02-architecture/decisions/ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only              | Accepted           | 2025-12-30 |
+| [ADR-023](02-architecture/decisions/ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | Accepted           | 2026-01-06 |
+| [ADR-024](02-architecture/decisions/ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | Accepted           | 2026-01-06 |
+| [ADR-025](02-architecture/decisions/ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | Accepted           | 2026-01-19 |
+| [ADR-026](02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | Accepted           | 2026-01-15 |
+| [ADR-027](02-architecture/decisions/ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | Accepted           | 2026-01-19 |
+| [ADR-028](02-architecture/decisions/ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | Accepted           | 2026-01-20 |
+| [ADR-029](02-architecture/decisions/ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | Accepted           | 2026-01-23 |
+| [ADR-030](02-architecture/decisions/ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | Accepted           | 2026-01-26 |
+| [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
+| [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
+| [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Accepted           | 2026-02    |
 
 ## История Изменений (Changelog)
+
 - **5.17** (2026-02-03): Chained Dependencies. Добавлена секция §2.9.1 "Dependency Pipelines (Chained Dependencies)" — поддержка `key_source` и `filter_field` для цепочечных зависимостей в composite pipelines. Обновлён ADR-026.
 - **5.16** (2026-02-02): ADR Registry Update + Doc Sync. Добавлен ADR-032 в реестр (Приложение F): Unified HTTP Client Pattern. Синхронизация метрик с кодовой базой.
 - **5.15** (2026-01-29): Field Group Registry. Добавлена §2.9.4 "Field Group Registry" — семантическая группировка полей для Gold-фильтрации и сортировки колонок. Домен: `FieldGroupRegistry`, `FieldMapping`, `FieldGroupDefinition`. YAML-конфиг: `configs/composite/field_groups/publication.yaml`. Интеграция с `MergeService` для автоматической фильтрации TRASH-полей из Gold.
@@ -1369,12 +1510,12 @@ fields:
 - **5.1** (2025-12-22): ADR additions (007-009), ADR index appendix.
 - **5.0** (2025-12-15): Production Ready. Final Governance Polish, Circuit Breaker half-open observability, Backfill lock timeouts, Generic Health Probes, Deprecation clarification.
 - **4.6** (2025-12-15): Governance & Stability. RFC 2119, Entity ID vs Content Hash, Bronze Lifecycle, Hard Limits, Threat Model. Added Log Schema, Provider Health Matrix, Circuit Breaker details, Backfill Locking, and Deprecation workflows.
-- **4.5** (2025-05-20): Final Polish & Governance. Medallion Paths, DQ Levels, Observability, Fencing Tokens, Security IAM. 
-- **4.4** (2025-05-20): Resilience & Operations. Circuit Breaker, DR Runbooks, Quarantine Ops, Env Isolation. 
-- **4.3** (2025-05-20): Security & DR. Salted Hashes, RPO/RTO, Heartbeat Locks, Environments, Delta Infrastructure. 
-- **4.2** (2025-05-20): Delta Lake Strategy, Unified Quarantine Schema, Threshold adjustments. 
-- **4.1** (2025-05-20): [DEPRECATED] Storage Fixes. (Заменено версией 4.2). 
-- **4.0** (2025-05-20): Data Contracts, Partitioning, Null Policy, Recovery Playbook. 
-- **3.0** (2025-05-20): Lineage, Backfill, Concurrency, Graceful Shutdown, Dev Experience. 
-- **2.0** (2025-05-20): Классификация ошибок, Medallion, Rate limiting, Перевод на русский. 
+- **4.5** (2025-05-20): Final Polish & Governance. Medallion Paths, DQ Levels, Observability, Fencing Tokens, Security IAM.
+- **4.4** (2025-05-20): Resilience & Operations. Circuit Breaker, DR Runbooks, Quarantine Ops, Env Isolation.
+- **4.3** (2025-05-20): Security & DR. Salted Hashes, RPO/RTO, Heartbeat Locks, Environments, Delta Infrastructure.
+- **4.2** (2025-05-20): Delta Lake Strategy, Unified Quarantine Schema, Threshold adjustments.
+- **4.1** (2025-05-20): [DEPRECATED] Storage Fixes. (Заменено версией 4.2).
+- **4.0** (2025-05-20): Data Contracts, Partitioning, Null Policy, Recovery Playbook.
+- **3.0** (2025-05-20): Lineage, Backfill, Concurrency, Graceful Shutdown, Dev Experience.
+- **2.0** (2025-05-20): Классификация ошибок, Medallion, Rate limiting, Перевод на русский.
 - **1.0** (2025-04-01): Черновик.

--- a/docs/02-architecture/00-overview.md
+++ b/docs/02-architecture/00-overview.md
@@ -8,30 +8,30 @@ BioETL follows a **Hexagonal Architecture** (Ports & Adapters) pattern with **Me
 
 ### Layer Documentation
 
-| Layer | Document | Key Contents |
-|-------|----------|--------------|
-| **Domain** | [01-domain-layer.md](01-domain-layer.md) | Ports, Models, Schemas, Pure logic |
-| **Application** | [02-application-layer.md](02-application-layer.md) | Pipelines, Use Cases, Orchestration |
-| **Infrastructure** | [03-infrastructure-layer.md](03-infrastructure-layer.md) | Adapters, HTTP clients, Storage |
-| **Interfaces** | [04-interfaces-layer.md](04-interfaces-layer.md) | CLI, API endpoints |
-| **Composition** | [05-composition-layer.md](05-composition-layer.md) | DI container, Bootstrap, Factories |
+| Layer              | Document                                                 | Key Contents                        |
+| ------------------ | -------------------------------------------------------- | ----------------------------------- |
+| **Domain**         | [01-domain-layer.md](01-domain-layer.md)                 | Ports, Models, Schemas, Pure logic  |
+| **Application**    | [02-application-layer.md](02-application-layer.md)       | Pipelines, Use Cases, Orchestration |
+| **Infrastructure** | [03-infrastructure-layer.md](03-infrastructure-layer.md) | Adapters, HTTP clients, Storage     |
+| **Interfaces**     | [04-interfaces-layer.md](04-interfaces-layer.md)         | CLI, API endpoints                  |
+| **Composition**    | [05-composition-layer.md](05-composition-layer.md)       | DI container, Bootstrap, Factories  |
 
 ### System Views
 
-| Document | Description | C4 Level |
-|----------|-------------|----------|
-| [system-context.md](system-context.md) | External systems interaction | Level 1 |
-| [container-diagram.md](container-diagram.md) | Internal containers & services | Level 2 |
-| [data-flow.md](data-flow.md) | Medallion data flow | - |
-| [data-layers.md](data-layers.md) | Bronze/Silver/Gold details | - |
-| [observability-layers.md](observability-layers.md) | Metrics, Tracing, Logging | - |
+| Document                                           | Description                    | C4 Level |
+| -------------------------------------------------- | ------------------------------ | -------- |
+| [system-context.md](system-context.md)             | External systems interaction   | Level 1  |
+| [container-diagram.md](container-diagram.md)       | Internal containers & services | Level 2  |
+| [data-flow.md](data-flow.md)                       | Medallion data flow            | -        |
+| [data-layers.md](data-layers.md)                   | Bronze/Silver/Gold details     | -        |
+| [observability-layers.md](observability-layers.md) | Metrics, Tracing, Logging      | -        |
 
 ### Diagrams
 
 - [diagrams/](diagrams/) — 35 Mermaid diagram files
 - [diagrams/diagrams-index.md](diagrams/diagrams-index.md) — Full diagram index
 - [diagrams.md](diagrams.md) — Inline diagram collection
-- [diagrams/mermaid/](diagrams/mermaid/) — Additional 26 diagrams (includes Composite Pipeline workflow)
+- [diagrams/mermaid/](diagrams/mermaid/) — Additional 22 diagrams (актуально на 2026-02-11) (includes Composite Pipeline workflow)
 
 ### Architecture Decision Records (ADRs)
 
@@ -39,77 +39,77 @@ See [decisions/README.md](decisions/README.md) for full index with categories.
 
 33 ADRs documenting key architectural decisions:
 
-| ADR | Topic | RULES.md Reference |
-|-----|-------|-------------------|
-| [ADR-001](decisions/ADR-001-delta-lake-vs-parquet.md) | Delta Lake vs Parquet | §2.1, §3 |
-| [ADR-002](decisions/ADR-002-medallion-architecture.md) | Medallion Architecture | §1 |
-| [ADR-003](decisions/ADR-003-in-memory-locking-strategy.md) | In-Memory Locking | §6 |
-| [ADR-004](decisions/ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses | - |
-| [ADR-005](decisions/ADR-005-composition-layer-separation.md) | Composition Layer | §1.1 |
-| [ADR-006](decisions/ADR-006-logger-metrics-ports.md) | Logger & Metrics Ports | - |
-| [ADR-007](decisions/ADR-007-circuit-breaker-implementation.md) | Circuit Breaker | §3.1.4 |
-| [ADR-008](decisions/ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown | §5.3 |
-| [ADR-009](decisions/ADR-009-paginated-fetcher-mixin.md) | Paginated Fetcher | - |
-| [ADR-010](decisions/ADR-010-local-only-deployment.md) | Local-Only Deployment | §5.6 |
-| [ADR-011](decisions/ADR-011-remove-watermark-mechanism.md) | Remove Watermark | - |
-| [ADR-012](decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract | §2.4 |
-| [ADR-013](decisions/ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | - |
-| [ADR-014](decisions/ADR-014-deterministic-writes.md) | Deterministic Writes | - |
-| [ADR-015](decisions/ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | - |
-| [ADR-016](decisions/ADR-016-error-handling-strategy.md) | Error Handling Strategy | §3.1 |
-| [ADR-017](decisions/ADR-017-observability-architecture.md) | Observability Architecture | §3.2 |
-| [ADR-018](decisions/ADR-018-gold-strict-validation.md) | Gold Strict Validation | §2.1 |
-| [ADR-019](decisions/ADR-019-observability-port-enforcement.md) | Observability Port Enforcement | - |
-| [ADR-020](decisions/ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition | - |
-| [ADR-021](decisions/ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates | - |
-| [ADR-022](decisions/ADR-022-tracing-noop.md) | Tracing NoOp | - |
-| [ADR-023](decisions/ADR-023-entity-type-patterns.md) | Entity Type Patterns | - |
-| [ADR-024](decisions/ADR-024-entity-naming-unification.md) | Entity Naming Unification | - |
-| [ADR-025](decisions/ADR-025-pipeline-config-unification.md) | Pipeline Config Unification | - |
-| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern | - |
-| [ADR-027](decisions/ADR-027-dq-rules-externalization.md) | DQ Rules Externalization | §3.1.2 |
-| [ADR-028](decisions/ADR-028-filter-rules-externalization.md) | Filter Rules Externalization | App D |
-| [ADR-029](decisions/ADR-029-output-metadata-unification.md) | Output Metadata Unification | §2.4 |
-| [ADR-030](decisions/ADR-030-publication-pagination-strategy.md) | Publication Pagination Strategy | - |
-| [ADR-031](decisions/ADR-031-loading-strategy-formalization.md) | Loading Strategy Formalization | - |
-| [ADR-032](decisions/ADR-032-unified-http-client.md) | Unified HTTP Client Pattern | §3.1 |
-| [ADR-033](decisions/ADR-033-publication-validation-strategy.md) | Publication Metadata Validation Strategy | - |
+| ADR                                                               | Topic                                    | RULES.md Reference |
+| ----------------------------------------------------------------- | ---------------------------------------- | ------------------ |
+| [ADR-001](decisions/ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | §2.1, §3           |
+| [ADR-002](decisions/ADR-002-medallion-architecture.md)            | Medallion Architecture                   | §1                 |
+| [ADR-003](decisions/ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking                        | §6                 |
+| [ADR-004](decisions/ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | -                  |
+| [ADR-005](decisions/ADR-005-composition-layer-separation.md)      | Composition Layer                        | §1.1               |
+| [ADR-006](decisions/ADR-006-logger-metrics-ports.md)              | Logger & Metrics Ports                   | -                  |
+| [ADR-007](decisions/ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker                          | §3.1.4             |
+| [ADR-008](decisions/ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown                        | §5.3               |
+| [ADR-009](decisions/ADR-009-paginated-fetcher-mixin.md)           | Paginated Fetcher                        | -                  |
+| [ADR-010](decisions/ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | §5.6               |
+| [ADR-011](decisions/ADR-011-remove-watermark-mechanism.md)        | Remove Watermark                         | -                  |
+| [ADR-012](decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract                   | §2.4               |
+| [ADR-013](decisions/ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | -                  |
+| [ADR-014](decisions/ADR-014-deterministic-writes.md)              | Deterministic Writes                     | -                  |
+| [ADR-015](decisions/ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | -                  |
+| [ADR-016](decisions/ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | §3.1               |
+| [ADR-017](decisions/ADR-017-observability-architecture.md)        | Observability Architecture               | §3.2               |
+| [ADR-018](decisions/ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | §2.1               |
+| [ADR-019](decisions/ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | -                  |
+| [ADR-020](decisions/ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | -                  |
+| [ADR-021](decisions/ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates                           | -                  |
+| [ADR-022](decisions/ADR-022-tracing-noop.md)                      | Tracing NoOp                             | -                  |
+| [ADR-023](decisions/ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | -                  |
+| [ADR-024](decisions/ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | -                  |
+| [ADR-025](decisions/ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | -                  |
+| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | -                  |
+| [ADR-027](decisions/ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | §3.1.2             |
+| [ADR-028](decisions/ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | App D              |
+| [ADR-029](decisions/ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | §2.4               |
+| [ADR-030](decisions/ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | -                  |
+| [ADR-031](decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | -                  |
+| [ADR-032](decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | §3.1               |
+| [ADR-033](decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | -                  |
 
----
+______________________________________________________________________
 
 ## Architecture Principles
 
 ### Import Matrix (Layer Dependencies)
 
-| From ↓ / To → | domain | application | composition | infrastructure | interfaces |
-|---------------|--------|-------------|-------------|----------------|------------|
-| **domain** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **application** | ✅ | ✅ | ❌ | ❌ | ❌ |
-| **composition** | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **infrastructure** | ✅ | ❌ | ❌ | ✅ | ❌ |
-| **interfaces** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| From ↓ / To →      | domain | application | composition | infrastructure | interfaces |
+| ------------------ | ------ | ----------- | ----------- | -------------- | ---------- |
+| **domain**         | ✅     | ❌          | ❌          | ❌             | ❌         |
+| **application**    | ✅     | ✅          | ❌          | ❌             | ❌         |
+| **composition**    | ✅     | ✅          | ✅          | ✅             | ❌         |
+| **infrastructure** | ✅     | ❌          | ❌          | ✅             | ❌         |
+| **interfaces**     | ✅     | ✅          | ✅          | ✅             | ✅         |
 
 **Violation = PR Blocker.** Enforced by `import-linter` and `tests/architecture/`.
 
 ### Key Patterns
 
 1. **Dependency Injection**: Dependencies injected via constructor
-2. **Ports & Adapters**: Interfaces in `domain/ports/`, implementations in `infrastructure/`
-3. **Composition Root**: Single assembly point in `composition/bootstrap/`
-4. **Medallion Architecture**: Bronze (raw) → Silver (normalized) → Gold (curated)
-5. **Composite Pipeline** (ADR-026): Multi-source data enrichment with seed → enrich (fan-out) → merge workflow
+1. **Ports & Adapters**: Interfaces in `domain/ports/`, implementations in `infrastructure/`
+1. **Composition Root**: Single assembly point in `composition/bootstrap/`
+1. **Medallion Architecture**: Bronze (raw) → Silver (normalized) → Gold (curated)
+1. **Composite Pipeline** (ADR-026): Multi-source data enrichment with seed → enrich (fan-out) → merge workflow
 
 ### Key Diagrams
 
-| Diagram | Description | File |
-|---------|-------------|------|
-| Five Layer Architecture | Complete system architecture with all 5 layers | [01_five_layer_architecture.mmd](diagrams/mermaid/01_five_layer_architecture.mmd) |
-| Layers Interaction | How layers communicate | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) |
-| Composite Pipeline | ADR-026 workflow: seed → enrich → merge | [26_composite_pipeline_workflow.mmd](diagrams/mermaid/26_composite_pipeline_workflow.mmd) |
-| Provider Adapters | 7 providers with rate limits | [23_provider_adapters_overview.mmd](diagrams/mermaid/23_provider_adapters_overview.mmd) |
-| Pipeline Hierarchy | Pipeline/Transformer inheritance | [17-pipeline-hierarchy.mermaid](diagrams/17-pipeline-hierarchy.mermaid) |
+| Diagram                 | Description                                    | File                                                                                      |
+| ----------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Five Layer Architecture | Complete system architecture with all 5 layers | [01_five_layer_architecture.mmd](diagrams/mermaid/01_five_layer_architecture.mmd)         |
+| Layers Interaction      | How layers communicate                         | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid)                   |
+| Composite Pipeline      | ADR-026 workflow: seed → enrich → merge        | [26_composite_pipeline_workflow.mmd](diagrams/mermaid/26_composite_pipeline_workflow.mmd) |
+| Provider Adapters       | 7 providers with rate limits                   | [23_provider_adapters_overview.mmd](diagrams/mermaid/23_provider_adapters_overview.mmd)   |
+| Pipeline Hierarchy      | Pipeline/Transformer inheritance               | [17-pipeline-hierarchy.mermaid](diagrams/17-pipeline-hierarchy.mermaid)                   |
 
----
+______________________________________________________________________
 
 ## Related Documents
 

--- a/docs/02-architecture/01-domain-layer.md
+++ b/docs/02-architecture/01-domain-layer.md
@@ -7,6 +7,7 @@
 Слой `Domain` — это ядро системы, содержащее чистую бизнес-логику и правила. Он не зависит ни от каких других слоёв и не содержит кода, связанного с вводом-выводом (I/O), базами данных, веб-фреймворками или другими инфраструктурными деталями.
 
 **Ключевые характеристики:**
+
 - **Чистота:** Только Python-объекты и чистые функции.
 - **Независимость:** Не импортирует модули из `application`, `infrastructure` или `interfaces`.
 - **Стабильность:** Изменяется только при изменении бизнес-правил, а не технических деталей.
@@ -21,9 +22,10 @@
 
 **Структура пакета (26 файлов):**
 
-Пакет содержит 26 protocol-файлов, организованных по категориям:
+Пакет содержит 26 protocol-файлов (актуально на 2026-02-11), организованных по категориям:
 
 **Основные порты:**
+
 - `DataSourcePort`, `FilterableDataSourcePort` — абстракция для источников данных
 - `StoragePort` — хранилища данных (Bronze, Silver, Gold)
 - `LockPort` — распределённые блокировки
@@ -31,27 +33,32 @@
 - `QuarantinePort` — карантин записей, не прошедших валидацию
 
 **Observability порты:**
+
 - `MetricsPort` — сбор метрик
 - `TracingPort` — распределённый трейсинг (OpenTelemetry)
 - `LoggerPort` — структурированное логирование
 - `DQMonitorPort` — Data Quality мониторинг
-- `PipelineObserverPort` — наблюдение за пайплайнами
+- `MetadataCoordinatorPort` — координация метаданных между слоями
 
 **Data Quality порты:**
+
 - `BronzeDQAnalyzerPort`, `SilverDQAnalyzerPort`, `GoldDQAnalyzerPort` — DQ анализ по слоям
 - `DQReportWriterPort` — запись DQ-отчётов
 - `GoldValidatorPort` — валидация Gold-записей
 
 **Input/Output порты:**
+
 - `InputFilterPort` — загрузка filter IDs
-- `ExportPort` — экспорт данных
+- `JsonEncoderPort` — сериализация JSON payload
 
 **Infrastructure порты:**
+
 - `HealthCheckPort` — проверка здоровья адаптеров
 - `AuditPort` — аудит операций
-- `RetentionPort` — управление политиками хранения
+- `ShutdownPort`, `MemoryMonitorPort`, `DeltaReaderPort`, `IDMappingPort`, `PiiHasherPort` — системные и вспомогательные порты
 
 **Правило импорта (MUST):**
+
 ```python
 # ✅ Правильно — из фасада:
 from bioetl.domain.ports import StoragePort, LockPort
@@ -70,6 +77,7 @@ from bioetl.domain.ports.storage import StoragePort  # Запрещено!
 См. [ADR-021: DDD Aggregates](decisions/ADR-021-ddd-aggregates-adoption.md).
 
 **Структура:**
+
 ```
 src/bioetl/domain/aggregates/
 ├── __init__.py
@@ -81,13 +89,16 @@ src/bioetl/domain/aggregates/
 
 **Ключевые агрегаты:**
 
-| Aggregate | Инварианты | State Machine |
-|-----------|------------|---------------|
-| `Batch` | Records sealed before write; sequential indices | OPEN → SEALED → WRITING → COMMITTED/FAILED |
-| `PipelineRun` | COMPLETED only if all stages SUCCESS | PENDING → RUNNING → COMPLETED/FAILED/SHUTDOWN |
-| `QuarantineEntry` | Atomic retry increment | PENDING → RETRYING → RECOVERED/DEAD_LETTER |
+| Aggregate         | Инварианты                                      | State Machine                                        |
+| ----------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| `Batch`           | Records sealed before write; sequential indices | OPEN → SEALED → WRITING → COMMITTED/FAILED           |
+| `PipelineRun`     | COMPLETED only if all stages SUCCESS            | NEW → RUNNING → COMPLETED/FAILED/SHUTDOWN            |
+| `QuarantineEntry` | Atomic retry increment                          | NEW → UNDER_REVIEW → IGNORED / REPROCESSED / EXPIRED |
+
+`QuarantineStatus(StrEnum)`: `NEW`, `UNDER_REVIEW`, `IGNORED`, `REPROCESSED`, `EXPIRED`.
 
 **Пример использования:**
+
 ```python
 from bioetl.domain.aggregates import Batch
 from bioetl.domain.types import RunID
@@ -108,19 +119,23 @@ events = batch.collect_events()  # [BatchCreated, BatchSealed, BatchWritten]
 Неизменяемые доменные примитивы с типобезопасностью (19 файлов).
 
 **Идентификаторы:**
+
 - `RunID(UUID)` — идентификатор запуска пайплайна
 - `BatchID(UUID)` — идентификатор batch
 - `EntityID(str)` — бизнес-ключ сущности
 - `ContentHash(str)` — SHA256 хэш содержимого
 
 **Измерения:**
+
 - `ActivityValue(value, unit, relation)` (`activity.py`, 329 LOC) — составной value object для биоактивности (IC50, EC50, Ki), включает `RelationOperator` enum и `ConfidenceScore`
 
 **Data Quality:**
+
 - `DQMetrics` — метрики качества данных
 - `DQReport` — отчёт о качестве данных
 
 **Pipeline Results:**
+
 - `BronzeResult` — результат записи в Bronze
 - `Publications` — value objects для публикаций
 - `ActivityValues` — concentration & unit handling
@@ -136,6 +151,7 @@ events = batch.collect_events()  # [BatchCreated, BatchSealed, BatchWritten]
 **Источник:** `src/bioetl/domain/config.py`
 
 Содержит dataclass Value Objects для конфигурации пайплайнов:
+
 - `PipelineConfig` — полная конфигурация пайплайна
 - `RuntimeConfig` — параметры выполнения
 - `DQConfig` — пороги Data Quality
@@ -146,6 +162,7 @@ events = batch.collect_events()  # [BatchCreated, BatchSealed, BatchWritten]
 **Источник:** `src/bioetl/domain/error_classifier.py`
 
 Реализует логику классификации ошибок в соответствии с правилами из `RULES.md` (раздел 3.1.1):
+
 - **Critical**: Ошибки, останавливающие пайплайн.
 - **Recoverable**: Временные сбои, требующие повторной попытки.
 - **Data Quality**: Проблемы с данными, которые можно пропустить, отправив запись в карантин.
@@ -154,19 +171,19 @@ events = batch.collect_events()  # [BatchCreated, BatchSealed, BatchWritten]
 
 Domain содержит 8 дополнительных поддиректорий:
 
-| Директория | Назначение | Содержание |
-|------------|------------|------------|
-| `composite/` | Composite pipeline domain | Field groups, state, strategy |
-| `configs/` | Конфигурационные базовые классы | Базовые dataclass-ы для конфигураций |
-| `contracts/gold/` | Gold-слой контракты данных | Pandera DataFrameModel схемы |
-| `entities/` | Доменные сущности | Entity-классы для каждого провайдера |
-| `exceptions/` | Доменные исключения | 5 файлов с иерархией ошибок |
-| `filtering/` | Фильтрация данных | Конфигурации и логика фильтров |
-| `mapping/` | Маппинг полей публикаций | Publication field & type mappings |
-| `models/` | Доменные модели | Filter & metadata models |
-| `registry/` | Реестр публикаций | Publication registry |
-| `schemas/` | Pydantic/Pandera схемы | ~60 файлов для всех провайдеров |
-| `services/` | Доменные сервисы | Нормализация, агрегация |
+| Директория        | Назначение                      | Содержание                                               |
+| ----------------- | ------------------------------- | -------------------------------------------------------- |
+| `composite/`      | Composite pipeline domain       | Field groups, state, strategy                            |
+| `configs/`        | Конфигурационные базовые классы | Базовые dataclass-ы для конфигураций                     |
+| `contracts/gold/` | Gold-слой контракты данных      | Pandera DataFrameModel схемы                             |
+| `entities/`       | Доменные сущности               | Entity-классы для каждого провайдера                     |
+| `exceptions/`     | Доменные исключения             | 7 файлов с иерархией ошибок (актуально на 2026-02-11)    |
+| `filtering/`      | Фильтрация данных               | Конфигурации и логика фильтров                           |
+| `mapping/`        | Маппинг полей публикаций        | Publication field & type mappings                        |
+| `models/`         | Доменные модели                 | Filter & metadata models                                 |
+| `registry/`       | Реестр публикаций               | Publication registry                                     |
+| `schemas/`        | Pydantic/Pandera схемы          | 37 файлов для всех провайдеров (актуально на 2026-02-11) |
+| `services/`       | Доменные сервисы                | Нормализация, агрегация                                  |
 
 ## 3. Принципы Работы
 
@@ -174,32 +191,32 @@ Domain содержит 8 дополнительных поддиректори�
 - **Валидация данных:** Логика валидации бизнес-сущностей (например, проверка SMILES-строк) может находиться здесь, если она не требует внешних зависимостей.
 - **Иммутабельность:** Предпочтение отдаётся иммутабельным структурам данных (например, `NamedTuple`, `dataclasses(frozen=True)`).
 
----
+______________________________________________________________________
 
 ## 4. Связанные Материалы
 
 ### Навигация по Слоям
 
-| ← Предыдущий | Текущий | Следующий → |
-|--------------|---------|-------------|
-| — | **Domain** | [Application Layer](02-application-layer.md) |
+| ← Предыдущий | Текущий    | Следующий →                                  |
+| ------------ | ---------- | -------------------------------------------- |
+| —            | **Domain** | [Application Layer](02-application-layer.md) |
 
 ### Связанные Диаграммы
 
-| Диаграмма | Файл | Описание |
-|-----------|------|----------|
-| Domain Layer Classes | [04-domain-layer-class-diagram.mermaid](diagrams/04-domain-layer-class-diagram.mermaid) | Классы портов, сущностей, конфигурации |
-| Domain DDD | [08-domain-ddd.mermaid](diagrams/08-domain-ddd.mermaid) | DDD-структура домена |
-| Domain Models | [13-domain-models-relationship.mermaid](diagrams/13-domain-models-relationship.mermaid) | Связи доменных моделей |
-| DDD Aggregates | [diagrams/mermaid/09_ddd_aggregates.mmd](diagrams/mermaid/09_ddd_aggregates.mmd) | DDD агрегаты: Batch, PipelineRun, QuarantineEntry |
-| Ports Architecture | [diagrams/mermaid/07_ports_architecture.mmd](diagrams/mermaid/07_ports_architecture.mmd) | Архитектура 26 портов |
+| Диаграмма            | Файл                                                                                     | Описание                                          |
+| -------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Domain Layer Classes | [04-domain-layer-class-diagram.mermaid](diagrams/04-domain-layer-class-diagram.mermaid)  | Классы портов, сущностей, конфигурации            |
+| Domain DDD           | [08-domain-ddd.mermaid](diagrams/08-domain-ddd.mermaid)                                  | DDD-структура домена                              |
+| Domain Models        | [13-domain-models-relationship.mermaid](diagrams/13-domain-models-relationship.mermaid)  | Связи доменных моделей                            |
+| DDD Aggregates       | [diagrams/mermaid/09_ddd_aggregates.mmd](diagrams/mermaid/09_ddd_aggregates.mmd)         | DDD агрегаты: Batch, PipelineRun, QuarantineEntry |
+| Ports Architecture   | [diagrams/mermaid/07_ports_architecture.mmd](diagrams/mermaid/07_ports_architecture.mmd) | Архитектура 26 портов                             |
 
 ### Связанные ADR
 
-| ADR | Тема |
-|-----|------|
+| ADR                                                     | Тема                                        |
+| ------------------------------------------------------- | ------------------------------------------- |
 | [ADR-004](decisions/ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses — выбор dataclasses |
-| [ADR-021](decisions/ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates — внедрение агрегатов |
+| [ADR-021](decisions/ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates — внедрение агрегатов        |
 
 ### Смежные Разделы Документации
 

--- a/docs/02-architecture/04-interfaces-layer.md
+++ b/docs/02-architecture/04-interfaces-layer.md
@@ -9,6 +9,7 @@
 Этот слой использует **Composition Root** (слой `Composition`) для сборки зависимостей и получения готовых к работе объектов.
 
 **Ключевые характеристики:**
+
 - **Точка входа:** Содержит код, который запускается напрямую (например, CLI-команды).
 - **Адаптация ввода/вывода:** Преобразует внешние запросы (например, аргументы командной строки) в вызовы методов слоя `Application`.
 - **Минимальная логика:** Не содержит логики сборки или бизнес-логики.
@@ -21,25 +22,28 @@
 
 Реализует CLI для взаимодействия с пользователем. Использует библиотеку **Click** для определения команд.
 
-**Доступные команды (17 модулей в `commands/`):**
+**Доступные команды (17 модулей в `commands/`, актуально на 2026-02-11):**
 
-| Команда | Модуль | Описание |
-|---------|--------|----------|
-| `run` | `run.py` | Запуск одного пайплайна |
-| `run-all` | `run_all.py` | Запуск всех пайплайнов провайдера |
+| Команда         | Модуль             | Описание                                |
+| --------------- | ------------------ | --------------------------------------- |
+| `run`           | `run.py`           | Запуск одного пайплайна                 |
+| `run-all`       | `run_all.py`       | Запуск всех пайплайнов провайдера       |
 | `run-composite` | `run_composite.py` | Запуск композитного пайплайна (ADR-026) |
-| `export` | `export.py` | Экспорт данных из Gold |
-| `quarantine` | `quarantine.py` | Управление карантинными записями |
-| `health` | `health.py` | Проверка здоровья провайдеров |
-| `config` | `config.py` | Просмотр и валидация конфигураций |
-| `checkpoint` | `checkpoint.py` | Управление checkpoint-ами |
-| `lock` | `lock.py` | Управление блокировками |
-| `vacuum` | `vacuum.py` | VACUUM операции для Delta Lake |
-| `cleanup` | `cleanup.py` | Очистка Bronze данных |
+| `export`        | `export.py`        | Экспорт данных из Gold                  |
+| `quarantine`    | `quarantine.py`    | Управление карантинными записями        |
+| `health`        | `health.py`        | Проверка здоровья провайдеров           |
+| `config`        | `config.py`        | Просмотр и валидация конфигураций       |
+| `checkpoint`    | `checkpoint.py`    | Управление checkpoint-ами               |
+| `lock`          | `lock.py`          | Управление блокировками                 |
+| `vacuum`        | `vacuum.py`        | VACUUM операции для Delta Lake          |
+| `cleanup`       | `cleanup.py`       | Очистка Bronze данных                   |
+
+Дополнительно в слое `interfaces/cli/` используются модули: `health_server_integration.py`, `metrics_server_integration.py`, `run_helpers.py`.
 | `maintenance` | `maintenance.py` | Maintenance операции |
 | `archive` | `archive.py` | Архивирование данных |
 
 **Примеры использования:**
+
 ```bash
 # Запуск пайплайна с лимитом
 python -m bioetl run --pipeline chembl_activity --limit 100
@@ -64,9 +68,15 @@ Endpoints: `/health`, `/health/live`, `/health/ready`.
 
 **Расположение:** `src/bioetl/interfaces/orchestration/`
 
-Содержит адаптеры для оркестрации пайплайнов и обработки сигналов операционной системы (graceful shutdown).
+`orchestration/` — модуль пуст. Signal handlers были удалены 2025-12-31.
+Graceful shutdown обрабатывается непосредственно в CLI командах:
 
----
+- `interfaces/cli/commands/run.py`
+- `interfaces/cli/commands/run_all.py`
+- `interfaces/cli/commands/run_composite.py`
+  Shutdown логика вынесена в `application/core/shutdown.py`.
+
+______________________________________________________________________
 
 Для подробной информации о том, как собираются компоненты системы, см. [Слой Composition](05-composition-layer.md).
 
@@ -76,29 +86,29 @@ Endpoints: `/health`, `/health/live`, `/health/ready`.
 - **Единственная ответственность:** Единственная ответственность этого слоя — запуск приложения и управление его жизненным циклом на самом верхнем уровне.
 - **Импорт из всех слоёв:** Это единственный слой, которому разрешено импортировать модули из `domain`, `application` и `infrastructure` для того, чтобы "собрать" приложение воедино.
 
----
+______________________________________________________________________
 
 ## 4. Связанные Материалы
 
 ### Навигация по Слоям
 
-| ← Предыдущий | Текущий | Следующий → |
-|--------------|---------|-------------|
+| ← Предыдущий                                       | Текущий        | Следующий →                                  |
+| -------------------------------------------------- | -------------- | -------------------------------------------- |
 | [Infrastructure Layer](03-infrastructure-layer.md) | **Interfaces** | [Composition Layer](05-composition-layer.md) |
 
 ### Связанные Диаграммы
 
-| Диаграмма | Файл | Описание |
-|-----------|------|----------|
+| Диаграмма               | Файл                                                                                               | Описание                              |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | Five Layer Architecture | [diagrams/mermaid/01_five_layer_architecture.mmd](diagrams/mermaid/01_five_layer_architecture.mmd) | Полная архитектура с Interfaces слоем |
-| Layers Interaction | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) | Взаимодействие слоёв |
-| Graceful Shutdown | [diagrams/mermaid/24_graceful_shutdown.mmd](diagrams/mermaid/24_graceful_shutdown.mmd) | Sequence diagram graceful shutdown |
+| Layers Interaction      | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid)                            | Взаимодействие слоёв                  |
+| Graceful Shutdown       | [diagrams/mermaid/24_graceful_shutdown.mmd](diagrams/mermaid/24_graceful_shutdown.mmd)             | Sequence diagram graceful shutdown    |
 
 ### Связанные ADR
 
-| ADR | Тема |
-|-----|------|
-| [ADR-008](decisions/ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy |
+| ADR                                                        | Тема                                |
+| ---------------------------------------------------------- | ----------------------------------- |
+| [ADR-008](decisions/ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy          |
 | [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline — расширения CLI |
 
 ### Смежные Разделы Документации

--- a/docs/02-architecture/05-composition-layer.md
+++ b/docs/02-architecture/05-composition-layer.md
@@ -4,11 +4,12 @@
 
 ## 1. Назначение
 
-Слой `Composition` (также известный как **Composition Root**) — это мозг системы сборки. Его единственная задача — соединить компоненты из разных слоев (`Domain`, `Application`, `Infrastructure`) в работающее приложение. 
+Слой `Composition` (также известный как **Composition Root**) — это мозг системы сборки. Его единственная задача — соединить компоненты из разных слоев (`Domain`, `Application`, `Infrastructure`) в работающее приложение.
 
 Согласно архитектурному решению ADR-005, этот код был вынесен в отдельный слой, чтобы избавить слои `Interfaces` и `Application` от ответственности за создание конкретных реализаций адаптеров.
 
 **Ключевые характеристики:**
+
 - **Глобальная осведомленность:** Единственный слой (наряду с `Interfaces`), который "знает" обо всех остальных слоях. Ему разрешено импортировать из `infrastructure`, `application` и `domain`.
 - **Сборка зависимостей:** Здесь происходит внедрение зависимостей (Dependency Injection).
 - **Конфигурация:** Преобразует сырые настройки из YAML или переменных окружения в доменные объекты конфигурации.
@@ -42,51 +43,53 @@ composition/bootstrap/
 
 **Расположение:** `src/bioetl/composition/factories/` (12 файлов)
 
-| Файл | Фабрика | Назначение |
-|------|---------|------------|
-| `pipeline_factory.py` | `GenericPipelineFactory` | Универсальный конструктор пайплайнов (декларативно) |
-| `pipeline_factories.py` | Реестр фабрик | Все зарегистрированные pipeline factories |
-| `data_source_factory.py` | `DataSourceFactory` | Создает `DataSourcePort` для провайдера |
-| `http_client_factory.py` | `HttpClientFactory` | Настроенные `UnifiedHTTPClient` с Rate Limits, Circuit Breaker |
-| `storage_factory.py` | `StorageFactory` | Сборка `StoragePort` (Bronze + Silver + Gold) |
-| `storage_adapter.py` | `StorageAdapterFactory` | Создание отдельных storage адаптеров |
-| `storage.py` | Storage helpers | Вспомогательные функции для storage |
-| `runner_factory.py` | `RunnerFactory` | Создание `PipelineRunner` с DI |
-| `services_factory.py` | `ServicesFactory` | Создание `PipelineServices` bundle |
-| `transformer_factory.py` | `TransformerFactory` | Создание трансформеров по провайдеру |
-| `dq_factory.py` | `DQFactory` | Создание Data Quality компонентов |
+| Файл                          | Фабрика                                                                                     | Назначение                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `pipeline_factory.py`         | `GenericPipelineFactory`                                                                    | Универсальный конструктор пайплайнов (декларативно)            |
+| `pipeline_factories.py`       | Реестр фабрик                                                                               | Все зарегистрированные pipeline factories                      |
+| `data_source_factory.py`      | `DataSourceFactory`                                                                         | Создает `DataSourcePort` для провайдера                        |
+| `http_client_factory.py`      | `HttpClientFactory`                                                                         | Настроенные `UnifiedHTTPClient` с Rate Limits, Circuit Breaker |
+| `storage_factory.py`          | `StorageFactory`                                                                            | Сборка `StoragePort` (Bronze + Silver + Gold)                  |
+| `storage_adapter.py`          | `StorageAdapter`                                                                            | Создание отдельных storage адаптеров                           |
+| `storage.py`                  | Storage helpers                                                                             | Вспомогательные функции для storage                            |
+| `bootstrap/cli/checkpoint.py` | CLI checkpoint bootstrap                                                                    | Настройка checkpoint зависимостей                              |
+| `bootstrap/cli/storage.py`    | CLI storage bootstrap                                                                       | Настройка storage зависимостей                                 |
+| `runner_factory.py`           | `RunnerFactory`                                                                             | Создание `PipelineRunner` с DI                                 |
+| `services_factory.py`         | `BaseServicesFactory / ServicesBuilder`                                                     | Создание `PipelineServices` bundle                             |
+| `transformer_factory.py`      | `transformer_factory.py — модуль с функциями register_transformer() и create_transformer()` | Создание трансформеров по провайдеру                           |
+| `dq_factory.py`               | `DQServicesFactory`                                                                         | Создание Data Quality компонентов                              |
 
-### 2.3. `providers/` — Реестр провайдеров
+### 2.3. Реестр провайдеров и DataSourceRegistry
 
-**Расположение:** `src/bioetl/composition/providers/`
+**Расположение:** `src/bioetl/composition/factories/data_source_factory.py:100` (DataSourceRegistry) и `src/bioetl/composition/providers/` (ProviderRegistry).
 
-Централизованная регистрация всех провайдеров данных:
+Централизованная регистрация всех провайдеров данных (8 провайдеров, включая `uniprot_idmapping`):
 
 - **`ProviderRegistry`**: Главный реестр провайдеров. Хранит конфигурацию каждого провайдера (data source creator, transformer class, pipelines).
 - **`DataSourceRegistry`**: Фасад для backward compatibility. Делегирует создание в `ProviderRegistry`.
 
 **Пример использования:**
+
 ```python
 # Получение data source creator
 creator = DataSourceRegistry.get("chembl")
 data_source = creator(settings, config, logger)
 
 # Или напрямую через ProviderRegistry
-data_source = ProviderRegistry.create_data_source(
-    "chembl", settings, config, logger
-)
+data_source = ProviderRegistry.create_data_source("chembl", settings, config, logger)
 ```
 
 **Зарегистрированные провайдеры (7 шт):**
-| Provider | Data Sources | Pipelines | Rate Limit |
-|----------|--------------|-----------|------------|
-| chembl | ChemblAdapter | activity, assay, molecule, target, document, target_component (13) | None |
-| pubchem | PubChemAdapter | compound | 5 req/sec |
-| uniprot | UniProtAdapter | protein | 100 req/sec |
-| pubmed | PubMedAdapter | publications | 3 req/sec |
-| crossref | CrossRefAdapter | publication | Polite pool |
-| openalex | OpenAlexAdapter | publication | 10 req/sec |
-| semanticscholar | SemanticScholarAdapter | publication | 100 req/5min |
+
+| Provider        | Data Sources           | Pipelines                                                          | Rate Limit   |
+| --------------- | ---------------------- | ------------------------------------------------------------------ | ------------ |
+| chembl          | ChemblAdapter          | activity, assay, molecule, target, document, target_component (13) | None         |
+| pubchem         | PubChemAdapter         | compound                                                           | 5 req/sec    |
+| uniprot         | UniProtAdapter         | protein                                                            | 100 req/sec  |
+| pubmed          | PubMedAdapter          | publications                                                       | 3 req/sec    |
+| crossref        | CrossRefAdapter        | publication                                                        | Polite pool  |
+| openalex        | OpenAlexAdapter        | publication                                                        | 10 req/sec   |
+| semanticscholar | SemanticScholarAdapter | publication                                                        | 100 req/5min |
 
 ### 2.3. `registry.py` — Реестр пайплайнов
 
@@ -102,44 +105,53 @@ data_source = ProviderRegistry.create_data_source(
 
 Для композитных пайплайнов доступна функция `bootstrap_composite_pipeline()`:
 
+````python
+from bioetl.composition.bootstrap.runtime.composite import bootstrap_composite_pipeline
+from bioetl.infrastructure.config.composite import CompositeConfig, CompositeRuntimeConfig
+
+runner = bootstrap_composite_pipeline(
+    config=CompositeConfig(...),
+    runtime=CompositeRuntimeConfig(...),
+)
+# -> CompositePipelineRunner
 ```python
 from bioetl.composition.bootstrap.runtime.composite import bootstrap_composite_pipeline
 
-runner = await bootstrap_composite_pipeline(
+runner = bootstrap_composite_pipeline(
     "composite_publication",
     limit=1000,
 )
 result = await runner.run()
-```
+````
 
 См. [ADR-026: Composite Pipeline Pattern](decisions/ADR-026-composite-pipeline-pattern.md) для деталей.
 
----
+______________________________________________________________________
 
 ## 4. Связанные Материалы
 
 ### Навигация по Слоям
 
-| ← Предыдущий | Текущий | Следующий → |
-|--------------|---------|-------------|
-| [Interfaces Layer](04-interfaces-layer.md) | **Composition** | — |
+| ← Предыдущий                               | Текущий         | Следующий → |
+| ------------------------------------------ | --------------- | ----------- |
+| [Interfaces Layer](04-interfaces-layer.md) | **Composition** | —           |
 
 ### Связанные Диаграммы
 
-| Диаграмма | Файл | Описание |
-|-----------|------|----------|
-| Composition Root | [diagrams/mermaid/11_composition_root.mmd](diagrams/mermaid/11_composition_root.mmd) | DI container, factories, bootstrap |
-| Factory Pattern | [diagrams/mermaid/20_factory_pattern_usage.mmd](diagrams/mermaid/20_factory_pattern_usage.mmd) | Использование Factory паттерна |
-| Five Layer Architecture | [diagrams/mermaid/01_five_layer_architecture.mmd](diagrams/mermaid/01_five_layer_architecture.mmd) | Composition слой в архитектуре |
-| Layers Interaction | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid) | Bootstrap → Factories → Runner |
+| Диаграмма               | Файл                                                                                               | Описание                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Composition Root        | [diagrams/mermaid/11_composition_root.mmd](diagrams/mermaid/11_composition_root.mmd)               | DI container, factories, bootstrap |
+| Factory Pattern         | [diagrams/mermaid/20_factory_pattern_usage.mmd](diagrams/mermaid/20_factory_pattern_usage.mmd)     | Использование Factory паттерна     |
+| Five Layer Architecture | [diagrams/mermaid/01_five_layer_architecture.mmd](diagrams/mermaid/01_five_layer_architecture.mmd) | Composition слой в архитектуре     |
+| Layers Interaction      | [05-layers-interaction.mermaid](diagrams/05-layers-interaction.mermaid)                            | Bootstrap → Factories → Runner     |
 
 ### Связанные ADR
 
-| ADR | Тема |
-|-----|------|
+| ADR                                                          | Тема                         |
+| ------------------------------------------------------------ | ---------------------------- |
 | [ADR-005](decisions/ADR-005-composition-layer-separation.md) | Composition Layer Separation |
-| [ADR-025](decisions/ADR-025-pipeline-config-unification.md) | Pipeline Config Unification |
-| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern |
+| [ADR-025](decisions/ADR-025-pipeline-config-unification.md)  | Pipeline Config Unification  |
+| [ADR-026](decisions/ADR-026-composite-pipeline-pattern.md)   | Composite Pipeline Pattern   |
 
 ### Смежные Разделы Документации
 

--- a/docs/02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md
+++ b/docs/02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md
@@ -1,3 +1,7 @@
+> **Superseded:** Signal handlers удалены 2025-12-31.
+> Graceful shutdown обрабатывается в CLI (run.py, run_all.py) и application/core/shutdown.py.
+> orchestration/ модуль пуст.
+
 # ADR-008: Graceful Shutdown Strategy
 
 **Status:** Accepted
@@ -14,9 +18,10 @@ ETL pipelines process large datasets in batches, maintaining state via checkpoin
 We have implemented a **two-layer shutdown coordination system**:
 
 1. **`ShutdownSignal`** (`application/core/shutdown.py`): Application-level signal object shared across components
-2. **OS Signal Handlers** (`interfaces/orchestration/signals.py`): Translate SIGTERM/SIGINT to ShutdownSignal
+1. **OS Signal Handlers** (`interfaces/orchestration/signals.py`): Translate SIGTERM/SIGINT to ShutdownSignal
 
 Key characteristics:
+
 - Idempotent shutdown requests
 - Async-friendly with `asyncio.Event`
 - Propagates to all pipeline components via dependency injection
@@ -53,10 +58,10 @@ Key characteristics:
 
 ### 1. Separation of Concerns
 
-| Layer | Responsibility |
-|-------|----------------|
-| interfaces | Captures OS signals, framework events |
-| application | Coordinates shutdown via shared signal |
+| Layer          | Responsibility                          |
+| -------------- | --------------------------------------- |
+| interfaces     | Captures OS signals, framework events   |
+| application    | Coordinates shutdown via shared signal  |
 | infrastructure | Releases resources (locks, connections) |
 
 This follows the hexagonal architecture: interfaces translate external events, application orchestrates, infrastructure cleans up.
@@ -64,11 +69,12 @@ This follows the hexagonal architecture: interfaces translate external events, a
 ### 2. Checkpoint-First Shutdown
 
 On shutdown signal:
+
 1. Current batch completes (no mid-batch abort)
-2. Checkpoint is saved with last processed watermark
-3. Lock heartbeat stops
-4. Lock is released
-5. Connections are closed
+1. Checkpoint is saved with last processed watermark
+1. Lock heartbeat stops
+1. Lock is released
+1. Connections are closed
 
 This ensures resumability—next run can continue from saved checkpoint.
 
@@ -146,12 +152,9 @@ async def execute(self, watermark, limit):
             break
         await self.process_batch(batch)
 
+
 # Runner passes signal to all components
-runner = PipelineRunner(
-    shutdown_signal=shutdown_signal,
-    executor=executor,
-    ...
-)
+runner = PipelineRunner(shutdown_signal=shutdown_signal, executor=executor, ...)
 ```
 
 ## Alternatives Considered
@@ -159,6 +162,7 @@ runner = PipelineRunner(
 ### 1. asyncio.CancelledError Propagation
 
 Rejected because:
+
 - Cancellation is abrupt, doesn't allow checkpoint saving
 - Hard to distinguish between timeout and shutdown
 - Less control over cleanup order
@@ -166,6 +170,7 @@ Rejected because:
 ### 2. Context Manager / RAII Pattern
 
 Rejected because:
+
 - Doesn't work well with async generators
 - Cleanup order is implicit (reverse of acquisition)
 - Less visibility into shutdown state
@@ -173,6 +178,7 @@ Rejected because:
 ### 3. Global Singleton Signal
 
 Rejected because:
+
 - Violates dependency injection principle
 - Hard to test (global state)
 - Doesn't work for multiple concurrent pipelines
@@ -180,6 +186,7 @@ Rejected because:
 ## Consequences
 
 ### Positive
+
 - Clean shutdown with checkpoint preservation
 - Resumable pipelines after interruption
 - Lock safety guaranteed
@@ -187,6 +194,7 @@ Rejected because:
 - Testable via signal injection
 
 ### Negative
+
 - **Main thread requirement**: Signal handlers can only be set in main thread. Mitigated by try/except in setup.
 - **Blocking operations**: Long-running sync operations can delay shutdown. Mitigated by using async throughout.
 
@@ -204,10 +212,11 @@ spec:
 ```
 
 The 5-minute grace period allows:
+
 1. Current batch to complete (~30s max)
-2. Checkpoint to be saved (~10s)
-3. Lock release and cleanup (~5s)
-4. Buffer for slow operations
+1. Checkpoint to be saved (~10s)
+1. Lock release and cleanup (~5s)
+1. Buffer for slow operations
 
 ## Related ADRs
 

--- a/docs/03-guides/getting-started.md
+++ b/docs/03-guides/getting-started.md
@@ -9,11 +9,12 @@ This guide will walk you through setting up a complete local development environ
 
 Ensure you have the following tools installed on your machine:
 
-*   **Python 3.11** or higher: [Download](https://www.python.org/downloads/)
-*   **Git**: Version control.
-*   **Make** (optional): Build automation tool. On Windows, use Chocolatey or WSL, or run commands manually.
+- **Python 3.11** or higher: [Download](https://www.python.org/downloads/)
+- **Git**: Version control.
+- **Make** (optional): Build automation tool. On Windows, use Chocolatey or WSL, or run commands manually.
 
 **Not required:**
+
 - Docker Desktop (Local-Only architecture)
 - Redis, MinIO, Postgres (replaced with local file system and in-memory locks)
 
@@ -33,6 +34,7 @@ make install
 ```
 
 *Note: If you are on Windows and don't have `make`, you can manually run:*
+
 ```powershell
 python -m venv .venv
 .venv\Scripts\activate
@@ -42,6 +44,7 @@ pip install -e .[dev,docs]
 ## 3. Configuration
 
 ### Environment Variables
+
 Copy the example environment file to create your local configuration:
 
 ```bash
@@ -51,11 +54,13 @@ cp .env.example .env
 Open `.env` and verify the settings. For local development, the defaults are usually sufficient.
 
 **Key Variables:**
-*   `BIOETL_ENV`: Set to `dev`.
-*   `BIOETL_DATA_DIR`: Directory for data storage (default: `./data`).
-*   `BIOETL_LOG_LEVEL`: Logging level (default: `INFO`).
+
+- `BIOETL_ENV`: Set to `dev`.
+- `BIOETL_DATA_DIR`: Directory for data storage (default: `./data`).
+- `BIOETL_LOG_LEVEL`: Logging level (default: `INFO`).
 
 ### Secrets
+
 If you plan to access APIs requiring authentication (e.g., UniProt, OpenAlex), add your keys to `.env`:
 
 ```ini
@@ -87,10 +92,11 @@ bioetl run --pipeline chembl_activity --limit 100
 ```
 
 This command will:
-1.  Fetch 100 records from the ChEMBL API.
-2.  Save raw data to the **Bronze** layer (`data/bronze/v1/chembl/activity/`).
-3.  Normalize and save to the **Silver** layer (`data/silver/chembl.activity/`).
-4.  Aggregate to the **Gold** layer (`data/gold/chembl.activity_gold/`).
+
+1. Fetch 100 records from the ChEMBL API.
+1. Save raw data to the **Bronze** layer (`data/output/bronze/chembl/activity/{date}/`).
+1. Normalize and save to the **Silver** layer (`data/output/silver/chembl/activity/`).
+1. Aggregate to the **Gold** layer (`data/output/gold/chembl/activity/`).
 
 ## Data Directory Structure
 
@@ -98,33 +104,38 @@ After running a pipeline, your data directory will look like:
 
 ```
 data/
-├── bronze/
-│   └── v1/chembl/activity/2025-12-24/
-│       └── batch_001.jsonl.zst
-├── silver/
-│   └── chembl.activity/
-│       └── _delta_log/
-├── gold/
-│   └── chembl.activity_gold/
-│       └── _delta_log/
-├── checkpoints/
-│   └── chembl_activity.json
-└── quarantine/
-    └── chembl/activity/
+└── output/
+    ├── bronze/
+    │   └── chembl/activity/{date}/
+    │       └── batch_001.jsonl.zst
+    ├── silver/
+    │   └── chembl/activity/
+    │       └── _delta_log/
+    ├── gold/
+    │   └── chembl/activity/
+    │       └── _delta_log/
+    ├── checkpoints/
+    │   └── chembl_activity.json
+    └── quarantine/
+        └── chembl/activity/
 ```
 
 ## Troubleshooting
 
 ### "Make command not found"
+
 On Windows, ensure you have installed Make via Chocolatey (`choco install make`) or use the manual commands listed above.
 
 ### Permission Denied on data/
+
 Ensure the `data/` directory is writable. On Linux/macOS: `chmod -R 755 data/`
 
 ### Tests Fail with "VCR cassette not found"
+
 Run tests with `--vcr-record=once` to record new cassettes, or ensure you're running against the existing fixtures.
 
 ### Pipeline Fails with "Lock already held"
+
 Another pipeline instance may be running. Check for zombie Python processes or wait for the current pipeline to complete.
 
 ## Next Steps

--- a/docs/03-guides/pipeline-configuration.md
+++ b/docs/03-guides/pipeline-configuration.md
@@ -5,7 +5,7 @@
 **Версия:** 6.0.0
 **Дата обновления:** 2026-02-03
 
----
+______________________________________________________________________
 
 ## Обзор
 
@@ -19,7 +19,7 @@ BioETL использует **YAML-файлы** для конфигурации 
 - **Pydantic валидация:** Схемы проверяются при загрузке
 - **Immutable Domain Objects:** Конфиги преобразуются в frozen dataclasses
 
----
+______________________________________________________________________
 
 ## Структура директорий
 
@@ -113,16 +113,16 @@ configs/
 
 ### Статистика конфигураций
 
-| Категория | Количество | Описание |
-|-----------|------------|----------|
-| Pipeline configs (entity) | 21 | Regular ETL pipelines |
-| Composite configs | 5 | Multi-provider pipelines (ADR-026) |
-| DQ configs | 30 | 1 defaults + 7 providers + 22 entities |
-| Filter configs | 8 | 1 defaults + 7 providers |
-| Source configs | 7 | Один на провайдера |
-| **Итого** | **71** | Все конфиги валидированы |
+| Категория                 | Количество | Описание                               |
+| ------------------------- | ---------- | -------------------------------------- |
+| Pipeline configs (entity) | 21         | Regular ETL pipelines                  |
+| Composite configs         | 5          | Multi-provider pipelines (ADR-026)     |
+| DQ configs                | 30         | 1 defaults + 7 providers + 22 entities |
+| Filter configs            | 8          | 1 defaults + 7 providers               |
+| Source configs            | 7          | Один на провайдера                     |
+| **Итого**                 | **71**     | Все конфиги валидированы               |
 
----
+______________________________________________________________________
 
 ## Pipeline YAML конфиг
 
@@ -143,24 +143,24 @@ gold_table: "chembl_activity"
 
 ### Полная структура конфига
 
-| Секция | Описание | Обязательно |
-|--------|----------|-------------|
-| `pipeline_name` | Уникальный идентификатор пайплайна | Да |
-| `provider` | Имя провайдера (lowercase) | Да |
-| `entity_type` | Тип сущности | Да |
-| `version` | Semver версия конфига | Да |
-| `primary_keys` | Первичные ключи | Да |
-| `silver_table` | Имя Silver таблицы | Да |
-| `gold_table` | Имя Gold таблицы | Нет |
-| `batch_size` | Размер батча (1-5000) | Нет (default: 100) |
-| `checkpoint_interval` | Интервал checkpoint | Нет (default: 10) |
-| `source` | Конфиг источника | Нет (auto-resolved) |
-| `dq_rules` | Inline DQ переопределения | Нет |
-| `sink` | Конфиги слоёв (Bronze/Silver/Gold) | Нет (auto-resolved) |
-| `circuit_breaker` | Настройки Circuit Breaker | Нет (from base) |
-| `maintenance` | VACUUM настройки | Нет (from base) |
-| `loading_strategy` | Стратегия загрузки | Нет (default: full) |
-| `force_full_scan` | Отключить checkpoint resume | Нет (default: false) |
+| Секция                | Описание                           | Обязательно          |
+| --------------------- | ---------------------------------- | -------------------- |
+| `pipeline_name`       | Уникальный идентификатор пайплайна | Да                   |
+| `provider`            | Имя провайдера (lowercase)         | Да                   |
+| `entity_type`         | Тип сущности                       | Да                   |
+| `version`             | Semver версия конфига              | Да                   |
+| `primary_keys`        | Первичные ключи                    | Да                   |
+| `silver_table`        | Имя Silver таблицы                 | Да                   |
+| `gold_table`          | Имя Gold таблицы                   | Нет                  |
+| `batch_size`          | Размер батча (1-5000)              | Нет (default: 100)   |
+| `checkpoint_interval` | Интервал checkpoint                | Нет (default: 10)    |
+| `source`              | Конфиг источника                   | Нет (auto-resolved)  |
+| `dq_rules`            | Inline DQ переопределения          | Нет                  |
+| `sink`                | Конфиги слоёв (Bronze/Silver/Gold) | Нет (auto-resolved)  |
+| `circuit_breaker`     | Настройки Circuit Breaker          | Нет (from base)      |
+| `maintenance`         | VACUUM настройки                   | Нет (from base)      |
+| `loading_strategy`    | Стратегия загрузки                 | Нет (default: full)  |
+| `force_full_scan`     | Отключить checkpoint resume        | Нет (default: false) |
 
 ### Пример с переопределениями
 
@@ -186,7 +186,7 @@ dq_rules:
       nullable: true
     - field: standard_type
       type: enum
-      allowed: [IC50, Ki, Kd, EC50, AC50]
+      allowed: [IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50, Kd, EC50, AC50]
 
 # Переопределение sink (опционально)
 sink:
@@ -197,7 +197,7 @@ sink:
       include_columns: ["activity_id", "standard_type", "standard_value"]
 ```
 
----
+______________________________________________________________________
 
 ## Composite Pipelines (ADR-026)
 
@@ -235,37 +235,37 @@ composite:
 
 ### Доступные Composite Pipelines
 
-| Composite | Seed | Enrichers | Описание |
-|-----------|------|-----------|----------|
-| `composite_activity` | `chembl_activity` | enrichers | Обогащённые данные активности |
-| `composite_assay` | `chembl_assay` | enrichers | Обогащённые данные анализов |
-| `composite_molecule` | `chembl_molecule` | pubchem_compound, enrichers | Обогащённые молекулы |
-| `composite_publication` | `chembl_publication` | crossref, openalex, pubmed, semanticscholar | Обогащённые публикации |
-| `composite_target` | `chembl_target` | target_component, protein_class, uniprot_idmapping, uniprot_protein | Обогащённые targets |
+| Composite               | Seed                 | Enrichers                                                           | Описание                      |
+| ----------------------- | -------------------- | ------------------------------------------------------------------- | ----------------------------- |
+| `composite_activity`    | `chembl_activity`    | enrichers                                                           | Обогащённые данные активности |
+| `composite_assay`       | `chembl_assay`       | enrichers                                                           | Обогащённые данные анализов   |
+| `composite_molecule`    | `chembl_molecule`    | pubchem_compound, enrichers                                         | Обогащённые молекулы          |
+| `composite_publication` | `chembl_publication` | crossref, openalex, pubmed, semanticscholar                         | Обогащённые публикации        |
+| `composite_target`      | `chembl_target`      | target_component, protein_class, uniprot_idmapping, uniprot_protein | Обогащённые targets           |
 
 ### Отличия от Regular Pipelines
 
-| Аспект | Regular Pipeline | Composite Pipeline |
-|--------|------------------|-------------------|
-| Корневой ключ | `pipeline_name`, `provider`, `entity_type` | `composite:` |
-| Source | Один провайдер | Несколько провайдеров через `enrichers` |
-| Schema | `_schema.json` | Отдельная схема (ADR-026) |
-| Пути | Auto-computed | Определяются в `merge.output` |
+| Аспект        | Regular Pipeline                           | Composite Pipeline                      |
+| ------------- | ------------------------------------------ | --------------------------------------- |
+| Корневой ключ | `pipeline_name`, `provider`, `entity_type` | `composite:`                            |
+| Source        | Один провайдер                             | Несколько провайдеров через `enrichers` |
+| Schema        | `_schema.json`                             | Отдельная схема (ADR-026)               |
+| Пути          | Auto-computed                              | Определяются в `merge.output`           |
 
----
+______________________________________________________________________
 
 ## Convention-based Path Resolution (ADR-029)
 
 Пути и ссылки вычисляются автоматически из `provider` и `entity_type`:
 
-| Поле | Auto-computed значение |
-|------|------------------------|
-| `source_file` | `../../sources/{provider}.yaml` |
-| `dq_config_file` | `../../dq/entities/{provider}/{entity_type}.yaml` |
+| Поле                 | Auto-computed значение                                |
+| -------------------- | ----------------------------------------------------- |
+| `source_file`        | `../../sources/{provider}.yaml`                       |
+| `dq_config_file`     | `../../dq/entities/{provider}/{entity_type}.yaml`     |
 | `filter_config_file` | `../../filter/entities/{provider}/{entity_type}.yaml` |
-| `sink.bronze.path` | `data/output/bronze/{provider}/{entity_type}` |
-| `sink.silver.path` | `data/output/silver/{provider}/{entity_type}` |
-| `sink.gold.path` | `data/output/gold/{provider}/{entity_type}` |
+| `sink.bronze.path`   | `data/output/bronze/{provider}/{entity_type}`         |
+| `sink.silver.path`   | `data/output/silver/{provider}/{entity_type}`         |
+| `sink.gold.path`     | `data/output/gold/{provider}/{entity_type}`           |
 
 ### Авто-пропагация sort_by (ADR-014 compliance)
 
@@ -274,10 +274,7 @@ composite:
 ```python
 # config_loader.py:155-176
 if "sort_by" not in sink_silver:
-    sink_silver["sort_by"] = {
-        "columns": config["primary_keys"],
-        "ascending": True
-    }
+    sink_silver["sort_by"] = {"columns": config["primary_keys"], "ascending": True}
 ```
 
 Это означает, что entity configs **не должны** явно указывать `sort_by` — он пропагируется из `primary_keys`:
@@ -288,9 +285,9 @@ pipeline_name: chembl_activity
 primary_keys: ["activity_id"]  # → sort_by.columns = ["activity_id"]
 ```
 
-> **Преимущество:** Снижает дублирование на ~30%. Разработчик указывает только переопределения. Все 19 entity configs соответствуют ADR-014 через авто-пропагацию.
+> **Преимущество:** Снижает дублирование на ~30%. Разработчик указывает только переопределения. Все 21 entity configs соответствуют ADR-014 через авто-пропагацию.
 
----
+______________________________________________________________________
 
 ## Data Quality (DQ) конфигурация
 
@@ -299,9 +296,9 @@ primary_keys: ["activity_id"]  # → sort_by.columns = ["activity_id"]
 DQ правила загружаются в порядке приоритета (позже выигрывают):
 
 1. `configs/dq/_defaults.yaml` — глобальные defaults
-2. `configs/dq/providers/{provider}.yaml` — provider-specific
-3. `configs/dq/entities/{provider}/{entity}.yaml` — entity-specific
-4. Inline `dq_rules` в pipeline конфиге — финальные переопределения
+1. `configs/dq/providers/{provider}.yaml` — provider-specific
+1. `configs/dq/entities/{provider}/{entity}.yaml` — entity-specific
+1. Inline `dq_rules` в pipeline конфиге — финальные переопределения
 
 ### Специальная merge логика
 
@@ -349,7 +346,7 @@ entity_field_validations:
     nullable: true
   - field: standard_type
     type: enum
-    allowed: [IC50, Ki, Kd, EC50, AC50, Potency]
+    allowed: [IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50, Kd, EC50, AC50, Potency]
 
 entity_cross_field_validations:
   - name: value_requires_units
@@ -370,16 +367,16 @@ entity_conditional_validations:
 
 ### Типы валидаций
 
-| Тип | Описание | Параметры |
-|-----|----------|-----------|
-| `required` | Обязательное поле | `nullable` |
-| `range` | Числовой диапазон | `min`, `max`, `nullable` |
-| `enum` | Допустимые значения | `allowed`, `nullable` |
-| `pattern` | Regex паттерн | `pattern`, `nullable` |
-| `length` | Длина строки | `min`, `max` |
-| `unique` | Уникальность | — |
+| Тип        | Описание            | Параметры                |
+| ---------- | ------------------- | ------------------------ |
+| `required` | Обязательное поле   | `nullable`               |
+| `range`    | Числовой диапазон   | `min`, `max`, `nullable` |
+| `enum`     | Допустимые значения | `allowed`, `nullable`    |
+| `pattern`  | Regex паттерн       | `pattern`, `nullable`    |
+| `length`   | Длина строки        | `min`, `max`             |
+| `unique`   | Уникальность        | —                        |
 
----
+______________________________________________________________________
 
 ## Filter конфигурация
 
@@ -388,9 +385,9 @@ entity_conditional_validations:
 Аналогично DQ, фильтры загружаются иерархически:
 
 1. `configs/filter/_defaults.yaml`
-2. `configs/filter/providers/{provider}.yaml`
-3. `configs/filter/entities/{provider}/{entity}.yaml`
-4. Inline `filter_rules` в pipeline конфиге
+1. `configs/filter/providers/{provider}.yaml`
+1. `configs/filter/entities/{provider}/{entity}.yaml`
+1. Inline `filter_rules` в pipeline конфиге
 
 ### Input Filter
 
@@ -418,7 +415,7 @@ gold_filters:
   columns:
     standard_type:
       operator: in
-      values: [IC50, Ki]
+      values: [IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50]
     pchembl_value:
       operator: is_not_null
 
@@ -435,16 +432,16 @@ gold_filters:
 
 ### Операторы фильтрации
 
-| Оператор | Описание |
-|----------|----------|
-| `in` | Значение в списке |
-| `not_in` | Значение не в списке |
-| `is_null` | NULL |
-| `is_not_null` | NOT NULL |
-| `is_empty` | Пустая строка или список |
+| Оператор       | Описание                    |
+| -------------- | --------------------------- |
+| `in`           | Значение в списке           |
+| `not_in`       | Значение не в списке        |
+| `is_null`      | NULL                        |
+| `is_not_null`  | NOT NULL                    |
+| `is_empty`     | Пустая строка или список    |
 | `is_not_empty` | Не пустая строка или список |
 
----
+______________________________________________________________________
 
 ## Source конфигурация
 
@@ -476,7 +473,7 @@ source:
     burst: 10
 
   health_check:
-    endpoint: /chembl/api/data/status.json
+    endpoint: /chembl/api/data/status
     timeout: 5
 
 entities:
@@ -489,17 +486,17 @@ entities:
 
 ### Rate Limits по провайдерам (7 source configs)
 
-| Provider | Source Config | Rate Limit | Burst | Batch Size |
-|----------|---------------|------------|-------|------------|
-| ChEMBL | `sources/chembl.yaml` | 5 req/sec | 10 | 20 |
-| PubChem | `sources/pubchem.yaml` | 5 req/sec | 10 | 1 |
-| UniProt | `sources/uniprot.yaml` | 100 req/sec | 200 | 100 |
-| CrossRef | `sources/crossref.yaml` | 10 req/sec | 20 | 50 |
-| OpenAlex | `sources/openalex.yaml` | 10 req/sec | 20 | 50 |
-| PubMed | `sources/pubmed.yaml` | 3 req/sec | 5 | 10 |
-| SemanticScholar | `sources/semanticscholar.yaml` | 100 req/5min | — | 100 |
+| Provider        | Source Config                  | Rate Limit   | Burst | Batch Size |
+| --------------- | ------------------------------ | ------------ | ----- | ---------- |
+| ChEMBL          | `sources/chembl.yaml`          | 5 req/sec    | 10    | 20         |
+| PubChem         | `sources/pubchem.yaml`         | 5 req/sec    | 10    | 1          |
+| UniProt         | `sources/uniprot.yaml`         | 100 req/sec  | 200   | 100        |
+| CrossRef        | `sources/crossref.yaml`        | 10 req/sec   | 20    | 50         |
+| OpenAlex        | `sources/openalex.yaml`        | 10 req/sec   | 20    | 50         |
+| PubMed          | `sources/pubmed.yaml`          | 3 req/sec    | 5     | 10         |
+| SemanticScholar | `sources/semanticscholar.yaml` | 100 req/5min | —     | 100        |
 
----
+______________________________________________________________________
 
 ## Sink конфигурация
 
@@ -543,21 +540,21 @@ sink:
 
 ### Write Modes
 
-| Mode | Bronze | Silver | Gold |
-|------|--------|--------|------|
-| `append` | Только append | — | — |
-| `merge` | — | Upsert по PK | — |
-| `overwrite` | — | Полная перезапись | Полная перезапись |
+| Mode        | Bronze        | Silver            | Gold              |
+| ----------- | ------------- | ----------------- | ----------------- |
+| `append`    | Только append | —                 | —                 |
+| `merge`     | —             | Upsert по PK      | —                 |
+| `overwrite` | —             | Полная перезапись | Полная перезапись |
 
 ### Schema Mismatch Handling
 
-| Режим | Описание |
-|-------|----------|
-| `error` | Падение при несовпадении схемы |
+| Режим    | Описание                                |
+| -------- | --------------------------------------- |
+| `error`  | Падение при несовпадении схемы          |
 | `evolve` | Автоматическое добавление новых колонок |
-| `ignore` | Игнорировать несовпадения |
+| `ignore` | Игнорировать несовпадения               |
 
----
+______________________________________________________________________
 
 ## Circuit Breaker конфигурация
 
@@ -569,11 +566,12 @@ circuit_breaker:
 ```
 
 **Состояния:**
+
 - **Closed:** Нормальная работа
 - **Open:** Все запросы блокируются
 - **Half-Open:** Пробные запросы для recovery
 
----
+______________________________________________________________________
 
 ## Maintenance конфигурация
 
@@ -589,7 +587,7 @@ maintenance:
     retention_days: 90          # Retention для Bronze файлов
 ```
 
----
+______________________________________________________________________
 
 ## Валидация конфигурации
 
@@ -613,15 +611,15 @@ bioetl config list-pipelines
 
 При загрузке конфига выполняются проверки:
 
-| Проверка | Описание |
-|----------|----------|
-| `validate_batch_size` | batch_size ≤ 5000 |
-| `validate_provider` | Provider в lowercase |
-| `validate_entity_type_canonical` | publication* вместо document* |
-| `validate_medallion_formats` | Bronze→JSONL, Silver→Delta, Gold→Delta/Parquet |
-| `validate_thresholds` | soft_fail < hard_fail |
+| Проверка                         | Описание                                       |
+| -------------------------------- | ---------------------------------------------- |
+| `validate_batch_size`            | batch_size ≤ 5000                              |
+| `validate_provider`              | Provider в lowercase                           |
+| `validate_entity_type_canonical` | publication\* вместо document\*                |
+| `validate_medallion_formats`     | Bronze→JSONL, Silver→Delta, Gold→Delta/Parquet |
+| `validate_thresholds`            | soft_fail < hard_fail                          |
 
----
+______________________________________________________________________
 
 ## Примеры конфигураций
 
@@ -684,7 +682,7 @@ sink:
       enabled: true
 ```
 
----
+______________________________________________________________________
 
 ## Миграция с JSON на YAML
 
@@ -692,6 +690,7 @@ sink:
 > Переход на YAML выполнен для улучшения читаемости и поддержки комментариев.
 
 **Было (JSON):**
+
 ```json
 {
   "pipeline_name": "chembl_activity",
@@ -702,6 +701,7 @@ sink:
 ```
 
 **Стало (YAML):**
+
 ```yaml
 pipeline_name: chembl_activity
 provider: chembl
@@ -711,7 +711,7 @@ batch_size: 100
 # Комментарии теперь поддерживаются!
 ```
 
----
+______________________________________________________________________
 
 ## Troubleshooting
 
@@ -723,28 +723,30 @@ bioetl config validate chembl_activity
 
 **Распространённые ошибки:**
 
-| Ошибка | Причина | Решение |
-|--------|---------|---------|
-| `batch_size > 5000` | Слишком большой batch | Уменьшить до ≤5000 |
+| Ошибка                   | Причина                     | Решение                |
+| ------------------------ | --------------------------- | ---------------------- |
+| `batch_size > 5000`      | Слишком большой batch       | Уменьшить до ≤5000     |
 | `provider not lowercase` | Provider в верхнем регистре | Использовать lowercase |
-| `soft_fail >= hard_fail` | Неверные пороги | soft_fail < hard_fail |
-| `unknown field` | Опечатка в имени поля | Проверить spelling |
+| `soft_fail >= hard_fail` | Неверные пороги             | soft_fail < hard_fail  |
+| `unknown field`          | Опечатка в имени поля       | Проверить spelling     |
 
 ### DQ правила не применяются
 
 1. Проверить путь к DQ файлу:
+
    ```bash
    ls configs/dq/entities/{provider}/{entity}.yaml
    ```
 
-2. Проверить merge логику — validation lists **concatenate**, не override.
+1. Проверить merge логику — validation lists **concatenate**, не override.
 
-3. Использовать CLI для просмотра resolved конфига:
+1. Использовать CLI для просмотра resolved конфига:
+
    ```bash
    bioetl config show chembl_activity --format json
    ```
 
----
+______________________________________________________________________
 
 ## См. также
 

--- a/docs/03-guides/quick-start.md
+++ b/docs/03-guides/quick-start.md
@@ -31,9 +31,9 @@ source .venv/bin/activate  # Linux/macOS
 bioetl run --pipeline chembl_activity --limit 100 --no-cached-bronze
 
 # Data will be stored in:
-# - data/bronze/v1/chembl/activity/
-# - data/silver/chembl.activity/
-# - data/gold/chembl.activity_gold/
+# - data/output/bronze/chembl/activity/{date}/
+# - data/output/silver/chembl/activity/
+# - data/output/gold/chembl/activity/
 ```
 
 ## Verify
@@ -48,25 +48,26 @@ make lint
 
 ## Common Commands
 
-| Task | Command |
-|------|---------|
-| Install dependencies | `make install` |
-| Run all tests | `make test` |
-| Run linting | `make lint` |
-| Run on fixtures | `make run-local` |
-| List pipelines | `bioetl list` |
-| Full rebuild | `bioetl run --pipeline <name> --full-rebuild` |
-| Resume from checkpoint | `bioetl run --pipeline <name> --resume` |
+| Task                   | Command                                           |
+| ---------------------- | ------------------------------------------------- |
+| Install dependencies   | `make install`                                    |
+| Run all tests          | `make test`                                       |
+| Run linting            | `make lint`                                       |
+| Run on fixtures        | `make run-local`                                  |
+| List pipelines         | `bioetl list`                                     |
+| Full rebuild           | `bioetl run --pipeline <name> --run-type rebuild` |
+| Resume from checkpoint | `bioetl run --pipeline <name> --resume`           |
 
 ## Project Structure (Data)
 
 ```
 data/
-├── bronze/          # Raw API responses (JSONL + zstd)
-├── silver/          # Cleaned Delta Lake tables
-├── gold/            # Aggregated/enriched tables
-├── checkpoints/     # Pipeline state for resume
-└── quarantine/      # Failed records for review
+└── output/
+    ├── bronze/          # Raw API responses (JSONL + zstd)
+    ├── silver/          # Cleaned Delta Lake tables
+    ├── gold/            # Aggregated/enriched tables
+    ├── checkpoints/     # Pipeline state for resume
+    └── quarantine/      # Failed records for review
 ```
 
 ## Next Steps

--- a/docs/04-reference/api/application/core.md
+++ b/docs/04-reference/api/application/core.md
@@ -9,92 +9,85 @@ Core pipeline execution infrastructure and services.
 Orchestrates pipeline execution lifecycle. Coordinates locking, checkpointing, and execution.
 
 ::: bioetl.application.core.runner.PipelineRunner
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - __init__
-            - run
-            - logger
-            - services
+options:
+show_root_heading: true
+show_source: false
+members:
+\- __init__
+\- run
+\- logger
+\- services
 
 ### BasePipeline
 
 Abstract base class for all ETL pipelines. Provides template method pattern for pipeline configuration.
 
 ::: bioetl.application.core.base.BasePipeline
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### BatchExecutor
 
 Unified batch executor for ETL pipeline orchestration. Handles extraction → transformation → writing flow with adaptive batch sizing.
 
 ::: bioetl.application.core.batch_executor.BatchExecutor
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - __init__
-            - execute
-            - execute_batch
+options:
+show_root_heading: true
+show_source: false
+members:
+\- __init__
+\- execute
+\- execute_batch
 
 ### BatchResult
 
 Result of batch execution containing metrics and status.
 
 ::: bioetl.application.core.batch_executor.BatchResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### RecordProcessor
 
 Processes individual records through the transformation pipeline.
 
 ::: bioetl.application.core.record_processor.RecordProcessor
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Batch Transformation
 
 ### BatchTransformer
 
+Streaming-режим интегрирован в BatchTransformer как streaming_processing mode.
+
 Transforms batches of records from Bronze to Silver/Gold layers.
 
 ::: bioetl.application.core.batch_transformer.BatchTransformer
-    options:
-        show_root_heading: true
-        show_source: false
-
-### StreamingBatchProcessor
-
-Streaming processor for large batches with memory management.
-
-::: bioetl.application.core.batch_transformer.StreamingBatchProcessor
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### TransformResult
 
 Result of a transformation operation.
 
 ::: bioetl.application.core.batch_transformer.TransformResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### TransformedRecord
 
 Container for a transformed record with metadata.
 
 ::: bioetl.application.core.batch_transformer.TransformedRecord
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Batch Writing
 
@@ -103,9 +96,9 @@ Container for a transformed record with metadata.
 Writes transformed batches to storage layers.
 
 ::: bioetl.application.core.batch_writer.BatchWriter
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Service Bundles
 
@@ -114,9 +107,9 @@ Writes transformed batches to storage layers.
 Bundle of common pipeline services injected via DI.
 
 ::: bioetl.application.core.pipeline_services.PipelineServices
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Infrastructure Services
 
@@ -125,58 +118,58 @@ Bundle of common pipeline services injected via DI.
 Pre-flight infrastructure validation before pipeline execution.
 
 ::: bioetl.application.core.preflight_service.PreflightService
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - execute
+options:
+show_root_heading: true
+show_source: false
+members:
+\- execute
 
 ### PostrunService
 
 Post-run operations: DQ checks, VACUUM, cleanup.
 
 ::: bioetl.application.core.postrun_service.PostrunService
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - execute
+options:
+show_root_heading: true
+show_source: false
+members:
+\- execute
 
 ### PostrunResult
 
 Result of post-run operations.
 
 ::: bioetl.application.core.postrun_service.PostrunResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### DQResult
 
 Data quality check result.
 
 ::: bioetl.application.core.postrun_service.DQResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### DQEvaluationStatus
 
 Enumeration for DQ evaluation status (PASSED, SOFT_FAIL, HARD_FAIL).
 
 ::: bioetl.application.core.postrun_service.DQEvaluationStatus
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### VacuumResult
 
 Result of VACUUM operation.
 
 ::: bioetl.application.core.postrun_service.VacuumResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## State Management
 
@@ -185,34 +178,34 @@ Result of VACUUM operation.
 Pipeline checkpoint persistence for resume capability.
 
 ::: bioetl.application.core.checkpoint_manager.CheckpointManager
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - save
-            - load
-            - delete
+options:
+show_root_heading: true
+show_source: false
+members:
+\- save
+\- load
+\- delete
 
 ### LockManager
 
 Distributed locking coordination.
 
 ::: bioetl.application.core.lock_manager.LockManager
-    options:
-        show_root_heading: true
-        show_source: false
-        members:
-            - acquire
-            - release
+options:
+show_root_heading: true
+show_source: false
+members:
+\- acquire
+\- release
 
 ### QuarantineManager
 
 Failed record quarantine management.
 
 ::: bioetl.application.core.quarantine_manager.QuarantineManager
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Memory Management
 
@@ -221,27 +214,27 @@ Failed record quarantine management.
 Memory usage monitoring for adaptive batch sizing.
 
 ::: bioetl.application.core.memory_monitor.MemoryMonitor
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### MemoryConfig
 
 Memory monitoring configuration.
 
 ::: bioetl.application.core.memory_monitor.MemoryConfig
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### MemoryStats
 
 Memory usage statistics.
 
 ::: bioetl.application.core.memory_monitor.MemoryStats
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Shutdown Handling
 
@@ -250,45 +243,45 @@ Memory usage statistics.
 Graceful shutdown signal handler.
 
 ::: bioetl.application.core.shutdown.ShutdownSignal
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### ShutdownService
 
 Service for coordinating graceful shutdown.
 
 ::: bioetl.application.core.shutdown.ShutdownService
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### ShutdownReason
 
 Enumeration for shutdown reasons.
 
 ::: bioetl.application.core.shutdown.ShutdownReason
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### PipelineShutdownError
 
 Raised when pipeline receives shutdown signal.
 
 ::: bioetl.application.core.shutdown.PipelineShutdownError
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### create_shutdown_service
 
 Factory function for creating shutdown service.
 
 ::: bioetl.application.core.shutdown.create_shutdown_service
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Cleanup Operations
 
@@ -297,36 +290,36 @@ Factory function for creating shutdown service.
 Cleanup operations for Bronze/Silver/Gold layers.
 
 ::: bioetl.application.core.cleanup_service.CleanupService
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### CleanupResult
 
 Result of cleanup operation.
 
 ::: bioetl.application.core.cleanup_service.CleanupResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### CleanupPreview
 
 Preview of files to be cleaned up.
 
 ::: bioetl.application.core.cleanup_service.CleanupPreview
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### LayerInfo
 
 Information about a storage layer.
 
 ::: bioetl.application.core.cleanup_service.LayerInfo
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Medallion Lifecycle
 
@@ -335,27 +328,27 @@ Information about a storage layer.
 Service for managing Medallion layer lifecycle operations.
 
 ::: bioetl.application.services.medallion_lifecycle.MedallionLifecycleService
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### ClearResult
 
 Result of a layer clear operation.
 
 ::: bioetl.application.services.medallion_types.ClearResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### PrepareResult
 
 Result of a layer prepare operation.
 
 ::: bioetl.application.services.medallion_types.PrepareResult
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Transform Utilities
 
@@ -363,52 +356,52 @@ Utility functions for data transformation.
 
 ### normalize_string
 
-::: bioetl.application.core.transform_utils.normalize_string
-    options:
-        show_root_heading: true
-        show_source: false
+::: bioetl.application.core.dict_transformers.normalize_string
+options:
+show_root_heading: true
+show_source: false
 
 ### safe_extract
 
-::: bioetl.application.core.transform_utils.safe_extract
-    options:
-        show_root_heading: true
-        show_source: false
+::: bioetl.application.core.dict_transformers.safe_extract
+options:
+show_root_heading: true
+show_source: false
 
 ### flatten_nested_dict
 
 ::: bioetl.application.core.transform_utils.flatten_nested_dict
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### extract_list_field
 
 ::: bioetl.application.core.transform_utils.extract_list_field
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### aggregate_nested_lists
 
 ::: bioetl.application.core.transform_utils.aggregate_nested_lists
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### parse_date_field
 
-::: bioetl.application.core.transform_utils.parse_date_field
-    options:
-        show_root_heading: true
-        show_source: false
+::: bioetl.application.core.dict_transformers.parse_date_field
+options:
+show_root_heading: true
+show_source: false
 
 ### validate_smiles
 
 ::: bioetl.application.core.transform_utils.validate_smiles
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Configuration
 
@@ -417,18 +410,18 @@ Utility functions for data transformation.
 Static pipeline configuration loaded from YAML.
 
 ::: bioetl.domain.config.PipelineConfig
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### RuntimeConfig
 
 Runtime configuration from CLI/environment.
 
 ::: bioetl.domain.config.RuntimeConfig
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Medallion Types
 
@@ -437,27 +430,27 @@ Runtime configuration from CLI/environment.
 Enumeration for Medallion layers (BRONZE, SILVER, GOLD).
 
 ::: bioetl.domain.medallion.Layer
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### WriteMode
 
 Enumeration for write modes (MERGE, APPEND, OVERWRITE).
 
 ::: bioetl.domain.medallion.WriteMode
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### WriteModePolicy
 
 Policy for determining write mode based on run type and layer.
 
 ::: bioetl.domain.medallion.WriteModePolicy
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Usage Example
 

--- a/docs/04-reference/api/composition.md
+++ b/docs/04-reference/api/composition.md
@@ -12,7 +12,7 @@ flowchart TB
 
         subgraph Factories["Factories"]
             PF[GenericPipelineFactory]
-            SF[ServicesFactory]
+            SF[BaseServicesFactory / ServicesBuilder]
             DF[DataSourceFactory]
             StF[StorageFactory]
         end
@@ -46,7 +46,7 @@ Entry point for pipeline creation:
 Component factories for DI:
 
 - `GenericPipelineFactory` - Pipeline instance creation
-- `ServicesFactory` - Service bundle creation
+- `BaseServicesFactory / ServicesBuilder` - Service bundle creation
 - `DataSourceFactory` - Data source adapter creation
 - `StorageFactory` - Storage writer creation
 
@@ -98,10 +98,13 @@ Pipelines are registered via decorator:
 ```python
 from bioetl.composition.registry import register
 
-@register("chembl_activity")
+registry.register_factory("chembl_activity", factory_fn)
+
+
 def chembl_activity_factory(ctx: PipelineRunContext) -> PipelineRunner:
     """Factory function for ChEMBL activity pipeline."""
     ...
+
 
 # Later: retrieve and create
 factory = registry.get("chembl_activity")
@@ -117,7 +120,7 @@ from bioetl.composition.bootstrap import bootstrap_pipeline
 # Factories
 from bioetl.composition.factories import (
     GenericPipelineFactory,
-    ServicesFactory,
+    BaseServicesFactory / ServicesBuilder,
     DataSourceFactory,
     StorageFactory,
 )

--- a/docs/04-reference/api/domain.md
+++ b/docs/04-reference/api/domain.md
@@ -24,14 +24,14 @@ classDiagram
         <<interface>>
         +acquire()
         +release()
-        +refresh()
+        +heartbeat()
     }
 
     class MetricsPort {
         <<interface>>
-        +increment()
-        +gauge()
-        +histogram()
+        +increment_counter()
+        +set_gauge()
+        +observe_histogram()
     }
 
     StoragePort <|.. SilverWriter
@@ -69,11 +69,11 @@ Core type definitions and enumerations:
 
 Domain model dataclasses representing bioactivity data:
 
-- `Activity` - Bioactivity measurement
+- `Bioactivity` - Bioactivity measurement
 - `Assay` - Experimental assay
 - `Molecule` - Chemical compound
 - `Target` - Biological target
-- `Document` - Publication reference
+- `ChemblPublication` - Publication reference
 
 ### [Exceptions](domain/exceptions.md)
 
@@ -114,13 +114,14 @@ writer: StoragePort = SilverWriter(...)
 Unique record identification using deterministic hashing:
 
 ```python
-from bioetl.domain.transformations import compute_content_hash
+from bioetl.domain.transformations import generate_content_hash
 
 # sha256(provider + canonical_json(record))
-hash = compute_content_hash("chembl", record)
+hash = generate_content_hash("chembl", record)
 ```
 
 Normalization rules:
+
 - NaN/Inf → `null`
 - Floats → rounded to 10 decimals
 - Dates → ISO format `YYYY-MM-DD`
@@ -135,14 +136,14 @@ from bioetl.domain import (
     DataSourcePort,
     RunType,
     HealthStatus,
-    Activity,
+    Bioactivity,
     DataQualityError,
 )
 
 # Alternative: Import from specific modules
 from bioetl.domain.ports import StoragePort
 from bioetl.domain.types import RunType
-from bioetl.domain.entities import Activity
+from bioetl.domain.entities import Bioactivity
 ```
 
 ## See Also

--- a/docs/04-reference/api/domain/entities.md
+++ b/docs/04-reference/api/domain/entities.md
@@ -12,12 +12,12 @@ BioETL entities follow these design principles:
 
 ### Field Classification
 
-| Category | Description | Example |
-|----------|-------------|---------|
-| **REQUIRED** | Must be non-None, validated in `__post_init__` | `entity_id`, `content_hash` |
-| **LINEAGE** | System metadata for tracking | `run_id`, `ingestion_ts` |
-| **API-OPTIONAL** | May be None (API-dependent) | `pchembl_value`, `target_name` |
-| **COMPUTED** | Derived from other fields | `pchembl_value` (log conversion) |
+| Category         | Description                                    | Example                          |
+| ---------------- | ---------------------------------------------- | -------------------------------- |
+| **REQUIRED**     | Must be non-None, validated in `__post_init__` | `entity_id`, `content_hash`      |
+| **LINEAGE**      | System metadata for tracking                   | `run_id`, `ingestion_ts`         |
+| **API-OPTIONAL** | May be None (API-dependent)                    | `pchembl_value`, `target_name`   |
+| **COMPUTED**     | Derived from other fields                      | `pchembl_value` (log conversion) |
 
 ## Base Entity
 
@@ -26,81 +26,81 @@ BioETL entities follow these design principles:
 Base class containing system fields for lineage and versioning.
 
 ::: bioetl.domain.entities.BaseEntity
-    options:
-        show_root_heading: true
-        show_source: true
-        members:
-            - entity_id
-            - content_hash
-            - run_id
-            - run_type
-            - ingestion_ts
-            - source_batch_id
+options:
+show_root_heading: true
+show_source: true
+members:
+\- entity_id
+\- content_hash
+\- run_id
+\- run_type
+\- ingestion_ts
+\- source_batch_id
 
 ### RequiredEntityFields
 
 Protocol defining minimum required fields for all entities.
 
 ::: bioetl.domain.entities.RequiredEntityFields
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## ChEMBL Entities
 
-### Activity
+### Bioactivity
 
 Bioactivity measurement from ChEMBL database.
 
-::: bioetl.domain.entities.Activity
-    options:
-        show_root_heading: true
-        show_source: false
+::: bioetl.domain.entities.Bioactivity
+options:
+show_root_heading: true
+show_source: false
 
 ### Assay
 
 Experimental assay information.
 
 ::: bioetl.domain.entities.Assay
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### Molecule
 
 Chemical compound structure.
 
 ::: bioetl.domain.entities.Molecule
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### Target
 
 Biological target (protein, gene, etc.).
 
 ::: bioetl.domain.entities.Target
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ### TargetComponent
 
 Component of a complex biological target.
 
 ::: bioetl.domain.entities.TargetComponent
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
-### Document
+### ChemblPublication
 
 Publication or patent reference.
 
-::: bioetl.domain.entities.Document
-    options:
-        show_root_heading: true
-        show_source: false
+::: bioetl.domain.entities.ChemblPublication
+options:
+show_root_heading: true
+show_source: false
 
 ## PubChem Entities
 
@@ -109,9 +109,9 @@ Publication or patent reference.
 PubChem compound with chemical properties.
 
 ::: bioetl.domain.entities.Compound
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## PubMed Entities
 
@@ -120,9 +120,9 @@ PubChem compound with chemical properties.
 Scientific publication metadata.
 
 ::: bioetl.domain.entities.Publication
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## UniProt Entities
 
@@ -131,20 +131,20 @@ Scientific publication metadata.
 UniProt protein entry.
 
 ::: bioetl.domain.entities.Protein
-    options:
-        show_root_heading: true
-        show_source: false
+options:
+show_root_heading: true
+show_source: false
 
 ## Usage Example
 
 ```python
-from bioetl.domain.entities import Activity, BaseEntity
+from bioetl.domain.entities import Bioactivity, BaseEntity
 from bioetl.domain.types import RunType, RunID, ContentHash
 from datetime import datetime
 from uuid import uuid4
 
 # Create an activity entity
-activity = Activity(
+activity = Bioactivity(
     entity_id="CHEMBL12345",
     content_hash=ContentHash("sha256:abc123..."),
     run_id=RunID(uuid4()),
@@ -160,6 +160,7 @@ activity = Activity(
 
 # Check required fields protocol
 from bioetl.domain.entities import RequiredEntityFields
+
 assert isinstance(activity, RequiredEntityFields)
 ```
 

--- a/docs/04-reference/api/infrastructure.md
+++ b/docs/04-reference/api/infrastructure.md
@@ -21,7 +21,7 @@ flowchart TB
         end
 
         subgraph Observability["Observability"]
-            Metrics[MetricsExporter]
+            Metrics[PrometheusMetrics]
             Tracing[NoOpTracing]
             Logging[StructlogLogger]
         end
@@ -57,10 +57,10 @@ Data source adapters implementing `DataSourcePort`:
 Storage writers implementing `StoragePort`:
 
 - `BronzeWriter` - JSONL + zstd compression
-- `SilverWriter` - Delta Lake Silver layer (formerly DeltaWriter)
+- `SilverWriter` - Delta Lake Silver layer
 - `GoldWriter` - Delta Lake Gold layer with SCD Type 2
 
-> **Note**: `DeltaWriter` is deprecated and will be removed after a 14-day deprecation period. Use `SilverWriter` instead.
+> **Note**: Функциональность перенесена в SilverWriter и GoldWriter.
 
 ### [Observability](infrastructure/observability.md)
 
@@ -69,7 +69,6 @@ Observability infrastructure:
 - `PrometheusMetrics` - Prometheus metrics exporter
 - `NoOpTracing` - Null Object Pattern tracing (see [ADR-022](../../02-architecture/decisions/ADR-022-tracing-noop.md))
 - `StructlogLogger` - Structured logging
-- `LineageTracker` - Data lineage tracking
 
 #### Tracing (NoOp)
 
@@ -86,15 +85,15 @@ class in `tracing.py` provides a ready implementation.
 
 ### Adapters vs Ports
 
-| Domain Port | Infrastructure Adapter |
-|-------------|----------------------|
-| `DataSourcePort` | `ChemblAdapter`, `PubChemAdapter` |
-| `StoragePort` | `BronzeWriter`, `SilverWriter`, `GoldWriter` |
-| `LockPort` | `MemoryLock` |
-| `CheckpointPort` | `LocalCheckpoint` |
-| `MetricsPort` | `PrometheusMetrics`, `NoOpMetrics` |
-| `TracingPort` | `NoOpTracing`, `OpenTelemetryTracer` |
-| `LoggerPort` | `StructlogLogger`, `NoOpLogger` |
+| Domain Port      | Infrastructure Adapter                       |
+| ---------------- | -------------------------------------------- |
+| `DataSourcePort` | `ChemblAdapter`, `PubChemAdapter`            |
+| `StoragePort`    | `BronzeWriter`, `SilverWriter`, `GoldWriter` |
+| `LockPort`       | `MemoryLock`                                 |
+| `CheckpointPort` | `LocalCheckpoint`                            |
+| `MetricsPort`    | `PrometheusMetrics`, `NoOpMetrics`           |
+| `TracingPort`    | `NoOpTracing`, `OpenTelemetryTracer`         |
+| `LoggerPort`     | `StructlogLogger`, `NoOpLogger`              |
 
 ### Medallion Storage Layers
 
@@ -129,10 +128,12 @@ All HTTP adapters use `UnifiedHTTPClient` for consistent behavior:
 from bioetl.infrastructure.adapters.http import UnifiedHTTPClient
 
 client = UnifiedHTTPClient(
-    base_url="https://www.ebi.ac.uk/chembl/api/data",
-    rate_limit=5.0,  # requests per second
-    timeout=30.0,
-    max_retries=3,
+    rate_limiter=rate_limiter,
+    circuit_breaker=circuit_breaker,
+    retry_config=retry_config,
+    metrics=metrics,
+    logger=logger,
+    tracing=tracing,
 )
 ```
 
@@ -142,7 +143,7 @@ client = UnifiedHTTPClient(
 # Storage writers
 from bioetl.infrastructure.storage import (
     BronzeWriter,
-    SilverWriter,  # Preferred (was DeltaWriter)
+    SilverWriter,
     GoldWriter,
 )
 

--- a/docs/04-reference/api/infrastructure/unified-http-client.md
+++ b/docs/04-reference/api/infrastructure/unified-http-client.md
@@ -4,11 +4,12 @@
 **Version:** 5.14.0
 **Last updated:** 2026-02-10
 
----
+______________________________________________________________________
 
 ## Overview
 
 `UnifiedHTTPClient` provides a standardized HTTP client for all data source adapters. It encapsulates:
+
 - **Rate limiting** (provider-specific)
 - **Circuit breaker** (cascading failure prevention)
 - **Retry logic** (exponential backoff)
@@ -18,7 +19,7 @@ All API adapters **MUST** use `UnifiedHTTPClient` instead of direct `httpx` call
 
 **Related ADR:** [ADR-032: Unified HTTP Client Pattern](../../../02-architecture/decisions/ADR-032-unified-http-client.md)
 
----
+______________________________________________________________________
 
 ## Architecture
 
@@ -49,11 +50,11 @@ flowchart TB
 ### Design Principles
 
 1. **Composition over Inheritance:** Ports injected, not inherited
-2. **SRP Compliance:** Each concern (rate limit, circuit breaker, retry) is a separate component
-3. **Observability Built-in:** Tracing and metrics integrated via ports
-4. **Async-first:** Uses `httpx.AsyncClient` for async HTTP
+1. **SRP Compliance:** Each concern (rate limit, circuit breaker, retry) is a separate component
+1. **Observability Built-in:** Tracing and metrics integrated via ports
+1. **Async-first:** Uses `httpx.AsyncClient` for async HTTP
 
----
+______________________________________________________________________
 
 ## Basic Usage
 
@@ -93,7 +94,7 @@ response = await client.post(
 )
 ```
 
----
+______________________________________________________________________
 
 ## Rate Limiting
 
@@ -101,15 +102,15 @@ response = await client.post(
 
 Each provider has different rate limit policies:
 
-| Provider | Limit | Implementation |
-|----------|-------|----------------|
-| **ChEMBL** | None | `NoOpRateLimiter` |
-| **PubChem** | 5 req/sec | `TokenBucketLimiter(rate=5.0)` |
-| **UniProt** | 100 req/sec | `TokenBucketLimiter(rate=100.0)` |
-| **PubMed** | 3 req/sec (no key) | `TokenBucketLimiter(rate=3.0)` |
-| **CrossRef** | Polite pool (50 req/sec) | `TokenBucketLimiter(rate=50.0)` |
-| **OpenAlex** | ~10 req/sec | `TokenBucketLimiter(rate=10.0)` |
-| **Semantic Scholar** | 100 req/5min | `SlidingWindowLimiter(100, window=300)` |
+| Provider             | Limit                    | Implementation                          |
+| -------------------- | ------------------------ | --------------------------------------- |
+| **ChEMBL**           | None                     | `NoOpRateLimiter`                       |
+| **PubChem**          | 5 req/sec                | `TokenBucketLimiter(rate=5.0)`          |
+| **UniProt**          | 100 req/sec              | `TokenBucketLimiter(rate=100.0)`        |
+| **PubMed**           | 3 req/sec (no key)       | `TokenBucketLimiter(rate=3.0)`          |
+| **CrossRef**         | Polite pool (50 req/sec) | `TokenBucketLimiter(rate=50.0)`         |
+| **OpenAlex**         | ~10 req/sec              | `TokenBucketLimiter(rate=10.0)`         |
+| **Semantic Scholar** | 100 req/5min             | `SlidingWindowLimiter(100, window=300)` |
 
 ### Token Bucket Example
 
@@ -171,7 +172,7 @@ The client automatically respects standard rate limit headers:
 # 3. Wait until reset time if limit exceeded
 ```
 
----
+______________________________________________________________________
 
 ## Circuit Breaker
 
@@ -180,12 +181,12 @@ The client automatically respects standard rate limit headers:
 ### Configuration
 
 ```python
-from bioetl.infrastructure.adapters.circuit_breaker import SimpleCircuitBreaker
+from bioetl.infrastructure.adapters.circuit_breaker import CircuitBreaker
 
-circuit_breaker = SimpleCircuitBreaker(
-    failure_threshold=5,      # Open after 5 consecutive failures
-    success_threshold=2,      # Close after 2 consecutive successes in half-open
-    timeout_seconds=60,       # Try again after 60 seconds
+circuit_breaker = CircuitBreaker(
+    failure_threshold=5,  # Open after 5 consecutive failures
+    success_threshold=2,  # Close after 2 consecutive successes in half-open
+    timeout_seconds=60,  # Try again after 60 seconds
     logger=logger,
     metrics=metrics,
 )
@@ -209,10 +210,10 @@ stateDiagram-v2
     Closed --> Closed: success
 ```
 
-| State | Behavior |
-|-------|----------|
-| **Closed** | Normal operation, all requests pass through |
-| **Open** | Circuit breaker tripped, all requests fail fast |
+| State         | Behavior                                               |
+| ------------- | ------------------------------------------------------ |
+| **Closed**    | Normal operation, all requests pass through            |
+| **Open**      | Circuit breaker tripped, all requests fail fast        |
 | **Half-Open** | Testing if service recovered, limited requests allowed |
 
 ### Exception Types
@@ -228,7 +229,7 @@ except CircuitBreakerOpenError:
     # Fail gracefully or use fallback
 ```
 
----
+______________________________________________________________________
 
 ## Retry Logic
 
@@ -238,10 +239,10 @@ except CircuitBreakerOpenError:
 from bioetl.domain.models.retry_config import RetryConfig
 
 retry_config = RetryConfig(
-    max_attempts=5,       # Maximum 5 attempts total
-    base_delay=1.0,       # Start with 1 second delay
-    max_delay=60.0,       # Cap delay at 60 seconds
-    backoff_factor=2.0,   # Double delay each retry
+    max_attempts=5,  # Maximum 5 attempts total
+    base_delay=1.0,  # Start with 1 second delay
+    max_delay=60.0,  # Cap delay at 60 seconds
+    backoff_factor=2.0,  # Double delay each retry
 )
 
 client = UnifiedHTTPClient(
@@ -257,12 +258,14 @@ client = UnifiedHTTPClient(
 ### Retry Strategy
 
 **Retryable errors:**
+
 - HTTP 429 (Rate Limit)
 - HTTP 500, 502, 503, 504 (Server errors)
 - Network errors (`httpx.NetworkError`)
 - Timeout errors (`httpx.TimeoutException`)
 
 **Non-retryable errors:**
+
 - HTTP 400, 401, 403, 404 (Client errors)
 - HTTP 422 (Unprocessable Entity)
 - JSON decode errors
@@ -279,7 +282,7 @@ except httpx.HTTPStatusError as e:
         logger.error("API server error after retries", exc_info=e)
 ```
 
----
+______________________________________________________________________
 
 ## Observability Integration
 
@@ -340,7 +343,7 @@ All HTTP operations are logged with structured context:
 }
 ```
 
----
+______________________________________________________________________
 
 ## Error Handling
 
@@ -365,6 +368,7 @@ from bioetl.domain.exceptions import (
     RateLimitExceededError,
 )
 import httpx
+
 
 async def fetch_with_error_handling(client: UnifiedHTTPClient, url: str):
     try:
@@ -400,7 +404,7 @@ async def fetch_with_error_handling(client: UnifiedHTTPClient, url: str):
         raise
 ```
 
----
+______________________________________________________________________
 
 ## Testing
 
@@ -411,16 +415,19 @@ import pytest
 import httpx
 import respx
 
+
 @respx.mock
 async def test_unified_http_client_retry():
     """Test retry logic with mocked responses."""
     # First two attempts fail, third succeeds
     route = respx.get("https://api.example.com/data")
-    route.mock(side_effect=[
-        httpx.Response(503),
-        httpx.Response(503),
-        httpx.Response(200, json={"result": "success"}),
-    ])
+    route.mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(200, json={"result": "success"}),
+        ]
+    )
 
     client = UnifiedHTTPClient(
         base_url="https://api.example.com",
@@ -443,6 +450,7 @@ async def test_unified_http_client_retry():
 import pytest
 import vcr
 
+
 @pytest.mark.vcr(cassette_library_dir="tests/fixtures/vcr/chembl")
 async def test_chembl_activity_fetch_real():
     """Test with recorded HTTP interactions."""
@@ -457,7 +465,7 @@ async def test_chembl_activity_fetch_real():
     assert "activities" in data
 ```
 
----
+______________________________________________________________________
 
 ## Configuration via YAML
 
@@ -484,13 +492,15 @@ http_config:
 
 **Note:** See [ADR-032 Configuration](../../../02-architecture/decisions/ADR-032-unified-http-client.md#configuration) for full schema.
 
----
+______________________________________________________________________
 
 ## Migration from Direct httpx
 
 **Before (legacy):**
+
 ```python
 import httpx
+
 
 async def fetch_data():
     async with httpx.AsyncClient() as client:
@@ -499,8 +509,10 @@ async def fetch_data():
 ```
 
 **After (unified):**
+
 ```python
 from bioetl.infrastructure.adapters.http import UnifiedHTTPClient
+
 
 class MyAdapter:
     def __init__(self, http_client: UnifiedHTTPClient):
@@ -512,13 +524,14 @@ class MyAdapter:
 ```
 
 **Benefits:**
+
 - ✅ Automatic rate limiting
 - ✅ Circuit breaker protection
 - ✅ Standardized retry logic
 - ✅ Built-in observability
 - ✅ Testability with NoOp implementations
 
----
+______________________________________________________________________
 
 ## See Also
 

--- a/docs/04-reference/pipelines/chembl/01-protein-class-spec.md
+++ b/docs/04-reference/pipelines/chembl/01-protein-class-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Protein Classification Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_protein_class` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | protein_class |
+| Parameter        | Value                                                 |
+| ---------------- | ----------------------------------------------------- |
+| **Pipeline ID**  | `chembl_protein_class`                                |
+| **Provider**     | ChEMBL (EBI)                                          |
+| **Entity**       | protein_class                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/protein_class` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                           |
+| **Rate Limit**   | None (polite usage recommended)                       |
+| **Health Check** | `/chembl/api/data/status`                             |
+| **Auth Type**    | None (public API)                                     |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -33,8 +33,8 @@ Protein Classification represents a **hierarchical taxonomy** of protein familie
 ### 2.2. Use Cases
 
 1. **Target Class Distribution**: Analyze which protein families have the most bioactivity data
-2. **Drug Target Identification**: Find unexplored protein classes for novel therapeutics
-3. **Hierarchical Queries**: Navigate from broad classes (Enzyme) to specific subfamilies (Kinase → Tyrosine Kinase → EGFR)
+1. **Drug Target Identification**: Find unexplored protein classes for novel therapeutics
+1. **Hierarchical Queries**: Navigate from broad classes (Enzyme) to specific subfamilies (Kinase → Tyrosine Kinase → EGFR)
 
 ### 2.3. Entity Relationships
 
@@ -50,15 +50,15 @@ protein_class (self-referential hierarchy)
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `full` (reference table) |
-| **Watermark Field** | N/A |
-| **Full Load Frequency** | On demand or weekly |
-| **Estimated Volume** | ~1,500 records |
-| **Batch Size** | 500 |
+| Parameter               | Value                    |
+| ----------------------- | ------------------------ |
+| **Strategy**            | `full` (reference table) |
+| **Watermark Field**     | N/A                      |
+| **Full Load Frequency** | On demand or weekly      |
+| **Estimated Volume**    | ~1,500 records           |
+| **Batch Size**          | 500                      |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -68,67 +68,69 @@ protein_class (self-referential hierarchy)
 from chembl_webresource_client.new_client import new_client
 
 protein_class = new_client.protein_class
-results = protein_class.filter().only([
-    'protein_class_id',
-    'parent_id',
-    'pref_name',
-    'short_name',
-    'protein_class_desc',
-    'definition',
-    'class_level',
-    'sort_order',
-    'downgraded',
-    'replaced_by'
-])
+results = protein_class.filter().only(
+    [
+        "protein_class_id",
+        "parent_id",
+        "pref_name",
+        "short_name",
+        "protein_class_desc",
+        "definition",
+        "class_level",
+        "sort_order",
+        "downgraded",
+        "replaced_by",
+    ]
+)
 ```
 
 ### 3.2. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Description | Example Value |
-|---|-----------|-----------|----------|-------------|---------------|
-| 1 | `protein_class_id` | integer | No | Primary key (internal ID) | `1` |
-| 2 | `parent_id` | integer | Yes | FK to parent classification | `null`, `1` |
-| 3 | `pref_name` | string | Yes | Preferred name | `"Kinase"` |
-| 4 | `short_name` | string | Yes | Short name | `"Kin"` |
-| 5 | `protein_class_desc` | string | Yes | Full description | `"Protein kinases"` |
-| 6 | `definition` | string | Yes | Definition text | `"Enzymes that phosphorylate..."` |
-| 7 | `class_level` | integer | Yes | Level in hierarchy (1-8) | `1`, `2`, `3` |
-| 8 | `sort_order` | integer | Yes | Display sort order | `100` |
-| 9 | `downgraded` | integer | Yes | Deprecated flag (0/1) | `0` |
-| 10 | `replaced_by` | integer | Yes | FK to replacement record | `null`, `456` |
+| #   | API Field            | JSON Type | Nullable | Description                 | Example Value                     |
+| --- | -------------------- | --------- | -------- | --------------------------- | --------------------------------- |
+| 1   | `protein_class_id`   | integer   | No       | Primary key (internal ID)   | `1`                               |
+| 2   | `parent_id`          | integer   | Yes      | FK to parent classification | `null`, `1`                       |
+| 3   | `pref_name`          | string    | Yes      | Preferred name              | `"Kinase"`                        |
+| 4   | `short_name`         | string    | Yes      | Short name                  | `"Kin"`                           |
+| 5   | `protein_class_desc` | string    | Yes      | Full description            | `"Protein kinases"`               |
+| 6   | `definition`         | string    | Yes      | Definition text             | `"Enzymes that phosphorylate..."` |
+| 7   | `class_level`        | integer   | Yes      | Level in hierarchy (1-8)    | `1`, `2`, `3`                     |
+| 8   | `sort_order`         | integer   | Yes      | Display sort order          | `100`                             |
+| 9   | `downgraded`         | integer   | Yes      | Deprecated flag (0/1)       | `0`                               |
+| 10  | `replaced_by`        | integer   | Yes      | FK to replacement record    | `null`, `456`                     |
 
 ### 3.3. Excluded Fields
 
-| Field | Reason |
-|-------|--------|
-| N/A | All fields are included |
+| Field | Reason                  |
+| ----- | ----------------------- |
+| N/A   | All fields are included |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `protein_class_id` |
-| **ID Source** | `from_api` |
-| **Format** | Integer (cast to string for entity_id) |
+| Parameter           | Value                                  |
+| ------------------- | -------------------------------------- |
+| **Entity ID Field** | `protein_class_id`                     |
+| **ID Source**       | `from_api`                             |
+| **Format**          | Integer (cast to string for entity_id) |
 
 ### 4.2. Field Normalization
 
-| Field | Normalization | Before | After |
-|-------|---------------|--------|-------|
-| `protein_class_id` | Cast to int | `"1"` | `1` |
-| `parent_id` | Cast to int or None | `"null"` | `None` |
-| `pref_name` | strip() | `" Kinase "` | `"Kinase"` |
-| `short_name` | strip() | `" Kin "` | `"Kin"` |
-| `protein_class_desc` | strip() | - | - |
-| `definition` | strip() | - | - |
-| `class_level` | Cast to int | `"1"` | `1` |
-| `sort_order` | Cast to int | `"100"` | `100` |
-| `downgraded` | Cast to int (0/1) | `"0"` | `0` |
-| `replaced_by` | Cast to int or None | `"null"` | `None` |
+| Field                | Normalization       | Before       | After      |
+| -------------------- | ------------------- | ------------ | ---------- |
+| `protein_class_id`   | Cast to int         | `"1"`        | `1`        |
+| `parent_id`          | Cast to int or None | `"null"`     | `None`     |
+| `pref_name`          | strip()             | `" Kinase "` | `"Kinase"` |
+| `short_name`         | strip()             | `" Kin "`    | `"Kin"`    |
+| `protein_class_desc` | strip()             | -            | -          |
+| `definition`         | strip()             | -            | -          |
+| `class_level`        | Cast to int         | `"1"`        | `1`        |
+| `sort_order`         | Cast to int         | `"100"`      | `100`      |
+| `downgraded`         | Cast to int (0/1)   | `"0"`        | `0`        |
+| `replaced_by`        | Cast to int or None | `"null"`     | `None`     |
 
 ### 4.3. Content Hash Specification
 
@@ -154,7 +156,7 @@ excluded = ["_ingestion_ts", "_run_id", "_run_type", "_dq_*"]
 content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
 ```
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -172,47 +174,31 @@ class ProteinClassificationSchema(ETLRecordSchema):
     """Protein Classification validation schema for Silver layer."""
 
     # === Primary Key ===
-    protein_class_id: Series[int] = pa.Field(
-        nullable=False,
-        description="Primary key."
-    )
+    protein_class_id: Series[int] = pa.Field(nullable=False, description="Primary key.")
 
     # === Foreign Keys ===
     parent_id: Series[int] | None = pa.Field(
-        nullable=True,
-        description="FK to parent classification."
+        nullable=True, description="FK to parent classification."
     )
     replaced_by: Series[int] | None = pa.Field(
-        nullable=True,
-        description="FK to replacement classification."
+        nullable=True, description="FK to replacement classification."
     )
 
     # === Metadata ===
     pref_name: Series[str] | None = pa.Field(
-        nullable=True,
-        description="Preferred name."
+        nullable=True, description="Preferred name."
     )
-    short_name: Series[str] | None = pa.Field(
-        nullable=True,
-        description="Short name."
-    )
+    short_name: Series[str] | None = pa.Field(nullable=True, description="Short name.")
     protein_class_desc: Series[str] | None = pa.Field(
-        nullable=True,
-        description="Description."
+        nullable=True, description="Description."
     )
-    definition: Series[str] | None = pa.Field(
-        nullable=True,
-        description="Definition."
-    )
+    definition: Series[str] | None = pa.Field(nullable=True, description="Definition.")
     class_level: Series[int] | None = pa.Field(
         nullable=True,
         ge=1,
         description="Class level.",
     )
-    sort_order: Series[int] | None = pa.Field(
-        nullable=True,
-        description="Sort order."
-    )
+    sort_order: Series[int] | None = pa.Field(nullable=True, description="Sort order.")
 
     # === Flags ===
     downgraded: Series[int] | None = pa.Field(
@@ -229,53 +215,53 @@ class ProteinClassificationSchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
-|-------|------|----------|-------------|----------|----------------|
-| `protein_class_id` | int | No | >= 1 | CRITICAL | Quarantine |
-| `parent_id` | int | Yes | >= 1 or None | WARNING | Log |
-| `replaced_by` | int | Yes | >= 1 or None | WARNING | Log |
-| `pref_name` | str | Yes | - | INFO | Log |
-| `short_name` | str | Yes | - | INFO | Log |
-| `protein_class_desc` | str | Yes | - | INFO | Log |
-| `definition` | str | Yes | - | INFO | Log |
-| `class_level` | int | Yes | >= 1 | WARNING | Log |
-| `sort_order` | int | Yes | - | INFO | Log |
-| `downgraded` | int | Yes | isin [0, 1] | WARNING | Log |
+| Field                | Type | Nullable | Constraints  | DQ Level | Failure Action |
+| -------------------- | ---- | -------- | ------------ | -------- | -------------- |
+| `protein_class_id`   | int  | No       | >= 1         | CRITICAL | Quarantine     |
+| `parent_id`          | int  | Yes      | >= 1 or None | WARNING  | Log            |
+| `replaced_by`        | int  | Yes      | >= 1 or None | WARNING  | Log            |
+| `pref_name`          | str  | Yes      | -            | INFO     | Log            |
+| `short_name`         | str  | Yes      | -            | INFO     | Log            |
+| `protein_class_desc` | str  | Yes      | -            | INFO     | Log            |
+| `definition`         | str  | Yes      | -            | INFO     | Log            |
+| `class_level`        | int  | Yes      | >= 1         | WARNING  | Log            |
+| `sort_order`         | int  | Yes      | -            | INFO     | Log            |
+| `downgraded`         | int  | Yes      | isin [0, 1]  | WARNING  | Log            |
 
 ### 5.3. Cross-Field Validation Rules
 
-| Rule Name | Fields | Condition | Failure Action |
-|-----------|--------|-----------|----------------|
-| `parent_self_ref` | `parent_id`, `protein_class_id` | parent_id != protein_class_id | Quarantine |
-| `replaced_inactive` | `downgraded`, `replaced_by` | downgraded=1 implies replaced_by is set | Warning |
+| Rule Name           | Fields                          | Condition                               | Failure Action |
+| ------------------- | ------------------------------- | --------------------------------------- | -------------- |
+| `parent_self_ref`   | `parent_id`, `protein_class_id` | parent_id != protein_class_id           | Quarantine     |
+| `replaced_inactive` | `downgraded`, `replaced_by`     | downgraded=1 implies replaced_by is set | Warning        |
 
 ### 5.4. DQ Thresholds
 
-| Threshold | Value | Action |
-|-----------|-------|--------|
-| Soft | 5% | Warning, continue |
-| Hard | 20% | Fail batch |
-| Critical field null | Any protein_class_id is null | Fail immediately |
+| Threshold           | Value                        | Action            |
+| ------------------- | ---------------------------- | ----------------- |
+| Soft                | 5%                           | Warning, continue |
+| Hard                | 20%                          | Fail batch        |
+| Critical field null | Any protein_class_id is null | Fail immediately  |
 
----
+______________________________________________________________________
 
 ## 6. Metadata Fields (RULES.md §2.4)
 
 All records contain:
 
-| Field | Type | Source | In Hash |
-|-------|------|--------|---------|
-| `entity_id` | str | protein_class_id (cast) | N/A |
-| `content_hash` | str | Computed | N/A |
-| `_run_id` | UUID | Generated | No |
-| `_run_type` | Enum | Config | No |
-| `_source_batch_id` | UUID | Generated | No |
-| `_ingestion_ts` | datetime | Generated (UTC) | No |
-| `_dq_warn` | bool | Validation | No |
-| `_dq_error` | bool | Validation | No |
-| `_index` | int | Generated | No |
+| Field              | Type     | Source                  | In Hash |
+| ------------------ | -------- | ----------------------- | ------- |
+| `entity_id`        | str      | protein_class_id (cast) | N/A     |
+| `content_hash`     | str      | Computed                | N/A     |
+| `_run_id`          | UUID     | Generated               | No      |
+| `_run_type`        | Enum     | Config                  | No      |
+| `_source_batch_id` | UUID     | Generated               | No      |
+| `_ingestion_ts`    | datetime | Generated (UTC)         | No      |
+| `_dq_warn`         | bool     | Validation              | No      |
+| `_dq_error`        | bool     | Validation              | No      |
+| `_index`           | int      | Generated               | No      |
 
----
+______________________________________________________________________
 
 ## 7. Output Schemas
 
@@ -301,27 +287,27 @@ VACUUM: Weekly, 7 days retention
 
 **Silver Schema Table:**
 
-| # | Column | Type | Nullable | Description |
-|---|--------|------|----------|-------------|
-| 1 | `entity_id` | string | No | = protein_class_id |
-| 2 | `content_hash` | string | No | SHA256 hash |
-| 3 | `protein_class_id` | int | No | PK |
-| 4 | `parent_id` | int | Yes | FK to parent |
-| 5 | `replaced_by` | int | Yes | FK to replacement |
-| 6 | `pref_name` | string | Yes | Preferred name |
-| 7 | `short_name` | string | Yes | Short name |
-| 8 | `protein_class_desc` | string | Yes | Description |
-| 9 | `definition` | string | Yes | Definition |
-| 10 | `class_level` | int | Yes | Hierarchy level |
-| 11 | `sort_order` | int | Yes | Sort order |
-| 12 | `downgraded` | int | Yes | Deprecated flag |
-| 13 | `_run_id` | uuid | No | Pipeline run ID |
-| 14 | `_run_type` | string | No | Run type |
-| 15 | `_source_batch_id` | uuid | Yes | Batch context |
-| 16 | `_ingestion_ts` | timestamp | No | Ingestion time |
-| 17 | `_dq_warn` | bool | No | DQ warning flag |
-| 18 | `_dq_error` | bool | No | DQ error flag |
-| 19 | `_index` | int | No | Record index |
+| #   | Column               | Type      | Nullable | Description        |
+| --- | -------------------- | --------- | -------- | ------------------ |
+| 1   | `entity_id`          | string    | No       | = protein_class_id |
+| 2   | `content_hash`       | string    | No       | SHA256 hash        |
+| 3   | `protein_class_id`   | int       | No       | PK                 |
+| 4   | `parent_id`          | int       | Yes      | FK to parent       |
+| 5   | `replaced_by`        | int       | Yes      | FK to replacement  |
+| 6   | `pref_name`          | string    | Yes      | Preferred name     |
+| 7   | `short_name`         | string    | Yes      | Short name         |
+| 8   | `protein_class_desc` | string    | Yes      | Description        |
+| 9   | `definition`         | string    | Yes      | Definition         |
+| 10  | `class_level`        | int       | Yes      | Hierarchy level    |
+| 11  | `sort_order`         | int       | Yes      | Sort order         |
+| 12  | `downgraded`         | int       | Yes      | Deprecated flag    |
+| 13  | `_run_id`            | uuid      | No       | Pipeline run ID    |
+| 14  | `_run_type`          | string    | No       | Run type           |
+| 15  | `_source_batch_id`   | uuid      | Yes      | Batch context      |
+| 16  | `_ingestion_ts`      | timestamp | No       | Ingestion time     |
+| 17  | `_dq_warn`           | bool      | No       | DQ warning flag    |
+| 18  | `_dq_error`          | bool      | No       | DQ error flag      |
+| 19  | `_index`             | int       | No       | Record index       |
 
 ### 7.3. Gold
 
@@ -333,45 +319,45 @@ Mode: Overwrite (reference table)
 
 **Gold Filter:** `downgraded = 0` AND `pref_name IS NOT NULL`
 
----
+______________________________________________________________________
 
 ## 8. Quarantine Handling
 
 ### 8.1. Error Codes
 
-| Code | Description | Typical Cause |
-|------|-------------|---------------|
-| `NULL_REQUIRED_PROTEIN_CLASS_ID` | PK is null | Source data issue |
-| `INVALID_CLASS_LEVEL` | class_level < 1 | Schema violation |
-| `SELF_REFERENTIAL_PARENT` | parent_id = protein_class_id | Data integrity issue |
-| `INVALID_DOWNGRADED` | downgraded not in [0,1] | API change |
+| Code                             | Description                  | Typical Cause        |
+| -------------------------------- | ---------------------------- | -------------------- |
+| `NULL_REQUIRED_PROTEIN_CLASS_ID` | PK is null                   | Source data issue    |
+| `INVALID_CLASS_LEVEL`            | class_level < 1              | Schema violation     |
+| `SELF_REFERENTIAL_PARENT`        | parent_id = protein_class_id | Data integrity issue |
+| `INVALID_DOWNGRADED`             | downgraded not in [0,1]      | API change           |
 
 ### 8.2. Recovery Procedures
 
-| Error Code | Recovery |
-|------------|----------|
-| `NULL_REQUIRED_*` | Investigate source, skip record |
-| `INVALID_*` | Log warning, coerce to valid value |
+| Error Code        | Recovery                           |
+| ----------------- | ---------------------------------- |
+| `NULL_REQUIRED_*` | Investigate source, skip record    |
+| `INVALID_*`       | Log warning, coerce to valid value |
 
----
+______________________________________________________________________
 
 ## 9. Dependencies
 
 ### 9.1. Upstream
 
-| Dependency | Type | Required | Notes |
-|------------|------|----------|-------|
-| ChEMBL API | API | Yes | Source of truth |
+| Dependency | Type | Required | Notes           |
+| ---------- | ---- | -------- | --------------- |
+| ChEMBL API | API  | Yes      | Source of truth |
 
 ### 9.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
+| Consumer                  | Impact                                   |
+| ------------------------- | ---------------------------------------- |
 | `chembl_target_component` | FK reference for protein classifications |
-| `chembl_target` | Enrichment with protein class hierarchy |
-| Analytics dashboards | Target class distribution reports |
+| `chembl_target`           | Enrichment with protein class hierarchy  |
+| Analytics dashboards      | Target class distribution reports        |
 
----
+______________________________________________________________________
 
 ## 10. Pipeline Configuration
 
@@ -381,7 +367,7 @@ Mode: Overwrite (reference table)
 pipeline_name: chembl_protein_class
 provider: chembl
 entity_type: protein_class
-version: "1.1.0"
+version: "1.2.0"
 description: "ChEMBL Protein Classification hierarchy"
 
 primary_keys: ["protein_class_id"]
@@ -422,7 +408,7 @@ input_filter:
   enabled: false
 ```
 
----
+______________________________________________________________________
 
 ## 11. Testing Requirements
 
@@ -443,7 +429,7 @@ input_filter:
 - [x] Schema strict mode validation
 - [x] Layer import compliance
 
----
+______________________________________________________________________
 
 ## 12. Field Mapping CSV
 

--- a/docs/04-reference/pipelines/chembl/02-cell-line-spec.md
+++ b/docs/04-reference/pipelines/chembl/02-cell-line-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Cell Line Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_cell_line` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | cell_line |
+| Parameter        | Value                                             |
+| ---------------- | ------------------------------------------------- |
+| **Pipeline ID**  | `chembl_cell_line`                                |
+| **Provider**     | ChEMBL (EBI)                                      |
+| **Entity**       | cell_line                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/cell_line` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                       |
+| **Rate Limit**   | None (polite usage recommended)                   |
+| **Health Check** | `/chembl/api/data/status`                         |
+| **Auth Type**    | None (public API)                                 |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -33,9 +33,9 @@ Cell Lines represent **biological cell cultures** used in experimental assays. T
 ### 2.2. Use Cases
 
 1. **Assay Context Analysis**: Determine which cell lines are most commonly used for specific target types
-2. **Tissue-Specific Studies**: Filter bioactivity data by cell line tissue origin
-3. **Cross-Database Linking**: Map ChEMBL cell lines to Cellosaurus for detailed metadata
-4. **Species Selection**: Filter by organism (human, mouse, rat cell lines)
+1. **Tissue-Specific Studies**: Filter bioactivity data by cell line tissue origin
+1. **Cross-Database Linking**: Map ChEMBL cell lines to Cellosaurus for detailed metadata
+1. **Species Selection**: Filter by organism (human, mouse, rat cell lines)
 
 ### 2.3. Entity Relationships
 
@@ -49,15 +49,15 @@ cell_line
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `incremental` with input filter |
-| **Watermark Field** | N/A (filtered by input CSV) |
-| **Full Load Frequency** | On demand |
-| **Estimated Volume** | ~2,500 records total |
-| **Batch Size** | 20 (filter batch) |
+| Parameter               | Value                           |
+| ----------------------- | ------------------------------- |
+| **Strategy**            | `incremental` with input filter |
+| **Watermark Field**     | N/A (filtered by input CSV)     |
+| **Full Load Frequency** | On demand                       |
+| **Estimated Volume**    | ~2,500 records total            |
+| **Batch Size**          | 20 (filter batch)               |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -73,53 +73,53 @@ results = cell_line.filter(cell_chembl_id__in=chembl_ids)
 
 ### 3.2. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Description | Example Value |
-|---|-----------|-----------|----------|-------------|---------------|
-| 1 | `cell_chembl_id` | string | No | Primary key (ChEMBL ID) | `"CHEMBL3307641"` |
-| 2 | `cell_name` | string | No | Cell line name | `"HeLa"` |
-| 3 | `cell_description` | string | Yes | Description | `"Cervical adenocarcinoma"` |
-| 4 | `cell_source_tissue` | string | Yes | Source tissue | `"Cervix"` |
-| 5 | `cell_source_organism` | string | Yes | Source organism | `"Homo sapiens"` |
-| 6 | `cell_source_tax_id` | integer | Yes | NCBI Taxonomy ID | `9606` |
-| 7 | `cell_type` | string | Yes | Cell type classification | `"Cancer cell line"` |
-| 8 | `cellosaurus_id` | string | Yes | Cellosaurus ID | `"CVCL_0030"` |
-| 9 | `clo_id` | string | Yes | Cell Line Ontology ID | `"CLO_0002063"` |
-| 10 | `cl_lincs_id` | string | Yes | LINCS ID | `"LCL-1024"` |
-| 11 | `efo_id` | string | Yes | EFO ontology ID | `"EFO_0002067"` |
+| #   | API Field                 | JSON Type | Nullable | Description              | Example Value               |
+| --- | ------------------------- | --------- | -------- | ------------------------ | --------------------------- |
+| 1   | `cell_chembl_id`          | string    | No       | Primary key (ChEMBL ID)  | `"CHEMBL3307641"`           |
+| 2   | `cell_name`               | string    | No       | Cell line name           | `"HeLa"`                    |
+| 3   | `cell_description`        | string    | Yes      | Description              | `"Cervical adenocarcinoma"` |
+| 4   | `cell_source_tissue`      | string    | Yes      | Source tissue            | `"Cervix"`                  |
+| 5   | `cell_source_organism`    | string    | Yes      | Source organism          | `"Homo sapiens"`            |
+| 6   | `cell_source_taxonomy_id` | integer   | Yes      | NCBI Taxonomy ID         | `9606`                      |
+| 7   | `cell_type`               | string    | Yes      | Cell type classification | `"Cancer cell line"`        |
+| 8   | `cellosaurus_id`          | string    | Yes      | Cellosaurus ID           | `"CVCL_0030"`               |
+| 9   | `clo_id`                  | string    | Yes      | Cell Line Ontology ID    | `"CLO_0002063"`             |
+| 10  | `cl_lincs_id`             | string    | Yes      | LINCS ID                 | `"LCL-1024"`                |
+| 11  | `efo_id`                  | string    | Yes      | EFO ontology ID          | `"EFO_0002067"`             |
 
 ### 3.3. Excluded Fields
 
-| Field | Reason |
-|-------|--------|
-| N/A | All fields are included |
+| Field | Reason                  |
+| ----- | ----------------------- |
+| N/A   | All fields are included |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `cell_chembl_id` |
-| **ID Source** | `from_api` |
-| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+| Parameter           | Value                    |
+| ------------------- | ------------------------ |
+| **Entity ID Field** | `cell_chembl_id`         |
+| **ID Source**       | `from_api`               |
+| **Format**          | ChEMBL ID (CHEMBL[0-9]+) |
 
 ### 4.2. Field Normalization
 
-| Field | Normalization | Before | After |
-|-------|---------------|--------|-------|
-| `cell_chembl_id` | Validate regex | `"CHEMBL3307641"` | `"CHEMBL3307641"` |
-| `cell_name` | strip() | `" HeLa "` | `"HeLa"` |
-| `cell_description` | strip() | - | - |
-| `cell_source_tissue` | strip() | - | - |
-| `cell_source_organism` | strip() | - | - |
-| `cell_source_tax_id` | Cast to int | `"9606"` | `9606` |
-| `cell_type` | strip() | - | - |
-| `cellosaurus_id` | Validate regex | `"CVCL_0030"` | `"CVCL_0030"` |
-| `clo_id` | Validate regex | `"CLO_0002063"` | `"CLO_0002063"` |
-| `cl_lincs_id` | strip() | - | - |
-| `efo_id` | Validate regex | `"EFO_0002067"` | `"EFO_0002067"` |
+| Field                     | Normalization  | Before            | After             |
+| ------------------------- | -------------- | ----------------- | ----------------- |
+| `cell_chembl_id`          | Validate regex | `"CHEMBL3307641"` | `"CHEMBL3307641"` |
+| `cell_name`               | strip()        | `" HeLa "`        | `"HeLa"`          |
+| `cell_description`        | strip()        | -                 | -                 |
+| `cell_source_tissue`      | strip()        | -                 | -                 |
+| `cell_source_organism`    | strip()        | -                 | -                 |
+| `cell_source_taxonomy_id` | Cast to int    | `"9606"`          | `9606`            |
+| `cell_type`               | strip()        | -                 | -                 |
+| `cellosaurus_id`          | Validate regex | `"CVCL_0030"`     | `"CVCL_0030"`     |
+| `clo_id`                  | Validate regex | `"CLO_0002063"`   | `"CLO_0002063"`   |
+| `cl_lincs_id`             | strip()        | -                 | -                 |
+| `efo_id`                  | Validate regex | `"EFO_0002067"`   | `"EFO_0002067"`   |
 
 ### 4.3. Content Hash Specification
 
@@ -130,7 +130,7 @@ hash_fields = [
     "cell_description",
     "cell_name",
     "cell_source_organism",
-    "cell_source_tax_id",
+    "cell_source_taxonomy_id",
     "cell_source_tissue",
     "cell_type",
     "cellosaurus_id",
@@ -146,7 +146,7 @@ excluded = ["_ingestion_ts", "_run_id", "_run_type", "_dq_*"]
 content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
 ```
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -190,7 +190,7 @@ class CellLineSchema(ETLRecordSchema):
         nullable=True,
         description="Source organism (e.g., Homo sapiens).",
     )
-    cell_source_tax_id: Series[int] | None = pa.Field(
+    cell_source_taxonomy_id: Series[int] | None = pa.Field(
         nullable=True,
         ge=1,
         description="NCBI Taxonomy ID for source organism.",
@@ -231,53 +231,53 @@ class CellLineSchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
-|-------|------|----------|-------------|----------|----------------|
-| `cell_chembl_id` | str | No | regex `^CHEMBL\d+$`, unique | CRITICAL | Quarantine |
-| `cell_name` | str | No | - | CRITICAL | Quarantine |
-| `cell_description` | str | Yes | - | INFO | Log |
-| `cell_source_tissue` | str | Yes | - | INFO | Log |
-| `cell_source_organism` | str | Yes | - | INFO | Log |
-| `cell_source_tax_id` | int | Yes | >= 1 | WARNING | Log |
-| `cell_type` | str | Yes | - | INFO | Log |
-| `cellosaurus_id` | str | Yes | regex `^CVCL_[A-Z0-9]+$` | WARNING | Log |
-| `clo_id` | str | Yes | regex `^CLO_\d+$` | WARNING | Log |
-| `cl_lincs_id` | str | Yes | - | INFO | Log |
-| `efo_id` | str | Yes | regex `^EFO_\d+$` | WARNING | Log |
+| Field                     | Type | Nullable | Constraints                 | DQ Level | Failure Action |
+| ------------------------- | ---- | -------- | --------------------------- | -------- | -------------- |
+| `cell_chembl_id`          | str  | No       | regex `^CHEMBL\d+$`, unique | CRITICAL | Quarantine     |
+| `cell_name`               | str  | No       | -                           | CRITICAL | Quarantine     |
+| `cell_description`        | str  | Yes      | -                           | INFO     | Log            |
+| `cell_source_tissue`      | str  | Yes      | -                           | INFO     | Log            |
+| `cell_source_organism`    | str  | Yes      | -                           | INFO     | Log            |
+| `cell_source_taxonomy_id` | int  | Yes      | >= 1                        | WARNING  | Log            |
+| `cell_type`               | str  | Yes      | -                           | INFO     | Log            |
+| `cellosaurus_id`          | str  | Yes      | regex `^CVCL_[A-Z0-9]+$`    | WARNING  | Log            |
+| `clo_id`                  | str  | Yes      | regex `^CLO_\d+$`           | WARNING  | Log            |
+| `cl_lincs_id`             | str  | Yes      | -                           | INFO     | Log            |
+| `efo_id`                  | str  | Yes      | regex `^EFO_\d+$`           | WARNING  | Log            |
 
 ### 5.3. Cross-Field Validation Rules
 
-| Rule Name | Fields | Condition | Failure Action |
-|-----------|--------|-----------|----------------|
-| `tax_id_organism_consistency` | `cell_source_tax_id`, `cell_source_organism` | If tax_id=9606, organism should contain "sapiens" | Warning |
+| Rule Name                     | Fields                                            | Condition                                         | Failure Action |
+| ----------------------------- | ------------------------------------------------- | ------------------------------------------------- | -------------- |
+| `tax_id_organism_consistency` | `cell_source_taxonomy_id`, `cell_source_organism` | If tax_id=9606, organism should contain "sapiens" | Warning        |
 
 ### 5.4. DQ Thresholds
 
-| Threshold | Value | Action |
-|-----------|-------|--------|
-| Soft | 5% | Warning, continue |
-| Hard | 20% | Fail batch |
-| Critical field null | cell_chembl_id or cell_name is null | Fail immediately |
+| Threshold           | Value                               | Action            |
+| ------------------- | ----------------------------------- | ----------------- |
+| Soft                | 5%                                  | Warning, continue |
+| Hard                | 20%                                 | Fail batch        |
+| Critical field null | cell_chembl_id or cell_name is null | Fail immediately  |
 
----
+______________________________________________________________________
 
 ## 6. Metadata Fields (RULES.md §2.4)
 
 All records contain:
 
-| Field | Type | Source | In Hash |
-|-------|------|--------|---------|
-| `entity_id` | str | cell_chembl_id | N/A |
-| `content_hash` | str | Computed | N/A |
-| `_run_id` | UUID | Generated | No |
-| `_run_type` | Enum | Config | No |
-| `_source_batch_id` | UUID | Generated | No |
-| `_ingestion_ts` | datetime | Generated (UTC) | No |
-| `_dq_warn` | bool | Validation | No |
-| `_dq_error` | bool | Validation | No |
-| `_index` | int | Generated | No |
+| Field              | Type     | Source          | In Hash |
+| ------------------ | -------- | --------------- | ------- |
+| `entity_id`        | str      | cell_chembl_id  | N/A     |
+| `content_hash`     | str      | Computed        | N/A     |
+| `_run_id`          | UUID     | Generated       | No      |
+| `_run_type`        | Enum     | Config          | No      |
+| `_source_batch_id` | UUID     | Generated       | No      |
+| `_ingestion_ts`    | datetime | Generated (UTC) | No      |
+| `_dq_warn`         | bool     | Validation      | No      |
+| `_dq_error`        | bool     | Validation      | No      |
+| `_index`           | int      | Generated       | No      |
 
----
+______________________________________________________________________
 
 ## 7. Output Schemas
 
@@ -303,22 +303,22 @@ VACUUM: Weekly, 7 days retention
 
 **Silver Schema Table:**
 
-| # | Column | Type | Nullable | Description |
-|---|--------|------|----------|-------------|
-| 1 | `entity_id` | string | No | = cell_chembl_id |
-| 2 | `content_hash` | string | No | SHA256 hash |
-| 3 | `cell_chembl_id` | string | No | PK |
-| 4 | `cell_name` | string | No | Cell line name |
-| 5 | `cell_description` | string | Yes | Description |
-| 6 | `cell_source_tissue` | string | Yes | Source tissue |
-| 7 | `cell_source_organism` | string | Yes | Source organism |
-| 8 | `cell_source_tax_id` | int | Yes | NCBI Taxonomy ID |
-| 9 | `cell_type` | string | Yes | Cell type |
-| 10 | `cellosaurus_id` | string | Yes | Cellosaurus ID |
-| 11 | `clo_id` | string | Yes | CLO ID |
-| 12 | `cl_lincs_id` | string | Yes | LINCS ID |
-| 13 | `efo_id` | string | Yes | EFO ID |
-| 14-22 | System fields | various | various | See §6 |
+| #     | Column                    | Type    | Nullable | Description      |
+| ----- | ------------------------- | ------- | -------- | ---------------- |
+| 1     | `entity_id`               | string  | No       | = cell_chembl_id |
+| 2     | `content_hash`            | string  | No       | SHA256 hash      |
+| 3     | `cell_chembl_id`          | string  | No       | PK               |
+| 4     | `cell_name`               | string  | No       | Cell line name   |
+| 5     | `cell_description`        | string  | Yes      | Description      |
+| 6     | `cell_source_tissue`      | string  | Yes      | Source tissue    |
+| 7     | `cell_source_organism`    | string  | Yes      | Source organism  |
+| 8     | `cell_source_taxonomy_id` | int     | Yes      | NCBI Taxonomy ID |
+| 9     | `cell_type`               | string  | Yes      | Cell type        |
+| 10    | `cellosaurus_id`          | string  | Yes      | Cellosaurus ID   |
+| 11    | `clo_id`                  | string  | Yes      | CLO ID           |
+| 12    | `cl_lincs_id`             | string  | Yes      | LINCS ID         |
+| 13    | `efo_id`                  | string  | Yes      | EFO ID           |
+| 14-22 | System fields             | various | various  | See §6           |
 
 ### 7.3. Gold
 
@@ -330,53 +330,53 @@ Mode: Overwrite
 
 **Gold Filter:** `cell_name IS NOT NULL`
 
----
+______________________________________________________________________
 
 ## 8. Quarantine Handling
 
 ### 8.1. Error Codes
 
-| Code | Description | Typical Cause |
-|------|-------------|---------------|
-| `NULL_REQUIRED_CELL_CHEMBL_ID` | PK is null | Source data issue |
-| `NULL_REQUIRED_CELL_NAME` | Name is null | Incomplete record |
-| `INVALID_CHEMBL_ID_FORMAT` | ID doesn't match regex | API change |
-| `INVALID_CELLOSAURUS_ID` | Cellosaurus ID format invalid | Data quality issue |
+| Code                           | Description                   | Typical Cause      |
+| ------------------------------ | ----------------------------- | ------------------ |
+| `NULL_REQUIRED_CELL_CHEMBL_ID` | PK is null                    | Source data issue  |
+| `NULL_REQUIRED_CELL_NAME`      | Name is null                  | Incomplete record  |
+| `INVALID_CHEMBL_ID_FORMAT`     | ID doesn't match regex        | API change         |
+| `INVALID_CELLOSAURUS_ID`       | Cellosaurus ID format invalid | Data quality issue |
 
 ### 8.2. Recovery Procedures
 
-| Error Code | Recovery |
-|------------|----------|
+| Error Code        | Recovery                        |
+| ----------------- | ------------------------------- |
 | `NULL_REQUIRED_*` | Investigate source, skip record |
-| `INVALID_*` | Log warning, set field to null |
+| `INVALID_*`       | Log warning, set field to null  |
 
----
+______________________________________________________________________
 
 ## 9. Dependencies
 
 ### 9.1. Upstream
 
-| Dependency | Type | Required | Notes |
-|------------|------|----------|-------|
-| ChEMBL API | API | Yes | Source of truth |
-| Input CSV | File | Optional | Filter for specific cell lines |
+| Dependency | Type | Required | Notes                          |
+| ---------- | ---- | -------- | ------------------------------ |
+| ChEMBL API | API  | Yes      | Source of truth                |
+| Input CSV  | File | Optional | Filter for specific cell lines |
 
 ### 9.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
-| `chembl_assay` | FK reference (cell_chembl_id) |
-| Cell line enrichment analytics | Tissue/organism analysis |
+| Consumer                       | Impact                        |
+| ------------------------------ | ----------------------------- |
+| `chembl_assay`                 | FK reference (cell_chembl_id) |
+| Cell line enrichment analytics | Tissue/organism analysis      |
 
 ### 9.3. Cross-Provider Mapping
 
-| This Entity Field | Maps To | Provider | Field |
-|-------------------|---------|----------|-------|
-| `cellosaurus_id` | Cellosaurus | ExPASy | Accession |
-| `clo_id` | CLO | OBO Foundry | ID |
-| `efo_id` | EFO | EMBL-EBI | ID |
+| This Entity Field | Maps To     | Provider    | Field     |
+| ----------------- | ----------- | ----------- | --------- |
+| `cellosaurus_id`  | Cellosaurus | ExPASy      | Accession |
+| `clo_id`          | CLO         | OBO Foundry | ID        |
+| `efo_id`          | EFO         | EMBL-EBI    | ID        |
 
----
+______________________________________________________________________
 
 ## 10. Pipeline Configuration
 
@@ -386,7 +386,7 @@ Mode: Overwrite
 pipeline_name: chembl_cell_line
 provider: chembl
 entity_type: cell_line
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract cell lines from ChEMBL API"
 
 primary_keys: ["cell_chembl_id"]
@@ -427,7 +427,7 @@ input_filter:
   batch_size: 20
 ```
 
----
+______________________________________________________________________
 
 ## 11. Testing Requirements
 
@@ -448,7 +448,7 @@ input_filter:
 - [x] Schema strict mode validation
 - [x] Layer import compliance
 
----
+______________________________________________________________________
 
 ## 12. Field Mapping CSV
 

--- a/docs/04-reference/pipelines/chembl/03-molecule-spec.md
+++ b/docs/04-reference/pipelines/chembl/03-molecule-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Molecule Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_molecule` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | molecule |
+| Parameter        | Value                                            |
+| ---------------- | ------------------------------------------------ |
+| **Pipeline ID**  | `chembl_molecule`                                |
+| **Provider**     | ChEMBL (EBI)                                     |
+| **Entity**       | molecule                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/molecule` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                      |
+| **Rate Limit**   | None (polite usage recommended)                  |
+| **Health Check** | `/chembl/api/data/status`                        |
+| **Auth Type**    | None (public API)                                |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -33,10 +33,10 @@ Molecules represent **chemical compounds** in ChEMBL with their structural and p
 ### 2.2. Use Cases
 
 1. **Compound Search**: Find molecules by structure, name, or properties
-2. **Drug Pipeline Analysis**: Analyze compounds by clinical phase
-3. **SAR Studies**: Correlate structural features with activity profiles
-4. **Toxicity Screening**: Identify compounds with black box warnings
-5. **Natural Product Discovery**: Filter for natural product-derived compounds
+1. **Drug Pipeline Analysis**: Analyze compounds by clinical phase
+1. **SAR Studies**: Correlate structural features with activity profiles
+1. **Toxicity Screening**: Identify compounds with black box warnings
+1. **Natural Product Discovery**: Filter for natural product-derived compounds
 
 ### 2.3. Entity Relationships
 
@@ -54,15 +54,15 @@ molecule
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `incremental` with input filter |
-| **Watermark Field** | N/A (filtered by input CSV) |
-| **Full Load Frequency** | On demand |
-| **Estimated Volume** | ~2.4M records total |
-| **Batch Size** | 20 (filter batch) |
+| Parameter               | Value                           |
+| ----------------------- | ------------------------------- |
+| **Strategy**            | `incremental` with input filter |
+| **Watermark Field**     | N/A (filtered by input CSV)     |
+| **Full Load Frequency** | On demand                       |
+| **Estimated Volume**    | ~2.4M records total             |
+| **Batch Size**          | 20 (filter batch)               |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -78,95 +78,95 @@ results = molecule.filter(molecule_chembl_id__in=chembl_ids)
 
 ### 3.2. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Nested | Description | Example |
-|---|-----------|-----------|----------|--------|-------------|---------|
-| 1 | `molecule_chembl_id` | string | No | - | Primary key | `"CHEMBL25"` |
-| 2 | `pref_name` | string | Yes | - | Preferred name | `"ASPIRIN"` |
-| 3 | `molecule_type` | string | Yes | - | Type | `"Small molecule"` |
-| 4 | `max_phase` | number | Yes | - | Clinical phase | `4` |
-| 5 | `structure_type` | string | Yes | - | Structure type | `"MOL"` |
-| 6 | `therapeutic_flag` | boolean | Yes | - | Is therapeutic | `true` |
-| 7 | `oral` | boolean | Yes | - | Oral delivery | `true` |
-| 8 | `parenteral` | boolean | Yes | - | Parenteral delivery | `false` |
-| 9 | `topical` | boolean | Yes | - | Topical delivery | `false` |
-| 10 | `black_box_warning` | integer | Yes | - | BBW flag | `0` |
-| 11 | `natural_product` | integer | Yes | - | Natural product flag | `0` |
-| 12 | `first_in_class` | integer | Yes | - | First in class | `0` |
-| 13 | `prodrug` | integer | Yes | - | Prodrug flag | `0` |
-| 14 | `inorganic_flag` | integer | Yes | - | Inorganic flag | `0` |
-| 15 | `polymer_flag` | integer | Yes | - | Polymer flag | `0` |
-| 16 | `first_approval` | integer | Yes | - | First approval year | `1899` |
-| 17 | `withdrawn_flag` | boolean | Yes | - | Withdrawn flag | `false` |
-| 18 | `molecule_hierarchy` | object | Yes | Yes | Hierarchy | JSON |
-| 19 | `molecule_properties` | object | Yes | Yes | Properties | JSON |
-| 20 | `molecule_structures` | object | Yes | Yes | Structures | JSON |
-| 21 | `molecule_synonyms` | array | Yes | Yes | Synonyms | JSON |
-| 22 | `cross_references` | array | Yes | Yes | Cross-refs | JSON |
-| 23 | `atc_classifications` | array | Yes | Yes | ATC codes | JSON |
+| #   | API Field             | JSON Type | Nullable | Nested | Description          | Example            |
+| --- | --------------------- | --------- | -------- | ------ | -------------------- | ------------------ |
+| 1   | `molecule_chembl_id`  | string    | No       | -      | Primary key          | `"CHEMBL25"`       |
+| 2   | `pref_name`           | string    | Yes      | -      | Preferred name       | `"ASPIRIN"`        |
+| 3   | `molecule_type`       | string    | Yes      | -      | Type                 | `"Small molecule"` |
+| 4   | `max_phase`           | number    | Yes      | -      | Clinical phase       | `4`                |
+| 5   | `structure_type`      | string    | Yes      | -      | Structure type       | `"MOL"`            |
+| 6   | `therapeutic_flag`    | boolean   | Yes      | -      | Is therapeutic       | `true`             |
+| 7   | `oral`                | boolean   | Yes      | -      | Oral delivery        | `true`             |
+| 8   | `parenteral`          | boolean   | Yes      | -      | Parenteral delivery  | `false`            |
+| 9   | `topical`             | boolean   | Yes      | -      | Topical delivery     | `false`            |
+| 10  | `black_box_warning`   | integer   | Yes      | -      | BBW flag             | `0`                |
+| 11  | `natural_product`     | integer   | Yes      | -      | Natural product flag | `0`                |
+| 12  | `first_in_class`      | integer   | Yes      | -      | First in class       | `0`                |
+| 13  | `prodrug`             | integer   | Yes      | -      | Prodrug flag         | `0`                |
+| 14  | `inorganic_flag`      | integer   | Yes      | -      | Inorganic flag       | `0`                |
+| 15  | `polymer_flag`        | integer   | Yes      | -      | Polymer flag         | `0`                |
+| 16  | `first_approval`      | integer   | Yes      | -      | First approval year  | `1899`             |
+| 17  | `withdrawn_flag`      | boolean   | Yes      | -      | Withdrawn flag       | `false`            |
+| 18  | `molecule_hierarchy`  | object    | Yes      | Yes    | Hierarchy            | JSON               |
+| 19  | `molecule_properties` | object    | Yes      | Yes    | Properties           | JSON               |
+| 20  | `molecule_structures` | object    | Yes      | Yes    | Structures           | JSON               |
+| 21  | `molecule_synonyms`   | array     | Yes      | Yes    | Synonyms             | JSON               |
+| 22  | `cross_references`    | array     | Yes      | Yes    | Cross-refs           | JSON               |
+| 23  | `atc_classifications` | array     | Yes      | Yes    | ATC codes            | JSON               |
 
 ### 3.3. Nested Structure: molecule_structures
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `canonical_smiles` | string | Canonical SMILES |
-| `standard_inchi` | string | Standard InChI |
+| Field                | Type   | Description                   |
+| -------------------- | ------ | ----------------------------- |
+| `canonical_smiles`   | string | Canonical SMILES              |
+| `standard_inchi`     | string | Standard InChI                |
 | `standard_inchi_key` | string | Standard InChI Key (27 chars) |
-| `molfile` | string | MOL file content |
+| `molfile`            | string | MOL file content              |
 
 ### 3.4. Nested Structure: molecule_properties
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `molecular_formula` | string | Molecular formula |
-| `full_mwt` | float | Full molecular weight |
-| `mw_freebase` | float | Freebase MW |
-| `mw_monoisotopic` | float | Monoisotopic MW |
-| `alogp` | float | ALogP |
-| `cx_logp` | float | ChemAxon LogP |
-| `cx_logd` | float | ChemAxon LogD |
-| `psa` | float | Polar surface area |
-| `hba` | integer | H-bond acceptors |
-| `hbd` | integer | H-bond donors |
-| `rtb` | integer | Rotatable bonds |
-| `num_ro5_violations` | integer | Rule of 5 violations |
-| `aromatic_rings` | integer | Aromatic rings |
-| `heavy_atoms` | integer | Heavy atoms |
-| `qed_weighted` | float | QED score |
+| Field                | Type    | Description           |
+| -------------------- | ------- | --------------------- |
+| `molecular_formula`  | string  | Molecular formula     |
+| `full_mwt`           | float   | Full molecular weight |
+| `mw_freebase`        | float   | Freebase MW           |
+| `mw_monoisotopic`    | float   | Monoisotopic MW       |
+| `alogp`              | float   | ALogP                 |
+| `cx_logp`            | float   | ChemAxon LogP         |
+| `cx_logd`            | float   | ChemAxon LogD         |
+| `psa`                | float   | Polar surface area    |
+| `hba`                | integer | H-bond acceptors      |
+| `hbd`                | integer | H-bond donors         |
+| `rtb`                | integer | Rotatable bonds       |
+| `num_ro5_violations` | integer | Rule of 5 violations  |
+| `aromatic_rings`     | integer | Aromatic rings        |
+| `heavy_atoms`        | integer | Heavy atoms           |
+| `qed_weighted`       | float   | QED score             |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `molecule_chembl_id` |
-| **ID Source** | `from_api` |
-| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+| Parameter           | Value                    |
+| ------------------- | ------------------------ |
+| **Entity ID Field** | `molecule_chembl_id`     |
+| **ID Source**       | `from_api`               |
+| **Format**          | ChEMBL ID (CHEMBL[0-9]+) |
 
 ### 4.2. Field Normalization
 
-| Field | Normalization | Before | After |
-|-------|---------------|--------|-------|
-| `molecule_chembl_id` | Validate regex | `"CHEMBL25"` | `"CHEMBL25"` |
-| `pref_name` | strip().upper() | `" aspirin "` | `"ASPIRIN"` |
-| `max_phase` | Cast to float | `"4"` | `4.0` |
-| `structure_standard_inchi_key` | Extract from nested | `{...}` | `"BSYNRYMUTXBXSQ-..."` |
-| Float properties | round(10) | `180.12345678901234` | `180.1234567890` |
-| Nested objects | JSON serialize | `{...}` | `'{"key": "value"}'` |
+| Field                          | Normalization       | Before               | After                  |
+| ------------------------------ | ------------------- | -------------------- | ---------------------- |
+| `molecule_chembl_id`           | Validate regex      | `"CHEMBL25"`         | `"CHEMBL25"`           |
+| `pref_name`                    | strip().upper()     | `" aspirin "`        | `"ASPIRIN"`            |
+| `max_phase`                    | Cast to float       | `"4"`                | `4.0`                  |
+| `structure_standard_inchi_key` | Extract from nested | `{...}`              | `"BSYNRYMUTXBXSQ-..."` |
+| Float properties               | round(10)           | `180.12345678901234` | `180.1234567890`       |
+| Nested objects                 | JSON serialize      | `{...}`              | `'{"key": "value"}'`   |
 
 ### 4.3. Flattening Strategy
 
-| Nested Path | Flattened Name | Strategy |
-|-------------|----------------|----------|
+| Nested Path                              | Flattened Name                 | Strategy       |
+| ---------------------------------------- | ------------------------------ | -------------- |
 | `molecule_structures.standard_inchi_key` | `structure_standard_inchi_key` | Extract scalar |
-| `molecule_hierarchy` | `molecule_hierarchy` | JSON string |
-| `molecule_properties` | `molecule_properties` | JSON string |
-| `molecule_structures` | `molecule_structures` | JSON string |
-| `molecule_synonyms` | `molecule_synonyms` | JSON string |
-| `cross_references` | `cross_references` | JSON string |
-| `atc_classifications` | `atc_classifications` | JSON string |
+| `molecule_hierarchy`                     | `molecule_hierarchy`           | JSON string    |
+| `molecule_properties`                    | `molecule_properties`          | JSON string    |
+| `molecule_structures`                    | `molecule_structures`          | JSON string    |
+| `molecule_synonyms`                      | `molecule_synonyms`            | JSON string    |
+| `cross_references`                       | `cross_references`             | JSON string    |
+| `atc_classifications`                    | `atc_classifications`          | JSON string    |
 
 ### 4.4. Content Hash Specification
 
@@ -203,7 +203,7 @@ hash_fields = [
 content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
 ```
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -211,6 +211,7 @@ content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
 
 ```python
 # src/bioetl/domain/schemas/chembl/molecule.py
+
 
 class MoleculeSchema(ETLRecordSchema):
     """Molecule validation schema for Silver layer."""
@@ -240,9 +241,17 @@ class MoleculeSchema(ETLRecordSchema):
     molecule_type: Series[str] | None = pa.Field(
         nullable=True,
         isin=[
-            "Small molecule", "Antibody", "Antibody drug conjugate",
-            "Protein", "Oligonucleotide", "Oligosaccharide", "Cell",
-            "Enzyme", "Unknown", "Unclassified", "Inorganic small molecule",
+            "Small molecule",
+            "Antibody",
+            "Antibody drug conjugate",
+            "Protein",
+            "Oligonucleotide",
+            "Oligosaccharide",
+            "Cell",
+            "Enzyme",
+            "Unknown",
+            "Unclassified",
+            "Inorganic small molecule",
             "Polymeric small molecule",
         ],
     )
@@ -277,24 +286,24 @@ class MoleculeSchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level | Failure Action |
-|-------|------|----------|-------------|----------|----------------|
-| `molecule_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL | Quarantine |
-| `structure_standard_inchi_key` | str | Yes | InChI Key format | WARNING | Log |
-| `pref_name` | str | Yes | - | INFO | Log |
-| `max_phase` | float | Yes | isin [-1,0,0.5,1,2,3,4] | WARNING | Log |
-| `molecule_type` | str | Yes | isin [...] | WARNING | Log |
-| `black_box_warning` | int | Yes | isin [0,1] | WARNING | Log |
+| Field                          | Type  | Nullable | Constraints             | DQ Level | Failure Action |
+| ------------------------------ | ----- | -------- | ----------------------- | -------- | -------------- |
+| `molecule_chembl_id`           | str   | No       | regex `^CHEMBL\d+$`     | CRITICAL | Quarantine     |
+| `structure_standard_inchi_key` | str   | Yes      | InChI Key format        | WARNING  | Log            |
+| `pref_name`                    | str   | Yes      | -                       | INFO     | Log            |
+| `max_phase`                    | float | Yes      | isin [-1,0,0.5,1,2,3,4] | WARNING  | Log            |
+| `molecule_type`                | str   | Yes      | isin [...]              | WARNING  | Log            |
+| `black_box_warning`            | int   | Yes      | isin [0,1]              | WARNING  | Log            |
 
 ### 5.3. DQ Thresholds
 
-| Threshold | Value | Action |
-|-----------|-------|--------|
-| Soft | 5% | Warning, continue |
-| Hard | 20% | Fail batch |
-| Critical field null | molecule_chembl_id is null | Fail immediately |
+| Threshold           | Value                      | Action            |
+| ------------------- | -------------------------- | ----------------- |
+| Soft                | 5%                         | Warning, continue |
+| Hard                | 20%                        | Fail batch        |
+| Critical field null | molecule_chembl_id is null | Fail immediately  |
 
----
+______________________________________________________________________
 
 ## 6. Output Schemas
 
@@ -327,33 +336,33 @@ Mode: Overwrite
 
 **Gold Filter:** Valid molecules with structure
 
----
+______________________________________________________________________
 
 ## 7. Dependencies
 
 ### 7.1. Upstream
 
 | Dependency | Type | Required |
-|------------|------|----------|
-| ChEMBL API | API | Yes |
-| Input CSV | File | Optional |
+| ---------- | ---- | -------- |
+| ChEMBL API | API  | Yes      |
+| Input CSV  | File | Optional |
 
 ### 7.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
-| `chembl_activity` | FK reference |
-| `chembl_compound_record` | FK reference |
-| SAR analytics | Structure-activity analysis |
+| Consumer                 | Impact                      |
+| ------------------------ | --------------------------- |
+| `chembl_activity`        | FK reference                |
+| `chembl_compound_record` | FK reference                |
+| SAR analytics            | Structure-activity analysis |
 
 ### 7.3. Cross-Provider Mapping
 
-| This Entity Field | Maps To | Provider | Field |
-|-------------------|---------|----------|-------|
-| `structure_standard_inchi_key` | PubChem | PubChem | `inchi_key` |
-| `cross_references[drugbank]` | DrugBank | DrugBank | ID |
+| This Entity Field              | Maps To  | Provider | Field       |
+| ------------------------------ | -------- | -------- | ----------- |
+| `structure_standard_inchi_key` | PubChem  | PubChem  | `inchi_key` |
+| `cross_references[drugbank]`   | DrugBank | DrugBank | ID          |
 
----
+______________________________________________________________________
 
 ## 8. Pipeline Configuration
 
@@ -363,7 +372,7 @@ Mode: Overwrite
 pipeline_name: chembl_molecule
 provider: chembl
 entity_type: molecule
-version: "1.1.0"
+version: "1.2.0"
 description: "Extract molecules from ChEMBL API"
 
 primary_keys: ["molecule_chembl_id"]
@@ -382,7 +391,7 @@ sink:
   silver:
     path: "data/output/silver"
     primary_key: ["molecule_chembl_id"]
-    partition_by: []
+    partition_by: ["molecule_type"]
     csv_export:
       path: "data/output/csv/silver"
   gold:
@@ -398,7 +407,7 @@ input_filter:
   batch_size: 20
 ```
 
----
+______________________________________________________________________
 
 ## 9. Testing Requirements
 

--- a/docs/04-reference/pipelines/chembl/04-target-spec.md
+++ b/docs/04-reference/pipelines/chembl/04-target-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Target Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_target` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | target |
+| Parameter        | Value                                          |
+| ---------------- | ---------------------------------------------- |
+| **Pipeline ID**  | `chembl_target`                                |
+| **Provider**     | ChEMBL (EBI)                                   |
+| **Entity**       | target                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/target` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                    |
+| **Rate Limit**   | None (polite usage recommended)                |
+| **Health Check** | `/chembl/api/data/status`                      |
+| **Auth Type**    | None (public API)                              |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -33,9 +33,9 @@ Targets represent **biological entities** that drugs interact with:
 ### 2.2. Use Cases
 
 1. **Target Identification**: Find druggable targets for diseases
-2. **Target Deconvolution**: Identify off-target effects
-3. **Species Translation**: Compare targets across organisms
-4. **Target Class Analysis**: Analyze druggability by target type
+1. **Target Deconvolution**: Identify off-target effects
+1. **Species Translation**: Compare targets across organisms
+1. **Target Class Analysis**: Analyze druggability by target type
 
 ### 2.3. Entity Relationships
 
@@ -54,64 +54,64 @@ target
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `incremental` with input filter |
-| **Watermark Field** | N/A |
-| **Estimated Volume** | ~15,000 records total |
-| **Batch Size** | 20 (filter batch) |
+| Parameter            | Value                           |
+| -------------------- | ------------------------------- |
+| **Strategy**         | `incremental` with input filter |
+| **Watermark Field**  | N/A                             |
+| **Estimated Volume** | ~15,000 records total           |
+| **Batch Size**       | 20 (filter batch)               |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
 ### 3.1. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Nested | Description |
-|---|-----------|-----------|----------|--------|-------------|
-| 1 | `target_chembl_id` | string | No | - | Primary key |
-| 2 | `target_type` | string | Yes | - | Type classification |
-| 3 | `pref_name` | string | Yes | - | Preferred name |
-| 4 | `organism` | string | Yes | - | Organism name |
-| 5 | `tax_id` | integer | Yes | - | NCBI Taxonomy ID |
-| 6 | `species_group_flag` | boolean | Yes | - | Species group flag |
-| 7 | `downgraded` | boolean | Yes | - | Deprecated flag |
-| 8 | `target_components` | array | Yes | Yes | Component list |
-| 9 | `cross_references` | array | Yes | Yes | External refs |
+| #   | API Field            | JSON Type | Nullable | Nested | Description         |
+| --- | -------------------- | --------- | -------- | ------ | ------------------- |
+| 1   | `target_chembl_id`   | string    | No       | -      | Primary key         |
+| 2   | `target_type`        | string    | Yes      | -      | Type classification |
+| 3   | `pref_name`          | string    | Yes      | -      | Preferred name      |
+| 4   | `organism`           | string    | Yes      | -      | Organism name       |
+| 5   | `tax_id`             | integer   | Yes      | -      | NCBI Taxonomy ID    |
+| 6   | `species_group_flag` | boolean   | Yes      | -      | Species group flag  |
+| 7   | `downgraded`         | boolean   | Yes      | -      | Deprecated flag     |
+| 8   | `target_components`  | array     | Yes      | Yes    | Component list      |
+| 9   | `cross_references`   | array     | Yes      | Yes    | External refs       |
 
 ### 3.2. Nested Structure: target_components
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `component_id` | integer | Component ID |
-| `component_type` | string | PROTEIN/DNA/RNA |
-| `accession` | string | UniProt accession |
-| `component_description` | string | Description |
-| `relationship` | string | Relationship type |
+| Field                   | Type    | Description       |
+| ----------------------- | ------- | ----------------- |
+| `component_id`          | integer | Component ID      |
+| `component_type`        | string  | PROTEIN/DNA/RNA   |
+| `accession`             | string  | UniProt accession |
+| `component_description` | string  | Description       |
+| `relationship`          | string  | Relationship type |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `target_chembl_id` |
-| **ID Source** | `from_api` |
-| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+| Parameter           | Value                    |
+| ------------------- | ------------------------ |
+| **Entity ID Field** | `target_chembl_id`       |
+| **ID Source**       | `from_api`               |
+| **Format**          | ChEMBL ID (CHEMBL[0-9]+) |
 
 ### 4.2. Flattening Strategy
 
-| Nested Path | Flattened Name | Strategy |
-|-------------|----------------|----------|
-| `target_components[*].accession` | `component_accessions` | Extract list |
-| `target_components[*].component_id` | `component_ids` | Extract list |
-| `target_components[*].component_type` | `component_types` | Extract list |
-| `target_components` | `target_components` | JSON string |
-| `cross_references` | `cross_references` | JSON string |
+| Nested Path                           | Flattened Name         | Strategy     |
+| ------------------------------------- | ---------------------- | ------------ |
+| `target_components[*].accession`      | `component_accessions` | Extract list |
+| `target_components[*].component_id`   | `component_ids`        | Extract list |
+| `target_components[*].component_type` | `component_types`      | Extract list |
+| `target_components`                   | `target_components`    | JSON string  |
+| `cross_references`                    | `cross_references`     | JSON string  |
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -131,10 +131,20 @@ class TargetSchema(ETLRecordSchema):
     target_type: Series[str] | None = pa.Field(
         nullable=True,
         isin=[
-            "SINGLE PROTEIN", "PROTEIN FAMILY", "PROTEIN COMPLEX",
-            "PROTEIN COMPLEX GROUP", "SELECTIVITY GROUP", "CHIMERIC PROTEIN",
-            "CELL-LINE", "TISSUE", "ORGANISM", "MACROMOLECULE",
-            "SMALL MOLECULE", "LIPID", "METAL", "UNKNOWN",
+            "SINGLE PROTEIN",
+            "PROTEIN FAMILY",
+            "PROTEIN COMPLEX",
+            "PROTEIN COMPLEX GROUP",
+            "SELECTIVITY GROUP",
+            "CHIMERIC PROTEIN",
+            "CELL-LINE",
+            "TISSUE",
+            "ORGANISM",
+            "MACROMOLECULE",
+            "SMALL MOLECULE",
+            "LIPID",
+            "METAL",
+            "UNKNOWN",
         ],
     )
 
@@ -164,25 +174,25 @@ class TargetSchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level |
-|-------|------|----------|-------------|----------|
-| `target_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
-| `target_type` | str | Yes | isin [...] | WARNING |
-| `tax_id` | int | Yes | >= 1 | WARNING |
-| `organism` | str | Yes | - | INFO |
+| Field              | Type | Nullable | Constraints         | DQ Level |
+| ------------------ | ---- | -------- | ------------------- | -------- |
+| `target_chembl_id` | str  | No       | regex `^CHEMBL\d+$` | CRITICAL |
+| `target_type`      | str  | Yes      | isin [...]          | WARNING  |
+| `tax_id`           | int  | Yes      | >= 1                | WARNING  |
+| `organism`         | str  | Yes      | -                   | INFO     |
 
----
+______________________________________________________________________
 
 ## 6. Dependencies
 
 ### 6.1. Cross-Provider Mapping
 
-| This Entity Field | Maps To | Provider | Field |
-|-------------------|---------|----------|-------|
-| `component_accessions[*]` | UniProt | UniProt | `accession` |
-| `target_chembl_id` | UniProt ID Mapping | UniProt | `from_id` |
+| This Entity Field         | Maps To            | Provider | Field       |
+| ------------------------- | ------------------ | -------- | ----------- |
+| `component_accessions[*]` | UniProt            | UniProt  | `accession` |
+| `target_chembl_id`        | UniProt ID Mapping | UniProt  | `from_id`   |
 
----
+______________________________________________________________________
 
 ## 7. Pipeline Configuration
 
@@ -190,7 +200,7 @@ class TargetSchema(ETLRecordSchema):
 pipeline_name: chembl_target
 provider: chembl
 entity_type: target
-version: "1.1.0"
+version: "1.2.0"
 
 primary_keys: ["target_chembl_id"]
 silver_table: "chembl_target"

--- a/docs/04-reference/pipelines/chembl/05-activity-spec.md
+++ b/docs/04-reference/pipelines/chembl/05-activity-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Activity Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_activity` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | activity |
+| Parameter        | Value                                            |
+| ---------------- | ------------------------------------------------ |
+| **Pipeline ID**  | `chembl_activity`                                |
+| **Provider**     | ChEMBL (EBI)                                     |
+| **Entity**       | activity                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/activity` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                      |
+| **Rate Limit**   | None (polite usage recommended)                  |
+| **Health Check** | `/chembl/api/data/status`                        |
+| **Auth Type**    | None (public API)                                |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -25,7 +25,7 @@
 
 Activities are the **core measurement data** in ChEMBL, representing bioactivity measurements of molecules against biological targets:
 
-- **Bioactivity measurements**: IC50, Ki, EC50, potency, inhibition
+- **Bioactivity measurements**: IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50, EC50, potency, inhibition
 - **Structure-Activity Relationships (SAR)**: Connect molecules to targets via measured values
 - **Drug discovery data**: Quantitative data from screening and assays
 - **Data quality tracking**: Standardized values with quality annotations
@@ -33,10 +33,10 @@ Activities are the **core measurement data** in ChEMBL, representing bioactivity
 ### 2.2. Use Cases
 
 1. **SAR Analysis**: Analyze activity profiles for lead compounds
-2. **Target Druggability**: Assess targets by activity data availability
-3. **Compound Ranking**: Rank molecules by pChEMBL value
-4. **Data Quality Assessment**: Filter by standardization and validity flags
-5. **Literature Mining**: Link activities to source publications
+1. **Target Druggability**: Assess targets by activity data availability
+1. **Compound Ranking**: Rank molecules by pChEMBL value
+1. **Data Quality Assessment**: Filter by standardization and validity flags
+1. **Literature Mining**: Link activities to source publications
 
 ### 2.3. Entity Relationships
 
@@ -57,14 +57,14 @@ activity
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `incremental` with input filter |
-| **Watermark Field** | N/A (filtered by assay/molecule/target IDs) |
-| **Estimated Volume** | ~20M records total |
-| **Batch Size** | 20 (filter batch) |
+| Parameter            | Value                                       |
+| -------------------- | ------------------------------------------- |
+| **Strategy**         | `incremental` with input filter             |
+| **Watermark Field**  | N/A (filtered by assay/molecule/target IDs) |
+| **Estimated Volume** | ~20M records total                          |
+| **Batch Size**       | 20 (filter batch)                           |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -80,98 +80,98 @@ results = activity.filter(target_chembl_id__in=target_ids)
 
 ### 3.2. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Description | Example |
-|---|-----------|-----------|----------|-------------|---------|
-| 1 | `activity_id` | integer | No | Primary key | `12345678` |
-| 2 | `assay_chembl_id` | string | No | FK to assay | `"CHEMBL123456"` |
-| 3 | `molecule_chembl_id` | string | No | FK to molecule | `"CHEMBL25"` |
-| 4 | `target_chembl_id` | string | Yes | FK to target | `"CHEMBL240"` |
-| 5 | `document_chembl_id` | string | Yes | FK to document | `"CHEMBL1234"` |
-| 6 | `standard_type` | string | Yes | Measurement type | `"IC50"` |
-| 7 | `standard_relation` | string | Yes | Relation | `"="` |
-| 8 | `standard_value` | number | Yes | Standardized value | `50.0` |
-| 9 | `standard_units` | string | Yes | Standardized units | `"nM"` |
-| 10 | `standard_flag` | integer | Yes | Standardized flag | `1` |
-| 11 | `pchembl_value` | number | Yes | -log10 molar | `7.3` |
-| 12 | `data_validity_comment` | string | Yes | DQ comment | `"Potential author error"` |
-| 13 | `activity_comment` | string | Yes | Text comment | `"Active"` |
-| 14 | `potential_duplicate` | integer | Yes | Duplicate flag | `0` |
-| 15 | `type` | string | Yes | Original type | `"IC50"` |
-| 16 | `relation` | string | Yes | Original relation | `"="` |
-| 17 | `value` | number | Yes | Original value | `50.0` |
-| 18 | `units` | string | Yes | Original units | `"nM"` |
-| 19 | `text_value` | string | Yes | Text value | `"Active"` |
-| 20 | `standard_text_value` | string | Yes | Std text value | `"Active"` |
-| 21 | `upper_value` | number | Yes | Upper bound | `100.0` |
-| 22 | `standard_upper_value` | number | Yes | Std upper bound | `100.0` |
-| 23 | `src_id` | integer | Yes | Source ID | `1` |
-| 24 | `record_id` | integer | Yes | FK compound_record | `12345` |
-| 25 | `toid` | integer | Yes | Test Occasion ID | `1` |
-| 26 | `bao_endpoint` | string | Yes | BAO endpoint ID | `"BAO:0000190"` |
-| 27 | `uo_units` | string | Yes | UO units ID | `"UO:0000065"` |
-| 28 | `qudt_units` | string | Yes | QUDT units | `"nM"` |
-| 29 | `ligand_efficiency` | object | Yes | Efficiency metrics | JSON |
-| 30 | `activity_properties` | array | Yes | Properties | JSON |
+| #   | API Field               | JSON Type | Nullable | Description        | Example                    |
+| --- | ----------------------- | --------- | -------- | ------------------ | -------------------------- |
+| 1   | `activity_id`           | integer   | No       | Primary key        | `12345678`                 |
+| 2   | `assay_chembl_id`       | string    | No       | FK to assay        | `"CHEMBL123456"`           |
+| 3   | `molecule_chembl_id`    | string    | No       | FK to molecule     | `"CHEMBL25"`               |
+| 4   | `target_chembl_id`      | string    | Yes      | FK to target       | `"CHEMBL240"`              |
+| 5   | `document_chembl_id`    | string    | Yes      | FK to document     | `"CHEMBL1234"`             |
+| 6   | `standard_type`         | string    | Yes      | Measurement type   | `"IC50"`                   |
+| 7   | `standard_relation`     | string    | Yes      | Relation           | `"="`                      |
+| 8   | `standard_value`        | number    | Yes      | Standardized value | `50.0`                     |
+| 9   | `standard_units`        | string    | Yes      | Standardized units | `"nM"`                     |
+| 10  | `standard_flag`         | integer   | Yes      | Standardized flag  | `1`                        |
+| 11  | `pchembl_value`         | number    | Yes      | -log10 molar       | `7.3`                      |
+| 12  | `data_validity_comment` | string    | Yes      | DQ comment         | `"Potential author error"` |
+| 13  | `activity_comment`      | string    | Yes      | Text comment       | `"Active"`                 |
+| 14  | `potential_duplicate`   | integer   | Yes      | Duplicate flag     | `0`                        |
+| 15  | `type`                  | string    | Yes      | Original type      | `"IC50"`                   |
+| 16  | `relation`              | string    | Yes      | Original relation  | `"="`                      |
+| 17  | `value`                 | number    | Yes      | Original value     | `50.0`                     |
+| 18  | `units`                 | string    | Yes      | Original units     | `"nM"`                     |
+| 19  | `text_value`            | string    | Yes      | Text value         | `"Active"`                 |
+| 20  | `standard_text_value`   | string    | Yes      | Std text value     | `"Active"`                 |
+| 21  | `upper_value`           | number    | Yes      | Upper bound        | `100.0`                    |
+| 22  | `standard_upper_value`  | number    | Yes      | Std upper bound    | `100.0`                    |
+| 23  | `src_id`                | integer   | Yes      | Source ID          | `1`                        |
+| 24  | `record_id`             | integer   | Yes      | FK compound_record | `12345`                    |
+| 25  | `toid`                  | integer   | Yes      | Test Occasion ID   | `1`                        |
+| 26  | `bao_endpoint`          | string    | Yes      | BAO endpoint ID    | `"BAO:0000190"`            |
+| 27  | `uo_units`              | string    | Yes      | UO units ID        | `"UO:0000065"`             |
+| 28  | `qudt_units`            | string    | Yes      | QUDT units         | `"nM"`                     |
+| 29  | `ligand_efficiency`     | object    | Yes      | Efficiency metrics | JSON                       |
+| 30  | `activity_properties`   | array     | Yes      | Properties         | JSON                       |
 
 ### 3.3. Nested Structure: ligand_efficiency
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `bei` | float | Binding Efficiency Index |
-| `le` | float | Ligand Efficiency |
+| Field | Type  | Description                  |
+| ----- | ----- | ---------------------------- |
+| `bei` | float | Binding Efficiency Index     |
+| `le`  | float | Ligand Efficiency            |
 | `lle` | float | Lipophilic Ligand Efficiency |
-| `sei` | float | Surface Efficiency Index |
+| `sei` | float | Surface Efficiency Index     |
 
 ### 3.4. Denormalized Fields (from related entities)
 
 The API also returns denormalized fields from related entities:
 
-| Field | Source Entity | Description |
-|-------|---------------|-------------|
-| `canonical_smiles` | molecule.structures | SMILES string |
-| `molecule_pref_name` | molecule | Molecule name |
-| `parent_molecule_chembl_id` | molecule.hierarchy | Parent molecule |
-| `target_pref_name` | target | Target name |
-| `target_organism` | target | Organism |
-| `target_tax_id` | target | Taxonomy ID |
-| `assay_type` | assay | Assay type |
-| `assay_description` | assay | Description |
-| `bao_format` | assay | BAO format |
-| `bao_label` | assay | BAO label |
-| `document_journal` | document | Journal |
-| `document_year` | document | Year |
+| Field                       | Source Entity       | Description     |
+| --------------------------- | ------------------- | --------------- |
+| `canonical_smiles`          | molecule.structures | SMILES string   |
+| `molecule_pref_name`        | molecule            | Molecule name   |
+| `parent_molecule_chembl_id` | molecule.hierarchy  | Parent molecule |
+| `target_pref_name`          | target              | Target name     |
+| `target_organism`           | target              | Organism        |
+| `target_tax_id`             | target              | Taxonomy ID     |
+| `assay_type`                | assay               | Assay type      |
+| `assay_description`         | assay               | Description     |
+| `bao_format`                | assay               | BAO format      |
+| `bao_label`                 | assay               | BAO label       |
+| `document_journal`          | document            | Journal         |
+| `document_year`             | document            | Year            |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `activity_id` |
-| **ID Source** | `from_api` |
-| **Format** | Integer (cast to string) |
+| Parameter           | Value                    |
+| ------------------- | ------------------------ |
+| **Entity ID Field** | `activity_id`            |
+| **ID Source**       | `from_api`               |
+| **Format**          | Integer (cast to string) |
 
 ### 4.2. Field Normalization
 
-| Field | Normalization | Before | After |
-|-------|---------------|--------|-------|
-| `activity_id` | Cast to string | `12345678` | `"12345678"` |
-| `standard_value` | round(10) | `50.123456789012` | `50.1234567890` |
-| `pchembl_value` | round(2) | `7.3456` | `7.35` |
-| `standard_relation` | Validate isin | `"="` | `"="` |
-| `standard_units` | strip() | `" nM "` | `"nM"` |
+| Field               | Normalization  | Before            | After           |
+| ------------------- | -------------- | ----------------- | --------------- |
+| `activity_id`       | Cast to string | `12345678`        | `"12345678"`    |
+| `standard_value`    | round(10)      | `50.123456789012` | `50.1234567890` |
+| `pchembl_value`     | round(2)       | `7.3456`          | `7.35`          |
+| `standard_relation` | Validate isin  | `"="`             | `"="`           |
+| `standard_units`    | strip()        | `" nM "`          | `"nM"`          |
 
 ### 4.3. Flattening Strategy
 
-| Nested Path | Flattened Name | Strategy |
-|-------------|----------------|----------|
+| Nested Path             | Flattened Name          | Strategy       |
+| ----------------------- | ----------------------- | -------------- |
 | `ligand_efficiency.bei` | `ligand_efficiency_bei` | Extract scalar |
-| `ligand_efficiency.le` | `ligand_efficiency_le` | Extract scalar |
+| `ligand_efficiency.le`  | `ligand_efficiency_le`  | Extract scalar |
 | `ligand_efficiency.lle` | `ligand_efficiency_lle` | Extract scalar |
 | `ligand_efficiency.sei` | `ligand_efficiency_sei` | Extract scalar |
-| `activity_properties` | `activity_properties` | JSON string |
+| `activity_properties`   | `activity_properties`   | JSON string    |
 
 ### 4.4. Content Hash Specification
 
@@ -192,16 +192,21 @@ hash_fields = [
 
 # Fields EXCLUDED from hash
 excluded = [
-    "_ingestion_ts", "_run_id", "_run_type", "_dq_*",
+    "_ingestion_ts",
+    "_run_id",
+    "_run_type",
+    "_dq_*",
     # Denormalized fields (can change independently)
-    "molecule_pref_name", "target_pref_name", "assay_description",
+    "molecule_pref_name",
+    "target_pref_name",
+    "assay_description",
 ]
 
 # Algorithm
 content_hash = sha256(f"chembl{canonical_json(filtered_record)}")
 ```
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -245,9 +250,19 @@ class ActivitySchema(ETLRecordSchema):
     standard_type: Series[str] | None = pa.Field(
         nullable=True,
         isin=[
-            "IC50", "EC50", "Ki", "Kd", "AC50", "GI50",
-            "Potency", "Inhibition", "% Inhibition", "Activity",
-            "Ratio", "ED50", "ID50",
+            "IC50",
+            "EC50",
+            "Ki",
+            "Kd",
+            "AC50",
+            "GI50",
+            "Potency",
+            "Inhibition",
+            "% Inhibition",
+            "Activity",
+            "Ratio",
+            "ED50",
+            "ID50",
         ],
     )
     standard_flag: Series[int] | None = pa.Field(
@@ -266,9 +281,12 @@ class ActivitySchema(ETLRecordSchema):
     data_validity_comment: Series[str] | None = pa.Field(
         nullable=True,
         isin=[
-            "Potential missing data", "Potential author error",
-            "Manually validated", "Potential transcription error",
-            "Outside typical range", "Non standard unit for type",
+            "Potential missing data",
+            "Potential author error",
+            "Manually validated",
+            "Potential transcription error",
+            "Outside typical range",
+            "Non standard unit for type",
             "Author confirmed error",
         ],
     )
@@ -306,33 +324,33 @@ class ActivitySchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level |
-|-------|------|----------|-------------|----------|
-| `activity_id` | str | No | unique | CRITICAL |
-| `assay_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
-| `molecule_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
-| `target_chembl_id` | str | Yes | regex `^CHEMBL\d+$` | WARNING |
-| `standard_value` | float | Yes | >= 0 | WARNING |
-| `pchembl_value` | float | Yes | [0, 14] | WARNING |
-| `standard_type` | str | Yes | isin [...] | WARNING |
-| `standard_relation` | str | Yes | isin ["=","<","<=",">",">="] | WARNING |
+| Field                | Type  | Nullable | Constraints                    | DQ Level |
+| -------------------- | ----- | -------- | ------------------------------ | -------- |
+| `activity_id`        | str   | No       | unique                         | CRITICAL |
+| `assay_chembl_id`    | str   | No       | regex `^CHEMBL\d+$`            | CRITICAL |
+| `molecule_chembl_id` | str   | No       | regex `^CHEMBL\d+$`            | CRITICAL |
+| `target_chembl_id`   | str   | Yes      | regex `^CHEMBL\d+$`            | WARNING  |
+| `standard_value`     | float | Yes      | >= 0                           | WARNING  |
+| `pchembl_value`      | float | Yes      | [0, 14]                        | WARNING  |
+| `standard_type`      | str   | Yes      | isin [...]                     | WARNING  |
+| `standard_relation`  | str   | Yes      | isin ["=","\<","\<=",">",">="] | WARNING  |
 
 ### 5.3. Cross-Field Validation Rules
 
-| Rule Name | Fields | Condition | Failure Action |
-|-----------|--------|-----------|----------------|
-| `value_relation_consistency` | `standard_value`, `standard_relation` | If relation is "=" then upper_value is null | Warning |
-| `pchembl_type_consistency` | `pchembl_value`, `standard_type` | pChEMBL only for binding types | Warning |
+| Rule Name                    | Fields                                | Condition                                   | Failure Action |
+| ---------------------------- | ------------------------------------- | ------------------------------------------- | -------------- |
+| `value_relation_consistency` | `standard_value`, `standard_relation` | If relation is "=" then upper_value is null | Warning        |
+| `pchembl_type_consistency`   | `pchembl_value`, `standard_type`      | pChEMBL only for binding types              | Warning        |
 
 ### 5.4. DQ Thresholds
 
-| Threshold | Value | Action |
-|-----------|-------|--------|
-| Soft | 5% | Warning, continue |
-| Hard | 20% | Fail batch |
-| Critical field null | activity_id, assay_chembl_id, molecule_chembl_id | Fail immediately |
+| Threshold           | Value                                            | Action            |
+| ------------------- | ------------------------------------------------ | ----------------- |
+| Soft                | 5%                                               | Warning, continue |
+| Hard                | 20%                                              | Fail batch        |
+| Critical field null | activity_id, assay_chembl_id, molecule_chembl_id | Fail immediately  |
 
----
+______________________________________________________________________
 
 ## 6. Output Schemas
 
@@ -364,33 +382,34 @@ Mode: Overwrite
 ```
 
 **Gold Filters:**
+
 - `standard_type IN ('IC50', 'Ki')` — Focus on binding data
 - `standard_units = 'nM'` — Normalized units
 - `standard_relation = '='` — Exact measurements
 - `target_chembl_id IS NOT NULL` — Target required
 
----
+______________________________________________________________________
 
 ## 7. Dependencies
 
 ### 7.1. Upstream
 
-| Dependency | Type | Required |
-|------------|------|----------|
-| ChEMBL API | API | Yes |
-| `chembl_assay` | Pipeline | Recommended |
+| Dependency        | Type     | Required    |
+| ----------------- | -------- | ----------- |
+| ChEMBL API        | API      | Yes         |
+| `chembl_assay`    | Pipeline | Recommended |
 | `chembl_molecule` | Pipeline | Recommended |
-| `chembl_target` | Pipeline | Recommended |
+| `chembl_target`   | Pipeline | Recommended |
 
 ### 7.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
-| SAR analytics | Activity-based analysis |
-| ML training datasets | Bioactivity prediction |
+| Consumer              | Impact                  |
+| --------------------- | ----------------------- |
+| SAR analytics         | Activity-based analysis |
+| ML training datasets  | Bioactivity prediction  |
 | Target prioritization | Druggability assessment |
 
----
+______________________________________________________________________
 
 ## 8. Pipeline Configuration
 
@@ -400,7 +419,7 @@ Mode: Overwrite
 pipeline_name: chembl_activity
 provider: chembl
 entity_type: activity
-version: "1.1.0"
+version: "1.2.0"
 
 primary_keys: ["activity_id"]
 silver_table: "chembl_activity"
@@ -408,8 +427,8 @@ gold_table: "chembl_activity"
 
 gold_filters:
   columns:
-    standard_type: [IC50, Ki]
-    standard_units: [nM]
+    standard_type: [IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50]
+    standard_units: [nM, uM, mM, pM, M, ug.mL-1, mg.kg-1]
     standard_relation: ["="]
   ranges:
     standard_value:
@@ -439,7 +458,7 @@ input_filter:
   batch_size: 20
 ```
 
----
+______________________________________________________________________
 
 ## 9. Testing Requirements
 

--- a/docs/04-reference/pipelines/chembl/06-assay-spec.md
+++ b/docs/04-reference/pipelines/chembl/06-assay-spec.md
@@ -1,23 +1,23 @@
 # ChEMBL Assay Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `chembl_assay` |
-| **Provider** | ChEMBL (EBI) |
-| **Entity** | assay |
+| Parameter        | Value                                         |
+| ---------------- | --------------------------------------------- |
+| **Pipeline ID**  | `chembl_assay`                                |
+| **Provider**     | ChEMBL (EBI)                                  |
+| **Entity**       | assay                                         |
 | **API Endpoint** | `https://www.ebi.ac.uk/chembl/api/data/assay` |
-| **Library** | `chembl_webresource_client` |
-| **Rate Limit** | None (polite usage recommended) |
-| **Health Check** | `/chembl/api/data/status.json` |
-| **Auth Type** | None (public API) |
+| **Library**      | `chembl_webresource_client`                   |
+| **Rate Limit**   | None (polite usage recommended)               |
+| **Health Check** | `/chembl/api/data/status`                     |
+| **Auth Type**    | None (public API)                             |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -33,9 +33,9 @@ Assays represent **experimental protocols** used to measure bioactivity:
 ### 2.2. Use Cases
 
 1. **Protocol Analysis**: Understand experimental conditions for activities
-2. **Assay Selection**: Choose appropriate assays for screening
-3. **Data Quality Assessment**: Filter by confidence and relationship type
-4. **Cell-based vs Biochemical**: Compare assay types
+1. **Assay Selection**: Choose appropriate assays for screening
+1. **Data Quality Assessment**: Filter by confidence and relationship type
+1. **Cell-based vs Biochemical**: Compare assay types
 
 ### 2.3. Entity Relationships
 
@@ -55,72 +55,72 @@ assay
 
 ### 2.4. Load Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Strategy** | `incremental` with input filter |
-| **Estimated Volume** | ~1.5M records total |
-| **Batch Size** | 20 (filter batch) |
+| Parameter            | Value                           |
+| -------------------- | ------------------------------- |
+| **Strategy**         | `incremental` with input filter |
+| **Estimated Volume** | ~1.5M records total             |
+| **Batch Size**       | 20 (filter batch)               |
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
 ### 3.1. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Description |
-|---|-----------|-----------|----------|-------------|
-| 1 | `assay_chembl_id` | string | No | Primary key |
-| 2 | `description` | string | Yes | Assay description |
-| 3 | `assay_type` | string | Yes | B/F/A/T/P/U |
-| 4 | `assay_test_type` | string | Yes | In vivo/vitro/ex vivo |
-| 5 | `assay_category` | string | Yes | screening/confirmatory/... |
-| 6 | `assay_organism` | string | Yes | Organism |
-| 7 | `assay_tax_id` | integer | Yes | NCBI Taxonomy ID |
-| 8 | `assay_strain` | string | Yes | Strain |
-| 9 | `assay_tissue` | string | Yes | Tissue |
-| 10 | `assay_cell_type` | string | Yes | Cell type |
-| 11 | `assay_subcellular_fraction` | string | Yes | Subcellular fraction |
-| 12 | `target_chembl_id` | string | Yes | FK to target |
-| 13 | `relationship_type` | string | Yes | D/H/M/N/S/U |
-| 14 | `relationship_description` | string | Yes | Relationship desc |
-| 15 | `confidence_score` | integer | Yes | 0-9 score |
-| 16 | `confidence_description` | string | Yes | Confidence desc |
-| 17 | `src_id` | integer | Yes | Source ID |
-| 18 | `src_assay_id` | string | Yes | Source assay ID |
-| 19 | `document_chembl_id` | string | Yes | FK to document |
-| 20 | `cell_chembl_id` | string | Yes | FK to cell_line |
-| 21 | `tissue_chembl_id` | string | Yes | FK to tissue |
-| 22 | `bao_format` | string | Yes | BAO format ID |
-| 23 | `bao_label` | string | Yes | BAO label |
-| 24 | `assay_classifications` | array | Yes | Classifications |
-| 25 | `assay_parameters` | array | Yes | Parameters |
-| 26 | `variant_sequence` | object | Yes | Variant info |
+| #   | API Field                    | JSON Type | Nullable | Description                |
+| --- | ---------------------------- | --------- | -------- | -------------------------- |
+| 1   | `assay_chembl_id`            | string    | No       | Primary key                |
+| 2   | `description`                | string    | Yes      | Assay description          |
+| 3   | `assay_type`                 | string    | Yes      | B/F/A/T/P/U                |
+| 4   | `assay_test_type`            | string    | Yes      | In vivo/vitro/ex vivo      |
+| 5   | `assay_category`             | string    | Yes      | screening/confirmatory/... |
+| 6   | `assay_organism`             | string    | Yes      | Organism                   |
+| 7   | `assay_tax_id`               | integer   | Yes      | NCBI Taxonomy ID           |
+| 8   | `assay_strain`               | string    | Yes      | Strain                     |
+| 9   | `assay_tissue`               | string    | Yes      | Tissue                     |
+| 10  | `assay_cell_type`            | string    | Yes      | Cell type                  |
+| 11  | `assay_subcellular_fraction` | string    | Yes      | Subcellular fraction       |
+| 12  | `target_chembl_id`           | string    | Yes      | FK to target               |
+| 13  | `relationship_type`          | string    | Yes      | D/H/M/N/S/U                |
+| 14  | `relationship_description`   | string    | Yes      | Relationship desc          |
+| 15  | `confidence_score`           | integer   | Yes      | 0-9 score                  |
+| 16  | `confidence_description`     | string    | Yes      | Confidence desc            |
+| 17  | `src_id`                     | integer   | Yes      | Source ID                  |
+| 18  | `src_assay_id`               | string    | Yes      | Source assay ID            |
+| 19  | `document_chembl_id`         | string    | Yes      | FK to document             |
+| 20  | `cell_chembl_id`             | string    | Yes      | FK to cell_line            |
+| 21  | `tissue_chembl_id`           | string    | Yes      | FK to tissue               |
+| 22  | `bao_format`                 | string    | Yes      | BAO format ID              |
+| 23  | `bao_label`                  | string    | Yes      | BAO label                  |
+| 24  | `assay_classifications`      | array     | Yes      | Classifications            |
+| 25  | `assay_parameters`           | array     | Yes      | Parameters                 |
+| 26  | `variant_sequence`           | object    | Yes      | Variant info               |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `assay_chembl_id` |
-| **ID Source** | `from_api` |
-| **Format** | ChEMBL ID (CHEMBL[0-9]+) |
+| Parameter           | Value                    |
+| ------------------- | ------------------------ |
+| **Entity ID Field** | `assay_chembl_id`        |
+| **ID Source**       | `from_api`               |
+| **Format**          | ChEMBL ID (CHEMBL[0-9]+) |
 
 ### 4.2. Flattening Strategy
 
-| Nested Path | Flattened Name | Strategy |
-|-------------|----------------|----------|
-| `variant_sequence.accession` | `variant_accession` | Extract scalar |
-| `variant_sequence.mutation` | `variant_mutation` | Extract scalar |
-| `variant_sequence.organism` | `variant_organism` | Extract scalar |
-| `variant_sequence.tax_id` | `variant_tax_id` | Extract scalar |
-| `variant_sequence.sequence` | `variant_sequence` | Extract scalar |
-| `assay_classifications` | `assay_classifications` | JSON string |
-| `assay_parameters` | `assay_parameters` | JSON string |
+| Nested Path                  | Flattened Name          | Strategy       |
+| ---------------------------- | ----------------------- | -------------- |
+| `variant_sequence.accession` | `variant_accession`     | Extract scalar |
+| `variant_sequence.mutation`  | `variant_mutation`      | Extract scalar |
+| `variant_sequence.organism`  | `variant_organism`      | Extract scalar |
+| `variant_sequence.tax_id`    | `variant_tax_id`        | Extract scalar |
+| `variant_sequence.sequence`  | `variant_sequence`      | Extract scalar |
+| `assay_classifications`      | `assay_classifications` | JSON string    |
+| `assay_parameters`           | `assay_parameters`      | JSON string    |
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -206,14 +206,14 @@ class AssaySchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level |
-|-------|------|----------|-------------|----------|
-| `assay_chembl_id` | str | No | regex `^CHEMBL\d+$` | CRITICAL |
-| `assay_type` | str | Yes | isin [B,F,A,T,P,U] | WARNING |
-| `confidence_score` | int | Yes | [0, 9] | WARNING |
-| `target_chembl_id` | str | Yes | regex `^CHEMBL\d+$` | INFO |
+| Field              | Type | Nullable | Constraints         | DQ Level |
+| ------------------ | ---- | -------- | ------------------- | -------- |
+| `assay_chembl_id`  | str  | No       | regex `^CHEMBL\d+$` | CRITICAL |
+| `assay_type`       | str  | Yes      | isin [B,F,A,T,P,U]  | WARNING  |
+| `confidence_score` | int  | Yes      | [0, 9]              | WARNING  |
+| `target_chembl_id` | str  | Yes      | regex `^CHEMBL\d+$` | INFO     |
 
----
+______________________________________________________________________
 
 ## 6. Pipeline Configuration
 
@@ -221,7 +221,7 @@ class AssaySchema(ETLRecordSchema):
 pipeline_name: chembl_assay
 provider: chembl
 entity_type: assay
-version: "1.1.0"
+version: "1.2.0"
 
 primary_keys: ["assay_chembl_id"]
 silver_table: "chembl_assay"
@@ -241,21 +241,21 @@ input_filter:
   batch_size: 20
 ```
 
----
+______________________________________________________________________
 
 ## 7. Dependencies
 
 ### 7.1. Upstream
 
-| Dependency | Type | Required |
-|------------|------|----------|
-| ChEMBL API | API | Yes |
+| Dependency      | Type     | Required    |
+| --------------- | -------- | ----------- |
+| ChEMBL API      | API      | Yes         |
 | `chembl_target` | Pipeline | Recommended |
 
 ### 7.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
-| `chembl_activity` | FK reference |
-| `chembl_assay_parameters` | FK reference |
-| Protocol analysis | Assay type statistics |
+| Consumer                  | Impact                |
+| ------------------------- | --------------------- |
+| `chembl_activity`         | FK reference          |
+| `chembl_assay_parameters` | FK reference          |
+| Protocol analysis         | Assay type statistics |

--- a/docs/04-reference/pipelines/pubchem/01-compound-spec.md
+++ b/docs/04-reference/pipelines/pubchem/01-compound-spec.md
@@ -1,23 +1,23 @@
 # PubChem Compound Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `pubchem_compound` |
-| **Provider** | PubChem (NCBI) |
-| **Entity** | compound |
-| **API Endpoint** | `https://pubchem.ncbi.nlm.nih.gov/rest/pug/` |
-| **Library** | `pubchempy` (sync, requires executor) |
-| **Rate Limit** | 5 req/sec |
+| Parameter        | Value                                               |
+| ---------------- | --------------------------------------------------- |
+| **Pipeline ID**  | `pubchem_compound`                                  |
+| **Provider**     | PubChem (NCBI)                                      |
+| **Entity**       | compound                                            |
+| **API Endpoint** | `https://pubchem.ncbi.nlm.nih.gov/rest/pug/`        |
+| **Library**      | `pubchempy` (sync, requires executor)               |
+| **Rate Limit**   | 5 req/sec                                           |
 | **Health Check** | `/compound/cid/2244/property/MolecularFormula/JSON` |
-| **Auth Type** | None (public API) |
+| **Auth Type**    | None (public API)                                   |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -34,9 +34,9 @@ PubChem compounds are **chemical structures** with computed descriptors:
 ### 2.2. Use Cases
 
 1. **Structure Enrichment**: Add computed properties to ChEMBL molecules
-2. **Property Calculation**: Access pre-computed descriptors
-3. **3D Modeling**: Use 3D conformer data
-4. **Compound Search**: Find by structure or property ranges
+1. **Property Calculation**: Access pre-computed descriptors
+1. **3D Modeling**: Use 3D conformer data
+1. **Compound Search**: Find by structure or property ranges
 
 ### 2.3. Entity Relationships
 
@@ -46,7 +46,7 @@ pubchem_compound
     └──► chembl_molecule (via inchi_key)
 ```
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -63,60 +63,60 @@ compounds = pcp.get_compounds(cid_list, namespace="cid")
 
 ### 3.2. Complete API Fields
 
-| # | API Field | Type | Nullable | Description |
-|---|-----------|------|----------|-------------|
-| 1 | `CID` | int | No | Compound ID (PK) |
-| 2 | `CanonicalSMILES` | str | Yes | Canonical SMILES |
-| 3 | `IsomericSMILES` | str | Yes | SMILES with stereochemistry |
-| 4 | `InChI` | str | Yes | InChI identifier |
-| 5 | `InChIKey` | str | Yes | InChI Key (27 chars) |
-| 6 | `MolecularFormula` | str | Yes | Molecular formula |
-| 7 | `MolecularWeight` | float | Yes | Molecular weight |
-| 8 | `ExactMass` | float | Yes | Exact mass |
-| 9 | `MonoisotopicMass` | float | Yes | Monoisotopic mass |
-| 10 | `IUPACName` | str | Yes | IUPAC name |
-| 11 | `XLogP` | float | Yes | Computed LogP |
-| 12 | `TPSA` | float | Yes | Topological PSA |
-| 13 | `Complexity` | float | Yes | Complexity score |
-| 14 | `Charge` | int | Yes | Formal charge |
-| 15 | `HBondDonorCount` | int | Yes | H-bond donors |
-| 16 | `HBondAcceptorCount` | int | Yes | H-bond acceptors |
-| 17 | `RotatableBondCount` | int | Yes | Rotatable bonds |
-| 18 | `HeavyAtomCount` | int | Yes | Heavy atoms |
-| 19 | `AtomStereoCount` | int | Yes | Total stereocenters |
-| 20 | `DefinedAtomStereoCount` | int | Yes | Defined stereocenters |
-| 21 | `UndefinedAtomStereoCount` | int | Yes | Undefined stereocenters |
-| 22 | `BondStereoCount` | int | Yes | E/Z bonds |
-| 23 | `DefinedBondStereoCount` | int | Yes | Defined E/Z |
-| 24 | `UndefinedBondStereoCount` | int | Yes | Undefined E/Z |
-| 25 | `IsotopeAtomCount` | int | Yes | Isotopic atoms |
-| 26 | `CovalentUnitCount` | int | Yes | Covalent units |
-| 27 | `Volume3D` | float | Yes | 3D volume |
-| 28 | `ConformerCount3D` | int | Yes | 3D conformers |
+| #   | API Field                  | Type  | Nullable | Description                 |
+| --- | -------------------------- | ----- | -------- | --------------------------- |
+| 1   | `CID`                      | int   | No       | Compound ID (PK)            |
+| 2   | `CanonicalSMILES`          | str   | Yes      | Canonical SMILES            |
+| 3   | `IsomericSMILES`           | str   | Yes      | SMILES with stereochemistry |
+| 4   | `InChI`                    | str   | Yes      | InChI identifier            |
+| 5   | `InChIKey`                 | str   | Yes      | InChI Key (27 chars)        |
+| 6   | `MolecularFormula`         | str   | Yes      | Molecular formula           |
+| 7   | `MolecularWeight`          | float | Yes      | Molecular weight            |
+| 8   | `ExactMass`                | float | Yes      | Exact mass                  |
+| 9   | `MonoisotopicMass`         | float | Yes      | Monoisotopic mass           |
+| 10  | `IUPACName`                | str   | Yes      | IUPAC name                  |
+| 11  | `XLogP`                    | float | Yes      | Computed LogP               |
+| 12  | `TPSA`                     | float | Yes      | Topological PSA             |
+| 13  | `Complexity`               | float | Yes      | Complexity score            |
+| 14  | `Charge`                   | int   | Yes      | Formal charge               |
+| 15  | `HBondDonorCount`          | int   | Yes      | H-bond donors               |
+| 16  | `HBondAcceptorCount`       | int   | Yes      | H-bond acceptors            |
+| 17  | `RotatableBondCount`       | int   | Yes      | Rotatable bonds             |
+| 18  | `HeavyAtomCount`           | int   | Yes      | Heavy atoms                 |
+| 19  | `AtomStereoCount`          | int   | Yes      | Total stereocenters         |
+| 20  | `DefinedAtomStereoCount`   | int   | Yes      | Defined stereocenters       |
+| 21  | `UndefinedAtomStereoCount` | int   | Yes      | Undefined stereocenters     |
+| 22  | `BondStereoCount`          | int   | Yes      | E/Z bonds                   |
+| 23  | `DefinedBondStereoCount`   | int   | Yes      | Defined E/Z                 |
+| 24  | `UndefinedBondStereoCount` | int   | Yes      | Undefined E/Z               |
+| 25  | `IsotopeAtomCount`         | int   | Yes      | Isotopic atoms              |
+| 26  | `CovalentUnitCount`        | int   | Yes      | Covalent units              |
+| 27  | `Volume3D`                 | float | Yes      | 3D volume                   |
+| 28  | `ConformerCount3D`         | int   | Yes      | 3D conformers               |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
-| **Entity ID Field** | `cid` |
-| **ID Source** | `from_api` |
-| **Format** | Integer (positive) |
+| Parameter           | Value              |
+| ------------------- | ------------------ |
+| **Entity ID Field** | `cid`              |
+| **ID Source**       | `from_api`         |
+| **Format**          | Integer (positive) |
 
 ### 4.2. Field Normalization
 
-| Field | Normalization | Before | After |
-|-------|---------------|--------|-------|
-| `cid` | Cast to int | `2244` | `2244` |
-| `molecular_weight` | round(10) | `180.157123456789` | `180.1571234568` |
-| `xlogp` | round(2) | `1.31456` | `1.31` |
-| `canonical_smiles` | RDKit canonical | - | Normalized SMILES |
-| `inchi_key` | Validate format | `BSYNRYMUTXBXSQ...` | Validated |
+| Field              | Normalization   | Before              | After             |
+| ------------------ | --------------- | ------------------- | ----------------- |
+| `cid`              | Cast to int     | `2244`              | `2244`            |
+| `molecular_weight` | round(10)       | `180.157123456789`  | `180.1571234568`  |
+| `xlogp`            | round(2)        | `1.31456`           | `1.31`            |
+| `canonical_smiles` | RDKit canonical | -                   | Normalized SMILES |
+| `inchi_key`        | Validate format | `BSYNRYMUTXBXSQ...` | Validated         |
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -184,16 +184,16 @@ class PubchemMoleculeSchema(ETLRecordSchema):
         coerce = True
 ```
 
----
+______________________________________________________________________
 
 ## 6. Cross-Provider Mapping
 
-| This Entity Field | Maps To | Provider | Field |
-|-------------------|---------|----------|-------|
-| `inchi_key` | ChEMBL | ChEMBL | `structure_standard_inchi_key` |
-| `cid` | PubChem BioAssay | PubChem | CID |
+| This Entity Field | Maps To          | Provider | Field                          |
+| ----------------- | ---------------- | -------- | ------------------------------ |
+| `inchi_key`       | ChEMBL           | ChEMBL   | `structure_standard_inchi_key` |
+| `cid`             | PubChem BioAssay | PubChem  | CID                            |
 
----
+______________________________________________________________________
 
 ## 7. Pipeline Configuration
 
@@ -201,7 +201,7 @@ class PubchemMoleculeSchema(ETLRecordSchema):
 pipeline_name: pubchem_compound
 provider: pubchem
 entity_type: compound
-version: "1.1.0"
+version: "1.2.0"
 
 primary_keys: ["cid"]
 silver_table: "pubchem_compound"
@@ -229,7 +229,7 @@ input_filter:
   batch_size: 100
 ```
 
----
+______________________________________________________________________
 
 ## 8. Special Considerations
 
@@ -241,9 +241,7 @@ PubChemPy is synchronous. BioETL wraps it using `BaseSyncAdapter`:
 class PubChemAdapter(BaseSyncAdapter):
     async def fetch(self, cids: list[int]) -> list[dict]:
         # Wrapped in executor
-        return await self._run_in_executor(
-            pcp.get_compounds, cids, namespace="cid"
-        )
+        return await self._run_in_executor(pcp.get_compounds, cids, namespace="cid")
 ```
 
 ### 8.2. Rate Limiting

--- a/docs/04-reference/pipelines/uniprot/01-protein-spec.md
+++ b/docs/04-reference/pipelines/uniprot/01-protein-spec.md
@@ -1,23 +1,23 @@
 # UniProt Protein Pipeline Specification
 
-*Version 1.1.0 | Aligned with RULES.md v5.17*
+*Version 1.2.0 | Aligned with RULES.md v5.17*
 
----
+______________________________________________________________________
 
 ## 1. Identification
 
-| Parameter | Value |
-|-----------|-------|
-| **Pipeline ID** | `uniprot_protein` |
-| **Provider** | UniProt (EBI/SIB/PIR) |
-| **Entity** | protein |
+| Parameter        | Value                                 |
+| ---------------- | ------------------------------------- |
+| **Pipeline ID**  | `uniprot_protein`                     |
+| **Provider**     | UniProt (EBI/SIB/PIR)                 |
+| **Entity**       | protein                               |
 | **API Endpoint** | `https://rest.uniprot.org/uniprotkb/` |
-| **Library** | `unipressed` (async) |
-| **Rate Limit** | 100 req/sec (with API key) |
-| **Health Check** | `/rest/beta/health` |
-| **Auth Type** | API Key (optional) |
+| **Library**      | `unipressed` (async)                  |
+| **Rate Limit**   | 100 req/sec (with API key)            |
+| **Health Check** | `/rest/beta/health`                   |
+| **Auth Type**    | API Key (optional)                    |
 
----
+______________________________________________________________________
 
 ## 2. Business Context
 
@@ -34,10 +34,10 @@ UniProt proteins are **curated protein entries** with comprehensive annotations:
 ### 2.2. Use Cases
 
 1. **Target Identification**: Find drug targets with ChEMBL links
-2. **Sequence Analysis**: Access protein sequences for alignment
-3. **Functional Annotation**: Understand protein functions
-4. **Drug-Target Networks**: Build networks via cross-references
-5. **Species Translation**: Compare orthologs across organisms
+1. **Sequence Analysis**: Access protein sequences for alignment
+1. **Functional Annotation**: Understand protein functions
+1. **Drug-Target Networks**: Build networks via cross-references
+1. **Species Translation**: Compare orthologs across organisms
 
 ### 2.3. Entity Relationships
 
@@ -51,7 +51,7 @@ uniprot_protein
     └──► GO terms (via go_terms)
 ```
 
----
+______________________________________________________________________
 
 ## 3. Extraction (Bronze Layer)
 
@@ -65,86 +65,95 @@ client = UniProtkbClient()
 results = await client.search(
     query="accession:P00533",
     fields=[
-        "accession", "id", "protein_name", "gene_names",
-        "organism_name", "organism_id", "sequence", "length",
-        "cc_function", "cc_pathway", "xref_chembl", "xref_drugbank"
-    ]
+        "accession",
+        "id",
+        "protein_name",
+        "gene_names",
+        "organism_name",
+        "organism_id",
+        "sequence",
+        "length",
+        "cc_function",
+        "cc_pathway",
+        "xref_chembl",
+        "xref_drugbank",
+    ],
 )
 ```
 
 ### 3.2. Complete API Fields
 
-| # | API Field | JSON Type | Nullable | Description |
-|---|-----------|-----------|----------|-------------|
-| 1 | `primaryAccession` | string | No | Primary accession (PK) |
-| 2 | `uniProtkbId` | string | No | Entry name |
-| 3 | `entryType` | string | Yes | Swiss-Prot/TrEMBL |
-| 4 | `secondaryAccessions` | array | Yes | Secondary accessions |
-| 5 | `proteinDescription` | object | Yes | Protein names |
-| 6 | `genes` | array | Yes | Gene names |
-| 7 | `organism` | object | Yes | Organism info |
-| 8 | `sequence` | object | Yes | Sequence data |
-| 9 | `features` | array | Yes | Sequence features |
-| 10 | `comments` | array | Yes | Functional annotations |
-| 11 | `dbreferences` | array | Yes | Cross-references |
-| 12 | `keywords` | array | Yes | UniProt keywords |
+| #   | API Field             | JSON Type | Nullable | Description            |
+| --- | --------------------- | --------- | -------- | ---------------------- |
+| 1   | `primaryAccession`    | string    | No       | Primary accession (PK) |
+| 2   | `uniProtkbId`         | string    | No       | Entry name             |
+| 3   | `entryType`           | string    | Yes      | Swiss-Prot/TrEMBL      |
+| 4   | `secondaryAccessions` | array     | Yes      | Secondary accessions   |
+| 5   | `proteinDescription`  | object    | Yes      | Protein names          |
+| 6   | `genes`               | array     | Yes      | Gene names             |
+| 7   | `organism`            | object    | Yes      | Organism info          |
+| 8   | `sequence`            | object    | Yes      | Sequence data          |
+| 9   | `features`            | array     | Yes      | Sequence features      |
+| 10  | `comments`            | array     | Yes      | Functional annotations |
+| 11  | `dbreferences`        | array     | Yes      | Cross-references       |
+| 12  | `keywords`            | array     | Yes      | UniProt keywords       |
 
 ### 3.3. Nested Structure: proteinDescription
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `recommendedName.fullName.value` | string | Recommended protein name |
-| `alternativeNames[*].fullName.value` | array | Alternative names |
-| `ecNumbers[*].value` | array | EC numbers |
+| Field                                | Type   | Description              |
+| ------------------------------------ | ------ | ------------------------ |
+| `recommendedName.fullName.value`     | string | Recommended protein name |
+| `alternativeNames[*].fullName.value` | array  | Alternative names        |
+| `ecNumbers[*].value`                 | array  | EC numbers               |
 
 ### 3.4. Nested Structure: organism
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `scientificName` | string | Scientific name |
-| `commonName` | string | Common name |
-| `taxonId` | integer | NCBI Taxonomy ID |
-| `lineage` | array | Taxonomic lineage |
+| Field            | Type    | Description       |
+| ---------------- | ------- | ----------------- |
+| `scientificName` | string  | Scientific name   |
+| `commonName`     | string  | Common name       |
+| `taxonId`        | integer | NCBI Taxonomy ID  |
+| `lineage`        | array   | Taxonomic lineage |
 
 ### 3.5. Nested Structure: sequence
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `value` | string | Amino acid sequence |
-| `length` | integer | Sequence length |
-| `molWeight` | integer | Molecular weight |
-| `crc64` | string | CRC64 checksum |
+| Field       | Type    | Description         |
+| ----------- | ------- | ------------------- |
+| `value`     | string  | Amino acid sequence |
+| `length`    | integer | Sequence length     |
+| `molWeight` | integer | Molecular weight    |
+| `crc64`     | string  | CRC64 checksum      |
 
----
+______________________________________________________________________
 
 ## 4. Transformation
 
 ### 4.1. Entity ID Strategy
 
-| Parameter | Value |
-|-----------|-------|
+| Parameter           | Value                          |
+| ------------------- | ------------------------------ |
 | **Entity ID Field** | `accession` (primaryAccession) |
-| **ID Source** | `from_api` |
-| **Format** | UniProt accession pattern |
+| **ID Source**       | `from_api`                     |
+| **Format**          | UniProt accession pattern      |
 
 ### 4.2. Flattening Strategy
 
-| Nested Path | Flattened Name | Strategy |
-|-------------|----------------|----------|
-| `proteinDescription.recommendedName.fullName.value` | `protein_name` | Extract scalar |
-| `proteinDescription.ecNumbers[*].value` | `protein_ec_numbers` | JSON array |
-| `genes[0].geneName.value` | `gene_primary` | Extract first |
-| `genes[*].synonyms[*].value` | `gene_synonyms` | JSON array |
-| `organism.scientificName` | `organism_scientific` | Extract scalar |
-| `organism.commonName` | `organism_common` | Extract scalar |
-| `organism.taxonId` | `taxonomy_id` | Extract scalar |
-| `sequence.value` | `sequence` | Extract scalar |
-| `sequence.length` | `sequence_length` | Extract scalar |
-| `sequence.molWeight` | `sequence_mass` | Extract scalar |
-| `dbreferences[type=ChEMBL]` | `chembl_ids` | Filter & extract |
-| `dbreferences[type=DrugBank]` | `drugbank_ids` | Filter & extract |
+| Nested Path                                         | Flattened Name        | Strategy         |
+| --------------------------------------------------- | --------------------- | ---------------- |
+| `proteinDescription.recommendedName.fullName.value` | `protein_name`        | Extract scalar   |
+| `proteinDescription.ecNumbers[*].value`             | `protein_ec_numbers`  | JSON array       |
+| `genes[0].geneName.value`                           | `gene_primary`        | Extract first    |
+| `genes[*].synonyms[*].value`                        | `gene_synonyms`       | JSON array       |
+| `organism.scientificName`                           | `organism_scientific` | Extract scalar   |
+| `organism.commonName`                               | `organism_common`     | Extract scalar   |
+| `organism.taxonId`                                  | `taxonomy_id`         | Extract scalar   |
+| `sequence.value`                                    | `sequence`            | Extract scalar   |
+| `sequence.length`                                   | `sequence_length`     | Extract scalar   |
+| `sequence.molWeight`                                | `sequence_mass`       | Extract scalar   |
+| `dbreferences[type=ChEMBL]`                         | `chembl_ids`          | Filter & extract |
+| `dbreferences[type=DrugBank]`                       | `drugbank_ids`        | Filter & extract |
 
----
+______________________________________________________________________
 
 ## 5. Validation
 
@@ -162,7 +171,9 @@ class UniprotTargetSchema(ETLRecordSchema):
 
     @pa.check("accession", name="accession_format")
     def _check_accession(cls, series):
-        pattern = r"^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
+        pattern = (
+            r"^[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}$"
+        )
         return series.str.match(pattern)
 
     entry_name: Series[str] = pa.Field(nullable=False)
@@ -230,27 +241,27 @@ class UniprotTargetSchema(ETLRecordSchema):
 
 ### 5.2. Field Validation Matrix
 
-| Field | Type | Nullable | Constraints | DQ Level |
-|-------|------|----------|-------------|----------|
-| `accession` | str | No | UniProt format | CRITICAL |
-| `entry_name` | str | No | format `XXX_SPECIES` | CRITICAL |
-| `sequence` | str | No | amino acid chars only | CRITICAL |
-| `sequence_length` | int | No | >= 1 | CRITICAL |
-| `taxonomy_id` | int | Yes | >= 1 | WARNING |
-| `reviewed` | bool | No | - | INFO |
+| Field             | Type | Nullable | Constraints           | DQ Level |
+| ----------------- | ---- | -------- | --------------------- | -------- |
+| `accession`       | str  | No       | UniProt format        | CRITICAL |
+| `entry_name`      | str  | No       | format `XXX_SPECIES`  | CRITICAL |
+| `sequence`        | str  | No       | amino acid chars only | CRITICAL |
+| `sequence_length` | int  | No       | >= 1                  | CRITICAL |
+| `taxonomy_id`     | int  | Yes      | >= 1                  | WARNING  |
+| `reviewed`        | bool | No       | -                     | INFO     |
 
----
+______________________________________________________________________
 
 ## 6. Cross-Provider Mapping
 
-| This Entity Field | Maps To | Provider | Field |
-|-------------------|---------|----------|-------|
-| `accession` | ChEMBL | ChEMBL | `target_component.accession` |
-| `chembl_ids[*]` | ChEMBL | ChEMBL | `target_chembl_id` |
-| `drugbank_ids[*]` | DrugBank | DrugBank | `drugbank_id` |
-| `taxonomy_id` | NCBI Taxonomy | NCBI | `tax_id` |
+| This Entity Field | Maps To       | Provider | Field                        |
+| ----------------- | ------------- | -------- | ---------------------------- |
+| `accession`       | ChEMBL        | ChEMBL   | `target_component.accession` |
+| `chembl_ids[*]`   | ChEMBL        | ChEMBL   | `target_chembl_id`           |
+| `drugbank_ids[*]` | DrugBank      | DrugBank | `drugbank_id`                |
+| `taxonomy_id`     | NCBI Taxonomy | NCBI     | `tax_id`                     |
 
----
+______________________________________________________________________
 
 ## 7. Pipeline Configuration
 
@@ -258,7 +269,7 @@ class UniprotTargetSchema(ETLRecordSchema):
 pipeline_name: uniprot_protein
 provider: uniprot
 entity_type: protein
-version: "1.1.0"
+version: "1.2.0"
 
 primary_keys: ["accession"]
 silver_table: "uniprot_protein"
@@ -291,21 +302,21 @@ input_filter:
   batch_size: 100  # Higher for UniProt
 ```
 
----
+______________________________________________________________________
 
 ## 8. Dependencies
 
 ### 8.1. Upstream
 
-| Dependency | Type | Required |
-|------------|------|----------|
-| UniProt REST API | API | Yes |
+| Dependency          | Type     | Required                      |
+| ------------------- | -------- | ----------------------------- |
+| UniProt REST API    | API      | Yes                           |
 | `uniprot_idmapping` | Pipeline | Optional (for ChEMBL→UniProt) |
 
 ### 8.2. Downstream
 
-| Consumer | Impact |
-|----------|--------|
-| Target annotation | Protein function/pathway data |
-| Cross-database linking | ChEMBL/DrugBank integration |
-| Sequence analysis | Protein sequences for alignment |
+| Consumer               | Impact                          |
+| ---------------------- | ------------------------------- |
+| Target annotation      | Protein function/pathway data   |
+| Cross-database linking | ChEMBL/DrugBank integration     |
+| Sequence analysis      | Protein sequences for alignment |

--- a/docs/04-reference/providers/chembl/activity.md
+++ b/docs/04-reference/providers/chembl/activity.md
@@ -5,13 +5,13 @@
 **Сущность:** `activity`
 **Версия схемы:** 1.2.0
 
----
+______________________________________________________________________
 
 ## 1. Описание
 
-Пайплайн извлекает данные о биологической активности молекул из API ChEMBL. Каждая запись содержит результат измерения активности (IC50, Ki и др.) для пары молекула-мишень.
+Пайплайн извлекает данные о биологической активности молекул из API ChEMBL. Каждая запись содержит результат измерения активности (IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50 и др.) для пары молекула-мишень.
 
----
+______________________________________________________________________
 
 ## 2. Конфигурация
 
@@ -56,7 +56,7 @@ dq_rules:
     hard_fail_threshold: 0.20   # 20% ошибок → FAIL BATCH
 ```
 
----
+______________________________________________________________________
 
 ## 3. Схема данных
 
@@ -64,118 +64,118 @@ dq_rules:
 
 **Файл:** `src/bioetl/domain/entities/bioactivity.py`
 
-Сущность `Activity` содержит **55 полей**, сгруппированных по категориям:
+Сущность `Activity` содержит **57 полей**, сгруппированных по категориям:
 
 #### Идентификаторы
 
-| Поле | Тип | Обязательное | Описание |
-|------|-----|--------------|----------|
-| `activity_id` | `str` | **Да** | Уникальный идентификатор записи активности |
-| `molecule_chembl_id` | `str` | **Да** | ChEMBL ID молекулы (например, `CHEMBL25`) |
-| `target_chembl_id` | `str` | Нет | ChEMBL ID мишени |
-| `assay_chembl_id` | `str` | Нет | ChEMBL ID анализа |
-| `document_chembl_id` | `str` | Нет | ChEMBL ID публикации |
-| `record_id` | `int` | Нет | Внутренний ID записи |
-| `src_id` | `int` | Нет | ID источника данных |
+| Поле                 | Тип   | Обязательное | Описание                                   |
+| -------------------- | ----- | ------------ | ------------------------------------------ |
+| `activity_id`        | `str` | **Да**       | Уникальный идентификатор записи активности |
+| `molecule_chembl_id` | `str` | **Да**       | ChEMBL ID молекулы (например, `CHEMBL25`)  |
+| `target_chembl_id`   | `str` | Нет          | ChEMBL ID мишени                           |
+| `assay_chembl_id`    | `str` | Нет          | ChEMBL ID анализа                          |
+| `document_chembl_id` | `str` | Нет          | ChEMBL ID публикации                       |
+| `record_id`          | `int` | Нет          | Внутренний ID записи                       |
+| `src_id`             | `int` | Нет          | ID источника данных                        |
 
 #### Данные молекулы
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `canonical_smiles` | `str` | SMILES-формула молекулы |
-| `molecule_pref_name` | `str` | Предпочтительное название молекулы |
-| `parent_molecule_chembl_id` | `str` | ID родительской молекулы |
+| Поле                        | Тип   | Описание                           |
+| --------------------------- | ----- | ---------------------------------- |
+| `canonical_smiles`          | `str` | SMILES-формула молекулы            |
+| `molecule_pref_name`        | `str` | Предпочтительное название молекулы |
+| `parent_molecule_chembl_id` | `str` | ID родительской молекулы           |
 
 #### Данные мишени
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `target_pref_name` | `str` | Название мишени |
-| `target_organism` | `str` | Организм мишени |
-| `target_tax_id` | `str` | Таксономический ID |
+| Поле               | Тип   | Описание           |
+| ------------------ | ----- | ------------------ |
+| `target_pref_name` | `str` | Название мишени    |
+| `target_organism`  | `str` | Организм мишени    |
+| `target_tax_id`    | `str` | Таксономический ID |
 
 #### Данные анализа
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `assay_type` | `str` | Тип анализа (B, F, A, T, P) |
-| `assay_description` | `str` | Описание анализа |
-| `bao_endpoint` | `str` | BAO endpoint (онтология) |
-| `bao_format` | `str` | BAO format |
-| `bao_label` | `str` | BAO label |
+| Поле                | Тип   | Описание                    |
+| ------------------- | ----- | --------------------------- |
+| `assay_type`        | `str` | Тип анализа (B, F, A, T, P) |
+| `assay_description` | `str` | Описание анализа            |
+| `bao_endpoint`      | `str` | BAO endpoint (онтология)    |
+| `bao_format`        | `str` | BAO format                  |
+| `bao_label`         | `str` | BAO label                   |
 
 #### Сырые значения активности
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `type` | `str` | Тип измерения (сырой) |
-| `value` | `float` | Значение (сырое) |
-| `units` | `str` | Единицы измерения (сырые) |
-| `relation` | `str` | Отношение (`=`, `<`, `>`, `~`) |
-| `upper_value` | `float` | Верхняя граница диапазона |
-| `text_value` | `str` | Текстовое значение |
+| Поле          | Тип     | Описание                       |
+| ------------- | ------- | ------------------------------ |
+| `type`        | `str`   | Тип измерения (сырой)          |
+| `value`       | `float` | Значение (сырое)               |
+| `units`       | `str`   | Единицы измерения (сырые)      |
+| `relation`    | `str`   | Отношение (`=`, `<`, `>`, `~`) |
+| `upper_value` | `float` | Верхняя граница диапазона      |
+| `text_value`  | `str`   | Текстовое значение             |
 
 #### Стандартизированные значения
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `standard_type` | `str` | Тип: IC50, Ki, EC50, Kd и др. |
-| `standard_value` | `float` | Стандартизированное значение |
-| `standard_units` | `str` | Единицы: nM, uM, и др. |
-| `standard_relation` | `str` | Отношение |
-| `standard_upper_value` | `float` | Верхняя граница |
-| `standard_flag` | `int` | Флаг стандартизации |
+| Поле                   | Тип     | Описание                                                             |
+| ---------------------- | ------- | -------------------------------------------------------------------- |
+| `standard_type`        | `str`   | Тип: IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50, EC50, Kd и др. |
+| `standard_value`       | `float` | Стандартизированное значение                                         |
+| `standard_units`       | `str`   | Единицы: nM, uM, и др.                                               |
+| `standard_relation`    | `str`   | Отношение                                                            |
+| `standard_upper_value` | `float` | Верхняя граница                                                      |
+| `standard_flag`        | `int`   | Флаг стандартизации                                                  |
 
 #### Вычисляемые метрики
 
-| Поле | Тип | Описание |
-|------|-----|----------|
+| Поле            | Тип     | Описание                       |
+| --------------- | ------- | ------------------------------ |
 | `pchembl_value` | `float` | pChEMBL = -log10(IC50 в молях) |
 
 ##### Метрики эффективности лиганда (Ligand Efficiency)
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `ligand_efficiency_bei` | `float` | **BEI** (Binding Efficiency Index) — эффективность связывания на атом |
-| `ligand_efficiency_le` | `float` | **LE** (Ligand Efficiency) — изменение энергии связывания на тяжелый атом |
+| Поле                    | Тип     | Описание                                                                   |
+| ----------------------- | ------- | -------------------------------------------------------------------------- |
+| `ligand_efficiency_bei` | `float` | **BEI** (Binding Efficiency Index) — эффективность связывания на атом      |
+| `ligand_efficiency_le`  | `float` | **LE** (Ligand Efficiency) — изменение энергии связывания на тяжелый атом  |
 | `ligand_efficiency_lle` | `float` | **LLE** (Lipophilic Ligand Efficiency) — баланс активности и липофильности |
-| `ligand_efficiency_sei` | `float` | **SEI** (Surface Efficiency Index) — эффективность по площади поверхности |
+| `ligand_efficiency_sei` | `float` | **SEI** (Surface Efficiency Index) — эффективность по площади поверхности  |
 
 > **Примечание**: Все метрики ligand_efficiency вычисляются ChEMBL и предоставляются через API. В Silver слое они разворачиваются из вложенного словаря в отдельные колонки для удобства аналитики.
 
 #### Метаданные качества
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `activity_comment` | `str` | Комментарий к активности |
-| `data_validity_comment` | `str` | Комментарий о валидности |
-| `data_validity_description` | `str` | Описание проблемы с данными |
-| `potential_duplicate` | `int` | Флаг потенциального дубликата |
+| Поле                        | Тип   | Описание                      |
+| --------------------------- | ----- | ----------------------------- |
+| `activity_comment`          | `str` | Комментарий к активности      |
+| `data_validity_comment`     | `str` | Комментарий о валидности      |
+| `data_validity_description` | `str` | Описание проблемы с данными   |
+| `potential_duplicate`       | `int` | Флаг потенциального дубликата |
 
 #### Тип действия (Action Type)
 
 Поля развёрнуты из вложенного словаря ChEMBL API (`action_type`):
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `action_type_action_type` | `str` | Тип действия: INHIBITOR, AGONIST, ANTAGONIST и др. |
-| `action_type_description` | `str` | Описание типа действия |
+| Поле                      | Тип   | Описание                                            |
+| ------------------------- | ----- | --------------------------------------------------- |
+| `action_type_action_type` | `str` | Тип действия: INHIBITOR, AGONIST, ANTAGONIST и др.  |
+| `action_type_description` | `str` | Описание типа действия                              |
 | `action_type_parent_type` | `str` | Родительская группа типа действия (может быть null) |
 
 > **Примечание**: Поля `action_type_*` извлекаются из вложенного словаря API с помощью `flatten_nested_dict()`. Если запись не содержит информации о типе действия, все поля будут `None`.
 
 #### Системные поля (добавляются при обработке)
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `entity_id` | `str` | `chembl:{activity_id}` |
-| `content_hash` | `str` | SHA256-хеш содержимого |
-| `_run_id` | `str` | UUID запуска пайплайна |
-| `_run_type` | `str` | `incremental`, `backfill`, `rebuild` |
-| `_source_batch_id` | `str` | UUID батча |
-| `_ingestion_ts` | `str` | Timestamp загрузки (ISO8601) |
+| Поле               | Тип   | Описание                             |
+| ------------------ | ----- | ------------------------------------ |
+| `entity_id`        | `str` | `chembl:{activity_id}`               |
+| `content_hash`     | `str` | SHA256-хеш содержимого               |
+| `_run_id`          | `str` | UUID запуска пайплайна               |
+| `_run_type`        | `str` | `incremental`, `backfill`, `rebuild` |
+| `_source_batch_id` | `str` | UUID батча                           |
+| `_ingestion_ts`    | `str` | Timestamp загрузки (ISO8601)         |
 
----
+______________________________________________________________________
 
 ### 3.2. Валидация при создании сущности
 
@@ -189,7 +189,7 @@ def _validate_invariants(self) -> None:
         raise ValueError("pChemBL value must be non-negative")
 ```
 
----
+______________________________________________________________________
 
 ## 4. Нормализация данных
 
@@ -218,13 +218,13 @@ def _validate_invariants(self) -> None:
 
 ### 4.2. Правила нормализации типов
 
-| Исходный тип | Преобразование |
-|--------------|----------------|
-| `float` с NaN/Inf | → `None` |
-| `float` | → `round(value, 10)` |
-| `int` | → безопасная конвертация или `None` |
-| `str` | → `strip()` |
-| `dict`, `list` | → JSON-строка |
+| Исходный тип      | Преобразование                      |
+| ----------------- | ----------------------------------- |
+| `float` с NaN/Inf | → `None`                            |
+| `float`           | → `round(value, 10)`                |
+| `int`             | → безопасная конвертация или `None` |
+| `str`             | → `strip()`                         |
+| `dict`, `list`    | → JSON-строка                       |
 
 ### 4.3. Генерация идентификаторов
 
@@ -233,9 +233,7 @@ def _validate_invariants(self) -> None:
 entity_id = f"chembl:{activity_id}"
 
 # Content Hash: SHA256 для версионирования
-content_hash = sha256(
-    "chembl" + canonical_json(business_fields)
-)
+content_hash = sha256("chembl" + canonical_json(business_fields))
 ```
 
 ### 4.4. Поля, исключённые из хеша
@@ -251,30 +249,30 @@ META_FIELDS = {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 5. Валидация и Data Quality
 
 ### 5.1. Классификация ошибок
 
-| Тип | Поведение | Примеры |
-|-----|-----------|---------|
-| **Critical** | Остановка пайплайна | Auth failure, schema mismatch |
-| **Recoverable** | Retry (3x, backoff 2.0) | 429, 502, 504 |
-| **Data Quality** | Карантин записи | Invalid SMILES, missing field |
+| Тип              | Поведение               | Примеры                       |
+| ---------------- | ----------------------- | ----------------------------- |
+| **Critical**     | Остановка пайплайна     | Auth failure, schema mismatch |
+| **Recoverable**  | Retry (3x, backoff 2.0) | 429, 502, 504                 |
+| **Data Quality** | Карантин записи         | Invalid SMILES, missing field |
 
 ### 5.2. DQ-правила для Activity
 
 1. **`standard_value` > 0** — не null, не отрицательный
-2. **`standard_type`** ∈ {IC50, Ki, EC50, Kd, ...}
-3. **`molecule_chembl_id`** соответствует regex `^CHEMBL\d+$`
+1. **`standard_type`** ∈ {IC50, Ki, Kd, EC50, AC50, GI50, ED50, MIC, CC50, EC50, Kd, ...}
+1. **`molecule_chembl_id`** соответствует regex `^CHEMBL\d+$`
 
 ### 5.3. Пороги ошибок
 
-| Порог | Условие | Действие |
-|-------|---------|----------|
-| Soft | > 5% ошибок в батче | WARNING в лог |
-| Hard | > 20% ошибок в батче | `DataQualityThresholdError` |
+| Порог | Условие              | Действие                    |
+| ----- | -------------------- | --------------------------- |
+| Soft  | > 5% ошибок в батче  | WARNING в лог               |
+| Hard  | > 20% ошибок в батче | `DataQualityThresholdError` |
 
 ### 5.4. Карантин
 
@@ -282,15 +280,15 @@ META_FIELDS = {
 
 ```python
 {
-    "raw_record": {...},      # Исходная запись
+    "raw_record": {...},  # Исходная запись
     "error_code": "INVALID_STANDARD_VALUE",
     "error_details": "standard_value is negative",
     "batch_id": "uuid",
-    "timestamp": "2025-12-19T10:30:00Z"
+    "timestamp": "2025-12-19T10:30:00Z",
 }
 ```
 
----
+______________________________________________________________________
 
 ## 6. Запись в слои Medallion
 
@@ -302,14 +300,15 @@ META_FIELDS = {
 Путь: bronze/v1/chembl/activity/2025-12-19/batch_{uuid}.jsonl.zst
 ```
 
-| Параметр | Значение |
-|----------|----------|
-| **Формат** | JSONL + Zstandard (level 3) |
-| **Режим** | Append-only |
-| **Retention** | 90 дней |
-| **Chunk size** | 256 KB |
+| Параметр       | Значение                    |
+| -------------- | --------------------------- |
+| **Формат**     | JSONL + Zstandard (level 3) |
+| **Режим**      | Append-only                 |
+| **Retention**  | 90 дней                     |
+| **Chunk size** | 256 KB                      |
 
 **Metadata sidecar** (`.meta.json`):
+
 ```json
 {
     "run_id": "uuid",
@@ -321,7 +320,7 @@ META_FIELDS = {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 6.2. Silver Layer
 
@@ -330,31 +329,33 @@ META_FIELDS = {
 **PyArrow Schema** (`src/bioetl/infrastructure/schemas/silver.py`):
 
 ```python
-CHEMBL_ACTIVITY_SCHEMA = pa.schema([
-    pa.field("entity_id", pa.string()),
-    pa.field("content_hash", pa.string()),
-    pa.field("activity_id", pa.string()),
-    pa.field("molecule_chembl_id", pa.string()),
-    pa.field("target_chembl_id", pa.string()),
-    pa.field("standard_type", pa.string()),
-    pa.field("standard_value", pa.float64()),
-    pa.field("standard_units", pa.string()),
-    pa.field("pchembl_value", pa.float64()),
-    pa.field("_run_id", pa.string()),
-    pa.field("_run_type", pa.string()),
-    pa.field("_ingestion_ts", pa.string()),
-    # ... всего 55 полей (включая action_type_*)
-])
+CHEMBL_ACTIVITY_SCHEMA = pa.schema(
+    [
+        pa.field("entity_id", pa.string()),
+        pa.field("content_hash", pa.string()),
+        pa.field("activity_id", pa.string()),
+        pa.field("molecule_chembl_id", pa.string()),
+        pa.field("target_chembl_id", pa.string()),
+        pa.field("standard_type", pa.string()),
+        pa.field("standard_value", pa.float64()),
+        pa.field("standard_units", pa.string()),
+        pa.field("pchembl_value", pa.float64()),
+        pa.field("_run_id", pa.string()),
+        pa.field("_run_type", pa.string()),
+        pa.field("_ingestion_ts", pa.string()),
+        # ... всего 57 полей (включая action_type_*)
+    ]
+)
 ```
 
-| Параметр | Значение |
-|----------|----------|
-| **Формат** | Delta Lake |
-| **Merge Key** | `activity_id` |
-| **Партиционирование** | `year`, `month` |
+| Параметр                 | Значение                         |
+| ------------------------ | -------------------------------- |
+| **Формат**               | Delta Lake                       |
+| **Merge Key**            | `activity_id`                    |
+| **Партиционирование**    | `year`, `month`                  |
 | **Приоритет конфликтов** | REBUILD > BACKFILL > INCREMENTAL |
 
----
+______________________________________________________________________
 
 ### 6.3. Gold Layer
 
@@ -364,19 +365,21 @@ CHEMBL_ACTIVITY_SCHEMA = pa.schema([
 
 ```python
 def should_include(self, context, record) -> bool:
-    return all([
-        record.get("standard_value") is not None,  # Есть значение
-        record.get("standard_units"),               # Есть единицы
-        record.get("target_chembl_id"),             # Есть мишень
-        record.get("standard_type") in {"IC50", "Ki"},  # Правильный тип
-        not record.get("data_validity_comment"),    # Нет флагов проблем
-    ])
+    return all(
+        [
+            record.get("standard_value") is not None,  # Есть значение
+            record.get("standard_units"),  # Есть единицы
+            record.get("target_chembl_id"),  # Есть мишень
+            record.get("standard_type") in {"IC50", "Ki"},  # Правильный тип
+            not record.get("data_validity_comment"),  # Нет флагов проблем
+        ]
+    )
 ```
 
-| Параметр | Значение |
-|----------|----------|
-| **Формат** | Delta Lake |
-| **Режим** | Overwrite |
+| Параметр      | Значение              |
+| ------------- | --------------------- |
+| **Формат**    | Delta Lake            |
+| **Режим**     | Overwrite             |
 | **Валидация** | Strict Pandera schema |
 
 #### Data Contract
@@ -401,7 +404,7 @@ def should_include(self, context, record) -> bool:
 }
 ```
 
----
+______________________________________________________________________
 
 ## 7. Полный поток данных
 
@@ -428,7 +431,7 @@ ChEMBL API (/activity.json)
 │  ─────────────────────────────────────  │
 │  • Формат: Delta Lake                   │
 │  • Merge by: activity_id                │
-│  • Schema: 55 полей (PyArrow)           │
+│  • Schema: 57 полей (PyArrow)           │
 │  • Партиции: year/month                 │
 └─────────────────────────────────────────┘
          │
@@ -446,20 +449,20 @@ ChEMBL API (/activity.json)
 └─────────────────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ## 8. Результат обработки батча
 
 ```python
 @dataclass
 class BatchResult:
-    bronze_count: int       # Записей в Bronze
-    silver_count: int       # Успешно трансформировано
-    gold_count: int         # Прошло Gold-фильтр
+    bronze_count: int  # Записей в Bronze
+    silver_count: int  # Успешно трансформировано
+    gold_count: int  # Прошло Gold-фильтр
     quarantined_count: int  # Отправлено в карантин
 ```
 
----
+______________________________________________________________________
 
 ## 9. Watermark (инкрементальная загрузка)
 
@@ -475,24 +478,24 @@ def extract(self, context, record) -> Watermark:
     return Watermark.from_id("")
 ```
 
----
+______________________________________________________________________
 
 ## 10. Связанные файлы
 
-| Компонент | Путь |
-|-----------|------|
-| Конфигурация | `configs/pipelines/chembl/activity.yaml` |
-| Сущность | `src/bioetl/domain/entities/bioactivity.py` |
-| Трансформер | `src/bioetl/application/pipelines/chembl/activity_transformer.py` |
-| Gold-фильтр | `src/bioetl/application/pipelines/chembl/activity_gold_filter.py` |
-| Watermark | `src/bioetl/application/pipelines/chembl/activity_watermark.py` |
-| Silver Schema | `src/bioetl/infrastructure/schemas/silver.py` |
-| Bronze Writer | `src/bioetl/infrastructure/storage/bronze_writer.py` |
-| Delta Writer | `src/bioetl/infrastructure/storage/delta_writer.py` |
-| Gold Writer | `src/bioetl/infrastructure/storage/gold_writer.py` |
-| Data Contract | `docs/contracts/gold/activity.json` |
+| Компонент     | Путь                                                              |
+| ------------- | ----------------------------------------------------------------- |
+| Конфигурация  | `configs/pipelines/chembl/activity.yaml`                          |
+| Сущность      | `src/bioetl/domain/entities/bioactivity.py`                       |
+| Трансформер   | `src/bioetl/application/pipelines/chembl/activity_transformer.py` |
+| Gold-фильтр   | `src/bioetl/application/pipelines/chembl/activity_gold_filter.py` |
+| Watermark     | `src/bioetl/application/pipelines/chembl/activity_watermark.py`   |
+| Silver Schema | `src/bioetl/infrastructure/schemas/silver.py`                     |
+| Bronze Writer | `src/bioetl/infrastructure/storage/bronze_writer.py`              |
+| Delta Writer  | `src/bioetl/infrastructure/storage/delta_writer.py`               |
+| Gold Writer   | `src/bioetl/infrastructure/storage/gold_writer.py`                |
+| Data Contract | `docs/contracts/gold/activity.json`                               |
 
----
+______________________________________________________________________
 
 ## 11. Пример использования CLI
 
@@ -510,6 +513,6 @@ bioetl run chembl_activity --run-type backfill --start-date 2024-01-01
 bioetl run chembl_activity --run-type rebuild
 ```
 
----
+______________________________________________________________________
 
 *Последнее обновление: 2025-12-24*

--- a/docs/04-reference/providers/crossref/publication.md
+++ b/docs/04-reference/providers/crossref/publication.md
@@ -3,9 +3,9 @@
 **Имя пайплайна:** `crossref_publication`
 **Провайдер:** `crossref`
 **Сущность:** `publication` (API-термин: `work`)
-**Версия схемы:** 1.0.0
+**Версия схемы:** 1.2.0
 
----
+______________________________________________________________________
 
 ## 1. Описание
 
@@ -14,59 +14,59 @@
 ### Основные сценарии использования
 
 1. **Обогащение документов ChEMBL** — добавление цитирований к публикациям из ChEMBL Documents
-2. **Обогащение PubMed публикаций** — дополнительные метаданные (citation_count, reference_count)
-3. **Резолюция DOI** — получение полных метаданных по списку DOI
+1. **Обогащение PubMed публикаций** — дополнительные метаданные (citation_count, reference_count)
+1. **Резолюция DOI** — получение полных метаданных по списку DOI
 
----
+______________________________________________________________________
 
 ## 2. Ключевые поля
 
 ### Идентификаторы
 
-| Поле | Тип | Описание |
-|------|-----|----------|
+| Поле  | Тип   | Описание                                                         |
+| ----- | ----- | ---------------------------------------------------------------- |
 | `doi` | `str` | Digital Object Identifier (нормализованный: lowercase, stripped) |
 
 ### Метаданные публикации
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `title` | `str \| None` | Название публикации |
-| `abstract` | `str \| None` | Аннотация (HTML-теги удалены) |
-| `authors` | `list[str]` | Список авторов в формате "given family" |
-| `journal` | `str \| None` | Название журнала (container-title) |
-| `publisher` | `str \| None` | Издатель |
+| Поле        | Тип           | Описание                                |
+| ----------- | ------------- | --------------------------------------- |
+| `title`     | `str \| None` | Название публикации                     |
+| `abstract`  | `str \| None` | Аннотация (HTML-теги удалены)           |
+| `authors`   | `list[str]`   | Список авторов в формате "given family" |
+| `journal`   | `str \| None` | Название журнала (container-title)      |
+| `publisher` | `str \| None` | Издатель                                |
 
 ### Библиографические данные
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `volume` | `str \| None` | Том |
-| `issue` | `str \| None` | Выпуск |
-| `first_page` | `str \| None` | Первая страница |
-| `last_page` | `str \| None` | Последняя страница |
-| `year` | `int \| None` | Год публикации |
-| `published_print` | `str \| None` | Дата печатной публикации (ISO) |
-| `published_online` | `str \| None` | Дата онлайн-публикации (ISO) |
+| Поле               | Тип           | Описание                       |
+| ------------------ | ------------- | ------------------------------ |
+| `volume`           | `str \| None` | Том                            |
+| `issue`            | `str \| None` | Выпуск                         |
+| `first_page`       | `str \| None` | Первая страница                |
+| `last_page`        | `str \| None` | Последняя страница             |
+| `year`             | `int \| None` | Год публикации                 |
+| `published_print`  | `str \| None` | Дата печатной публикации (ISO) |
+| `published_online` | `str \| None` | Дата онлайн-публикации (ISO)   |
 
 ### Метрики цитирования
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `citation_count` | `int \| None` | Количество цитирований (is-referenced-by-count) |
-| `reference_count` | `int \| None` | Количество ссылок в публикации |
+| Поле              | Тип           | Описание                                        |
+| ----------------- | ------------- | ----------------------------------------------- |
+| `citation_count`  | `int \| None` | Количество цитирований (is-referenced-by-count) |
+| `reference_count` | `int \| None` | Количество ссылок в публикации                  |
 
 ### Классификация
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `doc_type` | `str` | Тип документа: `PUBLICATION` или `PREPRINT` |
-| `issn` | `list[str]` | Список ISSN журнала |
-| `language` | `str \| None` | Код языка публикации |
-| `license_url` | `str \| None` | URL лицензии |
-| `subjects` | `list[str]` | Предметные области |
+| Поле          | Тип           | Описание                                    |
+| ------------- | ------------- | ------------------------------------------- |
+| `doc_type`    | `str`         | Тип документа: `PUBLICATION` или `PREPRINT` |
+| `issn`        | `list[str]`   | Список ISSN журнала                         |
+| `language`    | `str \| None` | Код языка публикации                        |
+| `license_url` | `str \| None` | URL лицензии                                |
+| `subjects`    | `list[str]`   | Предметные области                          |
 
----
+______________________________________________________________________
 
 ## 3. Трансформация
 
@@ -81,13 +81,13 @@ doi = normalize_doi("10.1234/ABC.DEF")  # → "10.1234/abc.def"
 
 ### Маппинг типов документов
 
-| CrossRef type | Internal type |
-|---------------|---------------|
-| `journal-article` | `PUBLICATION` |
-| `posted-content` | `PREPRINT` |
+| CrossRef type         | Internal type |
+| --------------------- | ------------- |
+| `journal-article`     | `PUBLICATION` |
+| `posted-content`      | `PREPRINT`    |
 | `proceedings-article` | `PUBLICATION` |
-| `book-chapter` | `PUBLICATION` |
-| `dissertation` | `PUBLICATION` |
+| `book-chapter`        | `PUBLICATION` |
+| `dissertation`        | `PUBLICATION` |
 
 ### Entity ID
 
@@ -99,10 +99,11 @@ entity_id = f"crossref:{normalized_doi}"
 ### Content Hash
 
 Вычисляется по бизнес-полям публикации для дедупликации:
+
 - Исключаются lineage поля (`_run_id`, `_ingestion_ts`, etc.)
 - None-значения исключаются из хэша
 
----
+______________________________________________________________________
 
 ## 4. Особенности
 
@@ -110,23 +111,25 @@ entity_id = f"crossref:{normalized_doi}"
 
 CrossRef API предоставляет "polite pool" с повышенными лимитами:
 
-| Режим | Лимит | Условие |
-|-------|-------|---------|
-| Без идентификации | ~5 req/sec | Базовый доступ |
-| С `mailto` | 50 req/sec | Указан email в User-Agent |
+| Режим             | Лимит      | Условие                   |
+| ----------------- | ---------- | ------------------------- |
+| Без идентификации | 50 req/sec | Базовый доступ            |
+| С `mailto`        | 50 req/sec | Указан email в User-Agent |
 
 ### Batch DOI Resolution
 
 Пайплайн поддерживает пакетную резолюцию DOI:
+
 - До 100 DOI в одном запросе через `filter=doi:doi1,doi2,...`
 - Значительно эффективнее индивидуальных запросов
 
 ### Fallback by Title
 
 При получении 404 для DOI:
+
 1. Если в `fallback_mapping` есть заголовок для DOI
-2. Выполняется поиск по заголовку: `title:"Publication Title"`
-3. Проверяется релевантность найденного результата
+1. Выполняется поиск по заголовку: `title:"Publication Title"`
+1. Проверяется релевантность найденного результата
 
 ### Конфигурация Input Filter
 
@@ -140,7 +143,7 @@ input_filter:
   fallback_column: "title"  # Поиск по заголовку при 404
 ```
 
----
+______________________________________________________________________
 
 ## 5. Использование CLI
 
@@ -168,44 +171,44 @@ doi,title
 10.1016/j.cell.2019.03.025,Structure of the human receptor
 ```
 
----
+______________________________________________________________________
 
 ## 6. Health Check
 
 CrossRef adapter реализует health check через `/works?rows=1`:
 
-| Статус | Условие |
-|--------|---------|
-| `HEALTHY` | Ответ 200 за < 5 сек |
-| `DEGRADED` | Ответ 200 за > 5 сек |
+| Статус      | Условие                  |
+| ----------- | ------------------------ |
+| `HEALTHY`   | Ответ 200 за < 5 сек     |
+| `DEGRADED`  | Ответ 200 за > 5 сек     |
 | `UNHEALTHY` | Ошибка или не-200 статус |
 
----
+______________________________________________________________________
 
 ## 7. Error Handling
 
 ### Recoverable Errors
 
-| Код | Поведение |
-|-----|-----------|
-| 429 | Rate limit — retry с backoff |
-| 502/504 | Timeout — retry (max 3) |
+| Код        | Поведение                          |
+| ---------- | ---------------------------------- |
+| 429        | Rate limit — retry с backoff       |
+| 502/504    | Timeout — retry (max 3)            |
 | Batch fail | Fallback на индивидуальные запросы |
 
 ### Critical Errors
 
-| Код | Поведение |
-|-----|-----------|
+| Код     | Поведение                       |
+| ------- | ------------------------------- |
 | 401/403 | Auth failure — fail immediately |
 
 ### Data Quality
 
-| Условие | Поведение |
-|---------|-----------|
-| Missing DOI | Skip record (log warning) |
-| Invalid DOI format | Skip record |
+| Условие            | Поведение                 |
+| ------------------ | ------------------------- |
+| Missing DOI        | Skip record (log warning) |
+| Invalid DOI format | Skip record               |
 
----
+______________________________________________________________________
 
 ## 8. Gold Filters
 
@@ -220,21 +223,21 @@ gold_filters:
       max: 2100
 ```
 
----
+______________________________________________________________________
 
 ## 9. Связанные файлы
 
-| Компонент | Путь |
-|-----------|------|
-| Конфигурация пайплайна | `configs/pipelines/crossref/publication.yaml` |
-| Конфигурация источника | `configs/sources/crossref.yaml` |
-| Трансформер | `src/bioetl/application/pipelines/crossref/transformer.py` |
-| Адаптер | `src/bioetl/infrastructure/adapters/crossref/client.py` |
-| Batch Processor | `src/bioetl/infrastructure/adapters/crossref/batch.py` |
-| Fallback Handler | `src/bioetl/infrastructure/adapters/crossref/fallback.py` |
-| Domain Entity | `src/bioetl/domain/entities/crossref.py` |
+| Компонент              | Путь                                                       |
+| ---------------------- | ---------------------------------------------------------- |
+| Конфигурация пайплайна | `configs/pipelines/crossref/publication.yaml`              |
+| Конфигурация источника | `configs/sources/crossref.yaml`                            |
+| Трансформер            | `src/bioetl/application/pipelines/crossref/transformer.py` |
+| Адаптер                | `src/bioetl/infrastructure/adapters/crossref/client.py`    |
+| Batch Processor        | `src/bioetl/infrastructure/adapters/crossref/batch.py`     |
+| Fallback Handler       | `src/bioetl/infrastructure/adapters/crossref/fallback.py`  |
+| Domain Entity          | `src/bioetl/domain/entities/crossref.py`                   |
 
----
+______________________________________________________________________
 
 ## 10. Примеры данных
 
@@ -277,6 +280,6 @@ gold_filters:
 }
 ```
 
----
+______________________________________________________________________
 
 *Последнее обновление: 2026-01-05*

--- a/docs/04-reference/providers/openalex/publication.md
+++ b/docs/04-reference/providers/openalex/publication.md
@@ -3,9 +3,9 @@
 **Имя пайплайна:** `openalex_publication`
 **Провайдер:** `openalex`
 **Сущность:** `publication` (API-термин: `work`)
-**Версия схемы:** 1.0.0
+**Версия схемы:** 1.2.0
 
----
+______________________________________________________________________
 
 ## 1. Описание
 
@@ -14,8 +14,8 @@
 ### Основные сценарии использования
 
 1. **Резолюция DOI** — получение полных метаданных публикаций по списку DOI
-2. **Обогащение документов ChEMBL** — добавление Open Access статуса и метрик цитирования
-3. **Fallback по заголовку** — поиск публикаций, когда DOI недоступен или не найден
+1. **Обогащение документов ChEMBL** — добавление Open Access статуса и метрик цитирования
+1. **Fallback по заголовку** — поиск публикаций, когда DOI недоступен или не найден
 
 ### Терминология
 
@@ -23,59 +23,59 @@
 - **Work** — термин OpenAlex API
 - Оба термина обозначают одну сущность — научную публикацию
 
----
+______________________________________________________________________
 
 ## 2. Ключевые поля
 
 ### Идентификаторы
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `openalex_id` | `str` | OpenAlex Work ID (e.g., W2148763428) — первичный ключ |
-| `doi` | `str \| None` | Digital Object Identifier (нормализованный) |
+| Поле          | Тип           | Описание                                              |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `openalex_id` | `str`         | OpenAlex Work ID (e.g., W2148763428) — первичный ключ |
+| `doi`         | `str \| None` | Digital Object Identifier (нормализованный)           |
 
 ### Метаданные публикации
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `title` | `str \| None` | Название публикации |
-| `abstract` | `str \| None` | Аннотация (реконструированная из inverted index) |
-| `authors` | `list[str]` | Список авторов (опционально хэшируются как PII) |
-| `journal` | `str \| None` | Название журнала/источника |
-| `issn` | `str \| None` | ISSN-L журнала |
-| `publisher` | `str \| None` | Название издателя |
+| Поле        | Тип           | Описание                                         |
+| ----------- | ------------- | ------------------------------------------------ |
+| `title`     | `str \| None` | Название публикации                              |
+| `abstract`  | `str \| None` | Аннотация (реконструированная из inverted index) |
+| `authors`   | `list[str]`   | Список авторов (опционально хэшируются как PII)  |
+| `journal`   | `str \| None` | Название журнала/источника                       |
+| `issn`      | `str \| None` | ISSN-L журнала                                   |
+| `publisher` | `str \| None` | Название издателя                                |
 
 ### Даты и тип
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `year` | `int \| None` | Год публикации (валидируется: 1900-2100) |
-| `publication_date` | `str \| None` | Дата публикации (YYYY-MM-DD) |
-| `doc_type` | `str` | Тип документа: `PUBLICATION`, `PREPRINT`, `DATASET`, `OTHER` |
+| Поле               | Тип           | Описание                                                     |
+| ------------------ | ------------- | ------------------------------------------------------------ |
+| `year`             | `int \| None` | Год публикации (валидируется: 1900-2100)                     |
+| `publication_date` | `str \| None` | Дата публикации (YYYY-MM-DD)                                 |
+| `doc_type`         | `str`         | Тип документа: `PUBLICATION`, `PREPRINT`, `DATASET`, `OTHER` |
 
 ### Open Access
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `is_oa` | `bool \| None` | Публикация в открытом доступе |
-| `oa_status` | `str \| None` | Статус OA: `gold`, `green`, `hybrid`, `bronze`, `closed` |
+| Поле        | Тип            | Описание                                                 |
+| ----------- | -------------- | -------------------------------------------------------- |
+| `is_oa`     | `bool \| None` | Публикация в открытом доступе                            |
+| `oa_status` | `str \| None`  | Статус OA: `gold`, `green`, `hybrid`, `bronze`, `closed` |
 
 ### Метрики и классификация
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `cited_by_count` | `int \| None` | Количество цитирований |
-| `concepts` | `list[str]` | Топ-10 концептов OpenAlex |
-| `language` | `str \| None` | Код языка публикации |
+| Поле             | Тип           | Описание                  |
+| ---------------- | ------------- | ------------------------- |
+| `cited_by_count` | `int \| None` | Количество цитирований    |
+| `concepts`       | `list[str]`   | Топ-10 концептов OpenAlex |
+| `language`       | `str \| None` | Код языка публикации      |
 
 ### Метаданные резолюции
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `_lookup_method` | `str` | Метод резолюции: `doi`, `title_fallback`, `title_only` |
-| `_original_doi` | `str \| None` | Оригинальный DOI из входного CSV (для fallback записей) |
+| Поле             | Тип           | Описание                                                |
+| ---------------- | ------------- | ------------------------------------------------------- |
+| `_lookup_method` | `str`         | Метод резолюции: `doi`, `title_fallback`, `title_only`  |
+| `_original_doi`  | `str \| None` | Оригинальный DOI из входного CSV (для fallback записей) |
 
----
+______________________________________________________________________
 
 ## 3. Трансформация
 
@@ -85,27 +85,27 @@
 
 Трансформер делегирует извлечение полей в `extractors.py`:
 
-| Функция | Назначение |
-|---------|------------|
-| `extract_openalex_id()` | Извлечение ID из URL (https://openalex.org/W... → W...) |
-| `extract_doi()` | Нормализация DOI (удаление https://doi.org/) |
-| `reconstruct_abstract()` | Реконструкция абстракта из inverted index |
-| `extract_authors()` | Извлечение display_name из authorships |
-| `extract_topics()` | Иерархическая классификация (domain/field/subfield/topic) |
-| `extract_primary_topic()` | Основная тема для быстрой категоризации |
-| `extract_journal_info()` | Журнал, ISSN-L, издатель из primary_location |
-| `extract_open_access_info()` | is_oa и oa_status из open_access |
+| Функция                      | Назначение                                                |
+| ---------------------------- | --------------------------------------------------------- |
+| `extract_openalex_id()`      | Извлечение ID из URL (https://openalex.org/W... → W...)   |
+| `extract_doi()`              | Нормализация DOI (удаление https://doi.org/)              |
+| `reconstruct_abstract()`     | Реконструкция абстракта из inverted index                 |
+| `extract_authors()`          | Извлечение display_name из authorships                    |
+| `extract_topics()`           | Иерархическая классификация (domain/field/subfield/topic) |
+| `extract_primary_topic()`    | Основная тема для быстрой категоризации                   |
+| `extract_journal_info()`     | Журнал, ISSN-L, издатель из primary_location              |
+| `extract_open_access_info()` | is_oa и oa_status из open_access                          |
 
 ### Маппинг типов документов
 
-| OpenAlex type | Internal type |
-|---------------|---------------|
+| OpenAlex type                | Internal type |
+| ---------------------------- | ------------- |
 | `article`, `journal-article` | `PUBLICATION` |
-| `book-chapter`, `book` | `PUBLICATION` |
-| `proceedings-article` | `PUBLICATION` |
-| `preprint`, `posted-content` | `PREPRINT` |
-| `dataset` | `DATASET` |
-| `other` | `OTHER` |
+| `book-chapter`, `book`       | `PUBLICATION` |
+| `proceedings-article`        | `PUBLICATION` |
+| `preprint`, `posted-content` | `PREPRINT`    |
+| `dataset`                    | `DATASET`     |
+| `other`                      | `OTHER`       |
 
 ### Entity ID
 
@@ -117,11 +117,12 @@ entity_id = f"openalex:{openalex_id}"
 ### Content Hash
 
 Вычисляется по бизнес-полям публикации для дедупликации:
+
 - Исключаются lookup-метаданные (`_lookup_method`, `_original_doi`)
 - Исключаются lineage-поля (`_run_id`, `_ingestion_ts`, etc.)
 - None-значения исключаются из хэша
 
----
+______________________________________________________________________
 
 ## 4. Особенности
 
@@ -129,16 +130,17 @@ entity_id = f"openalex:{openalex_id}"
 
 OpenAlex предоставляет "polite pool" с повышенными лимитами:
 
-| Режим | Лимит | Условие |
-|-------|-------|---------|
-| Без идентификации | ~5 req/sec | Базовый доступ |
-| С `mailto` | 10 req/sec | Указан email в User-Agent и параметрах |
+| Режим             | Лимит      | Условие                                |
+| ----------------- | ---------- | -------------------------------------- |
+| Без идентификации | 10 req/sec | Базовый доступ                         |
+| С `mailto`        | 10 req/sec | Указан email в User-Agent и параметрах |
 
 **Важно:** Переменная окружения `BIOETL_OPENALEX_EMAIL` обязательна для production.
 
 ### Batch DOI Resolution
 
 Пайплайн поддерживает пакетную резолюцию DOI:
+
 - До 50 DOI в одном запросе через `filter=doi:doi1|doi2|...`
 - Значительно эффективнее индивидуальных запросов
 - Pipe (`|`) используется как разделитель DOI
@@ -148,13 +150,14 @@ OpenAlex предоставляет "polite pool" с повышенными ли
 При неудачной резолюции DOI:
 
 1. Если в `fallback_mapping` есть заголовок для DOI
-2. Выполняется поиск по заголовку: `title.search:Publication+Title`
-3. Специальные символы экранируются: `:`, `|`, `,` удаляются, пробелы → `+`
-4. Возвращается запись с `_lookup_method = "title_fallback"` или `"title_only"`
+1. Выполняется поиск по заголовку: `title.search:Publication+Title`
+1. Специальные символы экранируются: `:`, `|`, `,` удаляются, пробелы → `+`
+1. Возвращается запись с `_lookup_method = "title_fallback"` или `"title_only"`
 
 ### Title-Only Lookup
 
 Когда DOI пустой во входном CSV:
+
 - Поиск выполняется только по заголовку
 - `_lookup_method = "title_only"`
 - `_original_doi` остаётся пустым
@@ -188,7 +191,7 @@ input_filter:
   fallback_column: "title"  # Поиск по заголовку при неудаче DOI
 ```
 
----
+______________________________________________________________________
 
 ## 5. Использование CLI
 
@@ -221,49 +224,49 @@ doi,title
 
 ### Переменные окружения
 
-| Переменная | Описание | Обязательна |
-|------------|----------|-------------|
-| `BIOETL_OPENALEX_EMAIL` | Email для polite pool | Да |
+| Переменная              | Описание              | Обязательна |
+| ----------------------- | --------------------- | ----------- |
+| `BIOETL_OPENALEX_EMAIL` | Email для polite pool | Да          |
 
----
+______________________________________________________________________
 
 ## 6. Health Check
 
 OpenAlex adapter реализует health check через `/works?per-page=1`:
 
-| Статус | Условие |
-|--------|---------|
-| `HEALTHY` | Ответ 200 за < 5 сек |
-| `DEGRADED` | Ответ 200 за > 5 сек |
+| Статус      | Условие                  |
+| ----------- | ------------------------ |
+| `HEALTHY`   | Ответ 200 за < 5 сек     |
+| `DEGRADED`  | Ответ 200 за > 5 сек     |
 | `UNHEALTHY` | Ошибка или не-200 статус |
 
----
+______________________________________________________________________
 
 ## 7. Error Handling
 
 ### Recoverable Errors
 
-| Код | Поведение |
-|-----|-----------|
-| 429 | Rate limit — retry с exponential backoff |
-| 502/504 | Timeout — retry (max 3) |
-| Batch fail | Fallback на индивидуальные запросы |
+| Код        | Поведение                                |
+| ---------- | ---------------------------------------- |
+| 429        | Rate limit — retry с exponential backoff |
+| 502/504    | Timeout — retry (max 3)                  |
+| Batch fail | Fallback на индивидуальные запросы       |
 
 ### Critical Errors
 
-| Код | Поведение |
-|-----|-----------|
+| Код     | Поведение                       |
+| ------- | ------------------------------- |
 | 401/403 | Auth failure — fail immediately |
 
 ### Data Quality
 
-| Условие | Поведение |
-|---------|-----------|
-| Missing openalex_id | Skip record (log warning) |
-| Invalid year range | Set year = None |
-| Empty title in fallback | Skip title search |
+| Условие                 | Поведение                 |
+| ----------------------- | ------------------------- |
+| Missing openalex_id     | Skip record (log warning) |
+| Invalid year range      | Set year = None           |
+| Empty title in fallback | Skip title search         |
 
----
+______________________________________________________________________
 
 ## 8. Gold Filters
 
@@ -278,22 +281,22 @@ gold_filters:
       max: 2100
 ```
 
----
+______________________________________________________________________
 
 ## 9. Связанные файлы
 
-| Компонент | Путь |
-|-----------|------|
-| Конфигурация пайплайна | `configs/pipelines/openalex/publication.yaml` |
-| Конфигурация источника | `configs/sources/openalex.yaml` |
-| Трансформер | `src/bioetl/application/pipelines/openalex/transformer.py` |
-| Экстракторы | `src/bioetl/application/pipelines/openalex/extractors.py` |
-| Адаптер | `src/bioetl/infrastructure/adapters/openalex/client.py` |
-| Fallback Handler | `src/bioetl/infrastructure/adapters/openalex/fallback.py` |
-| Domain Entity | `src/bioetl/domain/entities/openalex.py` |
-| Gold Schema | `src/bioetl/infrastructure/schemas/gold.py` |
+| Компонент              | Путь                                                       |
+| ---------------------- | ---------------------------------------------------------- |
+| Конфигурация пайплайна | `configs/pipelines/openalex/publication.yaml`              |
+| Конфигурация источника | `configs/sources/openalex.yaml`                            |
+| Трансформер            | `src/bioetl/application/pipelines/openalex/transformer.py` |
+| Экстракторы            | `src/bioetl/application/pipelines/openalex/extractors.py`  |
+| Адаптер                | `src/bioetl/infrastructure/adapters/openalex/client.py`    |
+| Fallback Handler       | `src/bioetl/infrastructure/adapters/openalex/fallback.py`  |
+| Domain Entity          | `src/bioetl/domain/entities/openalex.py`                   |
+| Gold Schema            | `src/bioetl/infrastructure/schemas/gold.py`                |
 
----
+______________________________________________________________________
 
 ## 10. Примеры данных
 
@@ -379,27 +382,28 @@ gold_filters:
 }
 ```
 
----
+______________________________________________________________________
 
 ## 11. Тестирование
 
 ### Unit Tests
 
-| Файл | Покрытие |
-|------|----------|
-| `tests/unit/infrastructure/adapters/openalex/test_adapter.py` | Adapter methods, DOI normalization |
-| `tests/unit/infrastructure/adapters/openalex/test_fallback.py` | Fallback logic |
-| `tests/unit/application/pipelines/openalex/test_extractors.py` | All extractors |
-| `tests/unit/application/pipelines/openalex/test_transformer.py` | Transformation flow |
+| Файл                                                            | Покрытие                           |
+| --------------------------------------------------------------- | ---------------------------------- |
+| `tests/unit/infrastructure/adapters/openalex/test_adapter.py`   | Adapter methods, DOI normalization |
+| `tests/unit/infrastructure/adapters/openalex/test_fallback.py`  | Fallback logic                     |
+| `tests/unit/application/pipelines/openalex/test_extractors.py`  | All extractors                     |
+| `tests/unit/application/pipelines/openalex/test_transformer.py` | Transformation flow                |
 
 ### Integration Tests
 
-| Файл | Покрытие |
-|------|----------|
-| `tests/integration/adapters/openalex/test_adapter.py` | HTTP interactions (VCR) |
-| `tests/integration/adapters/openalex/test_pipeline.py` | Transformer extractors |
+| Файл                                                   | Покрытие                |
+| ------------------------------------------------------ | ----------------------- |
+| `tests/integration/adapters/openalex/test_adapter.py`  | HTTP interactions (VCR) |
+| `tests/integration/adapters/openalex/test_pipeline.py` | Transformer extractors  |
 
 **VCR Configuration** (для test_adapter.py):
+
 ```python
 {
     "cassette_library_dir": "tests/fixtures/vcr/openalex",
@@ -409,7 +413,7 @@ gold_filters:
 }
 ```
 
----
+______________________________________________________________________
 
 ## 12. Архитектура
 
@@ -459,6 +463,6 @@ Silver → GoldWriter (validated)
     └─ Apply gold_filters, export CSV
 ```
 
----
+______________________________________________________________________
 
 *Последнее обновление: 2026-01-06*

--- a/docs/05-operations/runbooks/README.md
+++ b/docs/05-operations/runbooks/README.md
@@ -4,25 +4,25 @@ Runbooks for common operational scenarios in the BioETL pipeline system.
 
 ## Index
 
-| Runbook | Description | When to Use |
-|---------|-------------|-------------|
+| Runbook                                                   | Description                          | When to Use                       |
+| --------------------------------------------------------- | ------------------------------------ | --------------------------------- |
 | [Pipeline Failure Recovery](pipeline-failure-recovery.md) | Recovering from failed pipeline runs | Pipeline exits with non-zero code |
-| [VACUUM Procedures](vacuum-procedures.md) | Manual Delta Lake maintenance | Table optimization needed |
-| [Checkpoint Debugging](checkpoint-debugging.md) | Troubleshooting checkpoint issues | Pipeline resumes incorrectly |
-| [DQ Failure Investigation](dq-failure-investigation.md) | Data quality issue analysis | DQ threshold exceeded |
+| [VACUUM Procedures](vacuum-procedures.md)                 | Manual Delta Lake maintenance        | Table optimization needed         |
+| [Checkpoint Debugging](checkpoint-debugging.md)           | Troubleshooting checkpoint issues    | Pipeline resumes incorrectly      |
+| [DQ Failure Investigation](dq-failure-investigation.md)   | Data quality issue analysis          | DQ threshold exceeded             |
 
 ## Quick Reference
 
 ### Exit Codes
 
-| Code | Meaning | Action |
-|------|---------|--------|
-| 0 | Success | None required |
-| 1 | General error | Check logs, see [Pipeline Failure Recovery](pipeline-failure-recovery.md) |
-| 2 | Invalid arguments | Check CLI arguments |
-| 10 | Data quality hard threshold | See [DQ Failure Investigation](dq-failure-investigation.md) |
-| 130 | SIGINT (Ctrl+C) | Graceful shutdown, check checkpoint |
-| 143 | SIGTERM | Graceful shutdown, check checkpoint |
+| Code                    | Meaning                     | Action                                                                    |
+| ----------------------- | --------------------------- | ------------------------------------------------------------------------- |
+| 0                       | Success                     | None required                                                             |
+| 1                       | General error               | Check logs, see [Pipeline Failure Recovery](pipeline-failure-recovery.md) |
+| 2                       | Invalid arguments           | Check CLI arguments                                                       |
+| 83 (DATA_QUALITY_ERROR) | Data quality hard threshold | See [DQ Failure Investigation](dq-failure-investigation.md)               |
+| 130                     | SIGINT (Ctrl+C)             | Graceful shutdown, check checkpoint                                       |
+| 143                     | SIGTERM                     | Graceful shutdown, check checkpoint                                       |
 
 ### Key Directories
 

--- a/docs/05-operations/runbooks/backfill-rebuild.md
+++ b/docs/05-operations/runbooks/backfill-rebuild.md
@@ -1,14 +1,16 @@
 # Backfill and Rebuild Operations
 
-*Reference: [RULES.md §2.4](../../RULES.md#24-политика-backfill--replay)*
+*Reference: [RULES.md §2.4](../../RULES.md#24-%D0%BF%D0%BE%D0%BB%D0%B8%D1%82%D0%B8%D0%BA%D0%B0-backfill--replay)*
 
 This runbook describes how to perform Backfill (historical load) and Rebuild (full reload) operations.
 
 ## Definitions
+
 - **Backfill**: Loading historical data for a specific period.
 - **Rebuild**: Completely clearing Silver/Gold tables and reloading from source/Bronze.
 
 ## Prerequisites
+
 - **Exclusive Lock**: These operations require an exclusive lock (`lock:{provider}_{entity}:exclusive`).
 - **Downtime**: Incremental pipelines must be stopped or will be blocked.
 
@@ -17,17 +19,20 @@ This runbook describes how to perform Backfill (historical load) and Rebuild (fu
 1. **Stop Incremental Pipelines**:
    Ensure no incremental runs are scheduled.
 
-2. **Run Rebuild**:
+1. **Run Rebuild**:
+
    ```bash
-   make run-pipeline PIPELINE={pipeline_name} ARGS="--full-rebuild"
+   bioetl run --pipeline {name} --run-type rebuild
    ```
+
    *Note: This will automatically clear Silver and Gold tables for this entity.*
 
-3. **Verify Data**:
+1. **Verify Data**:
+
    - Check record counts in Silver/Gold.
    - Validate DQ metrics.
 
-4. **Resume Incremental**:
+1. **Resume Incremental**:
    Enable scheduled incremental runs.
 
 ## Procedure: Backfill (Time Range)
@@ -35,15 +40,17 @@ This runbook describes how to perform Backfill (historical load) and Rebuild (fu
 1. **Determine Range**:
    Identify start and end dates for backfill.
 
-2. **Run Backfill**:
+1. **Run Backfill**:
+
    ```bash
    # Example: Backfill for Jan 2024
-   make run-pipeline PIPELINE={pipeline_name} ARGS="--backfill --start-date 2024-01-01 --end-date 2024-01-31"
+   bioetl run --pipeline {name} --run-type backfill --start-date YYYY-MM-DD --end-date YYYY-MM-DD
    ```
 
-3. **Monitor Progress**:
+1. **Monitor Progress**:
    Watch logs for progress. Backfills can be long-running.
 
 ## Troubleshooting
+
 - **LockAcquisitionError**: Another process holds the lock. Wait or investigate.
 - **Memory Issues**: Backfills process large volumes. Watch for OOM. Reduce batch size if needed.

--- a/docs/05-operations/runbooks/data-recovery.md
+++ b/docs/05-operations/runbooks/data-recovery.md
@@ -7,45 +7,44 @@ This runbook provides procedures for recovering data in case of corruption, acci
 
 ## Scenario 1: Silver/Gold Data Corruption
 
-*   **Symptom**: Data in Silver or Gold layers is found to be incorrect, incomplete, or corrupted. The Bronze layer is intact.
-*   **Cause**: A bug in a transformation, incorrect business logic, or a failed merge operation.
-*   **Recovery Steps**:
-    1.  **Stop Pipelines**: Halt all pipelines that write to the affected tables to prevent further corruption.
-    2.  **Identify Blast Radius**: Determine which tables and partitions are affected.
-    3.  **Use Time Travel (Delta Lake)**: If the issue was recent (within 7 days), use Delta Lake's time travel to revert the table to a previous version or timestamp.
-        ```sql
-        -- Example: Revert a table to a specific version
-        RESTORE TABLE schema.table_name TO VERSION AS OF <version_number>;
+- **Symptom**: Data in Silver or Gold layers is found to be incorrect, incomplete, or corrupted. The Bronze layer is intact.
+- **Cause**: A bug in a transformation, incorrect business logic, or a failed merge operation.
+- **Recovery Steps**:
+  1. **Stop Pipelines**: Halt all pipelines that write to the affected tables to prevent further corruption.
+  1. **Identify Blast Radius**: Determine which tables and partitions are affected.
+  1. **Use Time Travel (Delta Lake)**: If the issue was recent (within 7 days), use Delta Lake's time travel to revert the table to a previous version or timestamp.
+     ```sql
+     -- Example: Revert a table to a specific version
+     RESTORE TABLE schema.table_name TO VERSION AS OF <version_number>;
 
-        -- Example: Revert to a timestamp
-        RESTORE TABLE schema.table_name TO TIMESTAMP AS OF 'YYYY-MM-DD HH:MI:SS';
-        ```
-    4.  **Full Rebuild from Bronze**: If time travel is not an option, the most reliable method is to rebuild from the Bronze layer.
-        *   Delete the corrupted data from the Silver/Gold tables.
-        *   Run the pipeline with the `--full-rebuild` flag. This will re-process all data from Bronze.
-        ```bash
-        bioetl run --pipeline <pipeline_name> --full-rebuild
-        ```
+     -- Example: Revert to a timestamp
+     RESTORE TABLE schema.table_name TO TIMESTAMP AS OF 'YYYY-MM-DD HH:MI:SS';
+     ```
+  1. **Full Rebuild from Bronze**: If time travel is not an option, the most reliable method is to rebuild from the Bronze layer.
+     - Delete the corrupted data from the Silver/Gold tables.
+     - Run the pipeline with the `--run-type rebuild` flag. This will re-process all data from Bronze.
+     ```bash
+     bioetl run --pipeline <pipeline_name> --run-type rebuild
+     ```
 
 ## Scenario 2: Bronze Data Loss or Corruption
 
-*   **Symptom**: Files in the Bronze layer (local storage) are deleted or corrupted.
-*   **Cause**: Accidental deletion, filesystem errors, or infrastructure failure.
-*   **Recovery Steps**:
-    1.  **Stop All Pipelines**: Immediately halt all data ingestion.
-    2.  **Restore Local Backup**:
-        *   Restore `data/output/bronze` from the latest backup or snapshot.
-        *   Verify the restore point is just before the incident occurred.
-    3.  **Rebuild Silver/Gold**: Once the Bronze layer is restored, follow the steps in **Scenario 1** to rebuild the downstream layers. A full rebuild is mandatory.
+- **Symptom**: Files in the Bronze layer (local storage) are deleted or corrupted.
+- **Cause**: Accidental deletion, filesystem errors, or infrastructure failure.
+- **Recovery Steps**:
+  1. **Stop All Pipelines**: Immediately halt all data ingestion.
+  1. **Restore Local Backup**:
+     - Restore `data/output/bronze` from the latest backup or snapshot.
+     - Verify the restore point is just before the incident occurred.
+  1. **Rebuild Silver/Gold**: Once the Bronze layer is restored, follow the steps in **Scenario 1** to rebuild the downstream layers. A full rebuild is mandatory.
 
 ## Scenario 3: Lost Checkpoint
 
-*   **Symptom**: A pipeline was interrupted, but the checkpoint file was lost or corrupted. The pipeline warns about a "Stale checkpoint" on restart.
-*   **Cause**: Local checkpoint write failure, race condition, or manual error.
-*   **Recovery Steps**:
-    1.  **Option A (Safest)**: Ignore the checkpoint and re-process a slightly larger window of data.
-        ```bash
-        bioetl run --pipeline <pipeline_name> --ignore-checkpoint
-        ```
-        *   **Impact**: This may create duplicate records in the Bronze layer, but the merge/upsert logic in the Silver layer will handle deduplication, ensuring correctness.
-    2.  **Option B (Advanced)**: Manually determine the last successfully processed record ID or timestamp from the Silver table and create a new checkpoint file. This is faster but more error-prone.
+- **Symptom**: A pipeline was interrupted, but the checkpoint file was lost or corrupted. The pipeline warns about a "Stale checkpoint" on restart.
+- **Cause**: Local checkpoint write failure, race condition, or manual error.
+- **Recovery Steps**:
+  1. **Option A (Safest)**: Ignore the checkpoint and re-process a slightly larger window of data.
+     ```bash
+     ```
+     - **Impact**: This may create duplicate records in the Bronze layer, but the merge/upsert logic in the Silver layer will handle deduplication, ensuring correctness.
+  1. **Option B (Advanced)**: Manually determine the last successfully processed record ID or timestamp from the Silver table and create a new checkpoint file. This is faster but more error-prone.

--- a/docs/05-operations/runbooks/dq-failure-investigation.md
+++ b/docs/05-operations/runbooks/dq-failure-investigation.md
@@ -6,12 +6,13 @@ Data Quality (DQ) checks ensure data integrity throughout the pipeline. This run
 
 ## DQ Thresholds
 
-| Threshold | Default | Behavior |
-|-----------|---------|----------|
-| Soft | 5% | Warning logged, pipeline continues |
-| Hard | 20% | Pipeline fails with exit code 10 |
+| Threshold | Default | Behavior                                              |
+| --------- | ------- | ----------------------------------------------------- |
+| Soft      | 5%      | Warning logged, pipeline continues                    |
+| Hard      | 20%     | Pipeline fails with exit code 83 (DATA_QUALITY_ERROR) |
 
 Configuration:
+
 ```yaml
 # configs/pipelines/chembl/activity.yaml
 dq:
@@ -31,11 +32,13 @@ dq:
 ### Step 1: Identify Failure Scope
 
 Check logs for DQ summary:
+
 ```bash
 grep "dq_check\|dq_threshold" logs/bioetl.log | tail -20
 ```
 
 Key log fields:
+
 - `dq_error_rate`: Percentage of failed records
 - `dq_errors_total`: Absolute count
 - `dq_records_processed`: Total records in batch
@@ -44,6 +47,7 @@ Key log fields:
 ### Step 2: Examine Quarantine Records
 
 Quarantined records are stored in:
+
 ```
 data/quarantine/{provider}/{entity}/{date}/
 ```
@@ -57,6 +61,7 @@ cat data/quarantine/chembl/activity/2026-01-02/*.jsonl | head -10 | jq
 ```
 
 Quarantine record structure:
+
 ```json
 {
   "original_record": { ... },
@@ -72,13 +77,13 @@ Quarantine record structure:
 
 Common DQ error categories:
 
-| Category | Examples | Severity |
-|----------|----------|----------|
-| Missing fields | `null` in required field | Medium |
-| Invalid format | Bad SMILES, invalid date | High |
-| Out of range | Negative IC50, >1M MW | Medium |
-| Type mismatch | String in numeric field | High |
-| Encoding issues | Invalid UTF-8 | Low |
+| Category        | Examples                 | Severity |
+| --------------- | ------------------------ | -------- |
+| Missing fields  | `null` in required field | Medium   |
+| Invalid format  | Bad SMILES, invalid date | High     |
+| Out of range    | Negative IC50, >1M MW    | Medium   |
+| Type mismatch   | String in numeric field  | High     |
+| Encoding issues | Invalid UTF-8            | Low      |
 
 ```python
 import json
@@ -102,16 +107,19 @@ for error, count in error_types.most_common():
 ### Step 4: Root Cause Analysis
 
 **Source Data Issues**
+
 - Check if upstream API changed response format
 - Verify API version in use
 - Compare with known-good historical data
 
 **Schema Evolution**
+
 - Check if new fields were added upstream
 - Verify transformer handles optional fields
 - Review schema validation rules
 
 **Pipeline Bug**
+
 - Review recent code changes to transformer
 - Check for off-by-one errors in parsing
 - Verify type coercion logic
@@ -127,10 +135,12 @@ dt = DeltaTable("data/silver/chembl_activity")
 df = pl.scan_delta(str(dt)).collect()
 
 # Count records by run_id
-run_stats = df.group_by("_run_id").agg([
-    pl.count().alias("records"),
-    pl.col("_dq_passed").sum().alias("passed"),
-])
+run_stats = df.group_by("_run_id").agg(
+    [
+        pl.count().alias("records"),
+        pl.col("_dq_passed").sum().alias("passed"),
+    ]
+)
 print(run_stats)
 ```
 
@@ -144,6 +154,7 @@ For fixable issues (e.g., encoding, format):
 import json
 from pathlib import Path
 
+
 def reprocess_quarantine(quarantine_dir: str, output_file: str):
     """Extract and fix quarantined records."""
     fixed_records = []
@@ -156,7 +167,7 @@ def reprocess_quarantine(quarantine_dir: str, output_file: str):
             # Apply fixes based on error type
             if record["error_type"] == "encoding_error":
                 # Fix encoding
-                original["field"] = original["field"].encode('utf-8', 'ignore').decode()
+                original["field"] = original["field"].encode("utf-8", "ignore").decode()
                 fixed_records.append(original)
 
     with open(output_file, "w") as f:
@@ -206,7 +217,7 @@ For unfixable records, quarantine is the correct behavior:
 bioetl quarantine stats --pipeline chembl_activity
 
 # Purge old quarantine (> 30 days)
-bioetl quarantine-purge --older-than 30d
+bioetl quarantine purge --pipeline <pipeline_name> --older-than-days 30
 ```
 
 ## Prevention
@@ -224,11 +235,13 @@ def test_activity_schema_handles_null_smiles():
 ### Monitor DQ Trends
 
 Set up dashboards for:
+
 - DQ error rate over time
 - Error type distribution
 - Records quarantined per run
 
 Alert on:
+
 - Soft threshold exceeded
 - New error type appearing
 - Sudden spike in quarantine rate
@@ -249,6 +262,7 @@ Maintain a list of known DQ issues:
 ## Metrics
 
 Key Prometheus metrics:
+
 - `bioetl_dq_records_processed_total{provider, entity}`
 - `bioetl_dq_records_passed_total{provider, entity}`
 - `bioetl_dq_records_failed_total{provider, entity}`
@@ -258,6 +272,7 @@ Key Prometheus metrics:
 ## Escalation
 
 Escalate if:
+
 - Hard threshold exceeded for > 3 consecutive runs
 - Error rate increasing over time
 - New error type not in known issues

--- a/docs/05-operations/runbooks/observability-checklist.md
+++ b/docs/05-operations/runbooks/observability-checklist.md
@@ -1,6 +1,6 @@
 # Observability Checklist
 
-*Reference: [RULES.md §3.2](../../RULES.md#32-наблюдаемость-observability)*
+*Reference: [RULES.md §3.2](../../RULES.md#32-%D0%BD%D0%B0%D0%B1%D0%BB%D1%8E%D0%B4%D0%B0%D0%B5%D0%BC%D0%BE%D1%81%D1%82%D1%8C-observability)*
 
 This checklist ensures all components meet the project's observability requirements.
 
@@ -11,7 +11,7 @@ Every adapter in `src/bioetl/infrastructure/adapters/` **MUST** implement:
 ### 1. Health Check Method
 
 ```python
-async def health_check(self) -> bool:
+async def health_check(self) -> HealthStatus:
     """Check if the external service is reachable.
 
     Returns:
@@ -21,25 +21,26 @@ async def health_check(self) -> bool:
 
 **Health Check Endpoints by Provider:**
 
-| Provider | Health Check |
-|----------|--------------|
-| ChEMBL | `GET /chembl/api/data/status.json` |
-| PubChem | `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
-| UniProt | Lightweight Search Probe |
-| Generic | `GET /` or `/status` with 5s timeout |
+| Provider | Health Check                                                     |
+| -------- | ---------------------------------------------------------------- |
+| ChEMBL   | `GET /chembl/api/data/status`                                    |
+| PubChem  | `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
+| UniProt  | Lightweight Search Probe                                         |
+| Generic  | `GET /` or `/status` with 5s timeout                             |
 
 ### 2. Structured Logging
 
 All log messages **MUST** include:
 
-| Field | Required | Example |
-|-------|----------|---------|
-| `run_id` | MUST | UUID |
-| `pipeline` | MUST | `chembl_activity` |
-| `stage` | MUST | `extract`, `transform`, `load` |
-| `dataset` | SHOULD | `chembl.activity` |
+| Field      | Required | Example                        |
+| ---------- | -------- | ------------------------------ |
+| `run_id`   | MUST     | UUID                           |
+| `pipeline` | MUST     | `chembl_activity`              |
+| `stage`    | MUST     | `extract`, `transform`, `load` |
+| `dataset`  | SHOULD   | `chembl/activity`              |
 
 **Example:**
+
 ```python
 self.logger.info(
     "Fetching records",
@@ -57,27 +58,27 @@ self.logger.info(
 
 ### Required Metrics (prefix: `bioetl_`)
 
-| Metric | Type | Labels |
-|--------|------|--------|
+| Metric                      | Type      | Labels                            |
+| --------------------------- | --------- | --------------------------------- |
 | `pipeline_duration_seconds` | Histogram | pipeline, stage, status, run_type |
-| `records_processed_total` | Counter | pipeline, stage, run_type |
-| `errors_total` | Counter | pipeline, stage, error_code |
-| `batch_size_records` | Histogram | pipeline, stage |
+| `records_processed_total`   | Counter   | pipeline, stage, run_type         |
+| `errors_total`              | Counter   | pipeline, stage, error_code       |
+| `batch_size_records`        | Histogram | pipeline, stage                   |
 
 ### DQ Metrics
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `dq_validation_score` | Gauge | pipeline, column, check |
-| `data_freshness_seconds` | Gauge | pipeline |
+| Metric                   | Type  | Labels                  |
+| ------------------------ | ----- | ----------------------- |
+| `dq_validation_score`    | Gauge | pipeline, column, check |
+| `data_freshness_seconds` | Gauge | pipeline                |
 
 ### Provider Health Metrics
 
-| Metric | Type | Labels |
-|--------|------|--------|
-| `provider_health_status` | Gauge | provider (0=Unhealthy, 1=Degraded, 2=Healthy) |
-| `circuit_breaker_state` | Gauge | provider (0=Closed, 1=Half-Open, 2=Open) |
-| `circuit_breaker_trips_total` | Counter | provider |
+| Metric                        | Type    | Labels                                        |
+| ----------------------------- | ------- | --------------------------------------------- |
+| `provider_health_status`      | Gauge   | provider (0=Unhealthy, 1=Degraded, 2=Healthy) |
+| `circuit_breaker_state`       | Gauge   | provider (0=Closed, 1=Half-Open, 2=Open)      |
+| `circuit_breaker_trips_total` | Counter | provider                                      |
 
 ## Verification Commands
 
@@ -107,11 +108,11 @@ cat logs/bioetl.log | jq 'select(.run_id and .pipeline and .stage)'
 When creating a new adapter:
 
 1. [ ] Implement `health_check()` method
-2. [ ] Use `structlog` for all logging
-3. [ ] Include `run_id` in all log messages
-4. [ ] Add rate limiting (TokenBucket)
-5. [ ] Register metrics in composition layer
-6. [ ] Add integration test with VCR cassette
+1. [ ] Use `structlog` for all logging
+1. [ ] Include `run_id` in all log messages
+1. [ ] Add rate limiting (TokenBucket)
+1. [ ] Register metrics in composition layer
+1. [ ] Add integration test with VCR cassette
 
 ## Architecture Test
 

--- a/docs/05-operations/runbooks/pipeline-failure-recovery.md
+++ b/docs/05-operations/runbooks/pipeline-failure-recovery.md
@@ -18,13 +18,13 @@ This runbook covers diagnosing and recovering from failed BioETL pipeline runs.
 echo $?  # After pipeline run
 ```
 
-| Exit Code | Meaning | Next Step |
-|-----------|---------|-----------|
-| 1 | General error | Check logs |
-| 2 | Invalid arguments | Review CLI args |
-| 10 | DQ hard threshold | See DQ runbook |
-| 130 | SIGINT | Check checkpoint |
-| 143 | SIGTERM | Check checkpoint |
+| Exit Code               | Meaning           | Next Step        |
+| ----------------------- | ----------------- | ---------------- |
+| 1                       | General error     | Check logs       |
+| 2                       | Invalid arguments | Review CLI args  |
+| 83 (DATA_QUALITY_ERROR) | DQ hard threshold | See DQ runbook   |
+| 130                     | SIGINT            | Check checkpoint |
+| 143                     | SIGTERM           | Check checkpoint |
 
 ### Step 2: Review Logs
 
@@ -37,6 +37,7 @@ grep "run_id.*<run-id>" logs/
 ```
 
 Key log fields to examine:
+
 - `error_category`: CRITICAL, RECOVERABLE, or DATA_QUALITY
 - `status_code`: HTTP status if external API error
 - `retry_count`: Number of retry attempts
@@ -49,6 +50,7 @@ cat data/checkpoints/{provider}_{entity}.json
 ```
 
 Checkpoint contains:
+
 - `last_offset`: Last successfully processed offset
 - `last_run_id`: Previous run identifier
 - `last_run_timestamp`: When last run completed
@@ -57,16 +59,19 @@ Checkpoint contains:
 ### Step 4: Identify Error Type
 
 **Critical Errors (Fail Immediately)**
+
 - Authentication failures (401, 403)
 - Schema mismatch in Gold layer
 - Database unavailable
 
 **Recoverable Errors (Auto-Retry)**
+
 - Rate limits (429)
 - Timeouts (502, 503, 504)
 - Temporary network issues
 
 **Data Quality Errors (Skip Record)**
+
 - Invalid SMILES strings
 - Missing required fields
 - Value out of range
@@ -82,9 +87,10 @@ bioetl run --pipeline chembl_activity --resume
 ```
 
 The pipeline will:
+
 1. Load checkpoint state
-2. Resume from `last_offset`
-3. Continue processing
+1. Resume from `last_offset`
+1. Continue processing
 
 ### Force Full Refresh
 
@@ -92,7 +98,7 @@ If checkpoint is corrupted or data inconsistent:
 
 ```bash
 # Clear checkpoint and reprocess all data
-bioetl run --pipeline chembl_activity --full-refresh
+bioetl run --pipeline chembl_activity --run-type rebuild
 ```
 
 **Warning**: This will reprocess all records from the beginning.
@@ -103,19 +109,19 @@ For schema issues or data corruption:
 
 ```bash
 # 1. Backup current Silver table
-mv data/silver/chembl_activity data/silver/chembl_activity.bak
+mv data/output/silver/chembl/activity data/output/silver/chembl/activity.bak
 
 # 2. Clear checkpoint
 rm data/checkpoints/chembl_activity.json
 
 # 3. Full refresh
-bioetl run --pipeline chembl_activity --full-refresh
+bioetl run --pipeline chembl_activity --run-type rebuild
 
 # 4. Verify data
-bioetl verify --table chembl_activity
+Для проверки данных используйте: `bioetl run --pipeline chembl_activity --run-type rebuild --limit 10`
 
 # 5. Remove backup if successful
-rm -rf data/silver/chembl_activity.bak
+rm -rf data/output/silver/chembl/activity.bak
 ```
 
 ### Handle Authentication Errors
@@ -123,36 +129,37 @@ rm -rf data/silver/chembl_activity.bak
 For 401/403 errors:
 
 1. Check API key validity
-2. Verify environment variables:
+1. Verify environment variables:
    ```bash
    echo $BIOETL_CHEMBL_API_KEY
    echo $BIOETL_UNIPROT_API_KEY
    ```
-3. Rotate API key if expired
-4. Resume pipeline
+1. Rotate API key if expired
+1. Resume pipeline
 
 ### Handle Rate Limit Errors
 
 For persistent 429 errors:
 
 1. Check current rate limit configuration in pipeline YAML
-2. Reduce batch size if needed:
+1. Reduce batch size if needed:
    ```yaml
    # configs/pipelines/chembl/activity.yaml
    batch_size: 500  # Reduce from default
    ```
-3. Add delay between requests:
+1. Add delay between requests:
    ```yaml
    rate_limit:
      requests_per_second: 5  # Reduce if hitting limits
    ```
-4. Resume pipeline
+1. Resume pipeline
 
 ## Prevention
 
 ### Enable Monitoring
 
 Set up alerts for:
+
 - Pipeline failures (exit code != 0)
 - DQ threshold warnings (soft threshold exceeded)
 - Long-running pipelines (> expected duration)
@@ -168,6 +175,6 @@ Set up alerts for:
 If recovery fails after 3 attempts:
 
 1. Document error details
-2. Check for upstream API issues
-3. Review recent code changes
-4. Escalate to development team
+1. Check for upstream API issues
+1. Review recent code changes
+1. Escalate to development team

--- a/tests/architecture/test_antipatterns.py
+++ b/tests/architecture/test_antipatterns.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+SRC = Path("src/bioetl")
+
+
+def _py_files() -> list[Path]:
+    return [p for p in SRC.rglob("*.py") if "tests" not in p.parts]
+
+
+def test_no_sentinel_values() -> None:
+    patterns = [r"\=\s*\-1\b", r'"N/A"', r'"n/a"', r"\=\s*9999\b"]
+    rx = re.compile("|".join(patterns))
+    violations: list[str] = []
+    for path in _py_files():
+        text = path.read_text(encoding="utf-8")
+        for i, line in enumerate(text.splitlines(), 1):
+            if line.strip().startswith("#"):
+                continue
+            if rx.search(line):
+                violations.append(f"{path}:{i}: {line.strip()}")
+    assert not violations, "Sentinel values found:\n" + "\n".join(violations[:50])
+
+
+def test_no_hardcoded_secrets() -> None:
+    rx = re.compile(r"(password|api_key|secret)\s*=\s*['\"][^'\"]+['\"]", re.I)
+    violations: list[str] = []
+    for path in _py_files():
+        if "ports" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for i, line in enumerate(text.splitlines(), 1):
+            if rx.search(line):
+                violations.append(f"{path}:{i}: {line.strip()}")
+    assert not violations, "Hardcoded secrets found:\n" + "\n".join(violations[:50])
+
+
+def test_no_print_in_production() -> None:
+    violations: list[str] = []
+    for path in _py_files():
+        if path.match("src/bioetl/interfaces/cli/*") or "interfaces/cli" in str(path):
+            continue
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.match(r"^\s*print\(", line):
+                violations.append(f"{path}:{i}: {line.strip()}")
+    assert not violations, "print() usage found:\n" + "\n".join(violations[:50])
+
+
+def test_no_blocking_io_in_async() -> None:
+    violations: list[str] = []
+    for path in _py_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                segment = (
+                    ast.get_source_segment(path.read_text(encoding="utf-8"), node) or ""
+                )
+                if any(x in segment for x in ["open(", "requests.", "urllib"]):
+                    violations.append(f"{path}:{node.lineno}: async def {node.name}")
+    assert not violations, "Blocking I/O in async functions:\n" + "\n".join(
+        violations[:50]
+    )

--- a/tests/architecture/test_documentation_sync.py
+++ b/tests/architecture/test_documentation_sync.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_ports_count_matches_docs() -> None:
+    actual = len(list(Path("src/bioetl/domain/ports").glob("*.py")))
+    text = Path("docs/02-architecture/01-domain-layer.md").read_text(encoding="utf-8")
+    assert str(actual) in text, (
+        f"Ports count {actual} not reflected in docs/02-architecture/01-domain-layer.md"
+    )
+
+
+def test_pipeline_count_matches_docs() -> None:
+    base = Path("configs/pipelines")
+    standard = [
+        p
+        for p in base.rglob("*.yaml")
+        if p.parent.name != "composite" and p.name not in {"_base.yaml", "_schema.json"}
+    ]
+    composite = list((base / "composite").glob("*.yaml"))
+    text = Path("docs/04-reference/pipelines/README.md").read_text(encoding="utf-8")
+    assert str(len(standard)) in text and str(len(composite)) in text
+
+
+def test_quarantine_states_match_docs() -> None:
+    code = Path("src/bioetl/domain/aggregates/quarantine_entry.py").read_text(
+        encoding="utf-8"
+    )
+    states = re.findall(r'^\s+([A-Z_]+)\s*=\s*"[a-z_]+"', code, flags=re.M)
+    doc = Path("docs/02-architecture/01-domain-layer.md").read_text(encoding="utf-8")
+    missing = [s for s in states if s not in doc]
+    assert not missing, f"Missing states in docs: {missing}"
+
+
+def test_exit_codes_match_docs() -> None:
+    code = Path("src/bioetl/interfaces/cli/exit_codes.py").read_text(encoding="utf-8")
+    names = re.findall(r"^\s+([A-Z_]+)\s*=\s*\d+", code, flags=re.M)
+    doc = Path("docs/04-reference/cli.md").read_text(encoding="utf-8")
+    missing = [n for n in names if n not in doc]
+    assert not missing, (
+        f"Exit codes missing in docs/04-reference/cli.md: {missing[:10]}"
+    )

--- a/tests/architecture/test_medallion_invariants.py
+++ b/tests/architecture/test_medallion_invariants.py
@@ -182,3 +182,57 @@ class TestSilverLayerInvariants:
                 pytest.fail(
                     f"SilverWriter seems to use raw '{method}()'. MUST use write_deltalake()."
                 )
+
+
+from unittest.mock import AsyncMock, Mock
+
+from bioetl.application.services.medallion_lifecycle import MedallionLifecycleService
+from bioetl.domain.medallion import MedallionPolicy
+from bioetl.domain.types import RunType
+
+
+class TestMedallionClearPolicy:
+    async def test_rebuild_clears_silver_and_gold(self) -> None:
+        storage = Mock()
+        storage.clear_silver = AsyncMock(return_value=1)
+        storage.clear_gold = AsyncMock(return_value=1)
+        service = MedallionLifecycleService(storage=storage, logger=Mock())
+
+        await service.clear(
+            policy=MedallionPolicy.for_run_type(RunType.REBUILD),
+            silver_table="chembl.activity",
+            gold_table="chembl.activity",
+        )
+
+        storage.clear_silver.assert_awaited_once()
+        storage.clear_gold.assert_awaited_once()
+
+    async def test_backfill_clears_silver_and_gold(self) -> None:
+        storage = Mock()
+        storage.clear_silver = AsyncMock(return_value=1)
+        storage.clear_gold = AsyncMock(return_value=1)
+        service = MedallionLifecycleService(storage=storage, logger=Mock())
+
+        await service.clear(
+            policy=MedallionPolicy.for_run_type(RunType.BACKFILL),
+            silver_table="chembl.activity",
+            gold_table="chembl.activity",
+        )
+
+        storage.clear_silver.assert_awaited_once()
+        storage.clear_gold.assert_awaited_once()
+
+    async def test_incremental_does_not_clear_silver_and_gold(self) -> None:
+        storage = Mock()
+        storage.clear_silver = AsyncMock(return_value=1)
+        storage.clear_gold = AsyncMock(return_value=1)
+        service = MedallionLifecycleService(storage=storage, logger=Mock())
+
+        await service.clear(
+            policy=MedallionPolicy.for_run_type(RunType.INCREMENTAL),
+            silver_table="chembl.activity",
+            gold_table="chembl.activity",
+        )
+
+        storage.clear_silver.assert_not_awaited()
+        storage.clear_gold.assert_not_awaited()

--- a/tests/architecture/test_naming_conventions.py
+++ b/tests/architecture/test_naming_conventions.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+SRC = Path("src/bioetl")
+
+
+def test_class_naming_suffixes() -> None:
+    suffixes = (
+        "Factory",
+        "Service",
+        "Transformer",
+        "Error",
+        "Config",
+        "Protocol",
+        "Port",
+    )
+    violations: list[str] = []
+    for path in (SRC / "application").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            if node.name.startswith("_"):
+                continue
+            if not node.name.endswith(suffixes):
+                violations.append(f"{path}:{node.lineno}:{node.name}")
+    assert not violations, "Class naming violations:\n" + "\n".join(violations[:80])
+
+
+def test_module_naming_snake_case() -> None:
+    banned = {"dw.py", "utils.py", "helpers.py", "misc.py"}
+    violations: list[str] = []
+    for path in SRC.rglob("*.py"):
+        name = path.name
+        if name in banned:
+            violations.append(str(path))
+        if not re.match(r"^[a-z0-9_]+\.py$", name):
+            violations.append(str(path))
+    assert not violations, "Module naming violations:\n" + "\n".join(violations[:80])
+
+
+def test_constants_upper_snake_case() -> None:
+    violations: list[str] = []
+    for path in SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        name = target.id
+                        if name.startswith("_"):
+                            continue
+                        if name.isupper() or name[0].isupper():
+                            continue
+                        if isinstance(
+                            node.value,
+                            (ast.Constant, ast.Tuple, ast.List, ast.Dict, ast.Set),
+                        ):
+                            violations.append(f"{path}:{node.lineno}:{name}")
+    assert not violations, "Constant naming violations:\n" + "\n".join(violations[:80])


### PR DESCRIPTION
## Summary
- Updated critical docs to match current runtime/code behavior:
  - data path examples in getting-started/quick-start to `data/output/{layer}/{provider}/{entity}/...`
  - UnifiedHTTPClient constructor example in API infrastructure reference
  - runbook CLI flags/commands (`--run-type rebuild`, quarantine command format, removed deprecated flags/commands)
  - DQ exit code references to `83 (DATA_QUALITY_ERROR)`
- Refreshed architecture/API references:
  - Quarantine states to `NEW -> UNDER_REVIEW -> IGNORED/REPROCESSED/EXPIRED`
  - `bootstrap_composite_pipeline` usage/signature docs
  - interfaces orchestration note (module emptied; shutdown handled in CLI + `application/core/shutdown.py`)
  - corrected domain port method names and entity naming (`Bioactivity`, `ChemblPublication`)
  - removed/replaced non-existent infra references (`MetricsExporter`, `LineageTracker`, `DeltaWriter`)
- Updated provider/spec/governance docs:
  - pipeline spec versions `1.1.0 -> 1.2.0`
  - molecule/cell-line/activity/target spec mismatches fixed (field names, counts, partitioning, value sets)
  - pipeline counts and composite coverage updates
  - ADR-008 marked superseded
  - governance/agent naming path patterns updated
  - provider rate-limit/version/count notes aligned with configs
- Added architecture tests:
  - `tests/architecture/test_antipatterns.py`
  - `tests/architecture/test_naming_conventions.py`
  - `tests/architecture/test_documentation_sync.py`
  - extended `tests/architecture/test_medallion_invariants.py` with medallion clear-policy tests

## Validation
- Pre-commit hooks passed during commit (ruff/format, isort, mdformat, secrets checks, pip-audit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c303d62b88324a320a00dc8324192)