### PR TITLE
Capture and use redirect URLs in UniProt ID mapping polling

### DIFF
--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -70,7 +70,10 @@ class CompositeRuntimeConfig:
         cached_bronze_enrichers: Override cached Bronze for enrichers.
             None=follow master, True=force cache, False=force API.
         cached_bronze_dependencies: Override cached Bronze for dependencies.
-            None=follow master, True=force cache, False=force API.
+            False by default — dependencies call APIs with seed-derived keys,
+            so their Bronze cache is often stale or absent (e.g. uniprot_idmapping
+            on first composite run). Set True to force cache if Bronze was
+            pre-populated by a standalone run with identical keys.
     """
 
     resume: bool = False
@@ -83,7 +86,7 @@ class CompositeRuntimeConfig:
     cached_bronze_path: str | None = None
     cached_bronze_date: str | None = None
     cached_bronze_enrichers: bool | None = None
-    cached_bronze_dependencies: bool | None = None
+    cached_bronze_dependencies: bool = False
 
     def __post_init__(self) -> None:
         """Convert types for immutability."""

--- a/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
@@ -161,11 +161,11 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         # Step 1: Submit job
         job_id = await self._submit_job(from_db, to_db, ids)
 
-        # Step 2: Poll for completion
-        await self._poll_until_ready(job_id)
+        # Step 2: Poll for completion (returns redirect URL if detected)
+        results_url = await self._poll_until_ready(job_id)
 
-        # Step 3: Retrieve results
-        return await self._fetch_results(job_id, ids)
+        # Step 3: Retrieve results using redirect URL or default
+        return await self._fetch_results(job_id, ids, results_url=results_url)
 
     async def _submit_job(
         self,
@@ -225,7 +225,7 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         self.logger.debug("idmapping_job_submitted", job_id=job_id)
         return str(job_id)
 
-    async def _poll_until_ready(self, job_id: str) -> None:
+    async def _poll_until_ready(self, job_id: str) -> str | None:
         """Poll job status until complete.
 
         GET /idmapping/status/{jobId}
@@ -239,6 +239,11 @@ class UniProtIDMappingClient(BaseHttpAdapter):
 
         Args:
             job_id: Job ID to poll.
+
+        Returns:
+            Results URL captured from redirect (e.g.
+            ``/idmapping/uniprotkb/results/{jobId}``), or None if the URL
+            was not detected via redirect.
 
         Raises:
             IDMappingJobError: If the job fails.
@@ -259,8 +264,9 @@ class UniProtIDMappingClient(BaseHttpAdapter):
                     job_id=job_id,
                     attempts=attempt + 1,
                     detected_by="redirect_to_results",
+                    results_url=response_url,
                 )
-                return
+                return response_url
 
             if response.status_code not in (200, 303):
                 self.logger.warning(
@@ -282,7 +288,7 @@ class UniProtIDMappingClient(BaseHttpAdapter):
                     attempts=attempt + 1,
                     detected_by="results_in_response",
                 )
-                return
+                return None
 
             status = result.get("jobStatus", "UNKNOWN")
 
@@ -297,7 +303,7 @@ class UniProtIDMappingClient(BaseHttpAdapter):
                     attempts=attempt + 1,
                     detected_by="job_status",
                 )
-                return
+                return None
 
             if status == "ERROR":
                 error_msg = result.get("errorMessage", "Unknown error")
@@ -317,6 +323,7 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         self,
         job_id: str,
         original_ids: list[str],
+        results_url: str | None = None,
     ) -> dict[str, dict[str, Any] | None]:
         """Fetch mapping results with full entry metadata.
 
@@ -329,6 +336,10 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         Args:
             job_id: Job ID to fetch results for.
             original_ids: Original list of IDs for initializing results dict.
+            results_url: Exact results URL captured from the polling redirect
+                (e.g. ``/idmapping/uniprotkb/results/{jobId}``).
+                When provided, avoids an extra redirect hop.  Falls back to
+                the generic ``/idmapping/results/{jobId}`` when *None*.
 
         Returns:
             Dict mapping source IDs to entry data dicts (None if not found).
@@ -337,7 +348,7 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         entries_by_id: dict[str, list[dict[str, Any]]] = {
             id_: [] for id_ in original_ids
         }
-        url: str | None = f"{self.base_url}/idmapping/results/{job_id}"
+        url: str | None = results_url or f"{self.base_url}/idmapping/results/{job_id}"
 
         while url:
             with self._adapter_metrics.measure_request("/idmapping/results"):

--- a/tests/unit/interfaces/cli/commands/test_run_composite.py
+++ b/tests/unit/interfaces/cli/commands/test_run_composite.py
@@ -593,10 +593,15 @@ class TestCompositeRuntimeConfigPostInit:
         config = CompositeRuntimeConfig()
         assert config.cached_bronze_enrichers is None
 
-    def test_cached_bronze_dependencies_default_none(self) -> None:
-        """Test cached_bronze_dependencies defaults to None (follow master)."""
+    def test_cached_bronze_dependencies_default_false(self) -> None:
+        """Test cached_bronze_dependencies defaults to False (always call APIs).
+
+        Dependencies receive seed-derived keys, so their Bronze cache is
+        typically stale or absent (e.g. uniprot_idmapping on first composite
+        run). Default False ensures APIs are always called.
+        """
         config = CompositeRuntimeConfig()
-        assert config.cached_bronze_dependencies is None
+        assert config.cached_bronze_dependencies is False
 
     def test_cached_bronze_enrichers_explicit_false(self) -> None:
         """Test cached_bronze_enrichers can be set to False."""


### PR DESCRIPTION
## Summary
This PR improves the UniProt ID mapping client to capture and utilize redirect URLs detected during job status polling, reducing unnecessary HTTP redirects when fetching results. It also corrects the default behavior for cached Bronze dependencies in composite runs.

## Key Changes

### UniProt ID Mapping Client (`idmapping_client.py`)
- **Modified `_poll_until_ready()`** to return the detected redirect URL (e.g., `/idmapping/uniprotkb/results/{jobId}`) instead of `None`
  - Captures the exact results URL when a redirect is detected during polling
  - Returns `None` when completion is detected via job status or response data
  - Updated return type from `None` to `str | None`
  - Enhanced docstring with Returns section documenting the redirect URL capture

- **Modified `_fetch_results()`** to accept and use the captured redirect URL
  - Added `results_url` parameter (optional, defaults to `None`)
  - Uses the provided redirect URL directly, avoiding an extra redirect hop
  - Falls back to the generic `/idmapping/results/{jobId}` endpoint when no redirect URL is captured
  - Updated docstring explaining the optimization

- **Updated `_map_batch()`** to thread the redirect URL through the polling and fetch pipeline
  - Captures the URL returned from `_poll_until_ready()`
  - Passes it to `_fetch_results()` for direct use

### Composite Runtime Configuration (`runner.py` and test)
- **Changed `cached_bronze_dependencies` default from `None` to `False`**
  - Dependencies use seed-derived cache keys, making their Bronze cache often stale or absent on first composite runs
  - Default `False` ensures APIs are always called for dependencies
  - Updated docstring to explain the rationale and when to override to `True`

- **Updated test** to reflect the new default behavior
  - Changed assertion from `is None` to `is False`
  - Enhanced test docstring explaining why dependencies should default to API calls

## Implementation Details
The redirect URL optimization is transparent to callers—the `_map_batch()` method handles the plumbing internally. This reduces latency by eliminating an extra HTTP redirect when the UniProt API returns a redirect during polling.

https://claude.ai/code/session_01DQ5Kh8iJGqgRwEVaFJtYq7