### PR TITLE
Deduplicate Semantic Scholar and PubChem base URL constants

### DIFF
--- a/src/bioetl/infrastructure/adapters/pubchem/client.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/client.py
@@ -36,9 +36,6 @@ from bioetl.infrastructure.adapters.common.api_request_collector import (
 )
 from bioetl.infrastructure.adapters.filterable_mixin import FilterableStubMixin
 from bioetl.infrastructure.adapters.pubchem.entity_mapper import PubChemEntityMapper
-from bioetl.infrastructure.adapters.pubchem.fetch_strategies import (
-    PubChemFetchStrategies,
-)
 from bioetl.infrastructure.adapters.sync_base import BaseSyncAdapter
 
 # PubChem REST API base URL
@@ -119,6 +116,10 @@ class PubChemAdapter(FilterableStubMixin, BaseSyncAdapter):
         )
         self._mapper = PubChemEntityMapper()
         self._request_collector = APIRequestCollector()
+        from bioetl.infrastructure.adapters.pubchem.fetch_strategies import (
+            PubChemFetchStrategies,
+        )
+
         self._strategies = PubChemFetchStrategies(
             logger=logger,
             rate_limiter=rate_limiter,

--- a/src/bioetl/infrastructure/adapters/pubchem/fetch_strategies.py
+++ b/src/bioetl/infrastructure/adapters/pubchem/fetch_strategies.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 import pubchempy as pcp
 
+from bioetl.infrastructure.adapters.pubchem.client import PUBCHEM_API_BASE
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
 
@@ -21,10 +23,6 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.adapters.http.circuit_breaker import CircuitBreaker
     from bioetl.infrastructure.adapters.http.rate_limiter import TokenBucket
     from bioetl.infrastructure.adapters.pubchem.entity_mapper import PubChemEntityMapper
-
-
-# PubChem REST API base URL for request metadata
-PUBCHEM_API_BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
 
 
 class PubChemFetchStrategies:

--- a/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
@@ -34,9 +34,6 @@ from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.common.api_request_collector import (
     APIRequestCollector,
 )
-from bioetl.infrastructure.adapters.semanticscholar.fallback import (
-    SemanticScholarTitleFallbackHandler,
-)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -98,6 +95,10 @@ class SemanticScholarAdapter(BaseHttpAdapter):
 
     def __post_init__(self) -> None:
         """Initialize adapter metrics and helper components."""
+        from bioetl.infrastructure.adapters.semanticscholar.fallback import (
+            SemanticScholarTitleFallbackHandler,
+        )
+
         metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
         self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
 

--- a/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/fallback.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from bioetl.infrastructure.adapters.common import BaseTitleFallbackHandler, titles_match
+from bioetl.infrastructure.adapters.semanticscholar.adapter import (
+    SEMANTICSCHOLAR_BASE_URL,
+)
 
 if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort
@@ -26,8 +29,6 @@ __all__ = [
     "titles_match",
 ]
 
-# Semantic Scholar API configuration
-SEMANTICSCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1"
 DEFAULT_SEARCH_FIELDS = (
     "paperId,externalIds,title,abstract,year,publicationDate,"
     "venue,authors,citationCount,referenceCount,isOpenAccess,"


### PR DESCRIPTION
### Motivation
- Remove duplicated base-URL constants to prevent drift and centralize canonical values for each adapter.
- Avoid import-time circular dependencies between adapter modules by deferring cross-module imports to runtime.

### Description
- Keep `SEMANTICSCHOLAR_BASE_URL` canonical in `src/bioetl/infrastructure/adapters/semanticscholar/adapter.py` and remove the duplicate from `src/bioetl/infrastructure/adapters/semanticscholar/fallback.py` by importing the constant from the adapter.
- Keep `PUBCHEM_API_BASE` canonical in `src/bioetl/infrastructure/adapters/pubchem/client.py` and remove the duplicate from `src/bioetl/infrastructure/adapters/pubchem/fetch_strategies.py` by importing the constant from the client.
- Move potentially circular imports to runtime locations (`SemanticScholarTitleFallbackHandler` import in `__post_init__` of the semanticscholar adapter and `PubChemFetchStrategies` import inside the pubchem client constructor) to prevent import cycles while preserving behavior.
- Update imports and remove the now-unused top-level constant definitions so that each constant has exactly one assignment in `src/`.

### Testing
- Ran `python -m compileall` against the modified modules and it succeeded without syntax errors.
- Ran `ruff check` on the modified files and all linter checks passed.
- Verified with `rg -n "^SEMANTICSCHOLAR_BASE_URL\s*=" src` and `rg -n "^PUBCHEM_API_BASE\s*=" src` that there is exactly one assignment for each constant in `src/`.
- Attempted pre-commit checks resulted in unrelated environment failures due to a missing `scripts/check_constructor_args.py` and a missing `pip-audit` executable, which are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cef9fe1a48324ade0ffeae6612030)