### PR TITLE
docs: add architecture audit for previous-hour branch review scope

### DIFF
--- a/reports/architecture_audit_2026-02-11-2214.md
+++ b/reports/architecture_audit_2026-02-11-2214.md
@@ -1,0 +1,62 @@
+# Architecture Audit Report
+
+Date: 2026-02-11
+Scope: Git branches created during the previous hour (local repository refs)
+
+## Executive Summary
+
+- Total branches in scope: 0
+- Critical (MUST): 0
+- Moderate (SHOULD): 0
+- Informational (MAY): 1
+
+## Findings
+
+## [MAY] No branches were created in the previous hour
+
+**Location**: Git refs (`refs/heads`)
+
+**Rule Evaluated**: Requested scope filter — "branches created during previous hour"
+
+**Evidence**:
+
+- Current UTC timestamp and one-hour cutoff were computed.
+- `refs/heads/work` has creator date `2026-02-11 19:05:55 +0000`, which is outside the one-hour window.
+
+**Impact**:
+
+- There are no candidate branches to review for correctness, errors, or transfer to `main`.
+
+**Recommendation**:
+
+- Re-run the same audit after new branches are created, or provide explicit branch names/range to review.
+
+**Verification**:
+
+```bash
+date '+%Y-%m-%d %H:%M:%S %z'
+git for-each-ref --sort=-creatordate --format='%(refname:short)|%(creatordate:iso8601)|%(objectname:short)|%(subject)' refs/heads
+python - <<'PY'
+from datetime import datetime, timezone, timedelta
+import subprocess
+now=datetime.now(timezone.utc)
+out=subprocess.check_output(['git','for-each-ref','--format=%(refname:short)|%(creatordate:iso8601)','refs/heads']).decode().strip().splitlines()
+cut=now-timedelta(hours=1)
+print('now_utc',now.isoformat())
+print('cutoff',cut.isoformat())
+for line in out:
+    name,dt=line.split('|',1)
+    t=datetime.fromisoformat(dt.replace(' ','T',1))
+    print(name,dt,'within_last_hour=',t>=cut)
+PY
+```
+
+## Positive Observations
+
+- No unreviewed in-scope branch changes exist; therefore, no risk of unvalidated merge into `main` from the requested time window.
+
+## Verification Log
+
+- `date '+%Y-%m-%d %H:%M:%S %z'`
+- `git for-each-ref --sort=-creatordate --format='%(refname:short)|%(creatordate:iso8601)|%(objectname:short)|%(subject)' refs/heads`
+- Python check comparing `creatordate` against `now - 1 hour`.


### PR DESCRIPTION
### Motivation
- Проверить ветки, созданные за предыдущий час, определить обоснованные изменения для переноса в `main` и задокументировать вывод аудита для прозрачности.

### Description
- Добавлен файл `reports/architecture_audit_2026-02-11-2214.md`, содержащий область проверки, использованные команды и доказательства, выводы и рекомендации; кодовых изменений в проект не вносилось.

### Testing
- Выполнены локальные проверки временной метки и списка веток с помощью `date` и `git for-each-ref` для фильтрации по `creatordate` в окне `now - 1 hour`. 
- Запущен Python-скрипт, который парсит `creatordate` и сравнивает с `now - 1 hour`, результат — ни одна локальная ветка не попадает в указанный интервал. 
- Прогнаны pre-commit hooks: `mdformat` автоформатировал файл и затем прошёл, а `pip-audit` был пропущен из-за отсутствия исполняемого `pip-audit` в окружении. 
- Итог тестирования: нет веток/изменений, подходящих для переноса в `main` в заданном часовом окне.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfe6999e48324a29f21b7048e51fc)