### PR TITLE
Introduce distinct SilverFilterConfig and update config mapping & typing

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -116,7 +116,7 @@ class BaseTransformer(ABC):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -64,7 +64,7 @@ class BaseChemblTransformer(BaseTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -130,7 +130,7 @@ class PublicationTransformer(BaseChemblTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -70,7 +70,7 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -85,7 +85,7 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -44,7 +44,7 @@ class PubChemCompoundTransformer(BaseTransformer):
         entity_type: str = "compound",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -90,7 +90,7 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -84,7 +84,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
@@ -43,7 +43,7 @@ class IDMappingTransformer(BaseTransformer):
         entity_type: str = "idmapping",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -83,7 +83,7 @@ class UniProtProteinTransformer(BaseTransformer):
         entity_type: str = "protein",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -146,7 +146,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         self,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -49,7 +49,7 @@ def create_transformer(
     entity_type: str,
     tracer: TracingPort | None = None,
     metrics: MetricsPort | None = None,
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+    silver_filters: SilverFilterConfig | None = None,
     gold_filters: GoldFilterConfig | None = None,
     identity_service: IdentityService | None = None,
     pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/domain/config/pipeline.py
+++ b/src/bioetl/domain/config/pipeline.py
@@ -46,7 +46,7 @@ class PipelineConfig:
     table: TableConfig
 
     # Processing
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None
+    silver_filters: SilverFilterConfig | None = None
     gold_filters: GoldFilterConfig | None = None
     batch_size: int = 100
     checkpoint_interval: int = 1000

--- a/src/bioetl/domain/config/validation.py
+++ b/src/bioetl/domain/config/validation.py
@@ -1,8 +1,4 @@
-"""Validation configuration objects.
-
-Defines domain value-object validation ranges and field-level /
-cross-field / conditional validation rule descriptors.
-"""
+"""Validation configuration objects."""
 
 from __future__ import annotations
 
@@ -11,64 +7,22 @@ from typing import Literal
 
 from bioetl.domain.config._converters import freeze_sequences
 
-# =============================================================================
-# Validation Configuration
-# =============================================================================
-
 
 @dataclass(frozen=True, slots=True)
 class ValidationConfig:
-    """Centralized configuration for validation ranges.
+    """Centralized validation ranges for domain objects."""
 
-    Provides configurable validation parameters for domain value objects
-    and validation functions. This enables:
-    - Consistent validation across all components
-    - Override capability via pipeline config
-    - Single source of truth for validation rules
-
-    Attributes:
-        min_publication_year: Minimum valid publication year. Default 1500
-            covers historical scientific publications.
-        max_publication_year: Maximum valid publication year. Default 2100.
-        min_molecular_weight: Minimum molecular weight in Daltons. Default 10.0.
-        max_molecular_weight: Maximum molecular weight in Daltons. Default 10000.0
-            covers small molecules to large peptides.
-        max_pmid: Maximum valid PubMed ID. Default 10_000_000_000.
-        max_taxonomy_id: Maximum valid NCBI Taxonomy ID. Default 10_000_000.
-        min_pchembl_value: Minimum pChEMBL value. Default 0.0.
-        max_pchembl_value: Maximum pChEMBL value. Default 15.0 (-log10(10^-15 M)).
-        molecular_weight_precision: Decimal precision for MW rounding. Default 10.
-
-    Example:
-        >>> config = ValidationConfig()
-        >>> config.min_publication_year
-        1500
-
-    """
-
-    # Publication year range
     min_publication_year: int = 1500
     max_publication_year: int = 2100
-
-    # Molecular properties
     min_molecular_weight: float = 10.0
     max_molecular_weight: float = 10_000.0
     molecular_weight_precision: int = 10
-
-    # Identifiers
     max_pmid: int = 10_000_000_000
     max_taxonomy_id: int = 10_000_000
-
-    # Activity values
     min_pchembl_value: float = 0.0
     max_pchembl_value: float = 15.0
 
     def __post_init__(self) -> None:
-        """Validate configuration invariants."""
-        self._validate_ranges()
-
-    def _validate_ranges(self) -> None:
-        """Validate that min/max ranges are valid."""
         validations = [
             (
                 self.min_publication_year >= self.max_publication_year,
@@ -92,37 +46,12 @@ class ValidationConfig:
                 raise ValueError(message)
 
 
-# Default singleton instance for use when no custom config is provided
 DEFAULT_VALIDATION_CONFIG = ValidationConfig()
 
 
 @dataclass(frozen=True, slots=True)
 class FieldValidation:
-    """Configuration for a single field validation rule.
-
-    Supports multiple validation types:
-    - required: Field must be present and non-null
-    - not_null: Field should not be null (typically used with severity=warn)
-    - range: Numeric range validation (min/max)
-    - pattern: Regex pattern matching
-    - enum: Allowed values validation
-    - max_length: Maximum string length validation
-    - not_empty_list: List field must be non-empty when present
-    - custom: Custom validator function reference
-
-    Attributes:
-        field: Field name to validate.
-        validation_type: Type of validation.
-        nullable: Whether field can be null/None. Default: True.
-        severity: Severity level (error or warn). Default: error.
-        min_value: Minimum value for range validation.
-        max_value: Maximum value for range validation.
-        pattern: Regex pattern for pattern validation.
-        allowed: Allowed values for enum validation.
-        max_length: Maximum string length for max_length validation.
-        validator: Validator function name for custom validation.
-        error_message: Custom error message template.
-    """
+    """Configuration for one field-level validation rule."""
 
     field: str
     validation_type: Literal[
@@ -137,72 +66,43 @@ class FieldValidation:
     ]
     nullable: bool = True
     severity: Literal["error", "warn"] = "error"
-    # Range validation
     min_value: float | None = None
     max_value: float | None = None
-    # Pattern validation
     pattern: str | None = None
-    # Enum validation
     allowed: tuple[str, ...] = ()
-    # Max length validation
     max_length: int | None = None
-    # Custom validation
     validator: str | None = None
-    # Custom error message
     error_message: str | None = None
 
     def __post_init__(self) -> None:
-        """Convert lists to tuples for immutability."""
         freeze_sequences(self, ("allowed",))
 
 
 @dataclass(frozen=True, slots=True)
 class CrossFieldValidation:
-    """Configuration for cross-field validation rule.
-
-    Validates relationships between multiple fields.
-
-    Attributes:
-        name: Unique name for the validation rule.
-        fields: Fields involved in the validation.
-        condition: Validation condition type.
-        error_message: Custom error message template.
-    """
+    """Validation rule spanning multiple fields."""
 
     name: str
     fields: tuple[str, ...]
     condition: Literal[
-        "all_present",  # All fields must be non-null
-        "any_present",  # At least one field must be non-null
-        "mutually_exclusive",  # Only one field can be non-null
-        "conditional_required",  # If field A present, field B required
-        "custom",  # Custom validation function
+        "all_present",
+        "any_present",
+        "mutually_exclusive",
+        "conditional_required",
+        "custom",
     ]
-    # For conditional_required: (trigger_field, required_field)
     trigger_field: str | None = None
     required_field: str | None = None
-    # Custom validation
     validator: str | None = None
     error_message: str | None = None
 
     def __post_init__(self) -> None:
-        """Convert lists to tuples for immutability."""
         freeze_sequences(self, ("fields",))
 
 
 @dataclass(frozen=True, slots=True)
 class ConditionalValidation:
-    """Configuration for conditional validation rule.
-
-    Applies validation only when a condition is met.
-
-    Attributes:
-        name: Unique name for the validation rule.
-        condition_field: Field to check for condition.
-        condition_value: Value that triggers the validation.
-        condition_operator: Comparison operator (eq, ne, in, not_in).
-        then_validations: Field validations to apply when condition is true.
-    """
+    """Validation rule applied only when condition matches."""
 
     name: str
     condition_field: str
@@ -211,5 +111,4 @@ class ConditionalValidation:
     then_validations: tuple[FieldValidation, ...] = ()
 
     def __post_init__(self) -> None:
-        """Convert lists to tuples for immutability."""
         freeze_sequences(self, ("condition_value", "then_validations"))

--- a/src/bioetl/domain/filtering/silver_config.py
+++ b/src/bioetl/domain/filtering/silver_config.py
@@ -1,50 +1,260 @@
-"""Silver filter configuration.
-
-Provides SilverFilterConfig — a semantically distinct type for Silver layer
-filtering.  Structurally identical to GoldFilterConfig but typed separately
-so that mypy can catch accidental assignment of a Silver-layer filter to a
-Gold-layer slot (and vice versa).
-"""
+"""Silver filter configuration."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
-from bioetl.domain.filtering.gold_config import GoldFilterConfig
+from bioetl.domain.filtering.column_filter import FilterOperator, GoldColumnFilter
+from bioetl.domain.filtering.list_filters import (
+    GoldListContainsFilter,
+    GoldListLengthFilter,
+)
+from bioetl.domain.filtering.range_filter import GoldRangeFilter
 
 
 @dataclass(frozen=True, slots=True)
-class SilverFilterConfig(GoldFilterConfig):
-    """Filters applied during Silver layer processing.
-
-    Structurally identical to :class:`GoldFilterConfig` but kept as a
-    separate type so that the type checker can distinguish between
-    Silver-layer and Gold-layer filter configurations.
+class SilverFilterConfig:
+    """Полная конфигурация Gold фильтров.
 
     Attributes:
-        column_filters: Column value filters (IN / NOT_IN / IS_NULL etc.).
-        range_filters: Numeric range filters.
-        list_length_filters: List-length bound filters.
-        list_contains_filters: List-contents filters.
-        required_fields: Fields that must be non-null / non-empty.
-        exclude_if_present: Fields whose presence excludes a record.
+        column_filters: Фильтры по колонкам (значение должно быть в списке).
+        range_filters: Фильтры диапазонов значений.
+        list_length_filters: Фильтры по длине списков.
+        list_contains_filters: Фильтры по содержанию списков.
+        required_fields: Обязательные поля (должны быть не null/пустые).
+        exclude_if_present: Исключающие поля (если есть значение — запись исключается).
     """
 
-    # All fields are inherited from GoldFilterConfig.
-    # The class exists purely for nominal typing separation.
+    column_filters: tuple[GoldColumnFilter, ...] = ()
+    range_filters: tuple[GoldRangeFilter, ...] = ()
+    list_length_filters: tuple[GoldListLengthFilter, ...] = ()
+    list_contains_filters: tuple[GoldListContainsFilter, ...] = ()
+    required_fields: tuple[str, ...] = ()
+    exclude_if_present: tuple[str, ...] = ()
 
-    @classmethod
-    def from_gold_filter_config(cls, config: GoldFilterConfig) -> SilverFilterConfig:
-        """Create a SilverFilterConfig from an existing GoldFilterConfig.
+    def should_include(self, record: dict[str, Any]) -> bool:
+        """Проверяет все правила фильтрации.
 
-        Convenience factory for the migration period where infrastructure
-        loaders still produce GoldFilterConfig for Silver filters.
+        Args:
+            record: Запись для проверки.
+
+        Returns:
+            True если запись проходит все фильтры, False иначе.
         """
-        return cls(
-            column_filters=config.column_filters,
-            range_filters=config.range_filters,
-            list_length_filters=config.list_length_filters,
-            list_contains_filters=config.list_contains_filters,
-            required_fields=config.required_fields,
-            exclude_if_present=config.exclude_if_present,
+        checks = [
+            self._check_required_fields,
+            self._check_exclude_if_present,
+            self._check_column_filters,
+            self._check_range_filters,
+            self._check_list_length_filters,
+            self._check_list_contains_filters,
+        ]
+        return all(check(record) for check in checks)
+
+    def _check_required_fields(self, record: dict[str, Any]) -> bool:
+        """Проверяет наличие обязательных полей."""
+        return all(record.get(fld) not in (None, "") for fld in self.required_fields)
+
+    def _check_exclude_if_present(self, record: dict[str, Any]) -> bool:
+        """Проверяет отсутствие исключающих полей."""
+        return all(record.get(fld) in (None, "") for fld in self.exclude_if_present)
+
+    def _check_column_filters(self, record: dict[str, Any]) -> bool:
+        """Проверяет соответствие значений колонок фильтрам."""
+        return all(self._check_single_column(record, f) for f in self.column_filters)
+
+    def _check_single_column(self, record: dict[str, Any], f: GoldColumnFilter) -> bool:
+        """Проверяет одну колонку по оператору.
+
+        Args:
+            record: Запись для проверки.
+            f: Фильтр колонки с оператором.
+
+        Returns:
+            True если значение колонки проходит фильтр.
+        """
+        val = record.get(f.column)
+        checker = _OPERATOR_CHECKERS.get(f.operator)
+        if checker is None:
+            return False  # Unknown operator - fail safe
+        return checker(self, val, f.values)
+
+    def _check_op_in(self, val: Any, values: frozenset[str] | None) -> bool:
+        """Проверяет оператор IN."""
+        return str(val) in values  # type: ignore[operator]
+
+    def _check_op_not_in(self, val: Any, values: frozenset[str] | None) -> bool:
+        """Проверяет оператор NOT_IN."""
+        return str(val) not in values  # type: ignore[operator]
+
+    def _check_op_is_null(self, val: Any, _values: frozenset[str] | None) -> bool:
+        """Проверяет оператор IS_NULL."""
+        return val is None or val == ""
+
+    def _check_op_is_not_null(self, val: Any, _values: frozenset[str] | None) -> bool:
+        """Проверяет оператор IS_NOT_NULL."""
+        return val is not None and val != ""
+
+    def _check_op_is_empty(self, val: Any, _values: frozenset[str] | None) -> bool:
+        """Проверяет оператор IS_EMPTY."""
+        return self._is_empty_value(val)
+
+    def _check_op_is_not_empty(self, val: Any, _values: frozenset[str] | None) -> bool:
+        """Проверяет оператор IS_NOT_EMPTY."""
+        return not self._is_empty_value(val)
+
+    @staticmethod
+    def _is_empty_value(val: Any) -> bool:
+        """Проверяет, является ли значение 'пустым'.
+
+        Пустым считается:
+        - None
+        - Пустая строка или строка из пробелов
+        - Пустой список, словарь или множество
+
+        Args:
+            val: Значение для проверки.
+
+        Returns:
+            True если значение "пустое".
+        """
+        if val is None:
+            return True
+        if isinstance(val, str) and val.strip() == "":
+            return True
+        return isinstance(val, (list, dict, set)) and len(val) == 0
+
+    def _check_range_filters(self, record: dict[str, Any]) -> bool:
+        """Проверяет попадание значений в диапазоны."""
+        return all(self._check_single_range(record, f) for f in self.range_filters)
+
+    def _check_list_length_filters(self, record: dict[str, Any]) -> bool:
+        """Проверяет длину списков в колонках."""
+        return all(
+            self._check_single_list_length(record, f) for f in self.list_length_filters
         )
+
+    def _check_single_list_length(
+        self, record: dict[str, Any], f: GoldListLengthFilter
+    ) -> bool:
+        """Проверяет длину одного списка."""
+        length = self._get_list_length(record.get(f.column))
+        return self._length_in_bounds(length, f.min_length, f.max_length)
+
+    @staticmethod
+    def _get_list_length(val: Any) -> int:
+        """Вычисляет длину значения как списка."""
+        if val is None:
+            return 0
+        if isinstance(val, list):
+            return len(val)
+        return 1
+
+    @staticmethod
+    def _length_in_bounds(
+        length: int, min_len: int | None, max_len: int | None
+    ) -> bool:
+        """Проверяет, находится ли длина в допустимых границах."""
+        if min_len is not None and length < min_len:
+            return False
+        return not (max_len is not None and length > max_len)
+
+    def _check_list_contains_filters(self, record: dict[str, Any]) -> bool:
+        """Проверяет содержание списков."""
+        return all(
+            self._check_single_list_contains(record, f)
+            for f in self.list_contains_filters
+        )
+
+    def _check_single_list_contains(
+        self, record: dict[str, Any], f: GoldListContainsFilter
+    ) -> bool:
+        """Проверяет содержание одного списка."""
+        val = record.get(f.column)
+        if not val:  # None or empty list - пропускаем (vacuous truth)
+            return True
+
+        val_set = self._to_string_set(val)
+        return self._matches_contains_mode(val_set, f.values, f.mode)
+
+    @staticmethod
+    def _to_string_set(val: Any) -> set[str]:
+        """Преобразует значение в множество строк."""
+        if not isinstance(val, list):
+            val = [val]
+        return {str(v) for v in val}
+
+    @staticmethod
+    def _matches_contains_mode(
+        val_set: set[str], allowed: frozenset[str], mode: str
+    ) -> bool:
+        """Проверяет соответствие множества значений режиму фильтра."""
+        if mode == "all":
+            return val_set.issubset(allowed)
+        # mode == "any"
+        return bool(val_set.intersection(allowed))
+
+    def _check_single_range(self, record: dict[str, Any], f: GoldRangeFilter) -> bool:
+        """Проверяет одно значение на попадание в диапазон."""
+        val = record.get(f.column)
+        if val is None or val == "":
+            return False
+
+        try:
+            num_val = float(val)
+        except (ValueError, TypeError):
+            return False
+
+        return self._in_range(num_val, f)
+
+    def _in_range(self, num_val: float, f: GoldRangeFilter) -> bool:
+        """Проверяет, находится ли значение в диапазоне."""
+        min_ok = self._check_min_bound(num_val, f.min_value, f.include_min)
+        max_ok = self._check_max_bound(num_val, f.max_value, f.include_max)
+        return min_ok and max_ok
+
+    @staticmethod
+    def _check_min_bound(val: float, min_val: float | None, inclusive: bool) -> bool:
+        """Проверяет нижнюю границу диапазона."""
+        if min_val is None:
+            return True
+        return val >= min_val if inclusive else val > min_val
+
+    @staticmethod
+    def _check_max_bound(val: float, max_val: float | None, inclusive: bool) -> bool:
+        """Проверяет верхнюю границу диапазона."""
+        if max_val is None:
+            return True
+        return val <= max_val if inclusive else val < max_val
+
+    def is_empty(self) -> bool:
+        """Проверяет, пуста ли конфигурация фильтров.
+
+        Returns:
+            True если нет ни одного фильтра.
+        """
+        all_filters = (
+            self.column_filters,
+            self.range_filters,
+            self.list_length_filters,
+            self.list_contains_filters,
+            self.required_fields,
+            self.exclude_if_present,
+        )
+        return not any(all_filters)
+
+
+# Operator dispatch table - defined after class to reference methods
+# This mapping enables O(1) operator lookup with CC=1 per operator method
+_OPERATOR_CHECKERS: dict[
+    FilterOperator, Callable[[SilverFilterConfig, Any, frozenset[str] | None], bool]
+] = {
+    FilterOperator.IN: SilverFilterConfig._check_op_in,
+    FilterOperator.NOT_IN: SilverFilterConfig._check_op_not_in,
+    FilterOperator.IS_NULL: SilverFilterConfig._check_op_is_null,
+    FilterOperator.IS_NOT_NULL: SilverFilterConfig._check_op_is_not_null,
+    FilterOperator.IS_EMPTY: SilverFilterConfig._check_op_is_empty,
+    FilterOperator.IS_NOT_EMPTY: SilverFilterConfig._check_op_is_not_empty,
+}

--- a/src/bioetl/infrastructure/config/_base.py
+++ b/src/bioetl/infrastructure/config/_base.py
@@ -120,7 +120,14 @@ def _build_silver_filters(yaml_config: PipelineYamlConfig) -> SilverFilterConfig
     Returns a SilverFilterConfig for nominal type separation from Gold filters.
     """
     gold = yaml_config.silver_filters.to_domain()
-    return SilverFilterConfig.from_gold_filter_config(gold)
+    return SilverFilterConfig(
+        column_filters=gold.column_filters,
+        range_filters=gold.range_filters,
+        list_length_filters=gold.list_length_filters,
+        list_contains_filters=gold.list_contains_filters,
+        required_fields=gold.required_fields,
+        exclude_if_present=gold.exclude_if_present,
+    )
 
 
 def _build_gold_filters(yaml_config: PipelineYamlConfig) -> GoldFilterConfig:

--- a/src/bioetl/infrastructure/config/filter_config_loader.py
+++ b/src/bioetl/infrastructure/config/filter_config_loader.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from bioetl.domain.filtering import GoldFilterConfig, InputFilterConfig
+from bioetl.domain.filtering import (
+    GoldFilterConfig,
+    InputFilterConfig,
+    SilverFilterConfig,
+)
 from bioetl.domain.models.filter import ExtractionParams
 from bioetl.infrastructure.config.base_config_loader import BaseConfigLoader
 from bioetl.infrastructure.schemas.filter_config import FilterConfigFile
@@ -25,7 +29,7 @@ _FILTER_CONCAT_KEYS = frozenset({"required_fields", "exclude_if_present"})
 
 class FilterConfigLoader(
     BaseConfigLoader[
-        tuple[InputFilterConfig, GoldFilterConfig, GoldFilterConfig, ExtractionParams]
+        tuple[InputFilterConfig, SilverFilterConfig, GoldFilterConfig, ExtractionParams]
     ],
 ):
     """Loads and merges filter configurations from hierarchical files.
@@ -50,7 +54,9 @@ class FilterConfigLoader(
         provider: str,
         entity: str,
         inline_overrides: dict[str, Any] | None = None,
-    ) -> tuple[InputFilterConfig, GoldFilterConfig, GoldFilterConfig, ExtractionParams]:
+    ) -> tuple[
+        InputFilterConfig, SilverFilterConfig, GoldFilterConfig, ExtractionParams
+    ]:
         """Load merged filter config for provider/entity.
 
         Merge order (later wins for scalars, special handling for collections):
@@ -66,8 +72,7 @@ class FilterConfigLoader(
 
         Returns:
             Tuple of (InputFilterConfig, SilverFilterConfig, GoldFilterConfig,
-            ExtractionParams) domain objects.  Silver and Gold filters both use
-            GoldFilterConfig as the domain type.
+            ExtractionParams) domain objects.  Silver and Gold filters are represented by distinct domain types.
 
         Raises:
             FileNotFoundError: If _defaults.yaml doesn't exist.
@@ -106,7 +111,7 @@ class FilterConfigLoader(
         # Validate via Pydantic
         validated = FilterConfigFile.model_validate(merged)
         domain_configs: tuple[
-            InputFilterConfig, GoldFilterConfig, GoldFilterConfig, ExtractionParams
+            InputFilterConfig, SilverFilterConfig, GoldFilterConfig, ExtractionParams
         ] = validated.to_domain()
 
         # Cache result if no inline overrides

--- a/src/bioetl/infrastructure/schemas/filter_config.py
+++ b/src/bioetl/infrastructure/schemas/filter_config.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, field_validator
 
-from bioetl.domain.filtering import GoldFilterConfig
 from bioetl.domain.filtering import (
-    InputFilterConfig as DomainInputFilterConfig,
+    GoldFilterConfig,
+)
+from bioetl.domain.filtering import InputFilterConfig as DomainInputFilterConfig
+from bioetl.domain.filtering import (
+    SilverFilterConfig,
 )
 from bioetl.domain.models.filter import ExtractionParams
 from bioetl.infrastructure.schemas.base_schemas import (
@@ -102,10 +105,25 @@ class SilverFiltersFileConfig(BaseGoldFiltersConfig):
     def to_domain(self) -> GoldFilterConfig:
         """Convert to domain GoldFilterConfig dataclass.
 
+        Kept for compatibility with BaseGoldFiltersConfig contract.
+        """
+        return super().to_domain()
+
+    def to_silver_domain(self) -> SilverFilterConfig:
+        """Convert to domain SilverFilterConfig dataclass.
+
         Returns:
             GoldFilterConfig: Immutable domain filter configuration.
         """
-        return super().to_domain()
+        gold_filters = self.to_domain()
+        return SilverFilterConfig(
+            column_filters=gold_filters.column_filters,
+            range_filters=gold_filters.range_filters,
+            list_length_filters=gold_filters.list_length_filters,
+            list_contains_filters=gold_filters.list_contains_filters,
+            required_fields=gold_filters.required_fields,
+            exclude_if_present=gold_filters.exclude_if_present,
+        )
 
 
 class GoldFiltersFileConfig(BaseGoldFiltersConfig):
@@ -202,7 +220,10 @@ class FilterConfigFile(BaseModel):
     def to_domain(
         self,
     ) -> tuple[
-        DomainInputFilterConfig, GoldFilterConfig, GoldFilterConfig, ExtractionParams
+        DomainInputFilterConfig,
+        SilverFilterConfig,
+        GoldFilterConfig,
+        ExtractionParams,
     ]:
         """Convert to domain objects.
 
@@ -213,7 +234,7 @@ class FilterConfigFile(BaseModel):
         """
         return (
             self.input_filter.to_domain(),
-            self.silver_filters.to_domain(),
+            self.silver_filters.to_silver_domain(),
             self.gold_filters.to_domain(),
             ExtractionParams(params=self.extraction_params),
         )


### PR DESCRIPTION
### Motivation
- Prevent accidental interchange of Silver vs Gold filter configurations by giving Silver filters a nominal, separate domain type for stronger static typing and safer migrations.
- Align infrastructure → domain mapping so YAML loader produces a semantically-correct `SilverFilterConfig` instead of reusing `GoldFilterConfig` as a nominal Silver type.
- Reduce boilerplate in validation config and keep domain dataclasses frozen/slots-preserving while keeping backward-compatible conversion points.

### Description
- Added a standalone domain class `SilverFilterConfig` implementing the same filter logic and operator-dispatch as the gold variant but as an independent type (`src/bioetl/domain/filtering/silver_config.py`).
- Updated Pydantic filter schema conversions: added `SilverFiltersFileConfig.to_silver_domain()` and changed `FilterConfigFile.to_domain()` to return `(<InputFilterConfig>, <SilverFilterConfig>, <GoldFilterConfig>, <ExtractionParams>)` (`src/bioetl/infrastructure/schemas/filter_config.py`).
- Updated infrastructure mapping to construct a `SilverFilterConfig` from the validated schema in `_build_silver_filters()` and `yaml_config_to_domain()` so the domain model receives the correct nominal type (`src/bioetl/infrastructure/config/_base.py`).
- Propagated the `SilverFilterConfig` type through application signatures and factories by removing the previous `SilverFilterConfig | GoldFilterConfig` union for `silver_filters` parameters and using `SilverFilterConfig | None` instead (`src/bioetl/application/*`, `src/bioetl/composition/factories/*`, `src/bioetl/domain/config/pipeline.py`).
- Adjusted `FilterConfigLoader` typing and docs to return the new triple with distinct silver/gold types (`src/bioetl/infrastructure/config/filter_config_loader.py`).
- Simplified and trimmed `domain/config/validation.py` while preserving behavior and dataclass invariants (`src/bioetl/domain/config/validation.py`).

### Testing
- Ran `mypy --strict` on the changed config/filter files: `mypy --strict src/bioetl/infrastructure/config/filter_config_loader.py src/bioetl/infrastructure/schemas/filter_config.py src/bioetl/domain/filtering/silver_config.py` — succeeded.
- Ran focused unit tests: `pytest -o addopts='' -v tests/unit/infrastructure/schemas/test_filter_config.py tests/unit/application/test_pipeline_config.py` — all tests passed.
- Ran targeted architecture test: `pytest -o addopts='' -v tests/architecture/test_force_full_scan_publication.py` — all tests passed.
- Attempted broader `pytest tests/architecture/ -v` and full `mypy --strict src/bioetl/`; those runs surfaced unrelated repository baseline issues and missing environment dependencies during collection (external packages, global mypy baseline findings, and pre-commit tool constraints) that are outside the scope of these changes; therefore full-suite green CI was not reached in-session but the changed surface area was validated with type checks and focused tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee3f6a67c83249bcf943dd1d46752)