### PR TITLE
Refactor PipelineConfig to canonical TableConfig composition

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -116,7 +116,7 @@ class BaseTransformer(ABC):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/core/preflight_service.py
+++ b/src/bioetl/application/core/preflight_service.py
@@ -350,7 +350,7 @@ class _MedallionConfigValidator:
         write_mode_policy = WriteModePolicy()
 
         # Validate Silver write mode
-        silver_mode = self._config.write_mode
+        silver_mode = self._config.table.silver_write_mode
         try:
             write_mode_policy.validate(Layer.SILVER, WriteMode(silver_mode))
         except (PolicyViolationError, ValueError):
@@ -368,7 +368,7 @@ class _MedallionConfigValidator:
             )
 
         # Validate Gold write mode
-        gold_mode = self._config.gold_write_mode
+        gold_mode = self._config.table.gold_write_mode
         effective_gold_mode = "merge" if gold_mode == "scd2" else gold_mode
         try:
             write_mode_policy.validate(Layer.GOLD, WriteMode(effective_gold_mode))

--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -64,7 +64,7 @@ class BaseChemblTransformer(BaseTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -130,7 +130,7 @@ class PublicationTransformer(BaseChemblTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -70,7 +70,7 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -85,7 +85,7 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -44,7 +44,7 @@ class PubChemCompoundTransformer(BaseTransformer):
         entity_type: str = "compound",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -90,7 +90,7 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -84,7 +84,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
@@ -43,7 +43,7 @@ class IDMappingTransformer(BaseTransformer):
         entity_type: str = "idmapping",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -83,7 +83,7 @@ class UniProtProteinTransformer(BaseTransformer):
         entity_type: str = "protein",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/services/medallion_lifecycle.py
+++ b/src/bioetl/application/services/medallion_lifecycle.py
@@ -270,11 +270,16 @@ class MedallionLifecycleService:
 
         policy = MedallionPolicy.for_run_type(runtime.run_type)
 
-        gold_table = config.gold_table or f"{config.provider}.{config.entity_type}"
+        silver_table = (
+            config.table.silver_table or f"{config.provider}.{config.entity_type}"
+        )
+        gold_table = (
+            config.table.gold_table or f"{config.provider}.{config.entity_type}"
+        )
 
         result = await self.clear(
             policy=policy,
-            silver_table=config.silver_table,
+            silver_table=silver_table,
             gold_table=gold_table,
             dry_run=runtime.dry_run,
         )
@@ -325,7 +330,8 @@ class MedallionLifecycleService:
                 "stage": "optimize",
                 "retention_days": runtime.vacuum_retention_days,
                 "dry_run": runtime.dry_run,
-                "target": config.silver_table,
+                "target": config.table.silver_table
+                or f"{config.provider}.{config.entity_type}",
             },
         )
 
@@ -335,16 +341,21 @@ class MedallionLifecycleService:
             # even if table names differ (custom Gold table).
 
             # Optimize based on Silver table name (covers Silver layer + Bronze)
+            silver_table = (
+                config.table.silver_table or f"{config.provider}.{config.entity_type}"
+            )
             await self.storage.optimize(
-                table_name=config.silver_table,
+                table_name=silver_table,
                 retention_hours=runtime.vacuum_retention_days * 24,
                 dry_run=runtime.dry_run,
             )
 
-            gold_table = config.gold_table or f"{config.provider}.{config.entity_type}"
+            gold_table = (
+                config.table.gold_table or f"{config.provider}.{config.entity_type}"
+            )
 
             # Optimize based on Gold table name if different (covers Gold layer)
-            if gold_table != config.silver_table:
+            if gold_table != silver_table:
                 await self.storage.optimize(
                     table_name=gold_table,
                     retention_hours=runtime.vacuum_retention_days * 24,

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -146,7 +146,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         self,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -531,6 +531,8 @@ class ServicesBuilder:
         """
         callbacks = extract_pipeline_callbacks(pipeline)
 
+        default_table_name = f"{pipeline.config.provider}.{pipeline.config.entity_type}"
+
         return ServicesBuilder.create_record_processor(
             services=pipeline.services,
             context=pipeline.context,
@@ -540,12 +542,12 @@ class ServicesBuilder:
             silver_schema=silver_schema,
             gold_schema=gold_schema,
             dq_config=pipeline.config.dq,
-            primary_keys=pipeline.config.primary_keys,
-            silver_table=pipeline.config.silver_table,
-            gold_table=pipeline.config.gold_table,
-            silver_write_mode=pipeline.config.write_mode,
-            gold_write_mode=pipeline.config.gold_write_mode,
-            on_schema_mismatch=pipeline.config.on_schema_mismatch,
+            primary_keys=pipeline.config.table.primary_keys,
+            silver_table=pipeline.config.table.silver_table or default_table_name,
+            gold_table=pipeline.config.table.gold_table or default_table_name,
+            silver_write_mode=pipeline.config.table.silver_write_mode,
+            gold_write_mode=pipeline.config.table.gold_write_mode,
+            on_schema_mismatch=pipeline.config.table.on_schema_mismatch,
             transform_callback=callbacks.transform,
             gold_filter_callback=callbacks.gold_filter,
             gold_transform_callback=callbacks.gold_transform,

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -49,7 +49,7 @@ def create_transformer(
     entity_type: str,
     tracer: TracingPort | None = None,
     metrics: MetricsPort | None = None,
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+    silver_filters: SilverFilterConfig | None = None,
     gold_filters: GoldFilterConfig | None = None,
     identity_service: IdentityService | None = None,
     pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/domain/config/pipeline.py
+++ b/src/bioetl/domain/config/pipeline.py
@@ -31,10 +31,7 @@ class PipelineConfig:
 
     Table-related fields (primary_keys, silver_table, gold_table,
     write modes, partition_cols, on_schema_mismatch) are stored in the
-    nested ``table`` field (:class:`TableConfig`).  Convenience
-    properties forward the most common accesses so that
-    ``config.primary_keys`` continues to work alongside the canonical
-    ``config.table.primary_keys`` form.
+    nested ``table`` field (:class:`TableConfig`).
     """
 
     # Identity
@@ -46,7 +43,7 @@ class PipelineConfig:
     table: TableConfig
 
     # Processing
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None
+    silver_filters: SilverFilterConfig | None = None
     gold_filters: GoldFilterConfig | None = None
     batch_size: int = 100
     checkpoint_interval: int = 1000
@@ -103,43 +100,3 @@ class PipelineConfig:
     def lock_key(self) -> str:
         """Generate lock key for distributed locking."""
         return f"pipeline:{self.pipeline_name}"
-
-    # ------------------------------------------------------------------
-    # Convenience forwarding properties for backward compatibility.
-    # Canonical access is via ``self.table.<field>``.
-    # ------------------------------------------------------------------
-
-    @property
-    def primary_keys(self) -> tuple[str, ...]:
-        """Shortcut for ``self.table.primary_keys``."""
-        return self.table.primary_keys
-
-    @property
-    def silver_table(self) -> str | None:
-        """Shortcut for ``self.table.silver_table``."""
-        return self.table.silver_table
-
-    @property
-    def gold_table(self) -> str | None:
-        """Shortcut for ``self.table.gold_table``."""
-        return self.table.gold_table
-
-    @property
-    def write_mode(self) -> object:
-        """Shortcut for ``self.table.silver_write_mode``."""
-        return self.table.silver_write_mode
-
-    @property
-    def gold_write_mode(self) -> object:
-        """Shortcut for ``self.table.gold_write_mode``."""
-        return self.table.gold_write_mode
-
-    @property
-    def partition_cols(self) -> tuple[str, ...]:
-        """Shortcut for ``self.table.partition_cols``."""
-        return self.table.partition_cols
-
-    @property
-    def on_schema_mismatch(self) -> str:
-        """Shortcut for ``self.table.on_schema_mismatch``."""
-        return self.table.on_schema_mismatch


### PR DESCRIPTION
### Motivation

- Reduce duplication and ambiguity by making `TableConfig` the single source of truth for table-related settings instead of duplicating fields on `PipelineConfig`.
- Tighten type semantics for Silver/Gold filter usage so Silver-specific APIs only accept `SilverFilterConfig` where appropriate.
- Update call sites to the canonical `config.table.*` access pattern and provide safe fallbacks where downstream APIs require non-optional table names.

### Description

- Remove forwarding properties (`primary_keys`, `silver_table`, `gold_table`, `write_mode`, `gold_write_mode`, `partition_cols`, `on_schema_mismatch`) from `PipelineConfig`, leaving `table: TableConfig` as the canonical field. 
- Replace occurrences of `*.primary_keys`, `*.silver_table`, `*.gold_table`, `*.write_mode`, `*.gold_write_mode`, and `*.on_schema_mismatch` with `*.table.<field>` across services, factories and validators, and add a `"{provider}.{entity_type}"` default fallback where downstream code requires a non-optional table name. 
- Narrow signatures that previously accepted `SilverFilterConfig | GoldFilterConfig | None` to `SilverFilterConfig | None` in transformer and factory constructors to enforce semantic separation between Silver and Gold filters. 
- Update medallion write-mode validation to read `silver_write_mode`/`gold_write_mode` from `config.table` and adjust medallion lifecycle/storage code to use the canonical table field when building targets.

### Testing

- Ran `python -m compileall -q src/bioetl` which completed successfully. 
- Ran `pytest tests/architecture/ -q` which failed in this environment with `ModuleNotFoundError: No module named 'pandas'` (test environment missing dependency). 
- Ran `mypy --strict src/bioetl/` which produced existing baseline type errors in unrelated modules (several files reported by the checker) and did not indicate regressions limited to the refactor. 
- Executing the project's pre-commit checks surfaced baseline issues (Bandit warnings and missing helper tooling) that are unrelated to the changes in this PR and blocked full hook completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee3f6a67c83249bcf943dd1d46752)