### PR TITLE
refactor: narrow Silver filter typing to `SilverFilterConfig` across pipeline surface

### DIFF
--- a/src/bioetl/application/core/base_transformer.py
+++ b/src/bioetl/application/core/base_transformer.py
@@ -116,7 +116,7 @@ class BaseTransformer(ABC):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/base_chembl_transformer.py
@@ -64,7 +64,7 @@ class BaseChemblTransformer(BaseTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/chembl/publication_transformer.py
+++ b/src/bioetl/application/pipelines/chembl/publication_transformer.py
@@ -130,7 +130,7 @@ class PublicationTransformer(BaseChemblTransformer):
         entity_type: str | None = None,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/crossref/transformer.py
+++ b/src/bioetl/application/pipelines/crossref/transformer.py
@@ -70,7 +70,7 @@ class CrossRefPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/openalex/transformer.py
+++ b/src/bioetl/application/pipelines/openalex/transformer.py
@@ -85,7 +85,7 @@ class OpenAlexPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubchem/transformer.py
+++ b/src/bioetl/application/pipelines/pubchem/transformer.py
@@ -44,7 +44,7 @@ class PubChemCompoundTransformer(BaseTransformer):
         entity_type: str = "compound",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/pubmed/transformer.py
+++ b/src/bioetl/application/pipelines/pubmed/transformer.py
@@ -90,7 +90,7 @@ class PubMedPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/semanticscholar/transformer.py
+++ b/src/bioetl/application/pipelines/semanticscholar/transformer.py
@@ -84,7 +84,7 @@ class SemanticScholarPublicationTransformer(BasePublicationTransformer):
         entity_type: str = "publication",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/idmapping_transformer.py
@@ -43,7 +43,7 @@ class IDMappingTransformer(BaseTransformer):
         entity_type: str = "idmapping",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/application/pipelines/uniprot/transformer.py
+++ b/src/bioetl/application/pipelines/uniprot/transformer.py
@@ -83,7 +83,7 @@ class UniProtProteinTransformer(BaseTransformer):
         entity_type: str = "protein",
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/composition/factories/pipeline_factory.py
+++ b/src/bioetl/composition/factories/pipeline_factory.py
@@ -146,7 +146,7 @@ class GenericPipelineFactory(Generic[TPipeline]):
         self,
         tracer: TracingPort | None = None,
         metrics: MetricsPort | None = None,
-        silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+        silver_filters: SilverFilterConfig | None = None,
         gold_filters: GoldFilterConfig | None = None,
         identity_service: IdentityService | None = None,
         pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/composition/factories/transformer_factory.py
+++ b/src/bioetl/composition/factories/transformer_factory.py
@@ -49,7 +49,7 @@ def create_transformer(
     entity_type: str,
     tracer: TracingPort | None = None,
     metrics: MetricsPort | None = None,
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None,
+    silver_filters: SilverFilterConfig | None = None,
     gold_filters: GoldFilterConfig | None = None,
     identity_service: IdentityService | None = None,
     pii_hasher: PiiHasherPort | None = None,

--- a/src/bioetl/domain/config/pipeline.py
+++ b/src/bioetl/domain/config/pipeline.py
@@ -46,7 +46,7 @@ class PipelineConfig:
     table: TableConfig
 
     # Processing
-    silver_filters: SilverFilterConfig | GoldFilterConfig | None = None
+    silver_filters: SilverFilterConfig | None = None
     gold_filters: GoldFilterConfig | None = None
     batch_size: int = 100
     checkpoint_interval: int = 1000


### PR DESCRIPTION
### Motivation
- Strengthen nominal type separation between Silver- and Gold-layer filter configs so the type system prevents accidental assignment of Gold filters into Silver slots.
- Advance Phase 6 of the config refactor by encoding the intended semantic distinction in public APIs without changing runtime behavior.

### Description
- Narrowed `silver_filters` annotations from a union including `GoldFilterConfig` to `SilverFilterConfig | None` in the domain `PipelineConfig` (`src/bioetl/domain/config/pipeline.py`) and propagated the change to transformer and factory boundaries (several files under `src/bioetl/application/` and `src/bioetl/composition/factories/`).
- Updated constructor/type signatures in the base transformer, provider-specific transformers, and composition factory helpers so all public creation points accept only `SilverFilterConfig | None` for Silver-layer filters.
- No logic or runtime behavior was altered; conversions and runtime constructions still accept existing domain objects and the change is limited to static type annotations and docstrings to improve type-safety and readability.

### Testing
- Ran `pytest tests/architecture/ -v`, which could not run due to a missing test dependency (`pandas`) in the execution environment and therefore did not complete successfully.
- Ran `mypy --strict src/bioetl/`, which reported existing repository baseline type errors unrelated to the narrowing change; the modified signatures do not introduce behavioral changes.
- Ran repository pre-commit checks which reported failures (including `mypy`, `bandit`, and missing tooling like `pip-audit` / scripts referenced by hooks) that reflect project-wide checks rather than regressions caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ee3f6a67c83249bcf943dd1d46752)