### PR TITLE
Centralize filter config cloning in BaseFilterConfig

### DIFF
--- a/src/bioetl/domain/filtering/_base_filter_config.py
+++ b/src/bioetl/domain/filtering/_base_filter_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 from bioetl.domain.filtering.column_filter import FilterOperator, GoldColumnFilter
 from bioetl.domain.filtering.list_filters import (
@@ -24,6 +24,18 @@ class BaseFilterConfig:
     list_contains_filters: tuple[GoldListContainsFilter, ...] = ()
     required_fields: tuple[str, ...] = ()
     exclude_if_present: tuple[str, ...] = ()
+
+    @classmethod
+    def from_base(cls, other: BaseFilterConfig) -> Self:
+        """Create a config of current type by copying all filter fields."""
+        return cls(
+            column_filters=other.column_filters,
+            range_filters=other.range_filters,
+            list_length_filters=other.list_length_filters,
+            list_contains_filters=other.list_contains_filters,
+            required_fields=other.required_fields,
+            exclude_if_present=other.exclude_if_present,
+        )
 
     def should_include(self, record: dict[str, Any]) -> bool:
         """Check whether a record passes all configured filters."""

--- a/src/bioetl/domain/filtering/silver_config.py
+++ b/src/bioetl/domain/filtering/silver_config.py
@@ -10,15 +10,3 @@ from bioetl.domain.filtering._base_filter_config import BaseFilterConfig
 @dataclass(frozen=True, slots=True)
 class SilverFilterConfig(BaseFilterConfig):
     """Filters applied during Silver layer processing."""
-
-    @classmethod
-    def from_base(cls, other: BaseFilterConfig) -> SilverFilterConfig:
-        """Create a SilverFilterConfig from another base filter config."""
-        return cls(
-            column_filters=other.column_filters,
-            range_filters=other.range_filters,
-            list_length_filters=other.list_length_filters,
-            list_contains_filters=other.list_contains_filters,
-            required_fields=other.required_fields,
-            exclude_if_present=other.exclude_if_present,
-        )

--- a/tests/unit/domain/filtering/test_silver_config.py
+++ b/tests/unit/domain/filtering/test_silver_config.py
@@ -81,3 +81,25 @@ class TestSilverFromBaseAndBehavior:
         silver = SilverFilterConfig.from_base(gold)
 
         assert silver.should_include(record) == gold.should_include(record)
+
+
+@pytest.mark.unit
+class TestBaseFromBaseFactory:
+    """BaseFilterConfig.from_base keeps logic in one place for all descendants."""
+
+    def test_gold_from_base_copies_all_fields_and_type(self) -> None:
+        source = GoldFilterConfig(
+            required_fields=("id",),
+            exclude_if_present=("deleted",),
+            column_filters=(
+                GoldColumnFilter(column="status", values=frozenset({"ACTIVE"})),
+            ),
+            range_filters=(
+                GoldRangeFilter(column="score", min_value=0.0, max_value=10.0),
+            ),
+        )
+
+        gold_copy = GoldFilterConfig.from_base(source)
+
+        assert isinstance(gold_copy, GoldFilterConfig)
+        assert gold_copy == source


### PR DESCRIPTION
### Motivation

- Reduce duplicated cloning logic for filter dataclasses by providing a single factory on the base type to ensure consistent behavior across Gold/Silver configs.
- Remove redundant override in `SilverFilterConfig` because inherited behavior from the base fully covers the intended semantics.
- Add a unit-safe regression to lock in the factory behavior and prevent future accidental divergence.

### Description

- Added `@classmethod from_base(cls, other: BaseFilterConfig) -> Self` to `src/bioetl/domain/filtering/_base_filter_config.py` that copies all shared filter fields into an instance of `cls`.
- Removed the duplicate `from_base` implementation from `src/bioetl/domain/filtering/silver_config.py` so `SilverFilterConfig` uses the base implementation.
- Updated `tests/unit/domain/filtering/test_silver_config.py` to add a `GoldFilterConfig.from_base` (Gold→Gold) test that verifies the returned type and field equality, while existing tests continue to validate Gold→Silver and behavior equivalence (`should_include`).
- Verified that existing call sites using `SilverFilterConfig.from_base(...)` in `src/bioetl/infrastructure/schemas/filter_config.py` and `src/bioetl/infrastructure/config/_base.py` remain unchanged and still route through the same field-copying semantics.

### Testing

- Ran `python -m compileall` on the modified modules and tests, which succeeded for `src/bioetl/domain/filtering/_base_filter_config.py`, `src/bioetl/domain/filtering/silver_config.py`, and the updated test file.
- Attempted to run `pytest -q tests/unit/domain/filtering/test_silver_config.py`, but test execution failed in this environment with `ModuleNotFoundError: No module named 'pandas'` due to missing project test dependencies, so full test execution could not be completed here.
- Performed lightweight runtime import checks with `PYTHONPATH=src` but those failed when importing unrelated project modules because of missing dependencies (e.g., `pandera`/`pandas`), which confirms tests require the full test environment to run end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d7587edc8324856a72b4f1ef1851)