### PR TITLE
style: fix ruff import and formatting issues

### DIFF
--- a/src/bioetl/infrastructure/schemas/filter_config.py
+++ b/src/bioetl/infrastructure/schemas/filter_config.py
@@ -25,11 +25,9 @@ from pydantic import BaseModel, Field, field_validator
 
 from bioetl.domain.filtering import (
     GoldFilterConfig,
-)
-from bioetl.domain.filtering import InputFilterConfig as DomainInputFilterConfig
-from bioetl.domain.filtering import (
     SilverFilterConfig,
 )
+from bioetl.domain.filtering import InputFilterConfig as DomainInputFilterConfig
 from bioetl.domain.models.filter import ExtractionParams
 from bioetl.infrastructure.schemas.base_schemas import (
     BaseFilterColumnSchema,

--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -715,7 +715,11 @@ class GoldWriter(BaseDeltaWriter):
         for attempt in range(3):
             try:
                 await self._run_in_executor(
-                    lambda table_or_uri=table_path, data=arrow_data, mode=mode, partition_by=partition_cols, schema_mode=schema_mode: (
+                    lambda table_or_uri=table_path,
+                    data=arrow_data,
+                    mode=mode,
+                    partition_by=partition_cols,
+                    schema_mode=schema_mode: (
                         write_deltalake(
                             table_or_uri=table_or_uri,
                             data=pa.RecordBatchReader.from_batches(
@@ -805,7 +809,10 @@ class GoldWriter(BaseDeltaWriter):
                         records, column_order=column_order
                     )
                     await self._run_in_executor(
-                        lambda table_or_uri=table_path, data=arrow_data, mode="append", partition_by=partition_cols: (
+                        lambda table_or_uri=table_path,
+                        data=arrow_data,
+                        mode="append",
+                        partition_by=partition_cols: (
                             write_deltalake(
                                 table_or_uri=table_or_uri,
                                 data=pa.RecordBatchReader.from_batches(


### PR DESCRIPTION
### Motivation
- CI linting and formatting jobs were failing due to import ordering and long lambda argument formatting which caused multiple checks (lint/arch-tests/architecture-metrics) to fail, so small style-only fixes were introduced to restore a clean CI run.

### Description
- Reordered/normalized imports in `src/bioetl/infrastructure/schemas/filter_config.py` and reformatted long lambda argument lists in `src/bioetl/infrastructure/storage/gold_writer.py` to satisfy `ruff`/formatting rules without changing runtime behavior.

### Testing
- Ran `ruff check`/`ruff format --check`, `mypy --config-file pyproject.toml`, `pytest tests/architecture/` (1149 passed, 21 skipped), `pytest tests/integration` (374 passed, 1 skipped), `lint-imports --config .importlinter`, `python src/tools/scripts/check_application_deps.py`, `python src/tools/scripts/check_architecture.py`, and `uv run radon cc src/bioetl --min C`, all of which passed; a local pre-commit hook referenced a missing script (`scripts/check_constructor_args.py`) so the commit was finalized after running the equivalent checks directly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ef75ae908324876870f3d2a856fa)