### PR TITLE
fix(format): align gold_writer formatting with Ruff 0.15 in CI

### DIFF
--- a/src/bioetl/infrastructure/storage/gold_writer.py
+++ b/src/bioetl/infrastructure/storage/gold_writer.py
@@ -715,11 +715,7 @@ class GoldWriter(BaseDeltaWriter):
         for attempt in range(3):
             try:
                 await self._run_in_executor(
-                    lambda table_or_uri=table_path,
-                    data=arrow_data,
-                    mode=mode,
-                    partition_by=partition_cols,
-                    schema_mode=schema_mode: (
+                    lambda table_or_uri=table_path, data=arrow_data, mode=mode, partition_by=partition_cols, schema_mode=schema_mode: (
                         write_deltalake(
                             table_or_uri=table_or_uri,
                             data=pa.RecordBatchReader.from_batches(
@@ -809,10 +805,7 @@ class GoldWriter(BaseDeltaWriter):
                         records, column_order=column_order
                     )
                     await self._run_in_executor(
-                        lambda table_or_uri=table_path,
-                        data=arrow_data,
-                        mode="append",
-                        partition_by=partition_cols: (
+                        lambda table_or_uri=table_path, data=arrow_data, mode="append", partition_by=partition_cols: (
                             write_deltalake(
                                 table_or_uri=table_or_uri,
                                 data=pa.RecordBatchReader.from_batches(


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `tests/architecture/test_code_formatting.py` reported `src/bioetl/infrastructure/storage/gold_writer.py` would be reformatted under Ruff 0.15 / Python 3.12, causing the architecture/lint pipeline to fail.

### Description
- Reformatted long lambda argument lists in the Delta write paths of `src/bioetl/infrastructure/storage/gold_writer.py` so the file matches Ruff 0.15 formatting rules; this is a formatting-only change with no runtime behavior modifications.

### Testing
- Ran `uv run --python 3.12 ruff check src tests` and `uv run --python 3.12 ruff format --check src tests`, both passed after the change.
- Ran `uv run --python 3.12 mypy --config-file pyproject.toml src/bioetl`, which passed with no issues.
- Ran the relevant formatting test `uv run --python 3.12 pytest tests/architecture/test_code_formatting.py -q` and the full architecture suite `uv run --python 3.12 pytest tests/architecture/`, both of which passed (architecture run: `1149 passed, 21 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f2eb7524832481c6b7116db92a41)