### PR TITLE
refactor: centralize BioETL version in domain/version and re-export get_version

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -21,19 +21,19 @@ from __future__ import annotations
 # Subpackage registrations (make them importable as bioetl.domain.<name>)
 from bioetl.domain import mapping  # noqa: F401
 from bioetl.domain import registry  # noqa: F401
-from bioetl.domain import version  # noqa: F401
-from bioetl.domain import composite, constants, contracts
+from bioetl.domain import composite, constants, contracts, version
 
 # Events
 from bioetl.domain.events import PipelineEvent
+from bioetl.domain.version import get_version
 
 __all__ = [
     "PipelineEvent",
     "composite",
     "version",
+    "get_version",
     # Data contracts (subpackage)
     "contracts",
     # Constants
     "constants",
-    "contracts",
 ]


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for BioETL package version in the domain layer so infrastructure and composition consumers can rely on `bioetl.domain` and avoid cross-layer import issues per ARCH-001.

### Description
- Re-exported `get_version` from `src/bioetl/domain/__init__.py` so callers can import `from bioetl.domain import get_version` instead of importing implementation locations directly.
- Verified `src/bioetl/domain/version.py` implements `get_version()` using `importlib.metadata.version` with a `PackageNotFoundError` fallback that returns `"unknown"`.
- Confirmed existing consumers (`src/bioetl/infrastructure/storage/metadata_builder.py` and `src/bioetl/composition/services/metadata_coordinator.py`) already reference the domain-level `get_version` implementation and are compatible with the re-export.

### Testing
- Installed `pytest-asyncio` and `pytest-timeout` to satisfy the project pytest configuration and the installation completed successfully.
- Ran `pytest tests/ -k "metadata_builder or metadata_coordinator" -v` which executed but failed during collection due to missing optional native/test dependencies such as `pyarrow`, `pandera`, `yaml`, and `orjson` so targeted tests could not be completed.
- Ran `pytest tests/architecture/ -v` which also failed during collection for the same missing dependencies (including `hypothesis`), preventing architecture tests from completing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924086b7ac83249ee57b25faf6e86c)