### PR TITLE
Fix Pandera custom check registration dispatch for Series validation

### DIFF
--- a/src/bioetl/domain/schemas/validators.py
+++ b/src/bioetl/domain/schemas/validators.py
@@ -123,7 +123,6 @@ json_object_check = pa.Check(is_valid_json_object, name="valid_json_object")
 
 @register_check_method(
     statistics=["min_value"],
-    supported_types=(pd.Series,),
 )
 def is_non_negative(pandas_obj: pd.Series, *, min_value: float | bool = 0) -> pd.Series:
     """Check that values are non-negative (>= 0).
@@ -142,7 +141,6 @@ def is_non_negative(pandas_obj: pd.Series, *, min_value: float | bool = 0) -> pd
 
 @register_check_method(
     statistics=["min_value"],
-    supported_types=(pd.Series,),
 )
 def is_positive(pandas_obj: pd.Series, *, min_value: int | bool = 1) -> pd.Series:
     """Check that values are positive (>= 1).
@@ -161,7 +159,6 @@ def is_positive(pandas_obj: pd.Series, *, min_value: int | bool = 1) -> pd.Serie
 
 @register_check_method(
     statistics=["min_val", "max_val"],
-    supported_types=(pd.Series,),
 )
 def in_closed_range(
     pandas_obj: pd.Series,
@@ -181,7 +178,6 @@ def in_closed_range(
 
 @register_check_method(
     statistics=["max_len"],
-    supported_types=(pd.Series,),
 )
 def max_str_length(pandas_obj: pd.Series, *, max_len: int) -> pd.Series:
     """Check that string length is within limit.
@@ -194,7 +190,6 @@ def max_str_length(pandas_obj: pd.Series, *, max_len: int) -> pd.Series:
 
 @register_check_method(
     statistics=["prefix"],
-    supported_types=(pd.Series,),
 )
 def str_starts_with(pandas_obj: pd.Series, *, prefix: str) -> pd.Series:
     """Check that strings start with a prefix.
@@ -207,7 +202,6 @@ def str_starts_with(pandas_obj: pd.Series, *, prefix: str) -> pd.Series:
 
 @register_check_method(
     statistics=["pattern"],
-    supported_types=(pd.Series,),
 )
 def str_matches_pattern(pandas_obj: pd.Series, *, pattern: str) -> pd.Series:
     """Check that strings match a regex pattern.


### PR DESCRIPTION
### Motivation
- Fix `pandera` dispatch `KeyError(<class 'pandas.Series'>)` encountered during schema validation by allowing Pandera to use its default type-dispatch for custom checks.

### Description
- Removed explicit `supported_types=(pd.Series,)` entries from `@register_check_method` decorators in `src/bioetl/domain/schemas/validators.py` so custom check methods register with Pandera's default dispatch behavior.

### Testing
- Ran unit tests: `tests/unit/domain/schemas/test_json_validators.py` passed; `tests/unit/domain/schemas/openalex/test_openalex_publication_validation.py` (relevant journal/affiliation checks) passed; `tests/unit/infrastructure/schemas/test_gold.py::TestGoldSchemaValidation::test_pubmed_publication_validates_correct_data` failed due to a pre-existing `publication_type` dtype mismatch that is unrelated to the register-method dispatch fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924b2adaa08324b4409c9367c0caa8)