### PR TITLE
Document TracingPort as OpenTelemetry facade with OTel API surface

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -606,6 +606,7 @@ _run_id → _run_id → pipeline_run_id
 
 См. [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md) и [ADR-022](02-architecture/decisions/ADR-022-tracing-noop.md) для NoOp Tracing.
 
+- **TracingPort = OTel facade**: `TracingPort` сознательно моделирует OpenTelemetry Tracing API (`get_tracer → start_as_current_span → Span`). Это обеспечивает единый calling convention для NoOp и реального OTel бэкенда. См. ADR-022.
 - **Correlation ID**: `run_id` обязателен во всех логах, метриках и блокировках.
 - **Retention**: Логи хранятся 30 дней, метрики — 90 дней.
 - **Логи**: Структурированный JSON.

--- a/docs/02-architecture/decisions/ADR-017-observability-architecture.md
+++ b/docs/02-architecture/decisions/ADR-017-observability-architecture.md
@@ -37,7 +37,12 @@ class MetricsPort(Protocol):
 
 @runtime_checkable
 class TracingPort(Protocol):
-    """Port for distributed tracing (OpenTelemetry)."""
+    """Port for distributed tracing — an OpenTelemetry Tracing API facade.
+
+    Deliberately modeled after the OTel API: get_tracer() returns an
+    OTel-compatible Tracer (start_as_current_span, Span context manager).
+    This is an intentional design choice — see ADR-022 for the rationale.
+    """
     def get_tracer(self, name: str) -> Any: ...
     def close(self) -> None: ...
 ```
@@ -90,7 +95,7 @@ live in `domain/ports/noop.py` (no I/O dependencies), while `NoOpLogger` lives i
 |------|---------------------|----------|
 | `LoggerPort` | `NoOpLogger` | `infrastructure/observability/noop_logger.py` |
 | `MetricsPort` | `NoOpMetrics` | `domain/ports/noop.py` |
-| `TracingPort` | `NoOpTracing` | `domain/ports/noop.py` |
+| `TracingPort` | `NoOpTracing` | `domain/ports/noop.py` (mirrors OTel API surface) |
 
 **Key Features of NoOp Implementations:**
 - Null Object Pattern: silently ignore all operations
@@ -177,7 +182,7 @@ src/bioetl/infrastructure/observability/
     logging_config.py       # Centralized structlog configuration
     metrics.py              # Prometheus metric definitions
     prometheus_metrics.py   # PrometheusMetrics adapter
-    tracing.py              # OpenTelemetryTracer + NoOpTracing re-export
+    tracing.py              # OpenTelemetryTracer (real OTel facade adapter)
     noop_logger.py          # NoOpLogger (adapter-level fallback)
     server.py               # Prometheus HTTP server
     anomaly/                # DataQualityMonitor

--- a/docs/02-architecture/decisions/ADR-022-tracing-noop.md
+++ b/docs/02-architecture/decisions/ADR-022-tracing-noop.md
@@ -32,19 +32,44 @@ This overhead provides no benefit for single-process local execution.
 
 ## The Decision
 
+### TracingPort = OpenTelemetry Facade (deliberate choice)
+
+`TracingPort` is intentionally modeled after the **OpenTelemetry Tracing API**.
+`get_tracer()` returns an object whose interface mirrors `opentelemetry.trace.Tracer`
+(`start_as_current_span`, span context manager, `set_attribute`, `record_exception`).
+
+**Why OTel as the port surface?**
+
+1. **Industry standard** — OTel is the CNCF-graduated vendor-neutral tracing API.
+   Adopting its surface avoids inventing a bespoke abstraction.
+2. **Zero-cost migration** — switching from `NoOpTracing` to `OpenTelemetryTracer`
+   requires only a composition wiring change; application code stays the same.
+3. **Ecosystem compatibility** — any OTel-compatible backend (Jaeger, Zipkin, Tempo,
+   OTLP Collector) can be plugged in without modifying the port contract.
+4. **`Any` return type** — `get_tracer()` returns `Any` to avoid a hard dependency
+   on the `opentelemetry` package in the domain layer while preserving the OTel
+   calling convention in all implementations.
+
+### Default: NoOpTracing (Null Object Pattern)
+
 Use **Null Object Pattern** (`NoOpTracing`) as the default tracing implementation.
 Request correlation is provided via `run_id` in structured logs.
 
 ### Implementation
 
 ```python
-# Default: NoOpTracing (zero overhead) — lives in domain/ports/noop.py
+# Default: NoOpTracing (zero overhead, mirrors OTel API) — lives in domain/ports/noop.py
 from bioetl.domain.ports import NoOpTracing
 tracing = NoOpTracing()
 
-# Extension point: OpenTelemetryTracer (when distributed deployment needed)
+# Extension point: real OTel adapter (when distributed deployment needed)
 from bioetl.infrastructure.observability.tracing import OpenTelemetryTracer
 tracing = OpenTelemetryTracer(service_name="bioetl")
+
+# Both implementations expose the same OTel calling convention:
+otel_tracer = tracing.get_tracer("bioetl.pipeline")
+with otel_tracer.start_as_current_span("my_operation", attributes={...}):
+    ...  # works identically with NoOp or real OTel
 ```
 
 ### Correlation via run_id (RULES.md §4.5)
@@ -111,9 +136,9 @@ Local-Only Deployment principle:
 
 | File | Purpose |
 |------|---------|
+| `domain/ports/observability.py` | TracingPort protocol (OTel facade contract) |
 | `domain/ports/noop.py` | NoOpTracing, _NoOpOtelTracer, _NoOpSpan (default) |
-| `domain/ports/observability.py` | TracingPort protocol |
-| `infrastructure/observability/tracing.py` | OpenTelemetryTracer + NoOpTracing re-export |
+| `infrastructure/observability/tracing.py` | OpenTelemetryTracer (real OTel adapter) + NoOpTracing re-export |
 | `composition/bootstrap/runtime/observability.py` | DI wiring (`bootstrap_tracer_port`) |
 
 ## Consequences

--- a/src/bioetl/domain/ports/noop.py
+++ b/src/bioetl/domain/ports/noop.py
@@ -35,10 +35,13 @@ if TYPE_CHECKING:
 
 
 class _NoOpSpan:
-    """No-op span that does nothing.
+    """No-op span that mirrors the ``opentelemetry.trace.Span`` interface.
 
-    Implements the span interface used by OpenTelemetry tracers.
-    Supports context manager protocol for use with `with` statements.
+    This class intentionally reproduces the OTel Span API surface
+    (``set_attribute``, ``set_status``, ``record_exception``, context manager)
+    so that application code can use the same calling convention regardless
+    of whether real tracing is enabled.  See TracingPort module docstring
+    for the OTel facade rationale.
     """
 
     def __enter__(self) -> Self:
@@ -64,9 +67,12 @@ class _NoOpSpan:
 
 
 class _NoOpOtelTracer:
-    """No-op OpenTelemetry tracer.
+    """No-op tracer that mirrors the ``opentelemetry.trace.Tracer`` interface.
 
-    Returns _NoOpSpan instances that implement the span interface.
+    Exposes ``start_as_current_span`` — the standard OTel entry point for
+    creating spans — and returns ``_NoOpSpan`` instances.  This ensures
+    application code written against the OTel calling convention works
+    transparently when tracing is disabled.
     """
 
     def start_as_current_span(self, *_args: Any, **_kwargs: Any) -> _NoOpSpan:
@@ -81,19 +87,26 @@ class _NoOpOtelTracer:
 
 
 class NoOpTracing:
-    """No-op implementation of TracingPort.
+    """No-op implementation of TracingPort (Null Object Pattern).
+
+    Returns ``_NoOpOtelTracer`` instances that mirror the OpenTelemetry
+    ``Tracer`` API surface.  This is a deliberate design choice: all
+    application code uses the OTel calling convention
+    (``get_tracer → start_as_current_span → span context manager``)
+    regardless of whether real tracing is active.  See ADR-022 for the
+    full rationale.
 
     Used when distributed tracing is disabled or not configured.
-    All operations are silently ignored.
+    All operations are silently ignored with zero overhead.
 
     Implements:
-        TracingPort: Domain port for distributed tracing.
+        TracingPort: Domain port for distributed tracing (OTel facade).
 
     Example:
         >>> tracer = NoOpTracing()
         >>> otel_tracer = tracer.get_tracer("bioetl.transformer")
         >>> with otel_tracer.start_as_current_span("operation"):
-        ...     # span is a no-op
+        ...     # span is a no-op — same calling convention as real OTel
         ...     pass
 
     """

--- a/src/bioetl/domain/ports/observability.py
+++ b/src/bioetl/domain/ports/observability.py
@@ -1,7 +1,21 @@
 """Observability ports for tracing, metrics, and logging.
 
-This module contains ports for distributed tracing (OpenTelemetry),
-metrics collection, and structured logging.
+This module contains ports for distributed tracing, metrics collection,
+and structured logging.
+
+Design Decision — TracingPort as OpenTelemetry facade:
+    TracingPort is intentionally modeled after the OpenTelemetry Tracing API.
+    ``get_tracer()`` returns an object whose interface mirrors
+    ``opentelemetry.trace.Tracer`` (``start_as_current_span``, span context
+    manager, ``set_attribute``, ``record_exception``).  This is a deliberate
+    architectural choice (see ADR-017, ADR-022):
+
+    * The OTel API is a vendor-neutral industry standard for distributed tracing.
+    * Adopting its surface as our port contract avoids inventing a bespoke
+      tracing abstraction and keeps the migration path to real OTel trivial.
+    * NoOp implementations (``_NoOpOtelTracer``, ``_NoOpSpan``) mirror the same
+      API surface so that application code uses a single calling convention
+      regardless of whether tracing is enabled.
 """
 
 from __future__ import annotations
@@ -11,13 +25,43 @@ from typing import Any, Protocol, Self, runtime_checkable
 
 @runtime_checkable
 class TracingPort(Protocol):
-    """Port for distributed tracing (OpenTelemetry).
+    """Port for distributed tracing — an OpenTelemetry Tracing API facade.
 
-    Abstracts the tracer implementation to allow no-op or specific backends.
+    This port is **deliberately** shaped after the OpenTelemetry API so that:
+
+    1. Application code calls ``tracer.get_tracer(name).start_as_current_span(...)``
+       — the standard OTel calling convention — regardless of the backend.
+    2. Switching from ``NoOpTracing`` to ``OpenTelemetryTracer`` requires zero
+       changes in application/domain code; only composition wiring changes.
+    3. Any OTel-compatible tracer (Jaeger, Zipkin, OTLP) can be plugged in
+       without altering the port contract.
+
+    The ``Any`` return type of ``get_tracer`` is intentional: it represents an
+    ``opentelemetry.trace.Tracer``-compatible object.  Using ``Any`` avoids a
+    hard dependency on the ``opentelemetry`` package in the domain layer while
+    preserving the OTel calling convention in all implementations (including
+    ``NoOpTracing``).
+
+    See Also:
+        - ADR-017: Observability Architecture — establishes port-based tracing.
+        - ADR-022: NoOp Tracing — documents the OTel facade rationale and
+          NoOp default for local-only deployment.
     """
 
     def get_tracer(self, name: str) -> Any:
-        """Get a tracer instance for instrumentation."""
+        """Return an OpenTelemetry-compatible tracer instance.
+
+        The returned object exposes ``start_as_current_span(name, attributes=...)``
+        — the standard OTel ``Tracer`` interface.  For ``NoOpTracing`` this is a
+        lightweight no-op; for ``OpenTelemetryTracer`` it delegates to the real
+        OTel SDK.
+
+        Args:
+            name: Instrumentation scope name (e.g. ``"bioetl.pipeline"``).
+
+        Returns:
+            An OTel-compatible tracer (concrete type depends on the implementation).
+        """
         ...
 
     def close(self) -> None:

--- a/src/bioetl/infrastructure/observability/tracing.py
+++ b/src/bioetl/infrastructure/observability/tracing.py
@@ -1,25 +1,29 @@
-"""Tracing infrastructure — Null Object Pattern implementation.
+"""OpenTelemetry tracer adapter — real TracingPort implementation.
+
+TracingPort is deliberately shaped as an OpenTelemetry Tracing API facade
+(see ADR-017, ADR-022).  This module provides ``OpenTelemetryTracer`` — the
+concrete adapter that delegates to the OTel SDK.
 
 Design Decision (ADR-010, ADR-022):
-    Local-Only Deployment does not require distributed tracing.
-    NoOpTracing (default) provides:
-    - Compliance with TracingPort interface
-    - Extension point for future distributed deployment
-    - Zero overhead in current configuration
+    Local-Only Deployment does not require distributed tracing by default.
+    ``NoOpTracing`` (in ``domain/ports/noop.py``) is the zero-overhead default.
+    ``OpenTelemetryTracer`` activates when ``tracing_enabled=True`` and
+    provides real span collection via OTLP or Console exporter.
+
+    Both implementations expose the same OTel-compatible API surface
+    (``get_tracer → start_as_current_span → Span``), so switching between
+    them requires no application code changes — only composition wiring.
 
 Correlation:
     Instead of trace_id, run_id is used (RULES.md §4.5).
     All structured logs include run_id for request correlation.
 
 Extension Point:
-    To enable tracing, use OpenTelemetryTracer (provided below),
-    register in composition/factories/observability.py.
+    To enable tracing, set ``BIOETL_OBSERVABILITY__TRACING_ENABLED=true``.
+    The composition layer (``bootstrap_tracer_port``) will return
+    ``OpenTelemetryTracer`` instead of ``NoOpTracing``.
 
-Available Implementations:
-    - NoOpTracing: Null Object Pattern, default for Local-Only
-    - OpenTelemetryTracer: Real OTel implementation (requires opentelemetry deps)
-
-Implements TracingPort.
+Implements TracingPort (OTel facade).
 """
 
 from __future__ import annotations
@@ -54,7 +58,14 @@ except ImportError:
 
 
 class OpenTelemetryTracer:
-    """Real OpenTelemetry tracer implementation."""
+    """Concrete TracingPort adapter backed by the OpenTelemetry SDK.
+
+    This is the "real" half of the OTel facade: ``get_tracer()`` delegates
+    to ``opentelemetry.trace.get_tracer()``, returning a genuine OTel
+    ``Tracer`` that creates exportable spans.  The port contract (TracingPort)
+    is intentionally aligned with the OTel API, so this adapter is a thin
+    wrapper rather than a translation layer.
+    """
 
     def __init__(self, service_name: str = "bioetl"):
         """Initialize OpenTelemetry tracer.


### PR DESCRIPTION
## Summary

This PR clarifies the architectural design of `TracingPort` by explicitly documenting it as an **OpenTelemetry Tracing API facade**. The port contract is intentionally shaped after the OTel API (`get_tracer()` → `start_as_current_span()` → span context manager) to enable zero-cost migration between `NoOpTracing` and `OpenTelemetryTracer` implementations without changing application code.

## Key Changes

- **Enhanced `TracingPort` documentation** (`src/bioetl/domain/ports/observability.py`):
  - Added detailed module-level docstring explaining the OTel facade design decision
  - Clarified that `get_tracer()` returns an OTel-compatible tracer object
  - Documented the rationale for using `Any` return type to avoid hard dependency on `opentelemetry` package in domain layer
  - Added cross-references to ADR-017 and ADR-022

- **Updated `NoOpTracing` and related classes** (`src/bioetl/domain/ports/noop.py`):
  - Clarified that `_NoOpSpan` intentionally mirrors `opentelemetry.trace.Span` interface
  - Clarified that `_NoOpOtelTracer` mirrors `opentelemetry.trace.Tracer` interface with `start_as_current_span` entry point
  - Updated `NoOpTracing` docstring to emphasize Null Object Pattern and OTel calling convention consistency
  - Added example showing identical calling convention for both NoOp and real OTel

- **Updated `OpenTelemetryTracer` documentation** (`src/bioetl/infrastructure/observability/tracing.py`):
  - Reframed module docstring to emphasize it as the "real" OTel adapter half of the facade
  - Clarified that it's a thin wrapper rather than a translation layer
  - Updated design decision notes to explain NoOp as zero-overhead default and OTel as extension point

- **Enhanced ADR-022** (`docs/02-architecture/decisions/ADR-022-tracing-noop.md`):
  - Added explicit section "TracingPort = OpenTelemetry Facade (deliberate choice)"
  - Documented four reasons for adopting OTel as the port surface (industry standard, zero-cost migration, ecosystem compatibility, `Any` return type)
  - Updated implementation examples to show identical calling convention across both implementations
  - Reorganized file structure table to reflect actual module locations

- **Updated ADR-017** (`docs/02-architecture/decisions/ADR-017-observability-architecture.md`):
  - Added clarification that `TracingPort` is deliberately modeled after OTel API
  - Updated NoOp implementations table to note OTel API surface mirroring

- **Updated RULES.md** (`docs/00-project/RULES.md`):
  - Added note about TracingPort as OTel facade in correlation section

## Implementation Details

The changes are purely **documentation and clarification** — no functional code changes. The architecture already implements this design; this PR makes the intent explicit:

1. **OTel as port surface**: All implementations (`NoOpTracing`, `OpenTelemetryTracer`) expose the same OTel calling convention
2. **Null Object Pattern**: `NoOpTracing` provides zero-overhead default with identical API surface
3. **Zero-cost migration**: Switching implementations requires only composition wiring changes, not application code changes
4. **Vendor neutrality**: Using `Any` return type avoids hard dependency on `opentelemetry` package in domain layer while preserving OTel calling convention

This design enables seamless evolution from local-only deployment (NoOp) to distributed deployment (real OTel) without refactoring application code.

https://claude.ai/code/session_01WrnkHuzxWeMdvFoDJwNaBr