### PR TITLE
Add extraction_params support for ChEMBL Assay filtering

### DIFF
--- a/configs/filters/entities/chembl/assay.yaml
+++ b/configs/filters/entities/chembl/assay.yaml
@@ -20,6 +20,63 @@ input_filter:
   filter_field: "assay_id"
   batch_size: 20
 
+# ---------------------------------------------------------------------------
+# Extraction-Level Filtering (ADR-028 §3)
+# ---------------------------------------------------------------------------
+# Server-side query parameters appended to every ChEMBL Assay API request.
+# Syntax: ChEMBL django-style lookups (__in, __isnull, __gte, etc.)
+# Reference: https://chembl.gitbook.io/chembl-interface-documentation/web-services/chembl-data-web-services
+#
+# These params reduce API traffic by excluding low-confidence and
+# non-binding/functional assays at the API level.
+# Does NOT affect content_hash (ADR-014).
+# Logged in SourceMetadata.query_string for audit/reproducibility.
+#
+# Resulting API URL pattern:
+#   /chembl/api/data/assay?format=json&limit=1000&offset=0
+#     &assay_type__in=B,F
+#     &confidence_score__gte=8
+#     &relationship_type=D
+#     &target_chembl_id__isnull=false
+extraction_params:
+    # Assay types: Binding and Functional (exclude ADMET, Toxicity, etc.)
+    assay_type__in: "B,F"
+
+    # High confidence only (8 or 9 on the 0-9 scale)
+    confidence_score__gte: 8
+
+    # Direct interaction only (exclude Homologous, Not-determined, etc.)
+    relationship_type: "D"
+
+    # Only assays with a known target
+    target_chembl_id__isnull: false
+
+# -----------------------------------------------------------------------------
+# Silver Filters — Domain-level quality gates (applied BEFORE Silver write)
+# -----------------------------------------------------------------------------
+# Records that fail these filters are excluded from the Silver layer entirely.
+# Defence-in-depth: mirrors extraction_params to catch API inconsistencies.
+silver_filters:
+    # Column value filters — strict inclusion lists
+    columns:
+        # Binding (B) and Functional (F) assays only
+        assay_type: [B, F]
+        # Direct interaction only
+        relationship_type: [D]
+
+    # Numeric range filters
+    ranges:
+        confidence_score:
+            min: 8
+            max: 9
+
+    # Required fields — must be non-null for silver
+    required_fields:
+        - assay_id
+        - assay_type
+        - description
+        - target_chembl_id
+
 # -----------------------------------------------------------------------------
 # Gold Filters
 # -----------------------------------------------------------------------------

--- a/tests/integration/chembl/test_assay_extraction_params.py
+++ b/tests/integration/chembl/test_assay_extraction_params.py
@@ -1,0 +1,227 @@
+"""Integration test: extraction_params applied to ChEMBL Assay API requests.
+
+Uses VCR.py cassette with pre-recorded filtered response.
+Verifies that extraction_params from YAML config are correctly
+appended to API request query string and recorded in Bronze SourceMetadata.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.models.filter import ExtractionParams
+from bioetl.domain.resilience import AdapterConfig
+from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+
+# VCR cassette directory for ChEMBL extraction params tests
+CASSETTE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "vcr" / "chembl"
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict[str, Any]:
+    """Configure VCR for ChEMBL extraction params tests."""
+    return {
+        "cassette_library_dir": str(CASSETTE_DIR),
+        "record_mode": os.environ.get("VCR_RECORD_MODE", "none"),
+        "match_on": ["method", "scheme", "host", "port", "path", "query"],
+        "decode_compressed_response": True,
+    }
+
+
+@pytest.mark.integration
+class TestAssayExtractionParams:
+    """Verify extraction_params flow from config to API request and metadata."""
+
+    @pytest.fixture
+    def extraction_params(self) -> ExtractionParams:
+        """Assay-specific extraction params matching ADR-028 §3."""
+        return ExtractionParams(
+            params={
+                "assay_type__in": "B,F",
+                "confidence_score__gte": 8,
+                "relationship_type": "D",
+                "target_chembl_id__isnull": False,
+            }
+        )
+
+    @pytest.fixture
+    def mock_logger(self) -> MagicMock:
+        """Create a mock logger for testing."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        from bioetl.domain.types import CircuitBreakerState
+
+        client = MagicMock()
+        client.circuit_breaker = MagicMock()
+        client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        client.circuit_breaker.get_failure_count.return_value = 0
+        return client
+
+    def test_build_params_includes_extraction_params(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """_build_params merges extraction_params into query dict."""
+        adapter = ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            adapter_config=AdapterConfig(page_size=500),
+            extraction_params=extraction_params,
+        )
+
+        params = adapter._build_params(offset=0, entity_type="assay")
+
+        # Standard pagination params present
+        assert params["format"] == "json"
+        assert params["limit"] == 500
+        assert params["offset"] == 0
+
+        # All 4 assay extraction params present
+        assert params["assay_type__in"] == "B,F"
+        assert params["confidence_score__gte"] == 8
+        assert params["relationship_type"] == "D"
+        assert params["target_chembl_id__isnull"] is False
+
+    def test_source_metadata_contains_query_string(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """SourceMetadata.query_string includes all extraction params."""
+        qs = extraction_params.to_query_string()
+
+        assert "assay_type__in=B,F" in qs
+        assert "confidence_score__gte=8" in qs
+        assert "relationship_type=D" in qs
+        assert "target_chembl_id__isnull=False" in qs
+
+    def test_source_metadata_query_string_deterministic(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """query_string is deterministic (sorted keys) across invocations."""
+        qs1 = extraction_params.to_query_string()
+        qs2 = extraction_params.to_query_string()
+
+        assert qs1 == qs2
+        # Keys must be sorted alphabetically
+        keys = [part.split("=")[0] for part in qs1.split("&")]
+        assert keys == sorted(keys)
+
+    def test_get_source_metadata_records_extraction_params(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """get_source_metadata writes extraction_params to query_string."""
+        adapter = ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            extraction_params=extraction_params,
+        )
+
+        metadata = adapter.get_source_metadata()
+
+        assert metadata.query_string is not None
+        assert "assay_type__in=B,F" in metadata.query_string
+        assert "confidence_score__gte=8" in metadata.query_string
+
+    def test_extraction_params_logged_at_init(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Adapter logs extraction_params at initialization for audit."""
+        ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            extraction_params=extraction_params,
+        )
+
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and c.args[0] == "chembl_extraction_params_configured"
+        ]
+        assert len(info_calls) == 1
+        kwargs = info_calls[0].kwargs
+        assert kwargs["param_count"] == 4
+        assert "assay_type__in" in kwargs["query_string"]
+
+    def test_no_overlap_with_assay_input_filter(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """Assay extraction_params do not overlap with input_filter.filter_field.
+
+        The assay input_filter uses filter_field="assay_id", which is not
+        present in extraction_params keys.
+        """
+        assay_input_filter_field = "assay_id"
+        assert assay_input_filter_field not in extraction_params.params
+
+    @pytest.mark.vcr("chembl_assay_filtered.yaml")
+    @pytest.mark.skip(
+        reason="VCR cassette not yet recorded. "
+        "Record with: VCR_RECORD_MODE=new_episodes pytest -k test_assay_filtered_api_request"
+    )
+    async def test_assay_filtered_api_request(
+        self,
+        token_bucket: Any,
+        circuit_breaker: Any,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Full flow: adapter sends filtered request to ChEMBL API.
+
+        This test requires a VCR cassette recorded with the filtered URL.
+        Record with:
+            VCR_RECORD_MODE=new_episodes pytest -k test_assay_filtered_api_request
+        """
+        from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+        ep = ExtractionParams(
+            params={
+                "assay_type__in": "B,F",
+                "confidence_score__gte": 8,
+                "relationship_type": "D",
+                "target_chembl_id__isnull": False,
+            }
+        )
+
+        client = UnifiedHTTPClient(
+            rate_limiter=token_bucket,
+            circuit_breaker=circuit_breaker,
+            timeout=30.0,
+        )
+
+        async with client:
+            adapter = ChemblAdapter(
+                http_client=client,
+                logger=mock_logger,
+                adapter_config=AdapterConfig(page_size=10),
+                extraction_params=ep,
+            )
+
+            records: list[dict[str, Any]] = []
+            async for record in adapter.fetch("assay", limit=5):
+                records.append(record)
+
+            assert len(records) > 0
+            for record in records:
+                assert "assay_chembl_id" in record
+
+            # Metadata should contain extraction params
+            metadata = adapter.get_source_metadata()
+            assert metadata.query_string is not None
+            assert "assay_type__in=B,F" in metadata.query_string

--- a/tests/unit/infrastructure/config/test_filter_config_loader.py
+++ b/tests/unit/infrastructure/config/test_filter_config_loader.py
@@ -505,6 +505,187 @@ extraction_params:
         assert extraction_params.params["standard_type__in"] == "Ki"
 
 
+class TestAssayExtractionParamsLoading:
+    """Tests for assay extraction_params loading via FilterConfigLoader."""
+
+    def test_assay_extraction_params_loaded(self, tmp_path: Path) -> None:
+        """Extraction params should be loaded from assay entity config."""
+        filter_root = tmp_path / "filters"
+        filter_root.mkdir()
+
+        (filter_root / "_defaults.yaml").write_text(
+            """
+version: "1.0.0"
+input_filter:
+  enabled: false
+  batch_size: 100
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        entities = filter_root / "entities" / "chembl"
+        entities.mkdir(parents=True)
+        (entities / "assay.yaml").write_text(
+            """
+version: "1.0.0"
+provider: chembl
+entity: assay
+input_filter:
+  enabled: true
+  source_path: "data/input/assay.csv"
+  column_name: "assay_chembl_id"
+  filter_field: "assay_id"
+  batch_size: 20
+extraction_params:
+  assay_type__in: "B,F"
+  confidence_score__gte: 8
+  relationship_type: "D"
+  target_chembl_id__isnull: false
+silver_filters:
+  columns:
+    assay_type: [B, F]
+    relationship_type: [D]
+  ranges:
+    confidence_score:
+      min: 8
+      max: 9
+  required_fields:
+    - assay_id
+    - assay_type
+    - description
+    - target_chembl_id
+gold_filters:
+  columns:
+    assay_type: [B, F]
+    confidence_score: ["8", "9"]
+    relationship_type: [D]
+  required_fields:
+    - assay_type
+    - description
+"""
+        )
+
+        loader = FilterConfigLoader(tmp_path)
+        input_filter, silver_filters, gold_filters, extraction_params = loader.load(
+            "chembl", "assay"
+        )
+
+        # Extraction params loaded
+        assert not extraction_params.is_empty
+        assert extraction_params.params["assay_type__in"] == "B,F"
+        assert extraction_params.params["confidence_score__gte"] == 8
+        assert extraction_params.params["relationship_type"] == "D"
+        assert extraction_params.params["target_chembl_id__isnull"] is False
+
+        # Input filter still enabled alongside extraction_params
+        assert input_filter.enabled is True
+        assert input_filter.filter_field == "assay_id"
+
+    def test_assay_extraction_params_no_input_filter_overlap(
+        self, tmp_path: Path
+    ) -> None:
+        """Assay extraction_params keys should not overlap with input_filter field."""
+        filter_root = tmp_path / "filters"
+        filter_root.mkdir()
+
+        (filter_root / "_defaults.yaml").write_text(
+            """
+version: "1.0.0"
+input_filter:
+  enabled: false
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        entities = filter_root / "entities" / "chembl"
+        entities.mkdir(parents=True)
+        (entities / "assay.yaml").write_text(
+            """
+version: "1.0.0"
+provider: chembl
+entity: assay
+input_filter:
+  enabled: true
+  source_path: "data/input/assay.csv"
+  column_name: "assay_chembl_id"
+  filter_field: "assay_id"
+  batch_size: 20
+extraction_params:
+  assay_type__in: "B,F"
+  confidence_score__gte: 8
+  relationship_type: "D"
+  target_chembl_id__isnull: false
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        loader = FilterConfigLoader(tmp_path)
+        input_filter, _, _, extraction_params = loader.load("chembl", "assay")
+
+        # No overlap: input_filter uses "assay_id", extraction_params has other keys
+        assert input_filter.filter_field not in extraction_params.params
+
+    def test_assay_silver_filters_loaded(self, tmp_path: Path) -> None:
+        """Silver filters should be loaded from assay entity config."""
+        filter_root = tmp_path / "filters"
+        filter_root.mkdir()
+
+        (filter_root / "_defaults.yaml").write_text(
+            """
+version: "1.0.0"
+input_filter:
+  enabled: false
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        entities = filter_root / "entities" / "chembl"
+        entities.mkdir(parents=True)
+        (entities / "assay.yaml").write_text(
+            """
+version: "1.0.0"
+provider: chembl
+entity: assay
+silver_filters:
+  columns:
+    assay_type: [B, F]
+    relationship_type: [D]
+  ranges:
+    confidence_score:
+      min: 8
+      max: 9
+  required_fields:
+    - assay_id
+    - assay_type
+    - description
+    - target_chembl_id
+gold_filters:
+  required_fields: []
+"""
+        )
+
+        loader = FilterConfigLoader(tmp_path)
+        _, silver_filters, _, _ = loader.load("chembl", "assay")
+
+        assert isinstance(silver_filters, SilverFilterConfig)
+        # Column filters
+        columns = {cf.column for cf in silver_filters.column_filters}
+        assert "assay_type" in columns
+        assert "relationship_type" in columns
+        # Range filter
+        assert len(silver_filters.range_filters) == 1
+        assert silver_filters.range_filters[0].column == "confidence_score"
+        assert silver_filters.range_filters[0].min_value == 8
+        assert silver_filters.range_filters[0].max_value == 9
+        # Required fields
+        assert "assay_id" in silver_filters.required_fields
+        assert "target_chembl_id" in silver_filters.required_fields
+
+
 class TestFilterConfigLoaderIntegration:
     """Integration tests with actual filter config structure."""
 


### PR DESCRIPTION
## Summary
Implements server-side query parameter filtering for ChEMBL Assay API requests via `extraction_params` configuration, as specified in ADR-028 §3. This allows filtering at the API level to reduce traffic and improve performance while maintaining audit trails through SourceMetadata.

## Key Changes

- **ChEMBL Assay Configuration** (`configs/filters/entities/chembl/assay.yaml`):
  - Added `extraction_params` section with four assay-specific filters:
    - `assay_type__in`: "B,F" (Binding and Functional assays only)
    - `confidence_score__gte`: 8 (high confidence threshold)
    - `relationship_type`: "D" (direct interactions only)
    - `target_chembl_id__isnull`: false (assays with known targets)
  - Added `silver_filters` section for defence-in-depth validation:
    - Column filters mirroring extraction_params constraints
    - Range filter for confidence_score (8-9)
    - Required fields validation

- **Unit Tests** (`tests/unit/infrastructure/config/test_filter_config_loader.py`):
  - `TestAssayExtractionParamsLoading` class with three test methods:
    - `test_assay_extraction_params_loaded`: Verifies extraction_params are correctly parsed from YAML
    - `test_assay_extraction_params_no_input_filter_overlap`: Ensures extraction_params keys don't conflict with input_filter.filter_field
    - `test_assay_silver_filters_loaded`: Validates silver filter configuration loading

- **Integration Tests** (`tests/integration/chembl/test_assay_extraction_params.py`):
  - New integration test suite with VCR cassette support
  - Tests covering:
    - `_build_params()` merges extraction_params into query dict
    - `to_query_string()` produces deterministic, sorted output
    - SourceMetadata correctly records extraction_params in query_string
    - Adapter logs extraction_params at initialization for audit
    - Full API request flow (skipped pending VCR cassette recording)

## Implementation Details

- Extraction params are applied at the API request level (not affecting content_hash per ADR-014)
- Query string generation is deterministic with alphabetically sorted keys for reproducibility
- Audit trail maintained through SourceMetadata.query_string
- Silver filters provide defence-in-depth validation to catch API inconsistencies
- No overlap between extraction_params keys and input_filter.filter_field ("assay_id")

https://claude.ai/code/session_01UPTS6KsPyexfYyyj2mseHD