### PR TITLE
Update Mermaid renderer to support .mermaid/.mmd and output PNGs to docs/02-architecture/diagrams/png

### DIFF
--- a/docs/02-architecture/diagrams/render_diagrams.sh
+++ b/docs/02-architecture/diagrams/render_diagrams.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # BioETL Diagram Rendering Script
-# Renders Mermaid (.mmd) diagrams to high-resolution PNG images
-# Version: 1.0 | Date: 2026-01-20
+# Renders Mermaid (.mermaid/.mmd) diagrams to high-resolution PNG images
+# Version: 1.1 | Date: 2026-02-17
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MERMAID_DIR="$SCRIPT_DIR/mermaid"
-IMAGES_DIR="$SCRIPT_DIR/images"
+MERMAID_DIR="$SCRIPT_DIR"
+IMAGES_DIR="$SCRIPT_DIR/png"
 
 # Configuration
 WIDTH=2400
@@ -47,9 +47,11 @@ fi
 echo -e "${GREEN}✓ mermaid-cli (mmdc) found${NC}"
 echo ""
 
-# Count total diagrams
-total_diagrams=$(find "$MERMAID_DIR" -name "*.mmd" | wc -l)
-echo "Found $total_diagrams Mermaid diagrams to render"
+# Find diagrams (.mermaid + .mmd)
+mapfile -d '' diagram_files < <(find "$MERMAID_DIR" -maxdepth 1 -type f \( -name "*.mermaid" -o -name "*.mmd" \) -print0 | sort -z)
+total_diagrams=${#diagram_files[@]}
+
+echo "Found $total_diagrams Mermaid diagrams to render (*.mermaid, *.mmd)"
 echo ""
 
 # Render each diagram
@@ -57,47 +59,46 @@ count=0
 success=0
 failed=0
 
-for file in "$MERMAID_DIR"/*.mmd; do
-    if [ -f "$file" ]; then
-        count=$((count + 1))
-        filename=$(basename "$file" .mmd)
-        output="$IMAGES_DIR/${filename}.png"
+for file in "${diagram_files[@]}"; do
+    count=$((count + 1))
+    base_name=$(basename "$file")
+    filename="${base_name%.*}"
+    output="$IMAGES_DIR/${filename}.png"
 
-        echo -e "${YELLOW}[$count/$total_diagrams]${NC} Rendering: $filename"
+    echo -e "${YELLOW}[$count/$total_diagrams]${NC} Rendering: $filename"
 
-        # Render diagram
-        if mmdc -i "$file" \
-                -o "$output" \
-                -w $WIDTH \
-                -H $HEIGHT \
-                -s $SCALE \
-                -b $BACKGROUND \
-                2>/dev/null; then
+    # Render diagram
+    if mmdc -i "$file" \
+            -o "$output" \
+            -w $WIDTH \
+            -H $HEIGHT \
+            -s $SCALE \
+            -b $BACKGROUND \
+            2>/dev/null; then
 
-            # Check if file was created
-            if [ -f "$output" ]; then
-                size=$(du -h "$output" | cut -f1)
-                dimensions=$(identify -format "%wx%h" "$output" 2>/dev/null || echo "unknown")
-                echo -e "  ${GREEN}✓${NC} Created: $output"
-                echo -e "    Size: $size | Dimensions: $dimensions"
-                success=$((success + 1))
-            else
-                echo -e "  ${RED}✗${NC} Error: Output file not created"
-                failed=$((failed + 1))
-            fi
+        # Check if file was created
+        if [ -f "$output" ]; then
+            size=$(du -h "$output" | cut -f1)
+            dimensions=$(identify -format "%wx%h" "$output" 2>/dev/null || echo "unknown")
+            echo -e "  ${GREEN}✓${NC} Created: $output"
+            echo -e "    Size: $size | Dimensions: $dimensions"
+            success=$((success + 1))
         else
-            echo -e "  ${RED}✗${NC} Error rendering diagram"
+            echo -e "  ${RED}✗${NC} Error: Output file not created"
             failed=$((failed + 1))
         fi
-
-        echo ""
+    else
+        echo -e "  ${RED}✗${NC} Error rendering diagram"
+        failed=$((failed + 1))
     fi
+
+    echo ""
 done
 
 echo "========================================="
 echo "Rendering Complete"
 echo "========================================="
-echo -e "Total diagrams: $total_diagrams"
+echo -e "Total diagrams discovered: $total_diagrams"
 echo -e "${GREEN}Successfully rendered: $success${NC}"
 if [ $failed -gt 0 ]; then
     echo -e "${RED}Failed: $failed${NC}"
@@ -110,34 +111,44 @@ echo ""
 INDEX_FILE="$IMAGES_DIR/INDEX.md"
 echo "Creating index file: $INDEX_FILE"
 
-cat > "$INDEX_FILE" << 'EOF'
-# BioETL Architecture Diagrams - PNG Index
+{
+    echo "# BioETL Architecture Diagrams - PNG Index"
+    echo ""
+    echo "*Generated: $(date)*"
+    echo ""
+    echo "## Rendered Diagrams"
+    echo ""
 
-*Generated: $(date)*
+    png_count=0
+    for file in "$IMAGES_DIR"/*.png; do
+        if [ -f "$file" ]; then
+            png_count=$((png_count + 1))
+            png_name=$(basename "$file" .png)
+            echo "### $png_name"
+            echo ""
+            echo "![${png_name}](./${png_name}.png)"
+            echo ""
+            echo "---"
+            echo ""
+        fi
+    done
 
-## Rendered Diagrams
-
-EOF
-
-# Add each diagram to index
-for file in "$IMAGES_DIR"/*.png; do
-    if [ -f "$file" ]; then
-        filename=$(basename "$file" .png)
-        echo "### $filename" >> "$INDEX_FILE"
-        echo "" >> "$INDEX_FILE"
-        echo "![${filename}](./${filename}.png)" >> "$INDEX_FILE"
-        echo "" >> "$INDEX_FILE"
-        echo "---" >> "$INDEX_FILE"
-        echo "" >> "$INDEX_FILE"
+    if [ "$png_count" -eq 0 ]; then
+        echo "_No PNG files were generated._"
+        echo ""
     fi
-done
+} > "$INDEX_FILE"
 
-echo -e "${GREEN}✓${NC} Index file created: $INDEX_FILE"
+echo -e "${GREEN}✓${NC} PNG index file created: $INDEX_FILE"
 echo ""
 
 # Summary
 if [ $failed -eq 0 ]; then
-    echo -e "${GREEN}All diagrams rendered successfully!${NC}"
+    if [ $total_diagrams -eq 0 ]; then
+        echo -e "${YELLOW}No Mermaid source files (*.mermaid, *.mmd) were found in $MERMAID_DIR.${NC}"
+    else
+        echo -e "${GREEN}All discovered diagrams rendered successfully!${NC}"
+    fi
     exit 0
 else
     echo -e "${YELLOW}Some diagrams failed to render. Check errors above.${NC}"


### PR DESCRIPTION
### Motivation

- Align diagram rendering with the repository layout by scanning `docs/02-architecture/diagrams/` directly instead of a nested `mermaid/` folder. 
- Support both common Mermaid source extensions (`*.mermaid` and `*.mmd`) so all diagrams are discovered and rendered. 
- Place generated PNGs into a documentation-friendly directory (`docs/02-architecture/diagrams/png/`) and make the index generation and summary match that output location.

### Description

- Set `MERMAID_DIR` to `"$SCRIPT_DIR"` and `IMAGES_DIR` to `"$SCRIPT_DIR/png"` in `docs/02-architecture/diagrams/render_diagrams.sh` to use the diagrams directory as the source and `png/` as the target. 
- Replace single-extension discovery with a `find` that matches `*.mermaid` OR `*.mmd`, load results into `mapfile` (sorted), and compute `total_diagrams` from the array length. 
- Iterate over the discovered files array, use `basename` to derive output names, and render each to `png/<name>.png` while preserving previous sizing and diagnostics. 
- Rewrote `INDEX.md` generation to emit the PNG index into the `png/` directory, include a generated date, list discovered PNGs, and show `_No PNG files were generated._` when none exist. 
- Improve end-of-run messaging so the script exits 0 when no diagrams are found (with an informational notice) and otherwise summarizes success/failure counts.

### Testing

- Ran syntax check with `bash -n docs/02-architecture/diagrams/render_diagrams.sh` which succeeded. 
- Performed an integration harness using a stubbed `mmdc` and three scenarios (`only *.mermaid`, `only *.mmd`, and no diagram files`), and all three cases passed with expected PNG/INDEX outputs. 
- A pre-commit run during commit surfaced unrelated repository checks that failed (`pip-audit` executable missing and root-level VCR cassette files detected), but those failures are unrelated to the modified script itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699409f1d6108324802d7dfd401b23ab)