### PR TITLE
Recalculate and reorder TOP-50 architecture diagram priorities

### DIFF
--- a/docs/02-architecture/diagrams/top-50-diagrams.md
+++ b/docs/02-architecture/diagrams/top-50-diagrams.md
@@ -1,119 +1,120 @@
 # TOP-50 Архитектурных Диаграмм BioETL
 
-*Версия: 1.0 | Дата: 2026-01-20*
+*Версия: 1.1 | Дата: 2026-02-17*
 
 Таблица 50 наиболее важных диаграмм для понимания архитектуры, логики и кодовой базы проекта BioETL, отсортированных по приоритету.
 
-**Методология приоритизации:**
-- **Arch** (1-10): Архитектурная важность
-- **Doc** (1-10): Документационная ценность
-- **Freq** (1-10): Частота использования
-- **Complex** (1-10): Сложность без диаграммы
-- **Coverage** (1-10): Охват кодовой базы
-- **Приоритет** = (Arch × 2 + Doc × 1.5 + Freq × 1.5 + Complex × 2 + Coverage × 1) / 8
+**Методология приоритизации (обновлено):**
 
----
+- **ArchitectureImpact** (1-10): влияние диаграммы на понимание целевой архитектуры.
+- **CodeCoverage** (1-10): насколько диаграмма покрывает ключевые модули/потоки кода.
+- **ComplexityReduction** (1-10): насколько диаграмма снижает когнитивную сложность.
+- **OperationalValue** (1-10): ценность для эксплуатации, инцидентов и поддержки.
+- **OnboardingValue** (1-10): ценность для ускорения онбординга разработчиков.
+- **Priority = 0.30×ArchitectureImpact + 0.25×CodeCoverage + 0.20×ComplexityReduction + 0.15×OperationalValue + 0.10×OnboardingValue**
+
+______________________________________________________________________
 
 ## TOP-50 Диаграммы
 
-| # | Название | Тип | Приоритет | Обоснование | Классы/Компоненты |
-|---|----------|-----|-----------|-------------|-------------------|
-| **1** | **Five Layer Architecture** | Component | **9.69** | Фундаментальная диаграмма для понимания всей архитектуры. Критична для новых разработчиков. Показывает разделение на Domain, Application, Composition, Infrastructure, Interfaces слои. | `domain/*`, `application/*`, `composition/*`, `infrastructure/*`, `interfaces/*` |
-| **2** | **Complete Pipeline Flow** | Flowchart | **9.56** | End-to-end поток данных от API до Gold layer. Самая частая ссылка при обсуждении pipeline. Показывает полный цикл обработки. | `PipelineRunner`, `BatchExecutor`, `RecordProcessor`, `BatchTransformer`, `BatchWriter`, `BronzeWriter`, `SilverWriter`, `GoldWriter` |
-| **3** | **Hexagonal Architecture Overview** | C4 Context | **9.50** | Ports & Adapters — ключевой паттерн проекта. Критично для понимания принципов DI и слоёв. | 24 Ports (все Protocol интерфейсы), Infrastructure Adapters |
-| **4** | **Layer Dependency Matrix** | Matrix | **9.44** | Матрица импортов — enforcement правило. Предотвращает архитектурные нарушения. Часто проверяется при code review. | Все слои проекта, `tests/architecture/test_layer_contracts.py` |
-| **5** | **Medallion Architecture Overview** | Flowchart | **9.38** | Bronze → Silver → Gold — core концепция хранения данных. Критично для понимания data pipeline. | `BronzeWriter`, `SilverWriter`, `GoldWriter`, `MedallionLifecycleService`, `MedallionPolicy` |
-| **6** | **Domain Model Overview** | Class | **9.31** | Полная доменная модель: entities, value objects, aggregates. Показывает business logic структуру. | `PipelineRun`, `Batch`, `QuarantineEntry`, `Activity`, `DQMetrics`, `RunContext`, все entities |
-| **7** | **Ports Architecture** | Interface | **9.25** | 24 порта — контракты между слоями. Критично для понимания DI и тестирования. | `StoragePort`, `DataSourcePort`, `LockPort`, `CheckpointPort`, `QuarantinePort`, `TracingPort`, `MetricsPort`, `LoggerPort` и др. (всего 24) |
-| **8** | **Batch Processing Flow** | Activity | **9.19** | Полный цикл обработки батча — core процесс pipeline. Сложный процесс с множеством шагов. | `Batch`, `RecordProcessor`, `BatchTransformer`, `BatchWriter`, `BatchMetricsRecorder`, `QuarantineManager` |
-| **9** | **DDD Aggregates** | Class | **9.13** | PipelineRun, Batch, QuarantineEntry — bounded contexts с инвариантами. Критично для понимания domain logic. | `PipelineRun` (574 LOC), `Batch` (536 LOC), `QuarantineEntry` (517 LOC), `StageResult`, `BatchRecord` |
-| **10** | **Pipeline Core Components** | Component | **9.06** | PipelineRunner, BatchExecutor, RecordProcessor — сердце application layer. Самые частые изменения. | `PipelineRunner` (189 LOC), `BatchExecutor` (786 LOC), `RecordProcessor` (222 LOC), `RunnerServices` |
-| **11** | **Composition Root** | Component | **9.00** | bootstrap_pipeline() — единственное место сборки DI. Критично для понимания wiring. | `bootstrap_pipeline()`, `bootstrap_observability()`, `bootstrap_storage()`, `bootstrap_checkpoint()`, `bootstrap_quarantine()` |
-| **12** | **Error Classification** | Flowchart | **8.94** | Critical/Recoverable/DQ — основа error handling стратегии. Сложная логика с множеством условий. | `BioETLError`, `CriticalError`, `RecoverableError`, `DataQualityError`, `ErrorService`, `ErrorClassifier` |
-| **13** | **Storage Architecture** | Component | **8.88** | Bronze/Silver/Gold writers — core infrastructure. Сложная Delta Lake интеграция. | `BronzeWriter` (814 LOC), `SilverWriter` (1154 LOC), `GoldWriter` (953 LOC), `BaseDeltaWriter`, `RetentionManager` |
-| **14** | **HTTP Infrastructure** | Component | **8.81** | UnifiedHTTPClient — унифицированная HTTP инфраструктура для всех провайдеров. | `UnifiedHTTPClient`, `RateLimiter`, `CircuitBreaker`, `HealthMonitor`, `Pagination`, `BaseHttpAdapter` |
-| **15** | **Circuit Breaker States** | State | **8.75** | Closed → Open → Half-Open — fault tolerance паттерн. Критично для resilience. | `CircuitBreaker`, `CircuitBreakerPort`, state transitions |
-| **16** | **PipelineRun Aggregate** | Class | **8.69** | Самый сложный aggregate с event sourcing. 574 LOC, множество state transitions. | `PipelineRun` (574 LOC), `StageResult`, `PipelineState` enum, domain events |
-| **17** | **Retry Mechanism** | Activity | **8.63** | Exponential backoff — критичная resilience логика. Сложный алгоритм с jitter. | Retry logic в `UnifiedHTTPClient`, backoff calculation, jitter addition |
-| **18** | **DQ Check Flow** | Sequence | **8.56** | Complete DQ process — критично для data quality. Сложный multi-stage процесс. | `DQMonitorPort`, `BronzeDQAnalyzerPort`, `SilverDQAnalyzerPort`, `GoldDQAnalyzerPort`, `DQReportService`, `PostrunService` |
-| **19** | **BaseTransformer Template Method** | Activity | **8.50** | Template Method pattern — base для всех transformers. Критично для понимания extension points. | `BaseTransformer` (821 LOC), hook methods: `transform_entity()`, `validate_input()`, `validate_output()` |
-| **20** | **Factory Pattern Usage** | Class | **8.44** | 8 фабрик — object creation strategy. Сложная система зависимостей. | `PipelineFactory`, `RunnerFactory`, `ServicesFactory`, `StorageFactory`, `HTTPClientFactory`, `DataSourceFactory`, `TransformerFactory`, `DQFactory` |
-| **21** | **Lock Acquisition Flow** | Sequence | **8.38** | acquire() → heartbeat → release() — distributed locking. Критично для concurrency. | `LockManager`, `MemoryLock`, `LockPort`, `Heartbeat`, TTL checker |
-| **22** | **Silver Merge Operation** | Sequence | **8.31** | Delta merge by content_hash — ACID операция. Сложная Delta Lake логика. | `SilverWriter` (1154 LOC), Delta merge, content_hash deduplication, ACID transaction |
-| **23** | **Provider Adapters Overview** | Component | **8.25** | 7 провайдеров — все data sources. Критично для понимания integration layer. | `ChemblAdapter`, `PubChemAdapter`, `UniProtAdapter`, `CrossRefAdapter`, `OpenAlexAdapter`, `PubMedAdapter`, `SemanticScholarAdapter` |
-| **24** | **Graceful Shutdown** | Sequence | **8.19** | SIGTERM → Cleanup → Exit — критично для production. Сложная координация ресурсов. | `Shutdown`, `ShutdownPort`, `PipelineRunner.shutdown()`, checkpoint save, lock release, `aclose()` cascade |
-| **25** | **PipelineConfig Structure** | Class | **8.13** | Complete pipeline configuration — core для всех pipelines. 100+ поля. | `PipelineConfig` (969 LOC), `ValidationConfig`, `DQConfig`, `TableConfig`, nested structures |
-| **26** | **Dependency Injection Flow** | Sequence | **8.06** | Как собираются зависимости через конструкторы. Критично для DI понимания. | Composition Root → Factories → Constructor injection chain |
-| **27** | **Bronze Write Operation** | Sequence | **8.00** | JSONL append with metadata — Bronze layer механика. Часто используется. | `BronzeWriter` (814 LOC), JSONL format, zstd compression, metadata YAML |
-| **28** | **Batch Aggregate** | Class | **7.94** | Batch aggregate — второй по сложности aggregate. 536 LOC, state machine. | `Batch` (536 LOC), `BatchRecord`, `BatchState` enum, quarantine logic |
-| **29** | **Rate Limiting** | Activity | **7.88** | Token bucket algorithm — критично для API compliance. Сложная математика. | `RateLimiter`, `RateLimiterPort`, token bucket, provider-specific limits |
-| **30** | **ChEMBL Adapter Architecture** | Component | **7.81** | Самый большой адаптер — 13 pipelines. Критично для ChEMBL integration. | `ChemblAdapter` (1170 LOC), `ChemblEntityMapper`, `CHEMBL_DTO_MODELS`, 13 entity types |
-| **31** | **Pipeline Lifecycle** | State | **7.75** | PENDING → RUNNING → COMPLETED/FAILED — pipeline states. Часто используется. | `PipelineRun` states, `PipelineRunner` lifecycle, state transitions |
-| **32** | **DQ Report Generation** | Sequence | **7.69** | Report creation — критично для DQ visibility. Сложный aggregation процесс. | `DQReportService`, `DQReportWriterPort`, `DQReport` VO, Bronze/Silver/Gold analyzers |
-| **33** | **Gold SCD2 Write** | Sequence | **7.63** | Slowly Changing Dimension Type 2 — сложная аналитическая логика. | `GoldWriter` (953 LOC), SCD2 mode, `valid_from`/`valid_to` timestamps |
-| **34** | **Observability Integration** | Component | **7.56** | PipelineObserver — cross-cutting concerns. Tracing + Metrics + Logging. | `PipelineObserver`, `TracingPort`, `MetricsPort`, `LoggerPort`, span hierarchy |
-| **35** | **System Context Diagram** | C4 Context | **7.50** | BioETL в контексте внешних систем — big picture. | BioETL System, 7 external providers (ChEMBL, PubChem, UniProt, CrossRef, OpenAlex, PubMed, SemanticScholar), Local Storage |
-| **36** | **Domain Services** | Component | **7.44** | Stateless domain logic — часто путают с application services. | `DataNormalizationService`, `IdentityService`, `UnitConverter`, `ActivityAggregator`, `ValueValidator`, `DQSerializer` |
-| **37** | **Checkpoint Lifecycle** | State | **7.38** | Create → Update → Load — state persistence. Критично для incremental runs. | `CheckpointManager`, `CheckpointPort`, `CheckpointAdapter`, checkpoint JSON schema |
-| **38** | **Entity Mapping** | Activity | **7.31** | DTO → Domain Entity — часто выполняется. Критично для transformation. | Entity mappers для всех провайдеров, DTO models, domain entities |
-| **39** | **Gold Write Flow** | Sequence | **7.25** | Filter → Validate → Delta Write — Gold layer механика. | `GoldWriter` (953 LOC), JSON filtering, strict validation, Delta write modes |
-| **40** | **Preflight Checklist** | Activity | **7.19** | Pre-run infrastructure validation — предотвращает ошибки. | `PreflightService` (816 LOC), health checks, storage validation, lock availability |
-| **41** | **Pipeline Services Bundle** | Component | **7.13** | PipelineServices — injected dependencies. Критично для понимания dependencies. | `PipelineServices` (152 LOC): `data_source`, `storage`, `lock`, `checkpoint`, `quarantine`, `metrics`, `logger`, `tracer` |
-| **42** | **Value Objects Hierarchy** | Class | **7.06** | Все value objects — immutable domain concepts. Часто используются. | `Activity`, `ActivityValues`, `DQMetrics`, `DQResult`, `DQReport`, `SilverResult`, `BronzeResult`, `RunContext`, `CompoundIds`, `TaxonomyId`, `Identifiers` |
-| **43** | **Incremental Run Flow** | Flowchart | **7.00** | Resume from checkpoint — самый частый run type. | `RuntimeConfig.run_type=incremental`, `CheckpointManager.load()`, resume logic |
-| **44** | **Configuration Loading Flow** | Sequence | **6.94** | YAML → PipelineConfig — критично для pipeline setup. | `ConfigLoader`, YAML parsing, `PipelineConfig` construction, validation |
-| **45** | **Memory Monitor Lifecycle** | Sequence | **6.88** | Adaptive batch sizing — critical для production stability. | `MemoryMonitor` (310 LOC), `MemoryMonitorPort`, batch size adaptation, memory stats |
-| **46** | **Quarantine Handling** | Activity | **6.81** | Failed record isolation — критично для data quality. | `QuarantineManager`, `QuarantinePort`, `QuarantineAdapter`, `QuarantineEntry` aggregate |
-| **47** | **CLI Flow** | Flowchart | **6.75** | User input → execution — entry point. Критично для user experience. | `cli/main.py`, `cli/commands/*`, 11+ commands, Click CLI routing |
-| **48** | **Data Normalization** | Activity | **6.69** | Text/Value/ID normalization — часто выполняется. | `DataNormalizationService`, `IdentityService`, `UnitConverter`, normalization algorithms |
-| **49** | **Schema Validation Flow** | Sequence | **6.63** | Pandera validation — критично для data integrity. | Pandera schemas для всех entities, validation logic, schema enforcement |
-| **50** | **Architecture Decision Records Map** | Mind Map | **6.56** | 27 ADR и их связи — architecture rationale. Критично для понимания "why". | ADR-001 (Delta Lake), ADR-007 (Circuit Breaker), ADR-008 (Graceful Shutdown), ADR-020 (BasePipeline Decomposition), ADR-021 (DDD Aggregates) и др. (27 total) |
+| #      | Название                              | Тип        | ArchitectureImpact | CodeCoverage | ComplexityReduction | OperationalValue | OnboardingValue | Priority | Обоснование                                                                                                                                                                             | Классы/Компоненты                                                                                                                                             |
+| ------ | ------------------------------------- | ---------- | -----------------: | -----------: | ------------------: | ---------------: | --------------: | -------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1**  | **Complete Pipeline Flow**            | Flowchart  |                 10 |           10 |                   9 |                9 |              10 | **9.65** | End-to-end поток данных от API до Gold layer. Самая частая ссылка при обсуждении pipeline. Показывает полный цикл обработки.                                                            | `PipelineRunner`, `BatchExecutor`, `RecordProcessor`, `BatchTransformer`, `BatchWriter`, `BronzeWriter`, `SilverWriter`, `GoldWriter`                         |
+| **2**  | **Five Layer Architecture**           | Component  |                 10 |           10 |                   9 |                9 |              10 | **9.65** | Фундаментальная диаграмма для понимания всей архитектуры. Критична для новых разработчиков. Показывает разделение на Domain, Application, Composition, Infrastructure, Interfaces слои. | `domain/*`, `application/*`, `composition/*`, `infrastructure/*`, `interfaces/*`                                                                              |
+| **3**  | **Hexagonal Architecture Overview**   | C4 Context |                 10 |           10 |                   9 |                9 |              10 | **9.65** | Ports & Adapters — ключевой паттерн проекта. Критично для понимания принципов DI и слоёв.                                                                                               | 24 Ports (все Protocol интерфейсы), Infrastructure Adapters                                                                                                   |
+| **4**  | **Layer Dependency Matrix**           | Matrix     |                 10 |           10 |                   9 |                9 |              10 | **9.65** | Матрица импортов — enforcement правило. Предотвращает архитектурные нарушения. Часто проверяется при code review.                                                                       | Все слои проекта, `tests/architecture/test_layer_contracts.py`                                                                                                |
+| **5**  | **Domain Model Overview**             | Class      |                 10 |            9 |                   9 |                9 |              10 | **9.40** | Полная доменная модель: entities, value objects, aggregates. Показывает business logic структуру.                                                                                       | `PipelineRun`, `Batch`, `QuarantineEntry`, `Activity`, `DQMetrics`, `RunContext`, все entities                                                                |
+| **6**  | **Medallion Architecture Overview**   | Flowchart  |                 10 |            9 |                   9 |                9 |              10 | **9.40** | Bronze → Silver → Gold — core концепция хранения данных. Критично для понимания data pipeline.                                                                                          | `BronzeWriter`, `SilverWriter`, `GoldWriter`, `MedallionLifecycleService`, `MedallionPolicy`                                                                  |
+| **7**  | **Ports Architecture**                | Interface  |                 10 |            9 |                   9 |                9 |               9 | **9.30** | 24 порта — контракты между слоями. Критично для понимания DI и тестирования.                                                                                                            | `StoragePort`, `DataSourcePort`, `LockPort`, `CheckpointPort`, `QuarantinePort`, `TracingPort`, `MetricsPort`, `LoggerPort` и др. (всего 24)                  |
+| **8**  | **Batch Processing Flow**             | Activity   |                  9 |            9 |                   9 |                9 |               9 | **9.00** | Полный цикл обработки батча — core процесс pipeline. Сложный процесс с множеством шагов.                                                                                                | `Batch`, `RecordProcessor`, `BatchTransformer`, `BatchWriter`, `BatchMetricsRecorder`, `QuarantineManager`                                                    |
+| **9**  | **Composition Root**                  | Component  |                  9 |            9 |                   9 |                9 |               9 | **9.00** | bootstrap_pipeline() — единственное место сборки DI. Критично для понимания wiring.                                                                                                     | `bootstrap_pipeline()`, `bootstrap_observability()`, `bootstrap_storage()`, `bootstrap_checkpoint()`, `bootstrap_quarantine()`                                |
+| **10** | **DDD Aggregates**                    | Class      |                  9 |            9 |                   9 |                9 |               9 | **9.00** | PipelineRun, Batch, QuarantineEntry — bounded contexts с инвариантами. Критично для понимания domain logic.                                                                             | `PipelineRun` (574 LOC), `Batch` (536 LOC), `QuarantineEntry` (517 LOC), `StageResult`, `BatchRecord`                                                         |
+| **11** | **Error Classification**              | Flowchart  |                  9 |            9 |                   9 |                9 |               9 | **9.00** | Critical/Recoverable/DQ — основа error handling стратегии. Сложная логика с множеством условий.                                                                                         | `BioETLError`, `CriticalError`, `RecoverableError`, `DataQualityError`, `ErrorService`, `ErrorClassifier`                                                     |
+| **12** | **Pipeline Core Components**          | Component  |                  9 |            9 |                   9 |                9 |               9 | **9.00** | PipelineRunner, BatchExecutor, RecordProcessor — сердце application layer. Самые частые изменения.                                                                                      | `PipelineRunner` (189 LOC), `BatchExecutor` (786 LOC), `RecordProcessor` (222 LOC), `RunnerServices`                                                          |
+| **13** | **Circuit Breaker States**            | State      |                  9 |            9 |                   9 |                8 |               9 | **8.85** | Closed → Open → Half-Open — fault tolerance паттерн. Критично для resilience.                                                                                                           | `CircuitBreaker`, `CircuitBreakerPort`, state transitions                                                                                                     |
+| **14** | **HTTP Infrastructure**               | Component  |                  9 |            9 |                   9 |                8 |               9 | **8.85** | UnifiedHTTPClient — унифицированная HTTP инфраструктура для всех провайдеров.                                                                                                           | `UnifiedHTTPClient`, `RateLimiter`, `CircuitBreaker`, `HealthMonitor`, `Pagination`, `BaseHttpAdapter`                                                        |
+| **15** | **Storage Architecture**              | Component  |                  9 |            9 |                   9 |                8 |               9 | **8.85** | Bronze/Silver/Gold writers — core infrastructure. Сложная Delta Lake интеграция.                                                                                                        | `BronzeWriter` (814 LOC), `SilverWriter` (1154 LOC), `GoldWriter` (953 LOC), `BaseDeltaWriter`, `RetentionManager`                                            |
+| **16** | **BaseTransformer Template Method**   | Activity   |                  9 |            9 |                   8 |                8 |               9 | **8.65** | Template Method pattern — base для всех transformers. Критично для понимания extension points.                                                                                          | `BaseTransformer` (821 LOC), hook methods: `transform_entity()`, `validate_input()`, `validate_output()`                                                      |
+| **17** | **DQ Check Flow**                     | Sequence   |                  9 |            9 |                   8 |                8 |               9 | **8.65** | Complete DQ process — критично для data quality. Сложный multi-stage процесс.                                                                                                           | `DQMonitorPort`, `BronzeDQAnalyzerPort`, `SilverDQAnalyzerPort`, `GoldDQAnalyzerPort`, `DQReportService`, `PostrunService`                                    |
+| **18** | **Factory Pattern Usage**             | Class      |                  9 |            9 |                   8 |                8 |               9 | **8.65** | 8 фабрик — object creation strategy. Сложная система зависимостей.                                                                                                                      | `PipelineFactory`, `RunnerFactory`, `ServicesFactory`, `StorageFactory`, `HTTPClientFactory`, `DataSourceFactory`, `TransformerFactory`, `DQFactory`          |
+| **19** | **PipelineRun Aggregate**             | Class      |                  9 |            9 |                   8 |                8 |               9 | **8.65** | Самый сложный aggregate с event sourcing. 574 LOC, множество state transitions.                                                                                                         | `PipelineRun` (574 LOC), `StageResult`, `PipelineState` enum, domain events                                                                                   |
+| **20** | **Retry Mechanism**                   | Activity   |                  9 |            9 |                   8 |                8 |               9 | **8.65** | Exponential backoff — критичная resilience логика. Сложный алгоритм с jitter.                                                                                                           | Retry logic в `UnifiedHTTPClient`, backoff calculation, jitter addition                                                                                       |
+| **21** | **Lock Acquisition Flow**             | Sequence   |                  9 |            8 |                   8 |                8 |               9 | **8.40** | acquire() → heartbeat → release() — distributed locking. Критично для concurrency.                                                                                                      | `LockManager`, `MemoryLock`, `LockPort`, `Heartbeat`, TTL checker                                                                                             |
+| **22** | **Silver Merge Operation**            | Sequence   |                  9 |            8 |                   8 |                8 |               9 | **8.40** | Delta merge by content_hash — ACID операция. Сложная Delta Lake логика.                                                                                                                 | `SilverWriter` (1154 LOC), Delta merge, content_hash deduplication, ACID transaction                                                                          |
+| **23** | **Provider Adapters Overview**        | Component  |                  9 |            8 |                   8 |                8 |               8 | **8.30** | 7 провайдеров — все data sources. Критично для понимания integration layer.                                                                                                             | `ChemblAdapter`, `PubChemAdapter`, `UniProtAdapter`, `CrossRefAdapter`, `OpenAlexAdapter`, `PubMedAdapter`, `SemanticScholarAdapter`                          |
+| **24** | **Batch Aggregate**                   | Class      |                  8 |            8 |                   8 |                8 |               8 | **8.00** | Batch aggregate — второй по сложности aggregate. 536 LOC, state machine.                                                                                                                | `Batch` (536 LOC), `BatchRecord`, `BatchState` enum, quarantine logic                                                                                         |
+| **25** | **Bronze Write Operation**            | Sequence   |                  8 |            8 |                   8 |                8 |               8 | **8.00** | JSONL append with metadata — Bronze layer механика. Часто используется.                                                                                                                 | `BronzeWriter` (814 LOC), JSONL format, zstd compression, metadata YAML                                                                                       |
+| **26** | **Dependency Injection Flow**         | Sequence   |                  8 |            8 |                   8 |                8 |               8 | **8.00** | Как собираются зависимости через конструкторы. Критично для DI понимания.                                                                                                               | Composition Root → Factories → Constructor injection chain                                                                                                    |
+| **27** | **Graceful Shutdown**                 | Sequence   |                  8 |            8 |                   8 |                8 |               8 | **8.00** | SIGTERM → Cleanup → Exit — критично для production. Сложная координация ресурсов.                                                                                                       | `Shutdown`, `ShutdownPort`, `PipelineRunner.shutdown()`, checkpoint save, lock release, `aclose()` cascade                                                    |
+| **28** | **PipelineConfig Structure**          | Class      |                  8 |            8 |                   8 |                8 |               8 | **8.00** | Complete pipeline configuration — core для всех pipelines. 100+ поля.                                                                                                                   | `PipelineConfig` (969 LOC), `ValidationConfig`, `DQConfig`, `TableConfig`, nested structures                                                                  |
+| **29** | **ChEMBL Adapter Architecture**       | Component  |                  8 |            8 |                   8 |                7 |               8 | **7.85** | Самый большой адаптер — 13 pipelines. Критично для ChEMBL integration.                                                                                                                  | `ChemblAdapter` (1170 LOC), `ChemblEntityMapper`, `CHEMBL_DTO_MODELS`, 13 entity types                                                                        |
+| **30** | **Pipeline Lifecycle**                | State      |                  8 |            8 |                   8 |                7 |               8 | **7.85** | PENDING → RUNNING → COMPLETED/FAILED — pipeline states. Часто используется.                                                                                                             | `PipelineRun` states, `PipelineRunner` lifecycle, state transitions                                                                                           |
+| **31** | **Rate Limiting**                     | Activity   |                  8 |            8 |                   8 |                7 |               8 | **7.85** | Token bucket algorithm — критично для API compliance. Сложная математика.                                                                                                               | `RateLimiter`, `RateLimiterPort`, token bucket, provider-specific limits                                                                                      |
+| **32** | **DQ Report Generation**              | Sequence   |                  8 |            8 |                   7 |                7 |               8 | **7.65** | Report creation — критично для DQ visibility. Сложный aggregation процесс.                                                                                                              | `DQReportService`, `DQReportWriterPort`, `DQReport` VO, Bronze/Silver/Gold analyzers                                                                          |
+| **33** | **Domain Services**                   | Component  |                  8 |            8 |                   7 |                7 |               8 | **7.65** | Stateless domain logic — часто путают с application services.                                                                                                                           | `DataNormalizationService`, `IdentityService`, `UnitConverter`, `ActivityAggregator`, `ValueValidator`, `DQSerializer`                                        |
+| **34** | **Gold SCD2 Write**                   | Sequence   |                  8 |            8 |                   7 |                7 |               8 | **7.65** | Slowly Changing Dimension Type 2 — сложная аналитическая логика.                                                                                                                        | `GoldWriter` (953 LOC), SCD2 mode, `valid_from`/`valid_to` timestamps                                                                                         |
+| **35** | **Observability Integration**         | Component  |                  8 |            8 |                   7 |                7 |               8 | **7.65** | PipelineObserver — cross-cutting concerns. Tracing + Metrics + Logging.                                                                                                                 | `PipelineObserver`, `TracingPort`, `MetricsPort`, `LoggerPort`, span hierarchy                                                                                |
+| **36** | **System Context Diagram**            | C4 Context |                  8 |            8 |                   7 |                7 |               8 | **7.65** | BioETL в контексте внешних систем — big picture.                                                                                                                                        | BioETL System, 7 external providers (ChEMBL, PubChem, UniProt, CrossRef, OpenAlex, PubMed, SemanticScholar), Local Storage                                    |
+| **37** | **Checkpoint Lifecycle**              | State      |                  8 |            7 |                   7 |                7 |               8 | **7.40** | Create → Update → Load — state persistence. Критично для incremental runs.                                                                                                              | `CheckpointManager`, `CheckpointPort`, `CheckpointAdapter`, checkpoint JSON schema                                                                            |
+| **38** | **Entity Mapping**                    | Activity   |                  8 |            7 |                   7 |                7 |               8 | **7.40** | DTO → Domain Entity — часто выполняется. Критично для transformation.                                                                                                                   | Entity mappers для всех провайдеров, DTO models, domain entities                                                                                              |
+| **39** | **Gold Write Flow**                   | Sequence   |                  8 |            7 |                   7 |                7 |               7 | **7.30** | Filter → Validate → Delta Write — Gold layer механика.                                                                                                                                  | `GoldWriter` (953 LOC), JSON filtering, strict validation, Delta write modes                                                                                  |
+| **40** | **Configuration Loading Flow**        | Sequence   |                  7 |            7 |                   7 |                7 |               7 | **7.00** | YAML → PipelineConfig — критично для pipeline setup.                                                                                                                                    | `ConfigLoader`, YAML parsing, `PipelineConfig` construction, validation                                                                                       |
+| **41** | **Incremental Run Flow**              | Flowchart  |                  7 |            7 |                   7 |                7 |               7 | **7.00** | Resume from checkpoint — самый частый run type.                                                                                                                                         | `RuntimeConfig.run_type=incremental`, `CheckpointManager.load()`, resume logic                                                                                |
+| **42** | **Pipeline Services Bundle**          | Component  |                  7 |            7 |                   7 |                7 |               7 | **7.00** | PipelineServices — injected dependencies. Критично для понимания dependencies.                                                                                                          | `PipelineServices` (152 LOC): `data_source`, `storage`, `lock`, `checkpoint`, `quarantine`, `metrics`, `logger`, `tracer`                                     |
+| **43** | **Preflight Checklist**               | Activity   |                  7 |            7 |                   7 |                7 |               7 | **7.00** | Pre-run infrastructure validation — предотвращает ошибки.                                                                                                                               | `PreflightService` (816 LOC), health checks, storage validation, lock availability                                                                            |
+| **44** | **Value Objects Hierarchy**           | Class      |                  7 |            7 |                   7 |                7 |               7 | **7.00** | Все value objects — immutable domain concepts. Часто используются.                                                                                                                      | `Activity`, `ActivityValues`, `DQMetrics`, `DQResult`, `DQReport`, `SilverResult`, `BronzeResult`, `RunContext`, `CompoundIds`, `TaxonomyId`, `Identifiers`   |
+| **45** | **CLI Flow**                          | Flowchart  |                  7 |            7 |                   7 |                6 |               7 | **6.85** | User input → execution — entry point. Критично для user experience.                                                                                                                     | `cli/main.py`, `cli/commands/*`, 11+ commands, Click CLI routing                                                                                              |
+| **46** | **Memory Monitor Lifecycle**          | Sequence   |                  7 |            7 |                   7 |                6 |               7 | **6.85** | Adaptive batch sizing — critical для production stability.                                                                                                                              | `MemoryMonitor` (310 LOC), `MemoryMonitorPort`, batch size adaptation, memory stats                                                                           |
+| **47** | **Quarantine Handling**               | Activity   |                  7 |            7 |                   7 |                6 |               7 | **6.85** | Failed record isolation — критично для data quality.                                                                                                                                    | `QuarantineManager`, `QuarantinePort`, `QuarantineAdapter`, `QuarantineEntry` aggregate                                                                       |
+| **48** | **Architecture Decision Records Map** | Mind Map   |                  7 |            7 |                   6 |                6 |               7 | **6.65** | 27 ADR и их связи — architecture rationale. Критично для понимания "why".                                                                                                               | ADR-001 (Delta Lake), ADR-007 (Circuit Breaker), ADR-008 (Graceful Shutdown), ADR-020 (BasePipeline Decomposition), ADR-021 (DDD Aggregates) и др. (27 total) |
+| **49** | **Data Normalization**                | Activity   |                  7 |            7 |                   6 |                6 |               7 | **6.65** | Text/Value/ID normalization — часто выполняется.                                                                                                                                        | `DataNormalizationService`, `IdentityService`, `UnitConverter`, normalization algorithms                                                                      |
+| **50** | **Schema Validation Flow**            | Sequence   |                  7 |            7 |                   6 |                6 |               7 | **6.65** | Pandera validation — критично для data integrity.                                                                                                                                       | Pandera schemas для всех entities, validation logic, schema enforcement                                                                                       |
 
----
+______________________________________________________________________
 
 ## Статистика по Категориям
 
-| Категория | Количество в TOP-50 |
-|-----------|---------------------|
-| Архитектурные Обзоры | 12 |
-| Потоки Данных | 10 |
-| Паттерны и Механизмы | 14 |
-| Компонентные Диаграммы | 8 |
-| Взаимодействия | 4 |
-| Состояния и Жизненные Циклы | 2 |
+| Категория                   | Количество в TOP-50 |
+| --------------------------- | ------------------- |
+| Архитектурные Обзоры        | 12                  |
+| Потоки Данных               | 10                  |
+| Паттерны и Механизмы        | 14                  |
+| Компонентные Диаграммы      | 8                   |
+| Взаимодействия              | 4                   |
+| Состояния и Жизненные Циклы | 2                   |
 
----
+______________________________________________________________________
 
-## TOP-25 для Создания (Приоритет ≥ 7.75)
+## TOP-25 для Создания (по новому Priority)
 
-Первые 25 диаграмм из списка выше будут созданы в формате Mermaid и отрендерены в PNG:
+Первые 25 диаграмм из пересортированного списка выше будут созданы в формате Mermaid и отрендерены в PNG:
 
-1. Five Layer Architecture (9.69)
-2. Complete Pipeline Flow (9.56)
-3. Hexagonal Architecture Overview (9.50)
-4. Layer Dependency Matrix (9.44)
-5. Medallion Architecture Overview (9.38)
-6. Domain Model Overview (9.31)
-7. Ports Architecture (9.25)
-8. Batch Processing Flow (9.19)
-9. DDD Aggregates (9.13)
-10. Pipeline Core Components (9.06)
-11. Composition Root (9.00)
-12. Error Classification (8.94)
-13. Storage Architecture (8.88)
-14. HTTP Infrastructure (8.81)
-15. Circuit Breaker States (8.75)
-16. PipelineRun Aggregate (8.69)
-17. Retry Mechanism (8.63)
-18. DQ Check Flow (8.56)
-19. BaseTransformer Template Method (8.50)
-20. Factory Pattern Usage (8.44)
-21. Lock Acquisition Flow (8.38)
-22. Silver Merge Operation (8.31)
-23. Provider Adapters Overview (8.25)
-24. Graceful Shutdown (8.19)
-25. PipelineConfig Structure (8.13)
+1. Complete Pipeline Flow (9.65)
+1. Five Layer Architecture (9.65)
+1. Hexagonal Architecture Overview (9.65)
+1. Layer Dependency Matrix (9.65)
+1. Domain Model Overview (9.40)
+1. Medallion Architecture Overview (9.40)
+1. Ports Architecture (9.30)
+1. Batch Processing Flow (9.00)
+1. Composition Root (9.00)
+1. DDD Aggregates (9.00)
+1. Error Classification (9.00)
+1. Pipeline Core Components (9.00)
+1. Circuit Breaker States (8.85)
+1. HTTP Infrastructure (8.85)
+1. Storage Architecture (8.85)
+1. BaseTransformer Template Method (8.65)
+1. DQ Check Flow (8.65)
+1. Factory Pattern Usage (8.65)
+1. PipelineRun Aggregate (8.65)
+1. Retry Mechanism (8.65)
+1. Lock Acquisition Flow (8.40)
+1. Silver Merge Operation (8.40)
+1. Provider Adapters Overview (8.30)
+1. Batch Aggregate (8.00)
+1. Bronze Write Operation (8.00)
 
----
+______________________________________________________________________
 
 *Следующий шаг: Создание Mermaid диаграмм для TOP-25*


### PR DESCRIPTION
### Motivation
- Сделать ранжирование диаграмм детерминированным и проверяемым путем перехода на явные количественные оценки по пяти требуемым критериям и фиксированной формуле расчета приоритета.
- Обеспечить прозрачность и воспроизводимость: добавить столбцы с критериями, чтобы любой мог проверить исходные оценки и итоговый `Priority`.

### Description
- Обновил файл `docs/02-architecture/diagrams/top-50-diagrams.md` (версия -> `1.1`, дата -> `2026-02-17`) и заменил старую методологию на новую с полями `ArchitectureImpact`, `CodeCoverage`, `ComplexityReduction`, `OperationalValue`, `OnboardingValue` и явной формулой `Priority = 0.30×ArchitectureImpact + 0.25×CodeCoverage + 0.20×ComplexityReduction + 0.15×OperationalValue + 0.10×OnboardingValue`.
- Добавил отдельные столбцы с оценками по всем 5 критериям для каждой из 50 диаграмм, пересчитал `Priority` по строгой формуле и пересортировал таблицу TOP-50 по убыванию нового `Priority`.
- Синхронизировал блок `TOP-25` (список диаграмм для создания) с новым порядком и показал значения `Priority` рядом с названиями.
- Привел таблицу к более однородному табличному формату (выравнивание колонок и отдельная разделяющая линия), сохранив обоснования и перечисления классов/компонентов.

### Testing
- Запустил в-репо валидационный скрипт на Python, который для каждой строки проверил, что `Priority` соответствует формуле и что таблица отсортирована по невозрастанию значения; команда проверки использовалась в виде `python - <<'PY' ... PY` и вернула `rows 50 ok True` для валидации формулы и порядка.
- Прогнал pre-commit набор проверок; `mdformat` автоматически модифицировал файл (форматирование Markdown), `pip-audit` вернул ошибку в окружении из-за отсутствия исполняемого `pip-audit`, и хук `check-root-vcr-cassettes` обнаружил root-level VCR cassettes вне области этого изменения, что привело к отказу части проверок; эти проблемы относятся к окружению/репозиторию, а не к логике пересчета.
- Проверил, что итоговый `docs/02-architecture/diagrams/top-50-diagrams.md` содержит 50 строк с числами по 5 критериям и что секция `TOP-25` обновлена и согласована с новым ранжированием.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940acb66fc8324b6bde229037bc1e9)