### PR TITLE
Add extraction_params support for ChEMBL filtering (ADR-028)

### DIFF
--- a/configs/filters/entities/chembl/publication.yaml
+++ b/configs/filters/entities/chembl/publication.yaml
@@ -20,6 +20,57 @@ input_filter:
   filter_field: "publication_id"
   batch_size: 16
 
+# ---------------------------------------------------------------------------
+# Extraction-Level Filtering (ADR-028 §3)
+# ---------------------------------------------------------------------------
+# Server-side query parameters appended to every ChEMBL Document API request.
+# Syntax: ChEMBL django-style lookups (__in, __isnull, __gte, __lte, etc.)
+# Reference: https://chembl.gitbook.io/chembl-interface-documentation/web-services/chembl-data-web-services
+#
+# These params reduce API traffic by excluding patents, books, and records
+# outside the valid publication year range at the API level.
+# Does NOT affect content_hash (ADR-014).
+# Logged in SourceMetadata.query_string for audit/reproducibility.
+#
+# Resulting API URL pattern:
+#   /chembl/api/data/document?format=json&limit=1000&offset=0
+#     &doc_type=PUBLICATION
+#     &year__gte=1950
+#     &year__lte=2050
+extraction_params:
+    # Publications only (exclude patents, books, etc.)
+    doc_type: "PUBLICATION"
+
+    # Year range lower bound (inclusive)
+    year__gte: 1950
+
+    # Year range upper bound (inclusive)
+    year__lte: 2050
+
+# -----------------------------------------------------------------------------
+# Silver Filters — Domain-level quality gates (applied BEFORE Silver write)
+# -----------------------------------------------------------------------------
+# Records that fail these filters are excluded from the Silver layer entirely.
+# Defence-in-depth: mirrors extraction_params to catch API inconsistencies.
+silver_filters:
+    # Column value filters — strict inclusion lists
+    columns:
+        # Publications only (mirrors extraction_params doc_type)
+        doc_type: [PUBLICATION]
+
+    # Numeric range filters
+    ranges:
+        # Mirrors extraction_params year range (field renamed in transformer)
+        publication_year:
+            min: 1950
+            max: 2050
+
+    # Required fields — must be non-null for silver
+    required_fields:
+        - publication_id
+        - doc_type
+        - title
+
 # -----------------------------------------------------------------------------
 # Gold Filters
 # -----------------------------------------------------------------------------

--- a/configs/filters/entities/chembl/publication_similarity.yaml
+++ b/configs/filters/entities/chembl/publication_similarity.yaml
@@ -16,6 +16,20 @@ entity: publication_similarity
 input_filter:
   enabled: false
 
+# ---------------------------------------------------------------------------
+# Extraction-Level Filtering (ADR-028 §3)
+# ---------------------------------------------------------------------------
+# NOT configured for publication_similarity.
+#
+# Reason: Gold filter uses derived field max_tani = max(mol_tani, tid_tani) >= 0.5.
+# The API only exposes individual mol_tani and tid_tani fields.
+# Filtering on individual fields (e.g., mol_tani__gte=0.5 AND tid_tani__gte=0.5)
+# would incorrectly exclude records where one score is high but the other is low
+# (e.g., mol_tani=0.8, tid_tani=0.1 → max_tani=0.8 passes gold but would fail
+# an API-level tid_tani__gte filter). Using OR logic is not supported by the API.
+#
+# Dataset size (~50K records) does not justify the risk of data loss.
+
 # -----------------------------------------------------------------------------
 # Gold Filters
 # -----------------------------------------------------------------------------

--- a/configs/filters/entities/chembl/publication_term.yaml
+++ b/configs/filters/entities/chembl/publication_term.yaml
@@ -20,6 +20,27 @@ input_filter:
   filter_field: "publication_id"
   batch_size: 20
 
+# ---------------------------------------------------------------------------
+# Extraction-Level Filtering (ADR-028 §3)
+# ---------------------------------------------------------------------------
+# Server-side query parameters appended to underlying ChEMBL Document API
+# requests. Publication terms are a derived entity: PublicationTermDataSource
+# fetches from /document endpoint via the wrapped ChemblAdapter, which
+# applies these params to every API request.
+#
+# Mirrors publication.yaml extraction_params for consistency.
+# Does NOT affect content_hash (ADR-014).
+# Logged in SourceMetadata.query_string for audit/reproducibility.
+extraction_params:
+    # Publications only (exclude patents, books, etc.)
+    doc_type: "PUBLICATION"
+
+    # Year range lower bound (inclusive)
+    year__gte: 1950
+
+    # Year range upper bound (inclusive)
+    year__lte: 2050
+
 # -----------------------------------------------------------------------------
 # Gold Filters
 # -----------------------------------------------------------------------------

--- a/tests/integration/chembl/test_publication_extraction_params.py
+++ b/tests/integration/chembl/test_publication_extraction_params.py
@@ -1,0 +1,223 @@
+"""Integration test: extraction_params applied to ChEMBL Document API requests.
+
+Uses VCR.py cassette with pre-recorded filtered response.
+Verifies that extraction_params from YAML config are correctly
+appended to API request query string and recorded in Bronze SourceMetadata.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bioetl.domain.models.filter import ExtractionParams
+from bioetl.domain.resilience import AdapterConfig
+from bioetl.infrastructure.adapters.chembl.client import ChemblAdapter
+
+# VCR cassette directory for ChEMBL extraction params tests
+CASSETTE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "vcr" / "chembl"
+
+
+@pytest.fixture(scope="module")
+def vcr_config() -> dict[str, Any]:
+    """Configure VCR for ChEMBL extraction params tests."""
+    return {
+        "cassette_library_dir": str(CASSETTE_DIR),
+        "record_mode": os.environ.get("VCR_RECORD_MODE", "none"),
+        "match_on": ["method", "scheme", "host", "port", "path", "query"],
+        "decode_compressed_response": True,
+    }
+
+
+@pytest.mark.integration
+class TestPublicationExtractionParams:
+    """Verify extraction_params flow from config to API request and metadata."""
+
+    @pytest.fixture
+    def extraction_params(self) -> ExtractionParams:
+        """Publication-specific extraction params matching ADR-028 §3."""
+        return ExtractionParams(
+            params={
+                "doc_type": "PUBLICATION",
+                "year__gte": 1950,
+                "year__lte": 2050,
+            }
+        )
+
+    @pytest.fixture
+    def mock_logger(self) -> MagicMock:
+        """Create a mock logger for testing."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_http_client(self) -> MagicMock:
+        """Create a mock HTTP client."""
+        from bioetl.domain.types import CircuitBreakerState
+
+        client = MagicMock()
+        client.circuit_breaker = MagicMock()
+        client.circuit_breaker.get_state.return_value = CircuitBreakerState.CLOSED
+        client.circuit_breaker.get_failure_count.return_value = 0
+        return client
+
+    def test_build_params_includes_extraction_params(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """_build_params merges extraction_params into query dict."""
+        adapter = ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            adapter_config=AdapterConfig(page_size=500),
+            extraction_params=extraction_params,
+        )
+
+        params = adapter._build_params(offset=0, entity_type="publication")
+
+        # Standard pagination params present
+        assert params["format"] == "json"
+        assert params["limit"] == 500
+        assert params["offset"] == 0
+
+        # All 3 publication extraction params present
+        assert params["doc_type"] == "PUBLICATION"
+        assert params["year__gte"] == 1950
+        assert params["year__lte"] == 2050
+
+    def test_source_metadata_contains_query_string(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """SourceMetadata.query_string includes all extraction params."""
+        qs = extraction_params.to_query_string()
+
+        assert "doc_type=PUBLICATION" in qs
+        assert "year__gte=1950" in qs
+        assert "year__lte=2050" in qs
+
+    def test_source_metadata_query_string_deterministic(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """query_string is deterministic (sorted keys) across invocations."""
+        qs1 = extraction_params.to_query_string()
+        qs2 = extraction_params.to_query_string()
+
+        assert qs1 == qs2
+        # Keys must be sorted alphabetically
+        keys = [part.split("=")[0] for part in qs1.split("&")]
+        assert keys == sorted(keys)
+
+    def test_get_source_metadata_records_extraction_params(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """get_source_metadata writes extraction_params to query_string."""
+        adapter = ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            extraction_params=extraction_params,
+        )
+
+        metadata = adapter.get_source_metadata()
+
+        assert metadata.query_string is not None
+        assert "doc_type=PUBLICATION" in metadata.query_string
+        assert "year__gte=1950" in metadata.query_string
+
+    def test_extraction_params_logged_at_init(
+        self,
+        extraction_params: ExtractionParams,
+        mock_http_client: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Adapter logs extraction_params at initialization for audit."""
+        ChemblAdapter(
+            http_client=mock_http_client,
+            logger=mock_logger,
+            extraction_params=extraction_params,
+        )
+
+        info_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and c.args[0] == "chembl_extraction_params_configured"
+        ]
+        assert len(info_calls) == 1
+        kwargs = info_calls[0].kwargs
+        assert kwargs["param_count"] == 3
+        assert "doc_type" in kwargs["query_string"]
+
+    def test_no_overlap_with_publication_input_filter(
+        self,
+        extraction_params: ExtractionParams,
+    ) -> None:
+        """Publication extraction_params do not overlap with input_filter.filter_field.
+
+        The publication input_filter uses filter_field="publication_id", which is not
+        present in extraction_params keys.
+        """
+        publication_input_filter_field = "publication_id"
+        assert publication_input_filter_field not in extraction_params.params
+
+    @pytest.mark.vcr("chembl_publication_filtered.yaml")
+    @pytest.mark.skip(
+        reason="VCR cassette not yet recorded. "
+        "Record with: VCR_RECORD_MODE=new_episodes pytest -k test_publication_filtered_api_request"
+    )
+    async def test_publication_filtered_api_request(
+        self,
+        token_bucket: Any,
+        circuit_breaker: Any,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Full flow: adapter sends filtered request to ChEMBL API.
+
+        This test requires a VCR cassette recorded with the filtered URL.
+        Record with:
+            VCR_RECORD_MODE=new_episodes pytest -k test_publication_filtered_api_request
+        """
+        from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
+
+        ep = ExtractionParams(
+            params={
+                "doc_type": "PUBLICATION",
+                "year__gte": 1950,
+                "year__lte": 2050,
+            }
+        )
+
+        client = UnifiedHTTPClient(
+            rate_limiter=token_bucket,
+            circuit_breaker=circuit_breaker,
+            timeout=30.0,
+        )
+
+        async with client:
+            adapter = ChemblAdapter(
+                http_client=client,
+                logger=mock_logger,
+                adapter_config=AdapterConfig(page_size=10),
+                extraction_params=ep,
+            )
+
+            records: list[dict[str, Any]] = []
+            async for record in adapter.fetch("publication", limit=5):
+                records.append(record)
+
+            assert len(records) > 0
+            for record in records:
+                assert "document_chembl_id" in record
+
+            # Metadata should contain extraction params
+            metadata = adapter.get_source_metadata()
+            assert metadata.query_string is not None
+            assert "doc_type=PUBLICATION" in metadata.query_string


### PR DESCRIPTION
## Summary
Implements server-side query parameter filtering for ChEMBL API requests via `extraction_params` configuration, enabling efficient filtering at the API level rather than post-fetch. This reduces unnecessary API traffic and improves data pipeline performance.

## Key Changes

- **Integration tests** (`test_publication_extraction_params.py`): Comprehensive test suite verifying:
  - `extraction_params` are correctly merged into API query parameters via `_build_params()`
  - Query strings are deterministically formatted (sorted keys) for reproducibility
  - Parameters are recorded in `SourceMetadata.query_string` for audit trails
  - Adapter logs extraction params at initialization for observability
  - No overlap between extraction params and input filter fields

- **ChEMBL publication filter config** (`publication.yaml`):
  - Added `extraction_params` section with server-side filters:
    - `doc_type: PUBLICATION` (exclude patents, books)
    - `year__gte: 1950` and `year__lte: 2050` (valid publication year range)
  - Added `silver_filters` section as defence-in-depth validation:
    - Column filters mirroring extraction params
    - Numeric range filters on `publication_year`
    - Required fields validation

- **ChEMBL publication_term filter config** (`publication_term.yaml`):
  - Added `extraction_params` mirroring publication.yaml for consistency
  - Documented that derived entity applies params via wrapped ChemblAdapter

- **ChEMBL publication_similarity filter config** (`publication_similarity.yaml`):
  - Explicitly documented why extraction_params are NOT configured
  - Explains API limitation: cannot filter on derived field `max_tani = max(mol_tani, tid_tani)` using individual field filters without risking data loss

## Implementation Details

- Extraction params use ChEMBL django-style lookup syntax (`__gte`, `__lte`, etc.)
- Parameters are appended to every Document API request query string
- Does NOT affect content_hash calculation (ADR-014 compliance)
- Query strings are deterministically sorted for reproducibility and audit trails
- VCR cassette test included (currently skipped pending cassette recording)

https://claude.ai/code/session_01GE9acAYtJGJUmhbiu3b9Xe