### PR TITLE
Enforce effective sort_by for merged pipeline configs

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -62,13 +62,16 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
   - `StoragePort` — для проверки storage backends
 
   Остальные порты (`LoggerPort`, `MetricsPort`, `TracingPort` и т.д.) используют structural subtyping без runtime проверок и **MAY** не иметь `@runtime_checkable`. Семантика поведения в runtime не проверяется типами.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -161,7 +164,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -241,19 +244,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -271,6 +275,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -332,6 +337,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -503,6 +509,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -919,7 +926,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1021,11 +1030,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1160,11 +1169,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1219,6 +1228,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1321,16 +1331,16 @@ ______________________________________________________________________
 
 **Структура папок:** `src/bioetl/infrastructure/adapters/{provider}/`
 
-| Источник     | Библиотека                  | Rate Limit               | Retry Strategy          | Auth Type       | Health Check                                                                  |
-| ------------ | --------------------------- | ------------------------ | ----------------------- | --------------- | ----------------------------------------------------------------------------- |
+| Источник     | Библиотека                      | Rate Limit               | Retry Strategy          | Auth Type       | Health Check                                                                  |
+| ------------ | ------------------------------- | ------------------------ | ----------------------- | --------------- | ----------------------------------------------------------------------------- |
 | **ChEMBL**   | `httpx` via `UnifiedHTTPClient` | Нет явного лимита        | Exponential backoff     | Public          | `GET /chembl/api/data/status`                                                 |
-| **PubChem**  | `pubchempy`                 | 5 req/sec                | 429 -> wait Retry-After | Public          | Lightweight: `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
-| **UniProt**  | `unipressed`                | 100 req/sec (c API key)  | Exponential backoff     | API Key         | Lightweight Search Probe                                                      |
-| **OpenAlex** | `pyalex`                    | 10 req/sec (polite pool) | 429 -> backoff          | API Key (Email) | Generic Probe\*                                                               |
-| **Semantic** | `semanticscholar`           | 100 req/5min             | Sliding window          | API Key         | Generic Probe\*                                                               |
-| **PubMed**   | `biopython`                 | 3 req/sec (10 c key)     | 429 -> backoff          | API Key         | Generic Probe\*                                                               |
-| **Crossref** | `habanero`                  | 50 req/sec (polite pool) | Exponential backoff     | Email           | Generic Probe\*                                                               |
-| **GtoP**     | `pyGtoP` (deprecated)       | -                        | -                       | None            | -                                                                             |
+| **PubChem**  | `pubchempy`                     | 5 req/sec                | 429 -> wait Retry-After | Public          | Lightweight: `GET /rest/pug/compound/cid/2244/property/MolecularFormula/JSON` |
+| **UniProt**  | `unipressed`                    | 100 req/sec (c API key)  | Exponential backoff     | API Key         | Lightweight Search Probe                                                      |
+| **OpenAlex** | `pyalex`                        | 10 req/sec (polite pool) | 429 -> backoff          | API Key (Email) | Generic Probe\*                                                               |
+| **Semantic** | `semanticscholar`               | 100 req/5min             | Sliding window          | API Key         | Generic Probe\*                                                               |
+| **PubMed**   | `biopython`                     | 3 req/sec (10 c key)     | 429 -> backoff          | API Key         | Generic Probe\*                                                               |
+| **Crossref** | `habanero`                      | 50 req/sec (polite pool) | Exponential backoff     | Email           | Generic Probe\*                                                               |
+| **GtoP**     | `pyGtoP` (deprecated)           | -                        | -                       | None            | -                                                                             |
 
 \* **Generic Probe**: Lightweight GET-запрос к базовому endpoint API (e.g., root или `/status`). Если API не предоставляет dedicated health endpoint, использовать минимальный запрос данных с timeout 5 секунд.
 
@@ -1347,20 +1357,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1392,18 +1402,24 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
 См. [ADR-025](02-architecture/decisions/ADR-025-pipeline-config-unification.md) для унификации конфигурации, [ADR-027](02-architecture/decisions/ADR-027-dq-rules-externalization.md) для DQ rules и [ADR-028](02-architecture/decisions/ADR-028-filter-rules-externalization.md) для filter rules.
+
+**Правило deterministic sort (MUST):**
+
+- `sink.silver.sort_by.columns` и `sink.gold.sort_by.columns` MAY наследоваться из `configs/pipelines/_base.yaml` (через merge).
+- После merge и применения convention defaults у каждого pipeline MUST быть эффективные непустые `sink.silver.sort_by.columns` и `sink.gold.sort_by.columns`.
+- Пустой override (`columns: []`) считается ошибкой конфигурации и приводит к отказу загрузки.
 
 ```yaml
 # configs/pipelines/chembl/activity.yaml
@@ -1530,7 +1546,7 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Accepted           | 2026-02    |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 
 ## История Изменений (Changelog)
 

--- a/docs/04-reference/pipelines/README.md
+++ b/docs/04-reference/pipelines/README.md
@@ -98,6 +98,11 @@ ______________________________________________________________________
 
 ## Configuration Files
 
+Rule for deterministic ordering:
+
+- `sort_by` for Silver/Gold can be inherited from `configs/pipelines/_base.yaml`.
+- After merge/default resolution each pipeline must have non-empty effective `sink.silver.sort_by.columns` and `sink.gold.sort_by.columns`; empty override is invalid.
+
 All pipeline configs are in `configs/pipelines/`:
 
 ```

--- a/src/bioetl/infrastructure/config_loader.py
+++ b/src/bioetl/infrastructure/config_loader.py
@@ -214,6 +214,34 @@ def _apply_convention_defaults(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def _validate_effective_sort_by(config: dict[str, Any]) -> None:
+    """Validate that effective sort keys are present after merge/defaults.
+
+    Rule: pipeline configs MAY inherit ``sort_by`` from ``configs/pipelines/_base.yaml``,
+    but after deep-merge and convention defaults each pipeline MUST have effective
+    ``sink.silver.sort_by.columns`` and ``sink.gold.sort_by.columns``.
+
+    Raises:
+        ValueError: If effective sort columns are missing or empty.
+    """
+    sink = config.get("sink")
+    if not isinstance(sink, dict):
+        raise ValueError("Pipeline config MUST define sink section")
+
+    for layer_name in ("silver", "gold"):
+        layer = sink.get(layer_name)
+        if not isinstance(layer, dict):
+            raise ValueError(f"Pipeline config MUST define sink.{layer_name} section")
+
+        sort_by = layer.get("sort_by")
+        columns = sort_by.get("columns") if isinstance(sort_by, dict) else None
+        if not isinstance(columns, list) or not columns:
+            raise ValueError(
+                "Pipeline config MUST have effective sink."
+                f"{layer_name}.sort_by.columns after merge/defaults"
+            )
+
+
 def _sync_timeout_aliases(d: dict[str, Any]) -> dict[str, Any]:
     """Ensure ``timeout`` and ``timeout_sec`` are kept in sync."""
     result = d.copy()
@@ -608,6 +636,7 @@ def load_pipeline_config(pipeline_name: str) -> PipelineYamlConfig:
 
     _load_column_groups_section(config, entity_config, config_path)
     _load_source_section(config, config_path)
+    _validate_effective_sort_by(config)
 
     validated: PipelineYamlConfig = PipelineYamlConfig.model_validate(config)
     return validated

--- a/tests/unit/infrastructure/test_config_dynamic.py
+++ b/tests/unit/infrastructure/test_config_dynamic.py
@@ -480,6 +480,65 @@ def test_convention_based_primary_key_propagation(setup_configs, tmp_path):
     assert config.sink["gold"].sort_by.columns == ["pk_field1", "pk_field2"]
 
 
+def test_sort_by_inheritance_from_base_validated(setup_configs, tmp_path):
+    """sort_by MAY be inherited from _base.yaml with post-merge validation."""
+    pipelines_dir = setup_configs
+
+    base_config = {
+        "sink": {
+            "silver": {"sort_by": {"ascending": True}},
+            "gold": {"sort_by": {"ascending": True}},
+        }
+    }
+    (pipelines_dir / "_base.yaml").write_text(yaml.dump(base_config))
+
+    config_data = {
+        "pipeline_name": "inherit_sort",
+        "provider": "inherit",
+        "entity_type": "entity",
+        "primary_keys": ["record_id"],
+        "silver_table": "inherit.entity",
+    }
+
+    inherit_dir = pipelines_dir / "inherit"
+    inherit_dir.mkdir()
+    (inherit_dir / "entity.yaml").write_text(yaml.dump(config_data))
+
+    config = load_pipeline_config("inherit_entity")
+
+    assert config.sink["silver"].sort_by.columns == ["record_id"]
+    assert config.sink["gold"].sort_by.columns == ["record_id"]
+    assert config.sink["silver"].sort_by.ascending is True
+    assert config.sink["gold"].sort_by.ascending is True
+
+
+def test_sort_by_validation_fails_without_effective_columns(setup_configs, tmp_path):
+    """Loading MUST fail when effective sink.silver/gold.sort_by.columns are empty."""
+    pipelines_dir = setup_configs
+
+    config_data = {
+        "pipeline_name": "missing_sort",
+        "provider": "nosort",
+        "entity_type": "entity",
+        "primary_keys": ["record_id"],
+        "silver_table": "nosort.entity",
+        "sink": {
+            "silver": {"sort_by": {"columns": []}},
+            "gold": {"sort_by": {"columns": []}},
+        },
+    }
+
+    nosort_dir = pipelines_dir / "nosort"
+    nosort_dir.mkdir()
+    (nosort_dir / "entity.yaml").write_text(yaml.dump(config_data))
+
+    with pytest.raises(
+        ValueError,
+        match=r"MUST have effective sink\.(silver|gold)\.sort_by\.columns",
+    ):
+        load_pipeline_config("nosort_entity")
+
+
 def test_explicit_paths_override_convention(setup_configs, tmp_path):
     """Verify explicitly specified paths override convention defaults."""
     pipelines_dir = setup_configs


### PR DESCRIPTION
### Motivation
- Ensure deterministic writes by requiring that `sink.silver.sort_by.columns` and `sink.gold.sort_by.columns` are non-empty after config merge/default resolution, while still allowing inheritance from `configs/pipelines/_base.yaml`.
- Remove ambiguity in pipeline YAMLs and make the sort-order rule explicit in project docs and validation so misconfigured pipelines fail fast.

### Description
- Add `_validate_effective_sort_by(config)` to `src/bioetl/infrastructure/config_loader.py` and invoke it after merge/default application and before Pydantic validation to enforce effective `sort_by.columns` for `silver` and `gold` layers.
- Add unit tests to `tests/unit/infrastructure/test_config_dynamic.py` covering successful inheritance from `_base.yaml` and failure when a pipeline explicitly overrides `sort_by.columns` with an empty list.
- Update documentation to declare the rule unambiguously in `docs/00-project/RULES.md` and `docs/04-reference/pipelines/README.md` so the behavior is discoverable by developers.

### Testing
- Ran `pytest -q tests/unit/infrastructure/test_config_dynamic.py -k "sort_by_inheritance_from_base_validated or sort_by_validation_fails_without_effective_columns or convention_based_primary_key_propagation"` and the selected tests passed.
- Resolved local test collection dependencies (`pyyaml`, `pydantic`, `pydantic-settings`, `pandas`, `pandera`, `pytest-asyncio`, `pytest-timeout`) to allow tests to run in this environment and confirmed the new tests exercise both inheritance and failure scenarios successfully.
- Pre-commit/formatters applied automatic fixes in this environment; unrelated CI-level hooks (external tooling checks) may surface additional items outside the functional scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994827d0ca48324a4d677185907952f)