### PR TITLE
Consolidate filter config loading into hierarchical system

### DIFF
--- a/docs/02-architecture/decisions/ADR-028-filter-rules-externalization.md
+++ b/docs/02-architecture/decisions/ADR-028-filter-rules-externalization.md
@@ -61,18 +61,25 @@ filter_config_file: ../../filter/entities/chembl/activity.yaml
    - `FilterConfigFile`: Complete schema with to_domain() conversion
 
 2. **Configuration loader**: `src/bioetl/infrastructure/config/filter_config_loader.py`
-   - `FilterConfigLoader.load(provider, entity, inline_overrides)`: Merges configs
+   - `FilterConfigLoader.load(provider, entity, inline_overrides)`: Merges and returns domain objects
+   - `FilterConfigLoader.load_as_dict(provider, entity, inline_overrides)`: Merges and returns raw dict (used by pipeline config loading)
+   - `FilterConfigLoader._merge_hierarchy()`: Shared 4-level merge logic
    - Thread-safe caching for performance
    - Deep merge with list deduplication for required_fields/exclude_if_present
 
-3. **Config files**: `configs/filters/`
+3. **Pipeline config integration**: `src/bioetl/infrastructure/config_loader.py`
+   - `_apply_hierarchical_filter_config()`: Single entry point for filter merge during pipeline loading
+   - Delegates to `FilterConfigLoader.load_as_dict()` for the full hierarchy
+   - Collects inline overrides from pipeline YAML (`input_filter`, `gold_filters`, `silver_filters`, `extraction_params`, `filter_rules`)
+
+4. **Config files**: `configs/filters/`
    - `_defaults.yaml`: Global defaults (batch_size=100)
-   - `providers/{provider}.yaml`: Provider-specific settings (e.g., ChEMBL batch_size=20)
+   - `providers/{provider}.yaml`: Provider-specific settings (e.g., ChEMBL batch_size=1000)
    - `entities/{provider}/{entity}.yaml`: Entity-specific rules
 
-4. **Pipeline schema update**: `src/bioetl/infrastructure/schemas/pipeline_config.py`
-   - Added `filter_config_file` field to `PipelineYamlConfig`
-   - Added `filter_rules` field for inline overrides
+5. **Pipeline schema**: `src/bioetl/infrastructure/schemas/pipeline_config.py`
+   - `filter_config_file` field for convention-based path (informational)
+   - `filter_rules` field for inline overrides
    - Legacy `input_filter`/`gold_filters` fields retained for backward compatibility
 
 ## Consequences
@@ -244,12 +251,15 @@ Define filters in Python code. Rejected because:
 
 | Requirement | Status | Implementation |
 |-------------|--------|----------------|
-| Hierarchical merge | PASS | `FilterConfigLoader._deep_merge()` |
+| Hierarchical merge | PASS | `FilterConfigLoader._merge_hierarchy()` |
+| Single merge mechanism | PASS | Consolidated into `FilterConfigLoader` (no duplication) |
 | Provider defaults | PASS | `providers/{provider}.yaml` |
 | Entity overrides | PASS | `entities/{provider}/{entity}.yaml` |
+| Inline overrides | PASS | `filter_rules` / inline sections in pipeline YAML |
 | Backward compatibility | PASS | Inline `input_filter`/`gold_filters` supported |
 | Domain conversion | PASS | `FilterConfigFile.to_domain()` |
 | Extraction params | PASS | `extraction_params` section in filter YAML |
+| Silver filters | PASS | `silver_filters` section now loaded from hierarchy |
 
 ## References
 
@@ -257,6 +267,7 @@ Define filters in Python code. Rejected because:
 - Domain models: `src/bioetl/domain/filtering/`
 - Schema: `src/bioetl/infrastructure/schemas/filter_config.py`
 - Loader: `src/bioetl/infrastructure/config/filter_config_loader.py`
+- Pipeline integration: `src/bioetl/infrastructure/config_loader.py` (`_apply_hierarchical_filter_config`)
 - Config files: `configs/filters/`
 - Tests: `tests/unit/infrastructure/config/test_filter_config_loader.py`
 
@@ -266,3 +277,4 @@ Define filters in Python code. Rejected because:
 |------|--------|--------|
 | 2026-01-20 | Claude Code | Initial version |
 | 2026-02-09 | Claude Code | Added §3 Extraction-Level Filtering (extraction_params) |
+| 2026-02-17 | Claude Code | Consolidated filter merge: removed legacy `_load_filter_config`/`_merge_filter_config` from `config_loader.py`, unified via `FilterConfigLoader._merge_hierarchy()`. All 4 filter sections (`input_filter`, `silver_filters`, `gold_filters`, `extraction_params`) now load from full hierarchy. |

--- a/src/bioetl/infrastructure/config/filter_config_loader.py
+++ b/src/bioetl/infrastructure/config/filter_config_loader.py
@@ -60,7 +60,7 @@ class FilterConfigLoader(
         """Load merged filter config for provider/entity.
 
         Merge order (later wins for scalars, special handling for collections):
-        1. _defaults.yaml
+        1. _defaults.yaml (MUST exist)
         2. providers/{provider}.yaml
         3. entities/{provider}/{entity}.yaml
         4. inline_overrides (from pipeline config filter_rules)
@@ -83,13 +83,79 @@ class FilterConfigLoader(
         if inline_overrides is None and cache_key in self._cache:
             return self._cache[cache_key]
 
-        # 1. Load defaults (MUST exist)
+        # _defaults.yaml MUST exist for validated domain conversion
         defaults_path = self._filter_root / "_defaults.yaml"
         if not defaults_path.exists():
             raise FileNotFoundError(
                 "Required filter defaults file not found in configs/filters/. "
                 "Create _defaults.yaml with global filter settings."
             )
+
+        merged = self._merge_hierarchy(provider, entity, inline_overrides)
+
+        # Validate via Pydantic
+        validated = FilterConfigFile.model_validate(merged)
+        domain_configs: tuple[
+            InputFilterConfig, SilverFilterConfig, GoldFilterConfig, ExtractionParams
+        ] = validated.to_domain()
+
+        # Cache result if no inline overrides
+        if inline_overrides is None:
+            self._cache[cache_key] = domain_configs
+
+        return domain_configs
+
+    def load_as_dict(
+        self,
+        provider: str,
+        entity: str,
+        inline_overrides: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Load merged filter config hierarchy as raw dict.
+
+        Same 4-level merge order as :meth:`load` but returns the merged
+        dict **without** Pydantic validation or domain conversion.
+        Returns empty dict when no filter config files exist at all.
+
+        Merge order (later wins for scalars, concat for collection keys):
+        1. _defaults.yaml (optional — empty dict if absent)
+        2. providers/{provider}.yaml (optional)
+        3. entities/{provider}/{entity}.yaml (optional)
+        4. inline_overrides from pipeline config (highest priority)
+
+        Used by pipeline config loading to integrate the filter hierarchy
+        into the pipeline config dict before PipelineYamlConfig validation.
+
+        Args:
+            provider: Provider name (e.g., "chembl").
+            entity: Entity name (e.g., "activity").
+            inline_overrides: Optional inline overrides from pipeline config.
+
+        Returns:
+            Merged configuration dict (may be empty).
+        """
+        return self._merge_hierarchy(provider, entity, inline_overrides)
+
+    def _merge_hierarchy(
+        self,
+        provider: str,
+        entity: str,
+        inline_overrides: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Merge the 4-level filter config hierarchy into a single dict.
+
+        Shared logic for both :meth:`load` and :meth:`load_as_dict`.
+
+        Args:
+            provider: Provider name.
+            entity: Entity name.
+            inline_overrides: Optional inline overrides.
+
+        Returns:
+            Merged configuration dict.
+        """
+        # 1. Load defaults (returns {} if absent)
+        defaults_path = self._filter_root / "_defaults.yaml"
         merged = self._load_yaml(defaults_path)
 
         # 2. Load provider config (optional)
@@ -110,17 +176,7 @@ class FilterConfigLoader(
         if inline_overrides:
             merged = self._deep_merge(merged, inline_overrides)
 
-        # Validate via Pydantic
-        validated = FilterConfigFile.model_validate(merged)
-        domain_configs: tuple[
-            InputFilterConfig, SilverFilterConfig, GoldFilterConfig, ExtractionParams
-        ] = validated.to_domain()
-
-        # Cache result if no inline overrides
-        if inline_overrides is None:
-            self._cache[cache_key] = domain_configs
-
-        return domain_configs
+        return merged
 
     def _deep_merge(
         self,

--- a/src/bioetl/infrastructure/config/pipeline_config_loader.py
+++ b/src/bioetl/infrastructure/config/pipeline_config_loader.py
@@ -23,15 +23,18 @@ from typing import Any
 from bioetl.domain.config import DQConfig
 from bioetl.infrastructure.config.converters import dq_overrides_to_domain
 from bioetl.infrastructure.config.dq_config_loader import DQConfigLoader
+from bioetl.infrastructure.config.filter_config_loader import FilterConfigLoader
 from bioetl.infrastructure.config_loader import load_pipeline_config as load_yaml_config
 from bioetl.infrastructure.schemas.pipeline_config import PipelineYamlConfig
 
 
 class ConfigLoader:
-    """Pipeline configuration loader with DQ config integration.
+    """Pipeline configuration loader with DQ and filter config integration.
 
     Loads pipeline configurations from YAML files and resolves DQ config
-    through the hierarchical DQConfigLoader system.
+    through the hierarchical DQConfigLoader system. Filter configs are
+    resolved via FilterConfigLoader during pipeline config loading
+    (see :func:`load_pipeline_config` in ``config_loader.py``).
 
     Resolution order for DQ config:
     1. If dq_config_file present: load from DQ hierarchy
@@ -42,12 +45,14 @@ class ConfigLoader:
     Attributes:
         _configs_root: Root path to configs/ directory.
         _dq_loader: DQ configuration loader instance.
+        _filter_loader: Filter configuration loader instance.
     """
 
     def __init__(
         self,
         configs_root: Path,
         dq_loader: DQConfigLoader | None = None,
+        filter_loader: FilterConfigLoader | None = None,
         relaxed_dq: bool = False,
     ) -> None:
         """Initialize loader with configs root directory.
@@ -55,12 +60,14 @@ class ConfigLoader:
         Args:
             configs_root: Path to configs/ directory.
             dq_loader: Optional DQ config loader. Created automatically if None.
+            filter_loader: Optional filter config loader. Created automatically if None.
             relaxed_dq: Whether to relax DQ thresholds (default: False).
         """
         self._configs_root = configs_root
         self._dq_loader = dq_loader or DQConfigLoader(
             configs_root, relaxed_dq=relaxed_dq
         )
+        self._filter_loader = filter_loader or FilterConfigLoader(configs_root)
 
     def load_pipeline_config(self, pipeline_name: str) -> PipelineYamlConfig:
         """Load pipeline configuration from YAML file.
@@ -295,11 +302,12 @@ class ConfigLoader:
         return result
 
     def clear_cache(self) -> None:
-        """Clear all caches (DQ loader cache).
+        """Clear all caches (DQ and filter loader caches).
 
         Call after modifying config files during development/testing.
         """
         self._dq_loader.clear_cache()
+        self._filter_loader.clear_cache()
 
 
 __all__ = ["ConfigLoader"]

--- a/src/bioetl/infrastructure/config_loader.py
+++ b/src/bioetl/infrastructure/config_loader.py
@@ -433,83 +433,63 @@ def load_source_config(provider: str) -> SourceYamlConfig:
     return config
 
 
-def _load_filter_config(
-    config_path: Path, filter_config_file: str
-) -> dict[str, Any] | None:
-    """Load filter configuration from filter_config_file.
-
-    Args:
-        config_path: Path to the pipeline config file (for relative resolution).
-        filter_config_file: Relative path to filter config file.
-
-    Returns:
-        Loaded filter config dict or None if file doesn't exist.
-    """
-    filter_path = config_path.parent / filter_config_file
-    if not filter_path.exists():
-        return None
-
-    with open(filter_path, encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+_FILTER_SECTIONS: tuple[str, ...] = (
+    "input_filter",
+    "silver_filters",
+    "gold_filters",
+    "extraction_params",
+)
 
 
-def _merge_filter_config(
+def _apply_hierarchical_filter_config(
     config: dict[str, Any],
-    filter_config: dict[str, Any],
-    explicit_entity_config: dict[str, Any],
+    entity_config: dict[str, Any],
 ) -> None:
-    """Merge filter config (input_filter, gold_filters, extraction_params) into pipeline config.
+    """Apply filter config from the hierarchical filter system (ADR-028).
 
-    Merge priority (highest to lowest):
-    1. Explicit entity config (from pipeline YAML file)
-    2. Filter config (from filter entity file)
-    3. Base defaults (from _base.yaml)
+    Uses FilterConfigLoader to merge the full 4-level hierarchy:
+    1. _defaults.yaml — global defaults
+    2. providers/{provider}.yaml — provider-specific
+    3. entities/{provider}/{entity}.yaml — entity-specific
+    4. Inline overrides from pipeline config — highest priority
 
-    This allows minimal pipeline configs that inherit from filter configs
-    while still allowing explicit overrides when needed.
+    Replaces the legacy _load_filter_config + _merge_filter_config functions
+    that only loaded the entity file without the full hierarchy.
 
     Args:
-        config: Pipeline config dict (modified in place). Contains merged
-            defaults + entity config.
-        filter_config: Filter config dict from filter entity file.
-        explicit_entity_config: Original entity config dict (before merging
-            with defaults). Used to determine what was explicitly set.
+        config: Pipeline config dict (modified in place).
+        entity_config: Original entity config dict (before base merge).
+            Used to extract inline filter overrides.
     """
-    # Merge input_filter
-    if "input_filter" in filter_config:
-        # Start with filter config as base
-        merged_input_filter = filter_config["input_filter"].copy()
+    from bioetl.infrastructure.config.filter_config_loader import FilterConfigLoader
 
-        # Only override with explicit pipeline values (not defaults from _base.yaml)
-        if "input_filter" in explicit_entity_config:
-            merged_input_filter = _deep_merge(
-                merged_input_filter, explicit_entity_config["input_filter"]
-            )
+    provider = config.get("provider", "")
+    entity_type = config.get("entity_type", "")
 
-        config["input_filter"] = merged_input_filter
+    if not provider or not entity_type:
+        return
 
-    # Merge gold_filters
-    if "gold_filters" in filter_config:
-        # Start with filter config as base
-        merged_gold_filters = filter_config["gold_filters"].copy()
+    # Collect inline filter overrides from pipeline YAML
+    inline_overrides: dict[str, Any] = {}
+    for section in _FILTER_SECTIONS:
+        if section in entity_config:
+            inline_overrides[section] = entity_config[section]
 
-        # Only override with explicit pipeline values (not defaults from _base.yaml)
-        if "gold_filters" in explicit_entity_config:
-            merged_gold_filters = _deep_merge(
-                merged_gold_filters, explicit_entity_config["gold_filters"]
-            )
+    # Also handle filter_rules key (ADR-028 inline override field)
+    filter_rules = entity_config.get("filter_rules")
+    if isinstance(filter_rules, dict):
+        inline_overrides = _deep_merge(inline_overrides, filter_rules)
 
-        config["gold_filters"] = merged_gold_filters
+    # Use FilterConfigLoader for hierarchical merge
+    loader = FilterConfigLoader(Path("configs"))
+    merged_filters = loader.load_as_dict(
+        provider, entity_type, inline_overrides or None
+    )
 
-    # Merge extraction_params (ADR-028 §3)
-    if "extraction_params" in filter_config:
-        merged_extraction_params = dict(filter_config["extraction_params"])
-
-        # Pipeline-level overrides take precedence
-        if "extraction_params" in explicit_entity_config:
-            merged_extraction_params.update(explicit_entity_config["extraction_params"])
-
-        config["extraction_params"] = merged_extraction_params
+    # Apply merged filter sections to pipeline config
+    for section in _FILTER_SECTIONS:
+        if section in merged_filters:
+            config[section] = merged_filters[section]
 
 
 def _load_column_groups_section(
@@ -561,7 +541,7 @@ def load_pipeline_config(pipeline_name: str) -> PipelineYamlConfig:
     1. Load base config from _base.yaml
     2. Merge with entity-specific config
     3. Apply convention-based defaults (auto-compute paths/references)
-    4. Load and merge filter config from filter_config_file
+    4. Apply hierarchical filter config (ADR-028: defaults → provider → entity → inline)
     5. Load source config from source_file
 
     Convention-based defaults auto-compute:
@@ -569,10 +549,11 @@ def load_pipeline_config(pipeline_name: str) -> PipelineYamlConfig:
     - Sink paths (bronze/silver/gold paths)
     - Primary key propagation to sink.silver.primary_key and sort_by
 
-    Filter config merging:
-    - input_filter and gold_filters from filter_config_file are merged
-    - Pipeline inline config acts as overrides on top of filter config
-    - This allows minimal pipeline configs with full filter inheritance
+    Filter config merging (ADR-028):
+    - Full 4-level hierarchy via FilterConfigLoader
+    - Merge order: _defaults.yaml → providers/{provider}.yaml →
+      entities/{provider}/{entity}.yaml → inline pipeline overrides
+    - Pipeline inline config acts as highest-priority overrides
 
     Args:
         pipeline_name: Pipeline name (e.g., "chembl_activity").
@@ -600,11 +581,8 @@ def load_pipeline_config(pipeline_name: str) -> PipelineYamlConfig:
     config = _deep_merge(defaults, entity_config)
     config = _apply_convention_defaults(config)
 
-    # Load and merge filter config from filter_config_file
-    if filter_config_file := config.get("filter_config_file"):
-        filter_config = _load_filter_config(config_path, filter_config_file)
-        if filter_config:
-            _merge_filter_config(config, filter_config, entity_config)
+    # Apply hierarchical filter config (ADR-028)
+    _apply_hierarchical_filter_config(config, entity_config)
 
     _load_column_groups_section(config, entity_config, config_path)
     _load_source_section(config, config_path)

--- a/tests/snapshots/pipeline_configs.json
+++ b/tests/snapshots/pipeline_configs.json
@@ -178,12 +178,88 @@
     "pipeline_name": "chembl_activity",
     "provider": "chembl",
     "silver_filters": {
-      "column_filters": [],
-      "exclude_if_present": [],
+      "column_filters": [
+        {
+          "column": "standard_type",
+          "operator": "in",
+          "values": [
+            "IC50",
+            "Ki"
+          ]
+        },
+        {
+          "column": "standard_relation",
+          "operator": "in",
+          "values": [
+            "="
+          ]
+        },
+        {
+          "column": "standard_units",
+          "operator": "in",
+          "values": [
+            "nM"
+          ]
+        },
+        {
+          "column": "assay_type",
+          "operator": "in",
+          "values": [
+            "B",
+            "F"
+          ]
+        },
+        {
+          "column": "potential_duplicate",
+          "operator": "in",
+          "values": [
+            "0"
+          ]
+        }
+      ],
+      "exclude_if_present": [
+        "data_validity_comment"
+      ],
       "list_contains_filters": [],
       "list_length_filters": [],
-      "range_filters": [],
-      "required_fields": []
+      "range_filters": [
+        {
+          "column": "activity_id",
+          "include_max": true,
+          "include_min": true,
+          "max_value": 10000000000.0,
+          "min_value": 1.0
+        },
+        {
+          "column": "standard_value",
+          "include_max": true,
+          "include_min": false,
+          "max_value": null,
+          "min_value": 0.0
+        },
+        {
+          "column": "pchembl_value",
+          "include_max": true,
+          "include_min": true,
+          "max_value": 10.0,
+          "min_value": 3.0
+        },
+        {
+          "column": "publication_year",
+          "include_max": true,
+          "include_min": true,
+          "max_value": 2050.0,
+          "min_value": 1950.0
+        }
+      ],
+      "required_fields": [
+        "activity_id",
+        "molecule_id",
+        "target_id",
+        "publication_id",
+        "standard_value",
+        "pchembl_value"
+      ]
     },
     "table": {
       "gold_table": "chembl_activity",


### PR DESCRIPTION
## Summary

Refactored filter configuration loading to use a unified hierarchical merge system via `FilterConfigLoader`, eliminating legacy separate functions and integrating the full 4-level configuration hierarchy into pipeline config loading.

## Key Changes

- **Removed legacy filter functions**: Deleted `_load_filter_config()` and `_merge_filter_config()` from `config_loader.py` that only loaded entity-specific filter files without the full hierarchy

- **Introduced `_apply_hierarchical_filter_config()`**: New single entry point in `config_loader.py` that:
  - Delegates to `FilterConfigLoader.load_as_dict()` for the complete 4-level merge
  - Collects inline filter overrides from pipeline YAML (`input_filter`, `silver_filters`, `gold_filters`, `extraction_params`, `filter_rules`)
  - Applies merged filters back to pipeline config

- **Extended `FilterConfigLoader`**: 
  - Added `load_as_dict()` method to return merged configuration as raw dict (without Pydantic validation)
  - Extracted shared merge logic into `_merge_hierarchy()` to avoid duplication between `load()` and `load_as_dict()`
  - Made `_defaults.yaml` optional in `load_as_dict()` (returns empty dict if absent) while keeping it required in `load()` for domain validation

- **Updated pipeline config loading**: Now applies the full filter hierarchy (defaults → provider → entity → inline) during pipeline config loading, replacing the previous approach that only loaded entity-specific files

- **Updated documentation**: ADR-028 now documents the consolidated approach with clear separation between `load()` (for domain objects) and `load_as_dict()` (for pipeline integration)

## Implementation Details

- Filter sections (`input_filter`, `silver_filters`, `gold_filters`, `extraction_params`) are now consistently loaded from the hierarchical system rather than only from entity-specific files
- Inline overrides from pipeline YAML maintain highest priority in the merge order
- The `filter_rules` field in pipeline YAML is properly merged with other inline filter sections
- Snapshot test updated to show `silver_filters` now populated from the hierarchy (previously empty)
- `ConfigLoader` docstring updated to clarify filter config resolution happens during pipeline config loading

https://claude.ai/code/session_01533r7CH2gTNE972Mpd3gjt