### PR TITLE
Update contract tooling imports/paths and add CI-friendly schema parity checker

### DIFF
--- a/docs/05-operations/verification/schema-parity-cli.md
+++ b/docs/05-operations/verification/schema-parity-cli.md
@@ -1,0 +1,58 @@
+# Schema Parity CLI
+
+`src/tools/verify_schema_parity.py` validates parity across:
+
+- Domain dataclass entities (`bioetl.domain.entities.*`)
+- Silver PyArrow schemas (`bioetl.infrastructure.schemas.silver`)
+- Gold Pandera contracts (`bioetl.domain.contracts.gold`)
+
+It compares:
+
+1. Field names
+1. Field types
+1. Nullability
+1. Field descriptions (when present in schema metadata)
+
+## Usage
+
+```bash
+PYTHONPATH=src .venv/bin/python src/tools/verify_schema_parity.py
+```
+
+Write report to a custom path:
+
+```bash
+PYTHONPATH=src .venv/bin/python src/tools/verify_schema_parity.py \
+  --report-path artifacts/schema-parity-report.json
+```
+
+Non-blocking mode (for exploratory runs):
+
+```bash
+PYTHONPATH=src .venv/bin/python src/tools/verify_schema_parity.py \
+  --no-fail-on-mismatch
+```
+
+## CI machine-readable output
+
+The tool always writes a JSON report (default: `artifacts/schema-parity-report.json`) with:
+
+- Per-entity mismatch details
+- Per-entity issue counts
+- Top-level summary status (`pass` or `fail`)
+
+Suggested CI pattern:
+
+```bash
+PYTHONPATH=src .venv/bin/python src/tools/verify_schema_parity.py \
+  --report-path artifacts/schema-parity-report.json
+```
+
+Then publish `artifacts/schema-parity-report.json` as a CI artifact.
+
+## Exit codes (blocking checks)
+
+- `0`: No parity issues found, or run with `--no-fail-on-mismatch`.
+- `1`: Parity issues found while blocking mode is enabled (default).
+
+Recommended for blocking CI checks: **do not** pass `--no-fail-on-mismatch`.

--- a/src/tools/scripts/generate_contracts.py
+++ b/src/tools/scripts/generate_contracts.py
@@ -7,13 +7,14 @@ Usage: python scripts/generate_contracts.py
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 # Ensure project root is in python path
-project_root = Path(__file__).resolve().parent.parent
+project_root = Path(__file__).resolve().parents[3]
 sys.path.append(str(project_root / "src"))
 
 try:
-    from bioetl.interfaces.contracts import (
+    from bioetl.domain.contracts.gold import (
         ChEMBLActivityGoldSchema,
         PubChemCompoundGoldSchema,
         PubMedPublicationGoldSchema,
@@ -23,9 +24,9 @@ except ImportError as e:
     print(f"Error importing schemas: {e}")
     sys.exit(1)
 
-CONTRACTS_DIR = project_root / "docs" / "contracts"
+CONTRACTS_DIR = project_root / "docs" / "04-reference" / "contracts" / "gold"
 
-ENTITY_SCHEMA_MAP = {
+ENTITY_SCHEMA_MAP: dict[str, Any] = {
     "chembl_activity": ChEMBLActivityGoldSchema,
     "pubchem_compound": PubChemCompoundGoldSchema,
     "uniprot_protein": UniProtProteinGoldSchema,
@@ -33,7 +34,7 @@ ENTITY_SCHEMA_MAP = {
 }
 
 
-def generate_contracts():
+def generate_contracts() -> None:
     CONTRACTS_DIR.mkdir(parents=True, exist_ok=True)
 
     for entity, schema_cls in ENTITY_SCHEMA_MAP.items():

--- a/src/tools/verify_schema_parity.py
+++ b/src/tools/verify_schema_parity.py
@@ -1,9 +1,26 @@
-"""Script to programmatically verify schema parity."""
+"""Programmatically verify parity between Domain entities, Silver schemas, and Gold contracts.
 
+This tool is CI-friendly and can produce a machine-readable JSON report.
+"""
+
+from __future__ import annotations
+
+import argparse
 import dataclasses
+import json
 import logging
 import sys
+from collections.abc import Iterable
+from pathlib import Path
+from types import UnionType
+from typing import Any, Union, get_args, get_origin
 
+from bioetl.domain.contracts.gold import (
+    ChEMBLActivityGoldSchema,
+    ChEMBLAssayGoldSchema,
+    ChEMBLMoleculeGoldSchema,
+    ChEMBLTargetGoldSchema,
+)
 from bioetl.domain.entities.bioactivity import Bioactivity
 from bioetl.domain.entities.chembl_activity import Assay
 from bioetl.domain.entities.chembl_structures import Molecule, Target
@@ -12,12 +29,6 @@ from bioetl.infrastructure.schemas.silver import (
     CHEMBL_ASSAY_SCHEMA,
     CHEMBL_MOLECULE_SCHEMA,
     CHEMBL_TARGET_SCHEMA,
-)
-from bioetl.interfaces.contracts import (
-    ChEMBLActivityGoldSchema,
-    ChEMBLAssayGoldSchema,
-    ChEMBLMoleculeGoldSchema,
-    ChEMBLTargetGoldSchema,
 )
 
 # Configure logging for CLI output
@@ -28,77 +39,288 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-
-def get_dataclass_fields(cls):
-    """Return set of field names from a dataclass, excluding system fields."""
-    return {f.name for f in dataclasses.fields(cls)}
-
-
-def get_pyarrow_fields(schema):
-    """Return set of field names from PyArrow schema."""
-    return {f.name for f in schema}
-
-
-def get_pandera_fields(model):
-    """Return set of field names from Pandera model."""
-    return model.to_schema().columns.keys()
+SYSTEM_FIELDS = {
+    "_run_id",
+    "_run_type",
+    "_source_batch_id",
+    "_ingestion_ts",
+    "entity_id",
+    "content_hash",
+    "ingestion_ts",
+    "run_id",
+    "run_type",
+    "source_batch_id",
+}
 
 
-def check_parity(name, domain_cls, silver_schema, gold_model):
+def _normalize_type(type_obj: Any) -> str:
+    """Normalize type representation for cross-schema comparison."""
+    if type_obj is None:
+        return "unknown"
+
+    origin = get_origin(type_obj)
+    if origin in (UnionType, Union):
+        args = [arg for arg in get_args(type_obj) if arg is not type(None)]
+        if len(args) == 1:
+            return _normalize_type(args[0])
+        return " | ".join(sorted(_normalize_type(arg) for arg in args))
+
+    if origin in (list, tuple, set, dict):
+        type_args = get_args(type_obj)
+        origin_name = str(getattr(origin, "__name__", "unknown"))
+        if type_args:
+            inner = ", ".join(_normalize_type(arg) for arg in type_args)
+            return f"{origin_name}[{inner}]"
+        return origin_name
+
+    if isinstance(type_obj, str):
+        return type_obj
+
+    if hasattr(type_obj, "__name__"):
+        return str(type_obj.__name__)
+
+    text = str(type_obj)
+    return text.replace("typing.", "")
+
+
+def get_domain_fields(cls: type[Any]) -> dict[str, dict[str, Any]]:
+    """Return domain field metadata keyed by field name."""
+    result: dict[str, dict[str, Any]] = {}
+    for field in dataclasses.fields(cls):
+        result[field.name] = {
+            "name": field.name,
+            "type": _normalize_type(field.type),
+            "nullable": "NoneType" in str(field.type) or "| None" in str(field.type),
+            "description": field.metadata.get("description")
+            if field.metadata
+            else None,
+        }
+    return result
+
+
+def get_silver_fields(schema: Any) -> dict[str, dict[str, Any]]:
+    """Return PyArrow field metadata keyed by field name."""
+    result: dict[str, dict[str, Any]] = {}
+    for field in schema:
+        description = None
+        if field.metadata and b"description" in field.metadata:
+            description = field.metadata[b"description"].decode("utf-8")
+
+        result[field.name] = {
+            "name": field.name,
+            "type": str(field.type),
+            "nullable": bool(field.nullable),
+            "description": description,
+        }
+    return result
+
+
+def get_gold_fields(model: Any) -> dict[str, dict[str, Any]]:
+    """Return Pandera model field metadata keyed by field name."""
+    result: dict[str, dict[str, Any]] = {}
+    schema = model.to_schema()
+    for name, column in schema.columns.items():
+        result[name] = {
+            "name": name,
+            "type": str(column.dtype),
+            "nullable": bool(column.nullable),
+            "description": column.description,
+        }
+    return result
+
+
+def _compare_field_details(
+    entity_name: str,
+    left_label: str,
+    right_label: str,
+    left_fields: dict[str, dict[str, Any]],
+    right_fields: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Compare types/nullability/descriptions for common fields."""
+    mismatches: list[dict[str, Any]] = []
+
+    for field_name in sorted(set(left_fields) & set(right_fields)):
+        left = left_fields[field_name]
+        right = right_fields[field_name]
+
+        for attr in ("type", "nullable", "description"):
+            if left[attr] != right[attr]:
+                mismatches.append(
+                    {
+                        "entity": entity_name,
+                        "field": field_name,
+                        "attribute": attr,
+                        "left_schema": left_label,
+                        "right_schema": right_label,
+                        "left_value": left[attr],
+                        "right_value": right[attr],
+                    }
+                )
+
+    return mismatches
+
+
+def _set_without_system(names: Iterable[str]) -> set[str]:
+    return {name for name in names if name not in SYSTEM_FIELDS}
+
+
+def check_parity(
+    name: str, domain_cls: type[Any], silver_schema: Any, gold_model: Any
+) -> dict[str, Any]:
+    """Check parity for one entity and return structured results."""
     logger.info("Checking %s...", name)
-    domain_fields = get_dataclass_fields(domain_cls)
-    silver_fields = get_pyarrow_fields(silver_schema)
-    gold_fields = get_pandera_fields(gold_model)
 
-    # System fields to ignore in domain comparison (added by BaseEntity/Infrastructure)
-    system_fields = {
-        "_run_id",
-        "_run_type",
-        "_source_batch_id",
-        "_ingestion_ts",
-        "entity_id",
-        "content_hash",
-        "ingestion_ts",
-        "run_id",
-        "run_type",
-        "source_batch_id",
+    domain_fields = get_domain_fields(domain_cls)
+    silver_fields = get_silver_fields(silver_schema)
+    gold_fields = get_gold_fields(gold_model)
+
+    domain_names = _set_without_system(domain_fields.keys())
+    silver_names = _set_without_system(silver_fields.keys())
+    gold_names = _set_without_system(gold_fields.keys())
+
+    missing_in_silver = sorted(domain_names - silver_names)
+    missing_in_gold = sorted(silver_names - gold_names)
+    missing_in_silver_from_gold = sorted(gold_names - silver_names)
+
+    silver_gold_mismatches = _compare_field_details(
+        entity_name=name,
+        left_label="silver",
+        right_label="gold",
+        left_fields={
+            k: v for k, v in silver_fields.items() if k in silver_names & gold_names
+        },
+        right_fields={
+            k: v for k, v in gold_fields.items() if k in silver_names & gold_names
+        },
+    )
+
+    domain_silver_mismatches = _compare_field_details(
+        entity_name=name,
+        left_label="domain",
+        right_label="silver",
+        left_fields={
+            k: v for k, v in domain_fields.items() if k in domain_names & silver_names
+        },
+        right_fields={
+            k: v for k, v in silver_fields.items() if k in domain_names & silver_names
+        },
+    )
+
+    issues_count = (
+        len(missing_in_silver)
+        + len(missing_in_gold)
+        + len(missing_in_silver_from_gold)
+        + len(silver_gold_mismatches)
+        + len(domain_silver_mismatches)
+    )
+
+    if issues_count == 0:
+        logger.info("  [OK] No parity issues found.")
+    else:
+        if missing_in_silver:
+            logger.error(
+                "  [ERROR] Domain fields missing in Silver: %s", missing_in_silver
+            )
+        if missing_in_gold:
+            logger.error("  [ERROR] Silver fields missing in Gold: %s", missing_in_gold)
+        if missing_in_silver_from_gold:
+            logger.error(
+                "  [ERROR] Gold fields missing in Silver: %s",
+                missing_in_silver_from_gold,
+            )
+        if silver_gold_mismatches:
+            logger.error(
+                "  [ERROR] Silver ↔ Gold detail mismatches: %d",
+                len(silver_gold_mismatches),
+            )
+        if domain_silver_mismatches:
+            logger.error(
+                "  [ERROR] Domain ↔ Silver detail mismatches: %d",
+                len(domain_silver_mismatches),
+            )
+
+    return {
+        "entity": name,
+        "summary": {
+            "missing_in_silver": len(missing_in_silver),
+            "missing_in_gold": len(missing_in_gold),
+            "missing_in_silver_from_gold": len(missing_in_silver_from_gold),
+            "silver_gold_mismatches": len(silver_gold_mismatches),
+            "domain_silver_mismatches": len(domain_silver_mismatches),
+            "total_issues": issues_count,
+        },
+        "missing_in_silver": missing_in_silver,
+        "missing_in_gold": missing_in_gold,
+        "missing_in_silver_from_gold": missing_in_silver_from_gold,
+        "silver_gold_mismatches": silver_gold_mismatches,
+        "domain_silver_mismatches": domain_silver_mismatches,
     }
 
-    missing_in_silver = {
-        f for f in domain_fields if f not in silver_fields and f not in system_fields
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=Path("artifacts/schema-parity-report.json"),
+        help="Path to machine-readable JSON report.",
+    )
+    parser.add_argument(
+        "--fail-on-mismatch",
+        action="store_true",
+        default=True,
+        help="Exit non-zero when mismatches are found (default behavior).",
+    )
+    parser.add_argument(
+        "--no-fail-on-mismatch",
+        action="store_false",
+        dest="fail_on_mismatch",
+        help="Always exit zero, even if mismatches are found.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    report: dict[str, Any] = {
+        "tool": "verify_schema_parity",
+        "version": 2,
+        "results": [
+            check_parity(
+                "Molecule", Molecule, CHEMBL_MOLECULE_SCHEMA, ChEMBLMoleculeGoldSchema
+            ),
+            check_parity(
+                "Target", Target, CHEMBL_TARGET_SCHEMA, ChEMBLTargetGoldSchema
+            ),
+            check_parity(
+                "Bioactivity",
+                Bioactivity,
+                CHEMBL_ACTIVITY_SCHEMA,
+                ChEMBLActivityGoldSchema,
+            ),
+            check_parity("Assay", Assay, CHEMBL_ASSAY_SCHEMA, ChEMBLAssayGoldSchema),
+        ],
     }
 
-    if missing_in_silver:
-        logger.error(
-            "  [ERROR] Fields in Domain but missing in Silver: %s", missing_in_silver
-        )
-    else:
-        logger.info("  [OK] All Domain fields present in Silver.")
+    total_issues = sum(item["summary"]["total_issues"] for item in report["results"])
+    report["summary"] = {
+        "entities_checked": len(report["results"]),
+        "total_issues": total_issues,
+        "status": "pass" if total_issues == 0 else "fail",
+    }
 
-    # Check 2: Silver vs Gold
-    # Gold Schema keys() usually returns the aliased name if defined, or the field name.
-    # In our Gold schema, we use alias="_run_id", so to_schema().columns keys should be "_run_id".
+    args.report_path.parent.mkdir(parents=True, exist_ok=True)
+    args.report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    logger.info("\nJSON report written to %s", args.report_path)
 
-    missing_in_gold = silver_fields - set(gold_fields)
-    missing_in_silver_from_gold = set(gold_fields) - silver_fields
+    if total_issues and args.fail_on_mismatch:
+        logger.error("\nSchema parity FAILED (%d issues).", total_issues)
+        return 1
 
-    if missing_in_gold:
-        logger.error(
-            "  [ERROR] Fields in Silver but missing in Gold: %s", missing_in_gold
-        )
-    elif missing_in_silver_from_gold:
-        logger.error(
-            "  [ERROR] Fields in Gold but missing in Silver: %s",
-            missing_in_silver_from_gold,
-        )
-    else:
-        logger.info("  [OK] Silver and Gold schemas match exactly.")
+    logger.info("\nSchema parity PASSED.")
+    return 0
 
 
 if __name__ == "__main__":
-    check_parity("Molecule", Molecule, CHEMBL_MOLECULE_SCHEMA, ChEMBLMoleculeGoldSchema)
-    check_parity("Target", Target, CHEMBL_TARGET_SCHEMA, ChEMBLTargetGoldSchema)
-    check_parity(
-        "Bioactivity", Bioactivity, CHEMBL_ACTIVITY_SCHEMA, ChEMBLActivityGoldSchema
-    )
-    check_parity("Assay", Assay, CHEMBL_ASSAY_SCHEMA, ChEMBLAssayGoldSchema)
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Bring contract tooling in line with current package layout by importing Gold schemas from `bioetl.domain.contracts.gold` and publishing JSON exports to the canonical docs location `docs/04-reference/contracts/gold`.
- Improve schema parity verification to catch more subtle contract drift (types, nullability, descriptions) and make the check usable in CI pipelines.
- Provide clear CLI docs and explicit exit-code semantics so the tool can be used as a blocking check in CI.

### Description

- Updated `src/tools/scripts/generate_contracts.py` to import Gold schemas from `bioetl.domain.contracts.gold`, fixed project-root resolution for the script, and changed the export directory to `docs/04-reference/contracts/gold`.
- Rewrote and extended `src/tools/verify_schema_parity.py` to collect rich metadata from Domain dataclasses, Silver PyArrow schemas, and Gold Pandera models, compare field names/types/nullability/descriptions, and emit a machine-readable JSON report; added CLI flags `--report-path` and `--no-fail-on-mismatch` to control report location and blocking behavior.
- Added usage and CI guidance in `docs/05-operations/verification/schema-parity-cli.md`, including recommended commands and explicit exit-code semantics for blocking checks.
- Small typing and hygiene updates (type annotations, normalized type rendering) to improve static-checker compatibility and maintainability of the tools.

### Testing

- Compiled both tools with `PYTHONPATH=src .venv/bin/python -m py_compile src/tools/scripts/generate_contracts.py src/tools/verify_schema_parity.py`, which succeeded.
- Ran static typing checks with `PYTHONPATH=src .venv/bin/mypy src/tools/scripts/generate_contracts.py src/tools/verify_schema_parity.py`, which succeeded.
- Executed the parity tool in non-blocking mode with `PYTHONPATH=src .venv/bin/python src/tools/verify_schema_parity.py --no-fail-on-mismatch --report-path /tmp/schema-parity-report.json`; the tool produced a JSON report and returned 0 while reporting parity issues in the log (report written to the specified path).
- Ran the contract generator (`PYTHONPATH=src .venv/bin/python src/tools/scripts/generate_contracts.py`) and verified JSON contract files were produced in `docs/04-reference/contracts/gold`.
- Note: repository pre-commit hook suite (run during commit attempts) flagged unrelated repository-wide checks (missing local helper script and `pip-audit` binary, and root-level VCR cassette placement), which prevented a normal hooks pass; these failures are unrelated to the changes in this PR and should be addressed separately by housekeeping tasks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948a0fa5748324aaa5004ddf9f48eb)