### PR TITLE
Enforce composite.version contract in v6 with legacy compatibility path

### DIFF
--- a/configs/_schema/composite.json
+++ b/configs/_schema/composite.json
@@ -123,7 +123,6 @@
           "type": "string"
         },
         "version": {
-          "default": "1.0.0",
           "description": "Configuration version (semver)",
           "minLength": 1,
           "title": "Version",
@@ -172,6 +171,7 @@
       },
       "required": [
         "name",
+        "version",
         "seed",
         "merge"
       ],

--- a/docs/03-guides/migration-5.14-to-6.0.md
+++ b/docs/03-guides/migration-5.14-to-6.0.md
@@ -1,0 +1,31 @@
+# Migration guide: 5.14.x → 6.0.0
+
+## Composite config contract hardening
+
+BioETL 6.0.0 restores strict composite config contract validation:
+
+- `composite.version` is required by the canonical Pydantic model.
+- `configs/_schema/composite.json` is generated from the same model and now marks `version` as required.
+
+### What changed
+
+Old (legacy) configs that omit `composite.version` are no longer part of the primary contract.
+
+During a transition window, runtime still accepts them via an explicit compatibility path and emits a `DeprecationWarning`.
+
+### Required action
+
+Update every composite YAML:
+
+```yaml
+composite:
+  name: composite_publication
+  version: "1.1.0"  # required in v6+
+```
+
+## Deprecation window
+
+- Compatibility mode for missing `composite.version`: **available in 6.0.x and 6.1.x**.
+- Planned removal: **6.2.0**.
+
+After removal, configs without `composite.version` will fail validation.

--- a/docs/03-guides/pipeline-configuration.md
+++ b/docs/03-guides/pipeline-configuration.md
@@ -113,14 +113,14 @@ configs/
 
 ### Статистика конфигураций
 
-| Категория                 | Количество | Описание                               |
-| ------------------------- | ---------- | -------------------------------------- |
-| Pipeline configs (entity) | 21         | Regular ETL pipelines                  |
-| Composite configs         | 5          | Multi-provider pipelines (ADR-026)     |
+| Категория                 | Количество | Описание                                          |
+| ------------------------- | ---------- | ------------------------------------------------- |
+| Pipeline configs (entity) | 21         | Regular ETL pipelines                             |
+| Composite configs         | 5          | Multi-provider pipelines (ADR-026)                |
 | DQ configs                | 31         | 1 defaults + 7 providers + 22 entities + 1 schema |
-| Filter configs            | 8          | 1 defaults + 7 providers               |
-| Source configs            | 7          | Один на провайдера                     |
-| **Итого**                 | **71**     | Все конфиги валидированы               |
+| Filter configs            | 8          | 1 defaults + 7 providers                          |
+| Source configs            | 7          | Один на провайдера                                |
+| **Итого**                 | **71**     | Все конфиги валидированы                          |
 
 ______________________________________________________________________
 
@@ -155,7 +155,7 @@ gold_table: "chembl_activity"
 | `batch_size`          | Размер батча (1-5000)              | Нет (default: 100)   |
 | `checkpoint_interval` | Интервал checkpoint                | Нет (default: 10)    |
 | `source`              | Конфиг источника                   | Нет (auto-resolved)  |
-| `dq_overrides`            | Inline DQ переопределения          | Нет                  |
+| `dq_overrides`        | Inline DQ переопределения          | Нет                  |
 | `sink`                | Конфиги слоёв (Bronze/Silver/Gold) | Нет (auto-resolved)  |
 | `circuit_breaker`     | Настройки Circuit Breaker          | Нет (from base)      |
 | `maintenance`         | VACUUM настройки                   | Нет (from base)      |
@@ -233,6 +233,56 @@ composite:
     conflict_resolution: prefer_seed  # При конфликте — seed выигрывает
 ```
 
+### Изменение контракта в v6.0 (breaking)
+
+Начиная с **BioETL 6.0.0** поле `composite.version` снова является обязательным в основном контракте (`configs/_schema/composite.json`).
+
+**Старый формат (legacy, до v6):**
+
+```yaml
+schema_version: "2.0.0"
+composite:
+  name: composite_publication
+  # version отсутствует
+  seed:
+    pipeline: chembl_publication
+    output_keys: [publication_id, doi]
+    silver_table: silver/chembl/publication
+  enrichers:
+    - pipeline: crossref_publication
+      join_keys: [doi]
+  merge:
+    output:
+      silver: silver/composite/publication
+      gold: gold/composite/publication
+```
+
+**Новый формат (v6+):**
+
+```yaml
+schema_version: "2.0.0"
+composite:
+  name: composite_publication
+  version: "1.1.0"
+  seed:
+    pipeline: chembl_publication
+    output_keys: [publication_id, doi]
+    silver_table: silver/chembl/publication
+  enrichers:
+    - pipeline: crossref_publication
+      join_keys: [doi]
+  merge:
+    output:
+      silver: silver/composite/publication
+      gold: gold/composite/publication
+```
+
+**Migration notes**
+
+- Добавьте `composite.version` во все пользовательские composite YAML.
+- Во время перехода runtime сохраняет явную совместимость для legacy-файлов и выдаёт `DeprecationWarning`.
+- **Deprecation window:** поддержка legacy-формата удаляется в **BioETL 6.2.0**.
+
 ### Доступные Composite Pipelines
 
 | Composite               | Seed                 | Enrichers                                                           | Описание                      |
@@ -258,14 +308,14 @@ ______________________________________________________________________
 
 Пути и ссылки вычисляются автоматически из `provider` и `entity_type`:
 
-| Поле                 | Auto-computed значение                                |
-| -------------------- | ----------------------------------------------------- |
-| `source_file`        | `../../sources/{provider}.yaml`                       |
-| `dq_config_file`     | `../../quality/entities/{provider}/{entity_type}.yaml`     |
+| Поле                 | Auto-computed значение                                 |
+| -------------------- | ------------------------------------------------------ |
+| `source_file`        | `../../sources/{provider}.yaml`                        |
+| `dq_config_file`     | `../../quality/entities/{provider}/{entity_type}.yaml` |
 | `filter_config_file` | `../../filters/entities/{provider}/{entity_type}.yaml` |
-| `sink.bronze.path`   | `data/output/bronze/{provider}/{entity_type}`         |
-| `sink.silver.path`   | `data/output/silver/{provider}/{entity_type}`         |
-| `sink.gold.path`     | `data/output/gold/{provider}/{entity_type}`           |
+| `sink.bronze.path`   | `data/output/bronze/{provider}/{entity_type}`          |
+| `sink.silver.path`   | `data/output/silver/{provider}/{entity_type}`          |
+| `sink.gold.path`     | `data/output/gold/{provider}/{entity_type}`            |
 
 ### Авто-пропагация sort_by (ADR-014 compliance)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bioetl"
-version = "5.14.0"
+version = "6.0.0"
 description = "BioETL: Bioactivity data acquisition and processing pipeline"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/bioetl/__init__.py
+++ b/src/bioetl/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "5.14.0"
+__version__ = "6.0.0"
 
 # Project-wide monkeypatch for Pandera compatibility with Pandas 3.0.0 on Python 3.14
 # Registers pd.Series in Pandera's function dispatch registry to avoid KeyError.

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -35,7 +35,9 @@ from bioetl.infrastructure.config.field_group_loader import (
     load_field_groups,
 )
 from bioetl.infrastructure.locking.memory_lock import MemoryLock
-from bioetl.infrastructure.schemas.composite_config import CompositeConfigFileSchema
+from bioetl.infrastructure.schemas.composite_config import (
+    validate_composite_config_payload,
+)
 from bioetl.infrastructure.storage.delta_reader import DeltaReader
 
 if TYPE_CHECKING:
@@ -97,7 +99,7 @@ def load_composite_config(name: str) -> CompositeConfig:
 
     try:
         # Validate using Pydantic schema
-        schema = CompositeConfigFileSchema.model_validate(raw)
+        schema = validate_composite_config_payload(raw)
         # Convert to immutable domain objects
         config: CompositeConfig = schema.to_domain()
         return config

--- a/src/bioetl/infrastructure/schemas/composite_config.py
+++ b/src/bioetl/infrastructure/schemas/composite_config.py
@@ -10,9 +10,10 @@ Usage:
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from bioetl.domain.composite.aggregation import (
     AggregationConfig,
@@ -652,7 +653,7 @@ class CompositeConfigSchema(BaseModel):
 
     name: str = Field(..., min_length=1, description="Composite pipeline name")
     version: str = Field(
-        default="1.0.0", min_length=1, description="Configuration version (semver)"
+        ..., min_length=1, description="Configuration version (semver)"
     )
     seed: SeedSchema = Field(..., description="Seed pipeline configuration")
     dependencies: list[DependencySchema] = Field(
@@ -783,7 +784,57 @@ class CompositeConfigFileSchema(BaseModel):
         return self.composite.to_domain()
 
 
+class LegacyCompositeConfigSchema(CompositeConfigSchema):
+    """Legacy schema for pre-v6 composite configs.
+
+    Keeps `version` optional to support a deprecation window for historical
+    YAML files that omitted `composite.version`.
+    """
+
+    version: str = Field(
+        default="1.0.0", min_length=1, description="Configuration version (semver)"
+    )
+
+
+class LegacyCompositeConfigFileSchema(CompositeConfigFileSchema):
+    """Legacy file schema where `composite.version` may be omitted."""
+
+    composite: LegacyCompositeConfigSchema = Field(
+        ..., description="The composite pipeline configuration"
+    )
+
+
+COMPOSITE_VERSION_DEPRECATION_TARGET = "6.2.0"
+
+
+def validate_composite_config_payload(
+    payload: dict[str, Any],
+) -> CompositeConfigFileSchema:
+    """Validate composite YAML payload with explicit legacy fallback.
+
+    Runtime and generated JSON Schema both use :class:`CompositeConfigFileSchema`
+    as the canonical contract. Legacy files (missing `composite.version`) are
+    accepted only via an explicit compatibility path and emit a deprecation
+    warning until BioETL v6.2.0.
+    """
+
+    try:
+        return CompositeConfigFileSchema.model_validate(payload)
+    except ValidationError:
+        legacy_schema = LegacyCompositeConfigFileSchema.model_validate(payload)
+        warnings.warn(
+            "Composite config without 'composite.version' is deprecated and will "
+            f"be removed in BioETL {COMPOSITE_VERSION_DEPRECATION_TARGET}. "
+            "Add 'composite.version' explicitly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        normalized = legacy_schema.model_dump(mode="python")
+        return CompositeConfigFileSchema.model_validate(normalized)
+
+
 __all__ = [
+    "COMPOSITE_VERSION_DEPRECATION_TARGET",
     "AggregationFieldSchema",
     "AggregationSchema",
     "ColumnGroupSchema",
@@ -802,4 +853,5 @@ __all__ = [
     "MergeSchema",
     "RetrySchema",
     "SeedSchema",
+    "validate_composite_config_payload",
 ]

--- a/tests/integration/composite/test_composite_config_backward_compatibility.py
+++ b/tests/integration/composite/test_composite_config_backward_compatibility.py
@@ -1,0 +1,51 @@
+"""Integration checks for composite YAML backward compatibility in v6."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from bioetl.infrastructure.schemas.composite_config import (
+    CompositeConfigFileSchema,
+    validate_composite_config_payload,
+)
+
+
+def _base_composite_yaml(with_version: bool) -> str:
+    version_line = '  version: "1.0.0"\n' if with_version else ""
+    return (
+        'schema_version: "2.0.0"\n'
+        "composite:\n"
+        "  name: composite_compat_test\n"
+        f"{version_line}"
+        "  seed:\n"
+        "    pipeline: chembl_publication\n"
+        "    output_keys: [publication_id, doi]\n"
+        "    silver_table: silver/chembl/publication\n"
+        "  enrichers:\n"
+        "    - pipeline: crossref_publication\n"
+        "      join_keys: [doi]\n"
+        "  merge:\n"
+        "    output:\n"
+        "      silver: silver/composite/publication\n"
+        "      gold: gold/composite/publication\n"
+    )
+
+
+def test_new_composite_yaml_validates_against_strict_contract() -> None:
+    """New format with explicit composite.version must pass strict schema."""
+    payload = yaml.safe_load(_base_composite_yaml(with_version=True))
+
+    schema = CompositeConfigFileSchema.model_validate(payload)
+
+    assert schema.composite.version == "1.0.0"
+
+
+def test_legacy_composite_yaml_supported_with_deprecation_warning() -> None:
+    """Old format (without composite.version) stays compatible during window."""
+    payload = yaml.safe_load(_base_composite_yaml(with_version=False))
+
+    with pytest.warns(DeprecationWarning, match="composite.version"):
+        schema = validate_composite_config_payload(payload)
+
+    assert schema.composite.version == "1.0.0"


### PR DESCRIPTION
### Motivation
- Restore a strict contract for composite configs by making `composite.version` a required field in the canonical model and JSON Schema to prevent implicit contract weakening.
- Provide a safe migration path for existing users who may have legacy composite YAMLs that omit `composite.version`.
- Ensure runtime validation and generated JSON Schema come from the same Pydantic source of truth to avoid divergence between schema generation and runtime checks.

### Description
- Made `version` required on the canonical Pydantic `CompositeConfigSchema` and regenerated `configs/_schema/composite.json` so `version` appears in the `required` list for composite configs.
- Introduced `validate_composite_config_payload(payload)` as the runtime entrypoint that validates with `CompositeConfigFileSchema` and falls back to a `LegacyCompositeConfigFileSchema` when needed, emitting a `DeprecationWarning` and normalizing the payload before re-validation.
- Updated runtime loader to use the shared entrypoint by replacing direct `CompositeConfigFileSchema.model_validate` calls with `validate_composite_config_payload` in `load_composite_config` (`src/bioetl/composition/bootstrap/runtime/composite.py`).
- Bumped project major version to `6.0.0` and added documentation covering the breaking change, old/new examples, migration notes, and the deprecation window ending at `6.2.0` (`docs/03-guides/pipeline-configuration.md`, `docs/03-guides/migration-5.14-to-6.0.md`).
- Added an integration test `tests/integration/composite/test_composite_config_backward_compatibility.py` that verifies strict validation for new configs and that legacy configs without `composite.version` are accepted via the compatibility path while emitting a `DeprecationWarning`.

### Testing
- Ran schema generation with `python scripts/generate_pipeline_schema.py` and the check mode `python scripts/generate_pipeline_schema.py --check`, both succeeded and updated/verified `configs/_schema/composite.json` against the Pydantic model.
- Executed the new integration test with `pytest -q tests/integration/composite/test_composite_config_backward_compatibility.py`, which passed (`..`).
- Local pre-commit hooks (`mypy`, `bandit`) flagged unrelated baseline issues during a commit-time check; focused validation (schema generation and the integration test above) succeeded and compatibility behavior is covered by the added test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699484f21cc883248b8d1ead762e272b)