### PR TITLE
docs: formalize contract versioning, add $changelog metadata and filename↔$version checks

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -62,7 +62,9 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие критические порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
@@ -72,6 +74,7 @@
 
   > **Текущее состояние:** Все 38 портов декорированы `@runtime_checkable` (100% coverage).
   > Минимальное требование — 4 критических порта выше; остальные декорированы для единообразия.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -164,7 +167,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -244,19 +247,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -274,6 +278,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -335,6 +340,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -506,6 +512,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -922,7 +929,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1024,11 +1033,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1163,11 +1172,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1222,6 +1231,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1267,10 +1277,11 @@ ______________________________________________________________________
 
 ### 8.1. Контракты Данных (Data Contracts)
 
-- **Реестр Схем**: Gold-схемы публикуются в `docs/contracts/gold/{entity}.json` (JSON Schema).
+- **Реестр Схем**: Gold-схемы публикуются в `docs/04-reference/contracts/gold/{entity}_v{major}.{minor}.json` (JSON Schema).
 - **Версионирование**: Семантическое версионирование схем: `{entity}_v{major}.{minor}`.
   - Minor: добавление nullable полей.
   - Major: удаление/переименование полей, изменение типов.
+- **Маркировка изменений в PR**: Каждый PR с изменением контракта **MUST** явно маркировать каждое изменение как `breaking` или `non-breaking` (в описании PR/чеклисте).
 - **Уведомление о Breaking Change**:
   1. PR с изменением Gold-схемы **MUST** иметь лейбл `breaking-change`.
   1. CI генерирует diff схемы и постит в Slack-канал `#bioetl-contracts`.
@@ -1352,20 +1363,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1397,14 +1408,14 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
@@ -1535,7 +1546,7 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 
 ## История Изменений (Changelog)
 

--- a/docs/04-reference/contracts/CHANGELOG.md
+++ b/docs/04-reference/contracts/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Contracts Changelog
+
+## 1.0.0
+
+- Initial publication of Gold contracts in `docs/04-reference/contracts/gold/`.

--- a/docs/04-reference/contracts/README.md
+++ b/docs/04-reference/contracts/README.md
@@ -1,0 +1,22 @@
+# Contract Versioning Rules
+
+## Change classification
+
+- **MAJOR**: rename/remove field, type narrowing, changing field from nullable to non-nullable.
+- **MINOR**: additive nullable fields, non-breaking enum extensions.
+- **PATCH**: description/example/editorial updates with no schema compatibility impact.
+
+## Mandatory metadata in JSON contracts
+
+Every contract JSON file **MUST** include:
+
+- `$version` — semantic version of the contract.
+- `$changelog` — link to contract changelog entry.
+
+## Filename/version sync
+
+Contract filenames use `*_vX.Y.json` and **MUST** be synchronized with `$version`:
+
+- `*_v1.0.json` → `$version: "1.0.0"`
+- `*_v1.1.json` → `$version: "1.1.0"`
+- `*_v2.3.json` → `$version: "2.3.0"`

--- a/docs/04-reference/contracts/gold/chembl_activity_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_activity_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Activity Gold Contract",
   "description": "Gold layer data contract for ChEMBL Activity Gold Contract. Auto-generated from Pandera schema ChEMBLActivityGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_assay_parameters_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_assay_parameters_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Assay Parameters Gold Contract",
   "description": "Gold layer data contract for ChEMBL Assay Parameters Gold Contract. Auto-generated from Pandera schema ChEMBLAssayParametersGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_assay_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_assay_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Assay Gold Contract",
   "description": "Gold layer data contract for ChEMBL Assay Gold Contract. Auto-generated from Pandera schema ChEMBLAssayGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_cell_line_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_cell_line_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Cell Line Gold Contract",
   "description": "Gold layer data contract for ChEMBL Cell Line Gold Contract. Auto-generated from Pandera schema ChEMBLCellLineGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_compound_record_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_compound_record_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Compound Record Gold Contract",
   "description": "Gold layer data contract for ChEMBL Compound Record Gold Contract. Auto-generated from Pandera schema ChEMBLCompoundRecordGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_document_similarity_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_document_similarity_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Document Similarity Gold Contract",
   "description": "Gold layer data contract for ChEMBL Document Similarity Gold Contract. Auto-generated from Pandera schema ChEMBLDocumentSimilarityGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_document_term_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_document_term_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Document Term Gold Contract",
   "description": "Gold layer data contract for ChEMBL Document Term Gold Contract. Auto-generated from Pandera schema ChEMBLDocumentTermGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_document_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_document_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Document Gold Contract",
   "description": "Gold layer data contract for ChEMBL Document Gold Contract. Auto-generated from Pandera schema ChEMBLDocumentGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_molecule_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_molecule_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Molecule Gold Contract",
   "description": "Gold layer data contract for ChEMBL Molecule Gold Contract. Auto-generated from Pandera schema ChEMBLMoleculeGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_protein_class_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_protein_class_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Protein Class Gold Contract",
   "description": "Gold layer data contract for ChEMBL Protein Class Gold Contract. Auto-generated from Pandera schema ChEMBLProteinClassGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_target_component_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_target_component_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Target Component Gold Contract",
   "description": "Gold layer data contract for ChEMBL Target Component Gold Contract. Auto-generated from Pandera schema ChEMBLTargetComponentGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/chembl_target_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_target_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "ChEMBL Target Gold Contract",
   "description": "Gold layer data contract for ChEMBL Target Gold Contract. Auto-generated from Pandera schema ChEMBLTargetGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/composite_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/composite_publication_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "Composite Publication Gold Contract",
   "description": "Gold layer data contract for Composite Publication. Merged multi-source entity combining chembl_publication (seed) with crossref, openalex, pubmed, and semanticscholar enrichers. Uses qualified column names ({provider}.{entity}.{field}) for enricher fields.",
   "type": "object",
@@ -31,7 +32,10 @@
       "description": "Run type (incremental/full)"
     },
     "_source_batch_id": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Source batch identifier"
     },
     "_ingestion_ts": {
@@ -43,15 +47,24 @@
       "description": "Record index within batch"
     },
     "_source": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Original data source (seed provider)"
     },
     "_lookup_method": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Lookup method used: direct, doi, pmid, title_fallback"
     },
     "_original_id": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Original identifier used for lookup"
     },
     "_composite_run_id": {

--- a/docs/04-reference/contracts/gold/crossref_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/crossref_publication_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "CrossRef Publication Gold Contract",
   "description": "Gold layer data contract for CrossRef Publication Gold Contract. Auto-generated from Pandera schema CrossRefPublicationGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/openalex_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/openalex_publication_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "OpenAlex Publication Gold Contract",
   "description": "Gold layer data contract for OpenAlex Publication Gold Contract. Auto-generated from Pandera schema OpenAlexPublicationGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/pubchem_compound_v1.0.json
+++ b/docs/04-reference/contracts/gold/pubchem_compound_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "PubChem Compound Gold Contract",
   "description": "Gold layer data contract for PubChem Compound Gold Contract. Auto-generated from Pandera schema PubChemCompoundGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/pubmed_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/pubmed_publication_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "PubMed Publication Gold Contract",
   "description": "Gold layer data contract for PubMed Publication Gold Contract. Auto-generated from Pandera schema PubMedPublicationGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/semanticscholar_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/semanticscholar_publication_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "Semantic Scholar Publication Gold Contract",
   "description": "Gold layer data contract for Semantic Scholar Publication Gold Contract. Auto-generated from Pandera schema SemanticScholarPublicationGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/uniprot_idmapping_v1.0.json
+++ b/docs/04-reference/contracts/gold/uniprot_idmapping_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "UniProt ID Mapping Gold Contract",
   "description": "Gold layer data contract for UniProt ID Mapping Gold Contract. Auto-generated from Pandera schema UniProtIDMappingGoldSchema.",
   "type": "object",

--- a/docs/04-reference/contracts/gold/uniprot_protein_v1.0.json
+++ b/docs/04-reference/contracts/gold/uniprot_protein_v1.0.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$version": "1.0.0",
+  "$changelog": "../CHANGELOG.md#100",
   "title": "UniProt Protein Gold Contract",
   "description": "Gold layer data contract for UniProt Protein Gold Contract. Auto-generated from Pandera schema UniProtProteinGoldSchema.",
   "type": "object",

--- a/tests/architecture/test_gold_schema_contracts.py
+++ b/tests/architecture/test_gold_schema_contracts.py
@@ -7,6 +7,7 @@ See docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,7 @@ REQUIRED_SCHEMAS = (
 REQUIRED_SCHEMA_PROPERTIES = {
     "$schema",
     "$version",
+    "$changelog",
     "title",
     "description",
     "type",
@@ -197,4 +199,46 @@ class TestGoldSchemaContracts:
             "Unversioned schema files found:\n"
             + "\n".join(f"  - {s}" for s in sorted(unversioned))
             + "\n\nAll Gold contracts must include version (e.g., entity_v1.0.json)."
+        )
+
+    @pytest.mark.parametrize("schema_name", sorted(REQUIRED_SCHEMAS))
+    def test_filename_version_matches_schema_version(
+        self, contracts_path: Path, schema_name: str
+    ) -> None:
+        """Filename version MUST match $version in schema."""
+        schema_path = contracts_path / schema_name
+
+        if not schema_path.exists():
+            pytest.skip(f"Schema {schema_name} not found (covered by existence test)")
+
+        match = re.search(r"_v(\d+)\.(\d+)\.json$", schema_name)
+        assert match, (
+            f"Schema filename does not follow *_vX.Y.json pattern: {schema_name}"
+        )
+
+        with schema_path.open() as f:
+            schema = json.load(f)
+
+        expected_version = f"{match.group(1)}.{match.group(2)}.0"
+        assert schema.get("$version") == expected_version, (
+            f"{schema_name} has $version={schema.get('$version')}, "
+            f"expected {expected_version} from filename"
+        )
+
+    @pytest.mark.parametrize("schema_name", sorted(REQUIRED_SCHEMAS))
+    def test_schema_has_changelog_link(
+        self, contracts_path: Path, schema_name: str
+    ) -> None:
+        """Each schema MUST contain changelog link metadata."""
+        schema_path = contracts_path / schema_name
+
+        if not schema_path.exists():
+            pytest.skip(f"Schema {schema_name} not found (covered by existence test)")
+
+        with schema_path.open() as f:
+            schema = json.load(f)
+
+        changelog = schema.get("$changelog")
+        assert isinstance(changelog, str) and changelog.strip(), (
+            f"{schema_name} missing non-empty $changelog link"
         )


### PR DESCRIPTION
### Motivation

- Introduce clear semantic-versioning and change-classification rules for Gold JSON contracts to reduce accidental breaking changes. 
- Ensure each contract carries machine-readable metadata (`$version`, changelog link) and that filenames remain authoritative and consistent with schema version. 
- Require explicit labeling of contract changes in PRs so reviewers and CI can identify breaking vs non-breaking edits.

### Description

- Added `docs/04-reference/contracts/README.md` describing MAJOR/MINOR/PATCH change classification, required `$version` and `$changelog` metadata, and filename/version synchronization rules. 
- Added `docs/04-reference/contracts/CHANGELOG.md` and injected `$changelog` into all Gold JSON contracts under `docs/04-reference/contracts/gold/` (20 files updated). 
- Updated `docs/00-project/RULES.md` (Contract Governance) to require explicit per-change marking in PRs as `breaking` or `non-breaking`. 
- Extended `tests/architecture/test_gold_schema_contracts.py` to require `$changelog` in schemas and to validate filename pattern `*_vX.Y.json` and that the filename-derived version matches the schema `$version` (e.g. `v1.0` → `$version: "1.0.0"`).

### Testing

- Ran Python byte-compile check for the modified test file with `python -m compileall tests/architecture/test_gold_schema_contracts.py`, which succeeded. 
- Executed a verification script that inspected all `docs/04-reference/contracts/gold/*_v*.json` files to confirm presence of `$version` and `$changelog` and that filename `vX.Y` maps to `$version` `X.Y.0`, which reported OK for 20 files. 
- Attempted `pytest tests/architecture/test_gold_schema_contracts.py` but test run was blocked in this environment due to a pytest configuration/plugin warning (`Unknown config option: asyncio_default_fixture_loop_scope`), so the full pytest run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489f4027c8324b77b5f96851401cf)