### PR TITLE
Add ChEMBL tissue/subcellular Gold contracts and completeness guard to contract generator

### DIFF
--- a/docs/04-reference/contracts/gold/chembl_subcellular_fraction_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_subcellular_fraction_v1.0.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$version": "1.0.0",
+  "title": "ChEMBL Subcellular Fraction Gold Contract",
+  "description": "Gold layer data contract for ChEMBL Subcellular Fraction Gold Contract. Auto-generated from Pandera schema ChEMBLSubcellularFractionGoldSchema.",
+  "type": "object",
+  "properties": {
+    "entity_id": {
+      "type": "string"
+    },
+    "content_hash": {
+      "type": "string"
+    },
+    "subcellular_fraction": {
+      "type": "string"
+    },
+    "assay_count": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "example_assay_chembl_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "_run_id": {
+      "type": "string"
+    },
+    "_run_type": {
+      "type": "string"
+    },
+    "_source_batch_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "_ingestion_ts": {
+      "type": "string"
+    },
+    "_index": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "_index",
+    "_ingestion_ts",
+    "_run_id",
+    "_run_type",
+    "content_hash",
+    "entity_id",
+    "subcellular_fraction"
+  ]
+}

--- a/docs/04-reference/contracts/gold/chembl_tissue_v1.0.json
+++ b/docs/04-reference/contracts/gold/chembl_tissue_v1.0.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$version": "1.0.0",
+  "title": "ChEMBL Tissue Gold Contract",
+  "description": "Gold layer data contract for ChEMBL Tissue Gold Contract. Auto-generated from Pandera schema ChEMBLTissueGoldSchema.",
+  "type": "object",
+  "properties": {
+    "tissue_chembl_id": {
+      "type": "string"
+    },
+    "pref_name": {
+      "type": "string"
+    },
+    "bto_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "caloha_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "efo_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "uberon_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "_run_id": {
+      "type": "string"
+    },
+    "_run_type": {
+      "type": "string"
+    },
+    "_source_batch_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "_ingestion_ts": {
+      "type": "string"
+    },
+    "_index": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "_index",
+    "_ingestion_ts",
+    "_run_id",
+    "_run_type",
+    "pref_name",
+    "tissue_chembl_id"
+  ]
+}

--- a/src/tools/scripts/generate_contracts.py
+++ b/src/tools/scripts/generate_contracts.py
@@ -1,58 +1,164 @@
 #!/usr/bin/env python3
-"""
-Generate JSON Schema contracts from Pandera models.
-Usage: python scripts/generate_contracts.py
-"""
+"""Generate versioned Gold JSON contracts from Pandera schemas."""
 
+from __future__ import annotations
+
+import inspect
 import json
 import sys
 from pathlib import Path
 
 # Ensure project root is in python path
-project_root = Path(__file__).resolve().parent.parent
+project_root = Path(__file__).resolve().parents[3]
 sys.path.append(str(project_root / "src"))
 
-try:
-    from bioetl.interfaces.contracts import (
-        ChEMBLActivityGoldSchema,
-        PubChemCompoundGoldSchema,
-        PubMedPublicationGoldSchema,
-        UniProtProteinGoldSchema,
-    )
-except ImportError as e:
-    print(f"Error importing schemas: {e}")
-    sys.exit(1)
+from bioetl.domain.contracts import gold as gold_contracts  # noqa: E402
 
-CONTRACTS_DIR = project_root / "docs" / "contracts"
-
-ENTITY_SCHEMA_MAP = {
-    "chembl_activity": ChEMBLActivityGoldSchema,
-    "pubchem_compound": PubChemCompoundGoldSchema,
-    "uniprot_protein": UniProtProteinGoldSchema,
-    "pubmed_publication": PubMedPublicationGoldSchema,
-}
+CONTRACTS_DIR = project_root / "docs" / "04-reference" / "contracts" / "gold"
+SCHEMA_SUFFIX = "GoldSchema"
+PROVIDER_PREFIXES = (
+    ("ChEMBL", "chembl"),
+    ("PubChem", "pubchem"),
+    ("PubMed", "pubmed"),
+    ("UniProt", "uniprot"),
+    ("CrossRef", "crossref"),
+    ("OpenAlex", "openalex"),
+    ("SemanticScholar", "semanticscholar"),
+    ("Composite", "composite"),
+)
 
 
-def generate_contracts():
+def to_contract_stem(schema_name: str) -> str:
+    """Convert a Gold schema class name to a contract file stem."""
+    if not schema_name.endswith(SCHEMA_SUFFIX):
+        raise ValueError(f"Schema class {schema_name} must end with {SCHEMA_SUFFIX}")
+
+    base_name = schema_name.removesuffix(SCHEMA_SUFFIX)
+
+    for class_prefix, file_prefix in PROVIDER_PREFIXES:
+        if base_name.startswith(class_prefix):
+            suffix = base_name.removeprefix(class_prefix)
+            if not suffix:
+                return file_prefix
+            return f"{file_prefix}_{_camel_to_snake(suffix)}"
+
+    raise ValueError(f"Unsupported schema class prefix in {schema_name}")
+
+
+def _camel_to_snake(value: str) -> str:
+    """Convert CamelCase to snake_case while preserving IDMapping as one token."""
+    value = value.replace("IDMapping", "Idmapping")
+
+    chunks: list[str] = []
+    current_chunk = ""
+    for char in value:
+        if char.isupper() and current_chunk:
+            chunks.append(current_chunk)
+            current_chunk = char
+        else:
+            current_chunk += char
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return "_".join(chunk.lower() for chunk in chunks)
+
+
+def _type_to_json_type(dtype: object) -> str:
+    """Map Pandera dtype to JSON schema scalar type."""
+    dtype_name = str(dtype).lower()
+    if "int" in dtype_name:
+        return "integer"
+    if "float" in dtype_name or "double" in dtype_name:
+        return "number"
+    if "bool" in dtype_name:
+        return "boolean"
+    return "string"
+
+
+def _stem_to_title(stem: str) -> str:
+    parts = []
+    for part in stem.split("_"):
+        if part == "chembl":
+            parts.append("ChEMBL")
+        else:
+            parts.append(part.capitalize())
+    return " ".join(parts)
+
+
+def get_gold_schema_classes() -> dict[str, type]:
+    """Discover all schema classes exported by bioetl.domain.contracts.gold."""
+    schema_classes: dict[str, type] = {}
+
+    for export_name in gold_contracts.__all__:
+        exported_obj = getattr(gold_contracts, export_name)
+        if inspect.isclass(exported_obj) and export_name.endswith(SCHEMA_SUFFIX):
+            schema_classes[export_name] = exported_obj
+
+    return schema_classes
+
+
+def build_contract(schema_cls: type, contract_stem: str) -> dict[str, object]:
+    """Build a record-level JSON contract from a Pandera DataFrameModel class."""
+    pandera_schema = schema_cls.to_schema()  # type: ignore[attr-defined]
+
+    properties: dict[str, dict[str, object]] = {}
+    required: list[str] = []
+
+    for column_name, column in pandera_schema.columns.items():
+        json_type = _type_to_json_type(column.dtype)
+        if column.nullable:
+            properties[column_name] = {"type": [json_type, "null"]}
+        else:
+            properties[column_name] = {"type": json_type}
+            required.append(column_name)
+
+    title = f"{_stem_to_title(contract_stem)} Gold Contract"
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$version": "1.0.0",
+        "title": title,
+        "description": (
+            f"Gold layer data contract for {title}. "
+            f"Auto-generated from Pandera schema {schema_cls.__name__}."
+        ),
+        "type": "object",
+        "properties": properties,
+        "required": sorted(required),
+    }
+
+
+def generate_contracts() -> None:
+    """Generate JSON contract files for every exported Gold schema class."""
     CONTRACTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    for entity, schema_cls in ENTITY_SCHEMA_MAP.items():
-        print(f"Generating contract for {entity}...")
-        try:
-            # Generate JSON Schema
-            json_schema = schema_cls.to_json_schema()
+    schema_classes = get_gold_schema_classes()
 
-            # Save to file
-            output_file = CONTRACTS_DIR / f"{entity}_gold.json"
-            with output_file.open("w", encoding="utf-8") as f:
-                json.dump(json_schema, f, indent=2)
-            print(f"  -> Saved to {output_file}")
+    for schema_name, schema_cls in sorted(schema_classes.items()):
+        contract_stem = to_contract_stem(schema_name)
+        contract_name = f"{contract_stem}_v1.0.json"
+        output_file = CONTRACTS_DIR / contract_name
 
-        except Exception as e:
-            print(f"Failed to generate contract for {entity}: {e}")
-            sys.exit(1)
+        print(f"Generating contract for {schema_name} -> {contract_name}...")
+        contract = build_contract(schema_cls, contract_stem)
 
-    print("\nAll contracts generated successfully.")
+        with output_file.open("w", encoding="utf-8") as handle:
+            json.dump(contract, handle, indent=2)
+            handle.write("\n")
+
+    generated_contracts = sorted(CONTRACTS_DIR.glob("*.json"))
+    if len(generated_contracts) != len(schema_classes):
+        raise RuntimeError(
+            "Gold contract completeness check failed: "
+            f"generated {len(generated_contracts)} JSON files, "
+            f"but found {len(schema_classes)} schema classes in "
+            "bioetl.domain.contracts.gold.__all__."
+        )
+
+    print(
+        f"\nGenerated {len(generated_contracts)} Gold contracts successfully "
+        f"in {CONTRACTS_DIR}."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/architecture/test_gold_schema_contracts.py
+++ b/tests/architecture/test_gold_schema_contracts.py
@@ -30,6 +30,8 @@ REQUIRED_SCHEMAS = (
     "chembl_protein_class_v1.0.json",
     "chembl_target_v1.0.json",
     "chembl_target_component_v1.0.json",
+    "chembl_tissue_v1.0.json",
+    "chembl_subcellular_fraction_v1.0.json",
     "crossref_publication_v1.0.json",
     "openalex_publication_v1.0.json",
     "pubchem_compound_v1.0.json",
@@ -181,6 +183,26 @@ class TestGoldSchemaContracts:
             f"{schema_name} missing lineage fields:\n"
             + "\n".join(f"  - {f}" for f in sorted(missing_lineage))
             + "\n\nLineage fields are required per RULES.md §2.4."
+        )
+
+    def test_contract_count_matches_gold_schema_exports(
+        self, schema_files: dict[str, Path]
+    ) -> None:
+        """Number of contracts must match number of exported Gold schema classes."""
+        from bioetl.domain.contracts import gold as gold_contracts
+
+        exported_schema_count = sum(
+            1
+            for export_name in gold_contracts.__all__
+            if export_name.endswith("GoldSchema")
+        )
+
+        assert len(schema_files) == exported_schema_count, (
+            "Gold contract completeness mismatch: "
+            f"found {len(schema_files)} JSON contracts in {CONTRACTS_DIR}, "
+            "but "
+            f"{exported_schema_count} schema classes are exported by "
+            "bioetl.domain.contracts.gold.__init__.py."
         )
 
     def test_no_extra_schemas_without_version(


### PR DESCRIPTION
### Motivation
- Ensure the Gold contract exporter publishes the two missing ChEMBL provider contracts (`ChEMBLTissueGoldSchema`, `ChEMBLSubcellularFractionGoldSchema`) so documentation and downstream consumers have full coverage. 
- Keep `docs/04-reference/contracts/gold/` aligned with the domain `*GoldSchema` exports by generating deterministic, versioned JSON Schema files. 
- Detect regressions early by adding a completeness check that compares generated JSON files to the set of exported Gold schema classes.

### Description
- Rewrote `src/tools/scripts/generate_contracts.py` to dynamically discover all exported `*GoldSchema` classes from `bioetl.domain.contracts.gold`, map class names to stable contract file stems, and emit record-level JSON contracts with `$schema`, `$version`, `title`, `description`, `type`, `properties`, and `required` fields. 
- Implemented class-name → filename conversion and `_camel_to_snake` logic plus Pandera-to-JSON-type mapping so filenames follow the existing `*_v1.0.json` convention and types map sensibly. 
- Added a completeness guard to the generator that raises if the number of generated JSON files does not match the number of exported `*GoldSchema` classes. 
- Added two generated JSON contract files: `docs/04-reference/contracts/gold/chembl_tissue_v1.0.json` and `docs/04-reference/contracts/gold/chembl_subcellular_fraction_v1.0.json`, and updated `tests/architecture/test_gold_schema_contracts.py` to include them and to add a test that verifies the contract count equals exported schema classes.

### Testing
- Ran `pytest tests/architecture/test_gold_schema_contracts.py` which completed successfully with `108 passed`. 
- Executed the updated contract generator end-to-end which reported generation of the expected contracts and completed with the completeness check satisfied. 
- Static checks on the modified script succeeded: `ruff` (style) and `mypy` (type checks) ran and passed for `src/tools/scripts/generate_contracts.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489bafe688324bc47d86b8a3be873)