### PR TITLE
docs: formalize Gold contract versioning and breaking-change policy

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -1,6 +1,6 @@
 # BioETL: Правила Проекта
 
-*Версия: 5.19 (Statistics Update), 2026-02-16*
+*Версия: 5.21 (Data Contracts Policy Update), 2026-02-17*
 
 ## Введение (Quick Reference)
 
@@ -1267,12 +1267,19 @@ ______________________________________________________________________
 
 ### 8.1. Контракты Данных (Data Contracts)
 
-- **Реестр Схем**: Gold-схемы публикуются в `docs/contracts/gold/{entity}.json` (JSON Schema).
-- **Версионирование**: Семантическое версионирование схем: `{entity}_v{major}.{minor}`.
-  - Minor: добавление nullable полей.
-  - Major: удаление/переименование полей, изменение типов.
+- **Реестр Схем**: Gold-схемы публикуются в `docs/04-reference/contracts/gold/{entity}_v{semver}.json` (JSON Schema).
+- **Policy генерации**: JSON-контракты в `docs/04-reference/contracts/gold` **MUST** генерироваться автоматически (CI/генератор) и **MUST NOT** редактироваться вручную.
+- **Версионирование**: Семантическое версионирование схем (`MAJOR.MINOR.PATCH`) с классификацией изменений:
+
+| Версия | Тип изменения |
+| --- | --- |
+| **MAJOR** | rename/remove field, type narrowing, nullable `true→false` |
+| **MINOR** | add nullable field, description-only additions |
+| **PATCH** | non-semantic formatting/fixes |
+
 - **Уведомление о Breaking Change**:
-  1. PR с изменением Gold-схемы **MUST** иметь лейбл `breaking-change`.
+  1. MAJOR-изменение Gold-контракта **MUST** иметь PR-label `breaking-change`.
+  1. MAJOR-изменение **MUST** включать `Migration Notes` в описании PR (план перехода, сроки депрекации, действия для consumer-команд).
   1. CI генерирует diff схемы и постит в Slack-канал `#bioetl-contracts`.
   1. Период депрекации: 2 недели до удаления поля.
 - **Consumer Tests**: Потребители могут подписаться на `contracts/` и запускать свои тесты при изменениях.
@@ -1539,6 +1546,7 @@ fields:
 
 ## История Изменений (Changelog)
 
+- **5.21** (2026-02-17): Data Contracts Policy Update. В §8.1 обновлён путь реестра Gold-контрактов на `docs/04-reference/contracts/gold/{entity}_v{semver}.json`, зафиксирована policy автогенерации (manual edits prohibited), добавлена MAJOR/MINOR/PATCH матрица и обязательные PR label + Migration Notes для MAJOR-изменений.
 - **5.20** (2026-02-17): Audit Sync. Future annotations (497→501, 93.8%). Тест-функций (`def test_`): ~9,442; параметризованных кейсов (`pytest --collect-only`): ~11,985. Python-файлов (~1,114→~1,161). Исправлен .importlinter gap (infrastructure→composition). Архивирован orphaned ADR-030. TYPE-002 `Any` justification — 21 инстанс.
 - **5.19** (2026-02-16): Documentation Sync. Файлов кода (517→534), future annotations (481→497, 93.1%). ADR-034 (Schema↔Domain Configuration Pairs) добавлен в реестр. Тестов (~7,090→~11,985). Python-файлов (~1,094→~1,114). Синхронизация 00-map.md, CLAUDE.md, 00-overview.md, decisions/README.md.
 - **5.18** (2026-02-15): Statistics Update. Обновлены числовые данные по результатам аудита 2026-02-14: файлов кода (499→517), future annotations (468→481), Int→Float coercion occurrences (~34→~88), publication field groups (94→106), LOC для ChemblAdapter (517→975), GoldWriter (593→946), PreflightService (527→818).


### PR DESCRIPTION
### Motivation

- Clarify where Gold JSON schema contracts live and enforce a generation policy to avoid manual edits and drift.  
- Provide an explicit semantic-versioning classification for schema changes to make breaking vs non-breaking edits unambiguous.  
- Strengthen governance for breaking (MAJOR) changes by requiring a PR label and migration guidance so consumers can prepare.  

### Description

- Updated `docs/00-project/RULES.md` §8.1 to point the Gold contract registry to `docs/04-reference/contracts/gold/{entity}_v{semver}.json`.  
- Added an explicit `MUST`/`MUST NOT` policy that JSON files in `docs/04-reference/contracts/gold` are auto-generated and must not be edited manually.  
- Added a `MAJOR/MINOR/PATCH` matrix classifying changes (MAJOR: rename/remove field, type narrowing, nullable `true→false`; MINOR: add nullable field, description-only additions; PATCH: formatting/fixes).  
- Required that MAJOR changes include PR-label `breaking-change` and a `Migration Notes` section in the PR description, and bumped the RULES document version to `5.21` with a changelog entry.  

### Testing

- Verified presence and content of edits with `rg` to find updated keywords and locations, which succeeded.  
- Reviewed diffs using `git diff -- docs/00-project/RULES.md` to confirm the exact changes, which succeeded.  
- Pre-commit checks were exercised during commit and reported failures: `mdformat` flagged formatting adjustments, `pip-audit` was not available in the environment, and `check-root-vcr-cassettes` detected existing root-level VCR files; these checks failed and require follow-up but are unrelated to the documentation semantics changed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489c497988324b2e970fd813efc0d)