### PR TITLE
Enforce explicit Gold write-mode matrix and add SCD2 scd_config + migration guidance

### DIFF
--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -32,7 +32,8 @@ filter_batch_size: 20
 # -----------------------------------------------------------------------------
 sink:
   silver: {}
-  gold: {}
+  gold:
+    mode: overwrite
 
 # -----------------------------------------------------------------------------
 # DQ Overrides (applied on top of entity DQ config)

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -53,4 +53,11 @@ dq_overrides:
 sink:
   silver:
     partition_by: ["assay_type"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["assay_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -37,4 +37,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["type"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["assay_param_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -35,4 +35,11 @@ gold_table: "chembl_cell_line"
 sink:
   bronze: {}
   silver: {}
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["cell_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -38,4 +38,11 @@ gold_table: "chembl_compound_record"
 sink:
   bronze: {}
   silver: {}
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["record_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -96,4 +96,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["molecule_type"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["molecule_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -41,4 +41,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["class_level"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["protein_class_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -57,4 +57,11 @@ sink:
     partition_by: ["doc_type"]
     flat_structure: true  # Delta directly in path, files named {table}_*.ext
   gold:
+    mode: scd2
+    scd_config:
+      business_key: ["publication_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version
     flat_structure: true  # Delta directly in path, files named {table}_*.ext

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -42,4 +42,5 @@ sink:
   bronze: {}
   silver:
     partition_by: []  # No good partition key
-  gold: {}
+  gold:
+    mode: overwrite

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -45,4 +45,5 @@ sink:
   bronze: {}
   silver:
     partition_by: ["term_type"]
-  gold: {}
+  gold:
+    mode: overwrite

--- a/configs/pipelines/chembl/subcellular_fraction.yaml
+++ b/configs/pipelines/chembl/subcellular_fraction.yaml
@@ -44,4 +44,11 @@ gold_table: "chembl_subcellular_fraction"
 sink:
   bronze: {}
   silver: {}
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["entity_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -67,4 +67,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["target_type"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["target_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -36,4 +36,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["organism"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["component_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/chembl/tissue.yaml
+++ b/configs/pipelines/chembl/tissue.yaml
@@ -22,4 +22,11 @@ gold_table: "chembl_tissue"
 sink:
   bronze: {}
   silver: {}
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["tissue_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -52,4 +52,11 @@ sink:
   silver:
     flat_structure: true
   gold:
+    mode: scd2
+    scd_config:
+      business_key: ["doi"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version
     flat_structure: true

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -59,4 +59,11 @@ sink:
     partition_by: ["year"]
     flat_structure: true
   gold:
+    mode: scd2
+    scd_config:
+      business_key: ["openalex_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version
     flat_structure: true

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -96,4 +96,11 @@ sink:
   bronze: {}
   silver:
     partition_by: ["batch_date"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["molecule_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/pubmed/publication.yaml
+++ b/configs/pipelines/pubmed/publication.yaml
@@ -51,4 +51,11 @@ sink:
     partition_by: ["pub_year"]
     flat_structure: true
   gold:
+    mode: scd2
+    scd_config:
+      business_key: ["pmid"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version
     flat_structure: true

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -54,4 +54,11 @@ sink:
     partition_by: ["year"]
     flat_structure: true
   gold:
+    mode: scd2
+    scd_config:
+      business_key: ["paper_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version
     flat_structure: true

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -62,4 +62,11 @@ sink:
     # NOTE: enabled: false is not yet implemented in code, so Bronze is still written
   silver:
     partition_by: []  # No partitioning - small dataset
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["target_id"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -24,4 +24,11 @@ gold_table: "uniprot_protein"
 sink:
   silver:
     partition_by: ["organism"]
-  gold: {}
+  gold:
+    mode: scd2
+    scd_config:
+      business_key: ["accession"]
+      valid_from: valid_from
+      valid_to: valid_to
+      is_current: is_current
+      version: version

--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -1,6 +1,6 @@
 # BioETL: Правила Проекта
 
-*Версия: 5.19 (Statistics Update), 2026-02-16*
+*Версия: 5.20 (Gold Write Modes & SCD2 Matrix), 2026-02-17*
 
 ## Введение (Quick Reference)
 
@@ -62,7 +62,9 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие критические порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
@@ -72,6 +74,7 @@
 
   > **Текущее состояние:** Все 38 портов декорированы `@runtime_checkable` (100% coverage).
   > Минимальное требование — 4 критических порта выше; остальные декорированы для единообразия.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -152,6 +155,46 @@ class MyAdapter:
 - **APPEND**: Добавление новых партиций (для timeseries данных).
 - **SCD2**: Slowly Changing Dimensions Type 2 (историчность). Требует `scd_config` (ключи, valid_from/to).
 
+##### 2.1.2.a. Матрица выбора режима записи Gold (MUST)
+
+Выбор `sink.gold.mode` **MUST** быть явно зафиксирован в pipeline config. Запрещено полагаться на неявный дефолт из `_base.yaml`.
+
+| Класс сущности                                          | Примеры                                                                                                     | Режим Gold                                          | Требование                     |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------ |
+| Справочники (reference/master data)                     | `chembl_target`, `chembl_assay`, `chembl_molecule`, `chembl_cell_line`, `chembl_tissue`, `uniprot_protein`  | `scd2`                                              | **MUST**                       |
+| Publication metadata                                    | `*_publication` (ChEMBL, CrossRef, OpenAlex, PubMed, SemanticScholar, composite publication)                | `scd2`                                              | **MUST**                       |
+| Медленно меняющиеся сущности (slowly evolving entities) | `pubchem_compound`, `chembl_compound_record`, `chembl_protein_class`, `chembl_target_component`             | `scd2`                                              | **MUST**                       |
+| Факты/агрегаты и производные скоринги                   | `chembl_activity`, `chembl_publication_term`, `chembl_publication_similarity`, materialized aggregate views | `overwrite` (или `append` для истинного timeseries) | **MAY** (`overwrite`/`append`) |
+
+Для `sink.gold.mode: scd2` блок `scd_config` **MUST** содержать поля:
+
+- `valid_from`
+- `valid_to`
+- `is_current`
+- `version`
+
+`business_key` **SHOULD** быть указан и совпадать с `primary_keys` сущности.
+
+##### 2.1.2.b. Backfill/Migration для перехода `overwrite -> scd2` (Delta)
+
+Для сущностей, переводимых с `overwrite` на `scd2`, миграция **MUST** выполняться отдельным `backfill`/`rebuild` запуском:
+
+1. **Freeze writes**: остановить incremental writer и взять `:exclusive` lock для сущности.
+1. **Schema prep**: добавить SCD-колонки (`valid_from`, `valid_to`, `is_current`, `version`) в Gold (schema evolution).
+1. **Bootstrap current snapshot**: загрузить текущий срез как базовую версию:
+   - `valid_from = <migration_ts>`
+   - `valid_to = null`
+   - `is_current = true`
+   - `version = 1`
+1. **Historical replay (если доступен)**: последовательно переиграть исторические Silver-срезы, закрывая предыдущие версии (`valid_to`) и инкрементируя `version`.
+1. **SCD2 invariants check**:
+   - ровно одна `is_current=true` запись на `business_key`,
+   - нет пересечений интервалов `valid_from/valid_to`,
+   - `version` монотонно растёт.
+1. **Cutover**: переключить `sink.gold.mode` на `scd2` и выполнить первый incremental run.
+
+Если исторический replay недоступен, разрешён bootstrap только от текущего среза при обязательной фиксации ограничения в ADR/PR (история до `migration_ts` недоступна).
+
 ### 2.1.3. Инфраструктура Delta Lake
 
 См. [ADR-001](02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md).
@@ -164,7 +207,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -244,19 +287,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -274,6 +318,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -335,6 +380,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -506,6 +552,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -922,7 +969,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1024,11 +1073,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1163,11 +1212,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1222,6 +1271,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1352,20 +1402,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1397,14 +1447,14 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
@@ -1535,7 +1585,7 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 
 ## История Изменений (Changelog)
 

--- a/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
+++ b/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
@@ -21,6 +21,7 @@ Gold-слой должен гарантировать качество данн�
 @dataclass(frozen=True)
 class PipelineConfig:
     """Конфигурация пайплайна."""
+
     name: str
     provider: str
     entity: str
@@ -30,11 +31,11 @@ class PipelineConfig:
 
 **Правила валидации:**
 
-| Условие | `strict_gold_validation=True` | `strict_gold_validation=False` |
-|---------|-------------------------------|--------------------------------|
-| `gold_schema=None` | `SchemaValidationError` (FAIL) | Warning в лог |
-| Несоответствие типов | `SchemaValidationError` (FAIL) | Warning + пропуск записи |
-| Отсутствующие поля | `SchemaValidationError` (FAIL) | Warning + `None` значение |
+| Условие              | `strict_gold_validation=True`  | `strict_gold_validation=False` |
+| -------------------- | ------------------------------ | ------------------------------ |
+| `gold_schema=None`   | `SchemaValidationError` (FAIL) | Warning в лог                  |
+| Несоответствие типов | `SchemaValidationError` (FAIL) | Warning + пропуск записи       |
+| Отсутствующие поля   | `SchemaValidationError` (FAIL) | Warning + `None` значение      |
 
 ### 2. Иерархия валидации
 
@@ -91,17 +92,46 @@ class BasePipeline:
 Feature flag `strict_gold_validation` позволяет:
 
 1. **Постепенную миграцию**: Существующие пайплайны продолжают работать
-2. **Явный opt-in**: Новые пайплайны включают строгую валидацию
-3. **Тестирование**: Можно включить в staging до production
+1. **Явный opt-in**: Новые пайплайны включают строгую валидацию
+1. **Тестирование**: Можно включить в staging до production
 
 **План миграции:**
 
-| Фаза | Действие | Срок |
-|------|----------|------|
-| 1 | Добавить `strict_gold_validation` flag | Сейчас |
-| 2 | Определить Gold-схемы для всех пайплайнов | - |
-| 3 | Включить `strict_gold_validation=True` поэтапно | - |
-| 4 | Сделать `strict_gold_validation=True` по умолчанию | - |
+| Фаза | Действие                                           | Срок   |
+| ---- | -------------------------------------------------- | ------ |
+| 1    | Добавить `strict_gold_validation` flag             | Сейчас |
+| 2    | Определить Gold-схемы для всех пайплайнов          | -      |
+| 3    | Включить `strict_gold_validation=True` поэтапно    | -      |
+| 4    | Сделать `strict_gold_validation=True` по умолчанию | -      |
+
+### 4.1. Gold write modes и влияние на миграцию
+
+В рамках строгой валидации Gold-схем вводится обязательная явная фиксация режима записи в pipeline config:
+
+- `sink.gold.mode: scd2` — для справочников, publication metadata и slowly evolving entities.
+- `sink.gold.mode: overwrite` (или `append` для true timeseries) — для фактов/агрегатов и производных скорингов.
+
+Для `scd2` блок `scd_config` обязателен и должен включать как минимум:
+
+- `valid_from`
+- `valid_to`
+- `is_current`
+- `version`
+
+Практически также требуется `business_key` (обычно `primary_keys`) для корректной дедупликации и закрытия версий.
+
+### 4.2. Migration impact (`overwrite -> scd2`)
+
+Переключение write mode на `scd2` влияет на Delta lifecycle и требует контролируемой миграции:
+
+1. Выполнить отдельный `backfill`/`rebuild` под эксклюзивной блокировкой сущности.
+1. Подготовить схему Gold: добавить SCD-атрибуты (`valid_from`, `valid_to`, `is_current`, `version`).
+1. Инициализировать текущий срез как версию `1` с `valid_to = null`, `is_current = true`.
+1. При наличии истории — переиграть исторические состояния в хронологическом порядке.
+1. Проверить SCD2-инварианты (одна current-строка на ключ, отсутствие пересечений интервалов, монотонность `version`).
+1. Только после успешной валидации переключить pipeline на `sink.gold.mode: scd2`.
+
+Если исторические снапшоты недоступны, допускается bootstrap только с текущего состояния, но это должно быть явно зафиксировано в PR/ADR как ограничение историчности.
 
 ### 5. Конфигурация пайплайна
 
@@ -159,6 +189,7 @@ class SchemaValidationError(BioETLError):
 ### 1. Гарантия качества данных
 
 Gold-слой потребляется downstream системами:
+
 - ML pipelines
 - Reporting dashboards
 - API endpoints
@@ -168,6 +199,7 @@ Gold-слой потребляется downstream системами:
 ### 2. Раннее обнаружение проблем
 
 Валидация на этапе трансформации:
+
 - Быстрый feedback loop
 - Проблемы обнаруживаются до записи в хранилище
 - Меньше затрат на исправление
@@ -175,6 +207,7 @@ Gold-слой потребляется downstream системами:
 ### 3. Документирование контракта
 
 Gold-схема служит документацией:
+
 - Явный контракт с consumers
 - Версионирование схемы возможно
 - Self-documenting pipeline configuration
@@ -182,6 +215,7 @@ Gold-схема служит документацией:
 ### 4. Feature Flag минимизирует риск
 
 Постепенное включение:
+
 - Нет breaking changes для существующих пайплайнов
 - Можно откатить на уровне конфигурации
 - Не требует code changes для rollback
@@ -210,6 +244,7 @@ src/bioetl/
 # infrastructure/validation/gold_validator.py
 import pandera as pa
 
+
 class GoldValidator:
     """Валидатор Gold-схем на основе Pandera."""
 
@@ -229,6 +264,7 @@ class GoldValidator:
 
 ```python
 # tests/unit/application/test_gold_validation.py
+
 
 def test_strict_validation_fails_without_schema():
     """strict_gold_validation=True без схемы должен падать."""
@@ -270,6 +306,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 1. Всегда требовать Gold-схему
 
 Отклонено потому что:
+
 - Breaking change для всех существующих пайплайнов
 - Требует одновременного обновления всех конфигов
 - Высокий риск при деплое
@@ -277,6 +314,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 2. Валидация только в production
 
 Отклонено потому что:
+
 - Проблемы обнаруживаются слишком поздно
 - Dev/prod parity нарушается
 - Сложнее отлаживать
@@ -284,6 +322,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 3. Schema inference вместо явной схемы
 
 Отклонено потому что:
+
 - Не гарантирует стабильность
 - Schema drift остаётся незамеченным
 - Нет документации контракта
@@ -291,6 +330,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 4. Валидация на уровне Delta Lake
 
 Отклонено потому что:
+
 - Delta Lake schema enforcement недостаточно гибкий
 - Нет semantic validation (ranges, patterns)
 - Ошибки обнаруживаются на этапе записи, не трансформации
@@ -315,15 +355,16 @@ def test_non_strict_validation_warns_without_schema(caplog):
 
 Все основные механизмы реализованы:
 
-| Компонент | Статус | Расположение |
-|-----------|--------|--------------|
-| `strict_gold_validation` флаг | ✅ Реализован | `domain/config.py:259` |
-| `GoldValidatorPort` протокол | ✅ Реализован | `domain/ports/validation.py:41-61` |
-| `PanderaGoldValidator` | ✅ Реализован | `infrastructure/validation/pandera_validator.py:97-210` |
-| `GoldWriter._validate_schema_strict()` | ✅ Реализован | `infrastructure/storage/gold_writer.py:226-232` |
-| `NoOpGoldValidator` | ✅ Реализован | `infrastructure/validation/pandera_validator.py:213-230` |
+| Компонент                              | Статус        | Расположение                                             |
+| -------------------------------------- | ------------- | -------------------------------------------------------- |
+| `strict_gold_validation` флаг          | ✅ Реализован | `domain/config.py:259`                                   |
+| `GoldValidatorPort` протокол           | ✅ Реализован | `domain/ports/validation.py:41-61`                       |
+| `PanderaGoldValidator`                 | ✅ Реализован | `infrastructure/validation/pandera_validator.py:97-210`  |
+| `GoldWriter._validate_schema_strict()` | ✅ Реализован | `infrastructure/storage/gold_writer.py:226-232`          |
+| `NoOpGoldValidator`                    | ✅ Реализован | `infrastructure/validation/pandera_validator.py:213-230` |
 
 **Отличия от первоначального предложения:**
+
 - Вместо `SchemaValidationError` используется `ValidationResult` с errors — более гибкий подход
 - Валидация интегрирована в `GoldWriter` через `_validate_schema_strict()` проверку
 - Feature flag находится в `RuntimeConfig` вместо `PipelineConfig` — централизованное управление


### PR DESCRIPTION
### Motivation

- Ensure deterministic, auditable Gold-layer behavior by forcing pipelines to declare `sink.gold.mode` and preventing accidental reliance on `_base.yaml` defaults.
- Require a minimum SCD2 contract (`scd_config` lifecycle fields) for entities that must preserve history to avoid silent data loss or schema drift.
- Provide operational guidance for safe Delta migrations when switching from `overwrite` to `scd2` to protect downstream consumers and preserve invariants.

### Description

- Added a decision matrix and binding rules to `docs/00-project/RULES.md` that declare which classes of entities **MUST** use `scd2` (reference/master data, publication metadata, slowly-evolving entities) and where `overwrite`/`append` are acceptable (facts/aggregates).
- Specified that `sink.gold.mode` **MUST** be explicitly set in pipeline configs and that `scd_config` for `scd2` **MUST** include `valid_from`, `valid_to`, `is_current`, and `version` (and that `business_key` should match `primary_keys`).
- Added a procedural backfill/migration section to `docs/00-project/RULES.md` and updated ADR-018 (`docs/02-architecture/decisions/ADR-018-gold-strict-validation.md`) with a new subsection describing write modes and the migration/cutover steps and invariants for `overwrite -> scd2` transitions.
- Updated pipeline configuration files under `configs/pipelines/*/*.yaml` to explicitly set `sink.gold.mode` for all pipelines inspected and added `scd_config` blocks (with `business_key` + lifecycle fields) for pipelines designated `scd2`; set `mode: overwrite` for pipelines classified as fact/aggregate examples (e.g., `chembl_activity`, `chembl_publication_term`, `chembl_publication_similarity`).
- Minor documentation bump: updated RULES.md version note to reflect the change (new release entry describing the Gold write-mode matrix and migration guidance).

### Testing

- Parsed the modified YAML pipeline configs with Ruby's YAML loader (`ruby -ryaml -e 'Dir[...]'`) which succeeded (YAML parse OK for changed files).
- Ran an automated scan to verify that pipelines marked `mode: scd2` contain the required `scd_config` keys (`valid_from`, `valid_to`, `is_current`, `version`) which returned no missing fields.
- Verified that there are no pipeline `sink` blocks lacking an explicit `mode` via a repository-wide search (no `NO_MODE` findings).
- Pre-commit checks: `check yaml` hook passed, while repository-level hooks flagged unrelated environment/format issues (markdown formatting adjustment and missing `pip-audit` executable plus existing root-level VCR cassette policy violations); these are environmental or pre-existing repo hygiene items and not regressions introduced by this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489c4cc0883249684e51cfa15b3fa)