### PR TITLE
docs: adopt canonical JSON string policy for Silver/Gold schema contracts

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -1,6 +1,6 @@
 # BioETL: Правила Проекта
 
-*Версия: 5.19 (Statistics Update), 2026-02-16*
+*Версия: 5.20 (JSON Field Typing Policy), 2026-02-17*
 
 ## Введение (Quick Reference)
 
@@ -62,7 +62,9 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие критические порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
@@ -72,6 +74,7 @@
 
   > **Текущее состояние:** Все 38 портов декорированы `@runtime_checkable` (100% coverage).
   > Минимальное требование — 4 критических порта выше; остальные декорированы для единообразия.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -164,7 +167,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -244,19 +247,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -274,6 +278,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -303,6 +308,29 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 - **MUST NOT** предполагать, что все значения — целые числа
 
 **Реализация**: `src/bioetl/infrastructure/schemas/gold.py`
+
+#### JSON Field Typing Policy (Silver ↔ Gold)
+
+**Проблема**: В схемах Silver и Gold исторически смешаны два представления JSON-подобных полей:
+
+- canonical JSON string (`pa.string()` / `Series[str]`)
+- native list/object (`pa.list_(...)` / `Series[object]`)
+
+Это приводит к дрейфу контрактов между слоями и усложняет strict validation в Gold.
+
+**Решение (MUST)**: Для всех JSON-подобных полей Silver и Gold использовать **canonical JSON string в обоих слоях**.
+
+- **Silver**: `pa.string()` для JSON payload/array/object полей.
+- **Gold**: `Series[str]` для тех же полей.
+- **Serialization (MUST)**: `json.dumps(obj, sort_keys=True, separators=(',', ':'), ensure_ascii=True)`.
+- **Null semantics (MUST)**: отсутствие данных хранится как `NULL`, а не как `'[]'`, `'{}'` или sentinel.
+
+**Допускается (MAY, временно)**: legacy native list/object в существующих таблицах до завершения миграции по [ADR-035](02-architecture/decisions/ADR-035-json-field-typing-policy.md), но новые поля **MUST NOT** вводиться как native list/object.
+
+**Инвентаризация и миграция**:
+
+- Полный реестр JSON-like полей и расхождений типов: [ADR-035](02-architecture/decisions/ADR-035-json-field-typing-policy.md) (Appendix A).
+- Согласование strict validation: [ADR-018](02-architecture/decisions/ADR-018-gold-strict-validation.md).
 
 #### Жизненный цикл Карантина
 
@@ -335,6 +363,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -506,6 +535,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -922,7 +952,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1024,11 +1056,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1163,11 +1195,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1222,6 +1254,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1352,20 +1385,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1397,14 +1430,14 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
@@ -1520,6 +1553,7 @@ fields:
 | [ADR-016](02-architecture/decisions/ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | 2025-12-26 |
 | [ADR-017](02-architecture/decisions/ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | 2025-12-26 |
 | [ADR-018](02-architecture/decisions/ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | 2025-12-28 |
+| [ADR-035](02-architecture/decisions/ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)   | Accepted           | 2026-02-17 |
 | [ADR-019](02-architecture/decisions/ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | 2025-12-26 |
 | [ADR-020](02-architecture/decisions/ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | 2025-12-16 |
 | [ADR-021](02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | 2025-12-29 |
@@ -1535,7 +1569,7 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 
 ## История Изменений (Changelog)
 

--- a/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
+++ b/docs/02-architecture/decisions/ADR-018-gold-strict-validation.md
@@ -21,6 +21,7 @@ Gold-слой должен гарантировать качество данн�
 @dataclass(frozen=True)
 class PipelineConfig:
     """Конфигурация пайплайна."""
+
     name: str
     provider: str
     entity: str
@@ -30,11 +31,11 @@ class PipelineConfig:
 
 **Правила валидации:**
 
-| Условие | `strict_gold_validation=True` | `strict_gold_validation=False` |
-|---------|-------------------------------|--------------------------------|
-| `gold_schema=None` | `SchemaValidationError` (FAIL) | Warning в лог |
-| Несоответствие типов | `SchemaValidationError` (FAIL) | Warning + пропуск записи |
-| Отсутствующие поля | `SchemaValidationError` (FAIL) | Warning + `None` значение |
+| Условие              | `strict_gold_validation=True`  | `strict_gold_validation=False` |
+| -------------------- | ------------------------------ | ------------------------------ |
+| `gold_schema=None`   | `SchemaValidationError` (FAIL) | Warning в лог                  |
+| Несоответствие типов | `SchemaValidationError` (FAIL) | Warning + пропуск записи       |
+| Отсутствующие поля   | `SchemaValidationError` (FAIL) | Warning + `None` значение      |
 
 ### 2. Иерархия валидации
 
@@ -91,17 +92,17 @@ class BasePipeline:
 Feature flag `strict_gold_validation` позволяет:
 
 1. **Постепенную миграцию**: Существующие пайплайны продолжают работать
-2. **Явный opt-in**: Новые пайплайны включают строгую валидацию
-3. **Тестирование**: Можно включить в staging до production
+1. **Явный opt-in**: Новые пайплайны включают строгую валидацию
+1. **Тестирование**: Можно включить в staging до production
 
 **План миграции:**
 
-| Фаза | Действие | Срок |
-|------|----------|------|
-| 1 | Добавить `strict_gold_validation` flag | Сейчас |
-| 2 | Определить Gold-схемы для всех пайплайнов | - |
-| 3 | Включить `strict_gold_validation=True` поэтапно | - |
-| 4 | Сделать `strict_gold_validation=True` по умолчанию | - |
+| Фаза | Действие                                           | Срок   |
+| ---- | -------------------------------------------------- | ------ |
+| 1    | Добавить `strict_gold_validation` flag             | Сейчас |
+| 2    | Определить Gold-схемы для всех пайплайнов          | -      |
+| 3    | Включить `strict_gold_validation=True` поэтапно    | -      |
+| 4    | Сделать `strict_gold_validation=True` по умолчанию | -      |
 
 ### 5. Конфигурация пайплайна
 
@@ -154,11 +155,22 @@ class SchemaValidationError(BioETLError):
         self.field = field
 ```
 
+### 7. Политика типов JSON-полей (дополнение)
+
+С 2026-02-17 strict validation в Gold синхронизирована с единой политикой типизации JSON-like полей:
+
+- **Канонический стандарт**: JSON-like поля в Silver и Gold представлены как canonical JSON string.
+- **Нормативный источник**: [ADR-035](ADR-035-json-field-typing-policy.md).
+- **Ограничение для strict mode**: при `strict_gold_validation=True` поля, определенные как JSON-like, валидируются как `Series[str]` (не `Series[object]`).
+
+Это устраняет классы ошибок, где Silver передает `pa.list_(...)`, а Gold ожидает `Series[str]` (или наоборот), и делает контракты межслойной валидации детерминированными.
+
 ## Justification
 
 ### 1. Гарантия качества данных
 
 Gold-слой потребляется downstream системами:
+
 - ML pipelines
 - Reporting dashboards
 - API endpoints
@@ -168,6 +180,7 @@ Gold-слой потребляется downstream системами:
 ### 2. Раннее обнаружение проблем
 
 Валидация на этапе трансформации:
+
 - Быстрый feedback loop
 - Проблемы обнаруживаются до записи в хранилище
 - Меньше затрат на исправление
@@ -175,6 +188,7 @@ Gold-слой потребляется downstream системами:
 ### 3. Документирование контракта
 
 Gold-схема служит документацией:
+
 - Явный контракт с consumers
 - Версионирование схемы возможно
 - Self-documenting pipeline configuration
@@ -182,6 +196,7 @@ Gold-схема служит документацией:
 ### 4. Feature Flag минимизирует риск
 
 Постепенное включение:
+
 - Нет breaking changes для существующих пайплайнов
 - Можно откатить на уровне конфигурации
 - Не требует code changes для rollback
@@ -210,6 +225,7 @@ src/bioetl/
 # infrastructure/validation/gold_validator.py
 import pandera as pa
 
+
 class GoldValidator:
     """Валидатор Gold-схем на основе Pandera."""
 
@@ -229,6 +245,7 @@ class GoldValidator:
 
 ```python
 # tests/unit/application/test_gold_validation.py
+
 
 def test_strict_validation_fails_without_schema():
     """strict_gold_validation=True без схемы должен падать."""
@@ -270,6 +287,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 1. Всегда требовать Gold-схему
 
 Отклонено потому что:
+
 - Breaking change для всех существующих пайплайнов
 - Требует одновременного обновления всех конфигов
 - Высокий риск при деплое
@@ -277,6 +295,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 2. Валидация только в production
 
 Отклонено потому что:
+
 - Проблемы обнаруживаются слишком поздно
 - Dev/prod parity нарушается
 - Сложнее отлаживать
@@ -284,6 +303,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 3. Schema inference вместо явной схемы
 
 Отклонено потому что:
+
 - Не гарантирует стабильность
 - Schema drift остаётся незамеченным
 - Нет документации контракта
@@ -291,6 +311,7 @@ def test_non_strict_validation_warns_without_schema(caplog):
 ### 4. Валидация на уровне Delta Lake
 
 Отклонено потому что:
+
 - Delta Lake schema enforcement недостаточно гибкий
 - Нет semantic validation (ranges, patterns)
 - Ошибки обнаруживаются на этапе записи, не трансформации
@@ -315,15 +336,16 @@ def test_non_strict_validation_warns_without_schema(caplog):
 
 Все основные механизмы реализованы:
 
-| Компонент | Статус | Расположение |
-|-----------|--------|--------------|
-| `strict_gold_validation` флаг | ✅ Реализован | `domain/config.py:259` |
-| `GoldValidatorPort` протокол | ✅ Реализован | `domain/ports/validation.py:41-61` |
-| `PanderaGoldValidator` | ✅ Реализован | `infrastructure/validation/pandera_validator.py:97-210` |
-| `GoldWriter._validate_schema_strict()` | ✅ Реализован | `infrastructure/storage/gold_writer.py:226-232` |
-| `NoOpGoldValidator` | ✅ Реализован | `infrastructure/validation/pandera_validator.py:213-230` |
+| Компонент                              | Статус        | Расположение                                             |
+| -------------------------------------- | ------------- | -------------------------------------------------------- |
+| `strict_gold_validation` флаг          | ✅ Реализован | `domain/config.py:259`                                   |
+| `GoldValidatorPort` протокол           | ✅ Реализован | `domain/ports/validation.py:41-61`                       |
+| `PanderaGoldValidator`                 | ✅ Реализован | `infrastructure/validation/pandera_validator.py:97-210`  |
+| `GoldWriter._validate_schema_strict()` | ✅ Реализован | `infrastructure/storage/gold_writer.py:226-232`          |
+| `NoOpGoldValidator`                    | ✅ Реализован | `infrastructure/validation/pandera_validator.py:213-230` |
 
 **Отличия от первоначального предложения:**
+
 - Вместо `SchemaValidationError` используется `ValidationResult` с errors — более гибкий подход
 - Валидация интегрирована в `GoldWriter` через `_validate_schema_strict()` проверку
 - Feature flag находится в `RuntimeConfig` вместо `PipelineConfig` — централизованное управление

--- a/docs/02-architecture/decisions/ADR-035-json-field-typing-policy.md
+++ b/docs/02-architecture/decisions/ADR-035-json-field-typing-policy.md
@@ -1,0 +1,106 @@
+# ADR-035: JSON Field Typing Policy (Silver ↔ Gold)
+
+**Status:** Accepted
+**Date:** 2026-02-17
+**Decision makers:** @BioETL-Team
+**Related:** ADR-018, ADR-034
+
+## Context
+
+В текущем коде JSON-like поля представлены непоследовательно:
+
+- часть полей хранится как canonical JSON string (`pa.string()` / `Series[str]`)
+- часть — как native list/object (`pa.list_(...)` / `Series[object]`)
+
+Из-за этого возникают типовые расхождения между `src/bioetl/infrastructure/schemas/silver.py` и `src/bioetl/domain/contracts/gold/*.py`, что повышает риск ошибок strict validation.
+
+## The Decision
+
+Для JSON-like полей вводится единый стандарт:
+
+1. **MUST**: Silver и Gold используют **canonical JSON string в обоих слоях**.
+1. **MUST**: сериализация выполняется как:
+   `json.dumps(obj, sort_keys=True, separators=(',', ':'), ensure_ascii=True)`.
+1. **MUST**: отсутствие значения представляется `NULL`.
+1. **MUST NOT**: новые JSON-like поля задавать как `pa.list_(...)` или `Series[object]`.
+1. **MAY (временно)**: legacy поля native list/object остаются до controlled migration.
+
+## Appendix A: Inventory (required scope)
+
+Полная инвентаризация JSON-like полей и статус согласованности типов размещены в:
+
+- `docs/03-data-model/json-field-typing-inventory.md`
+
+### A.1 Ключевые расхождения типов (MISMATCH)
+
+- `chemicals`: Silver `canonical_string`, Gold `native_object`
+- `databanks`: Silver `canonical_string`, Gold `native_object`
+- `gene_symbols`: Silver `canonical_string`, Gold `native_object`
+- `publication_types`: mixed on both layers (`canonical_string` + `native`)
+
+### A.2 Legacy, но согласованные native-типы (требуют миграции)
+
+- `component_accessions`, `component_ids`, `component_types`, `component_relationships`
+- `protein_classification_ids`, `alternative_id`, `content_domain_domains`
+- `institution_ids`, `institution_country_codes`, `subject_keywords`, `subject_mesh`, `gene_names`
+
+### A.3 Уже согласованные canonical string поля
+
+Примеры: `authors`, `affiliation_list`, `variant_sequence_json`, `features_json`,
+`all_mappings`, `citation_contexts`, `subject_topics`, `primary_topic`,
+`references`, `issn_list`, `ror_ids`, `chembl_ids`, `drugbank_ids`, `go_terms`.
+
+## Breaking Impact
+
+Перевод legacy native list/object полей в canonical JSON string является **breaking change** для downstream, которые:
+
+- ожидают Python list/object после чтения Parquet/Delta;
+- используют Pandera контракты с `Series[object]`.
+
+Риски:
+
+- поломка BI/ML скриптов с `.explode()` без явного `json.loads()`;
+- падение strict validation при смешанном наборе контрактов;
+- временный dual-compat слой в потребителях.
+
+## Backfill Strategy
+
+1. **Phase 0 (inventory + freeze)**
+   - Заморозить добавление новых native list/object JSON-like полей.
+1. **Phase 1 (dual-read)**
+   - Gold transformers читают оба представления (list/object и string) с нормализацией в canonical string.
+1. **Phase 2 (backfill)**
+   - Перезаписать Silver/Gold таблицы по сущностям с legacy native types.
+   - Для backfill использовать `run_type=backfill` с exclusive lock.
+1. **Phase 3 (strict enforcement)**
+   - Удалить `Series[object]` из Gold контрактов для JSON-like полей.
+   - Включить fail-fast в schema checks при обнаружении native list/object.
+
+## Delta Migration Steps
+
+1. Добавить migration notebook/script:
+   - read Delta table;
+   - для JSON-like legacy columns выполнить каноническую сериализацию (`to_json` + sorting keys where applicable);
+   - write to shadow table `*_v2` (Delta).
+1. Сверить row-count, null-rate и content hash стабильность для non-JSON полей.
+1. Переключить readers на `*_v2`.
+1. Выполнить smoke validation через Gold Pandera contracts.
+1. Архивировать старую таблицу, обновить catalog pointers.
+
+## Consequences
+
+### Positive
+
+- Единая типизация JSON-like полей в Silver/Gold.
+- Детерминированная strict validation.
+- Меньше provider-specific исключений в трансформерах.
+
+### Negative
+
+- Требуется backfill и обновление downstream-кода.
+- На миграционный период повышается сложность (dual-read).
+
+## Related ADRs
+
+- [ADR-018](ADR-018-gold-strict-validation.md): strict validation опирается на консистентные типы.
+- [ADR-034](ADR-034-schema-domain-pairs.md): выравнивание контрактов между слоями.

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -4,46 +4,48 @@ This directory contains Architecture Decision Records documenting significant ar
 
 ## ADR Index
 
-| ADR | Title | Status | Category | Date |
-|-----|-------|--------|----------|------|
-| [ADR-001](ADR-001-delta-lake-vs-parquet.md) | Delta Lake vs Parquet | Accepted | Storage | 2025-05-20 |
-| [ADR-002](ADR-002-medallion-architecture.md) | Medallion Architecture | Accepted | Architecture | 2025-05-20 |
-| [ADR-003](ADR-003-in-memory-locking-strategy.md) | In-Memory Locking (MemoryLock) | Accepted (Revised) | Locking | 2025-12-23 |
-| [ADR-004](ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses | Accepted | Data Modeling | 2025-05-20 |
-| [ADR-005](ADR-005-composition-layer-separation.md) | Composition Layer Separation | Accepted | Architecture | 2025-12-15 |
-| [ADR-006](ADR-006-logger-metrics-ports.md) | Logger and Metrics Ports | Accepted | Observability | 2025-12-18 |
-| [ADR-007](ADR-007-circuit-breaker-implementation.md) | Circuit Breaker Implementation | Accepted | Resilience | 2025-12-22 |
-| [ADR-008](ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy | Accepted | Lifecycle | 2025-12-22 |
-| [ADR-009](ADR-009-paginated-fetcher-mixin.md) | PaginatedFetcherMixin Design | Accepted | Data Fetching | 2025-12-22 |
-| [ADR-010](ADR-010-local-only-deployment.md) | Local-Only Deployment | Accepted | Deployment | 2025-12-23 |
-| [ADR-011](ADR-011-remove-watermark-mechanism.md) | Remove Watermark Mechanism | Accepted | Data Loading | 2025-12-23 |
-| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID | Accepted | Storage | 2025-12-23 |
-| [ADR-013](ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | Accepted | Storage | 2025-12-24 |
-| [ADR-014](ADR-014-deterministic-writes.md) | Deterministic Writes and Retries | Accepted | Reproducibility | 2025-12-24 |
-| [ADR-015](ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | Lifecycle | 2025-12-24 |
-| [ADR-016](ADR-016-error-handling-strategy.md) | Error Handling Strategy | Accepted | Resilience | 2025-12-26 |
-| [ADR-017](ADR-017-observability-architecture.md) | Observability Architecture | Accepted | Observability | 2025-12-26 |
-| [ADR-018](ADR-018-gold-strict-validation.md) | Gold Strict Validation | Accepted | Data Quality | 2025-12-26 |
-| [ADR-019](ADR-019-observability-port-enforcement.md) | Observability Port Enforcement | Accepted | Observability | 2025-12-26 |
-| [ADR-020](ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition | Accepted | Architecture | 2025-12-16 |
-| [ADR-021](ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates Adoption | Accepted | Domain Model | 2025-12-29 |
-| [ADR-022](ADR-022-tracing-noop.md) | NoOp Tracing for Local-Only | Accepted | Observability | 2025-12-30 |
-| [ADR-023](ADR-023-entity-type-patterns.md) | Entity Type Patterns | Accepted | Observability | 2026-01-06 |
-| [ADR-024](ADR-024-entity-naming-unification.md) | Entity Naming Unification | Accepted | Architecture | 2026-01-07 |
-| [ADR-025](ADR-025-pipeline-config-unification.md) | Pipeline Config Unification | Accepted | Configuration | 2026-01-14 |
-| [ADR-026](ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern | Accepted | Architecture | 2026-01-15 |
-| [ADR-027](ADR-027-dq-rules-externalization.md) | DQ Rules Externalization | Accepted | Data Quality | 2026-01-19 |
-| [ADR-028](ADR-028-filter-rules-externalization.md) | Filter Rules Externalization | Accepted | Configuration | 2026-01-20 |
-| [ADR-029](ADR-029-output-metadata-unification.md) | Output Metadata Unification | Accepted | Data Modeling | 2026-01-23 |
-| [ADR-030](ADR-030-publication-pagination-strategy.md) | Publication Pagination Strategy | Accepted | Data Fetching | 2026-01-25 |
-| [ADR-031](ADR-031-loading-strategy-formalization.md) | Loading Strategy Formalization | Accepted | Data Loading | 2026-01-26 |
-| [ADR-032](ADR-032-unified-http-client.md) | Unified HTTP Client Pattern | Accepted | HTTP/Networking | 2026-01-28 |
-| [ADR-033](ADR-033-publication-validation-strategy.md) | Publication Metadata Validation Strategy | Proposed | Data Quality | 2026-02-06 |
-| [ADR-034](ADR-034-schema-domain-pairs.md) | Schema↔Domain Configuration Pairs | Accepted | Architecture | 2026-02-15 |
+| ADR                                                     | Title                                    | Status             | Category        | Date       |
+| ------------------------------------------------------- | ---------------------------------------- | ------------------ | --------------- | ---------- |
+| [ADR-001](ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | Storage         | 2025-05-20 |
+| [ADR-002](ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | Architecture    | 2025-05-20 |
+| [ADR-003](ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | Locking         | 2025-12-23 |
+| [ADR-004](ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | Accepted           | Data Modeling   | 2025-05-20 |
+| [ADR-005](ADR-005-composition-layer-separation.md)      | Composition Layer Separation             | Accepted           | Architecture    | 2025-12-15 |
+| [ADR-006](ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                 | Accepted           | Observability   | 2025-12-18 |
+| [ADR-007](ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation           | Accepted           | Resilience      | 2025-12-22 |
+| [ADR-008](ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy               | Accepted           | Lifecycle       | 2025-12-22 |
+| [ADR-009](ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design             | Accepted           | Data Fetching   | 2025-12-22 |
+| [ADR-010](ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | Accepted           | Deployment      | 2025-12-23 |
+| [ADR-011](ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism               | Accepted           | Data Loading    | 2025-12-23 |
+| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID        | Accepted           | Storage         | 2025-12-23 |
+| [ADR-013](ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | Accepted           | Storage         | 2025-12-24 |
+| [ADR-014](ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries         | Accepted           | Reproducibility | 2025-12-24 |
+| [ADR-015](ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | Accepted           | Lifecycle       | 2025-12-24 |
+| [ADR-016](ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | Resilience      | 2025-12-26 |
+| [ADR-017](ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | Observability   | 2025-12-26 |
+| [ADR-018](ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | Data Quality    | 2025-12-26 |
+| [ADR-019](ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | Observability   | 2025-12-26 |
+| [ADR-020](ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | Architecture    | 2025-12-16 |
+| [ADR-021](ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | Domain Model    | 2025-12-29 |
+| [ADR-022](ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only              | Accepted           | Observability   | 2025-12-30 |
+| [ADR-023](ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | Accepted           | Observability   | 2026-01-06 |
+| [ADR-024](ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | Accepted           | Architecture    | 2026-01-07 |
+| [ADR-025](ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | Accepted           | Configuration   | 2026-01-14 |
+| [ADR-026](ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | Accepted           | Architecture    | 2026-01-15 |
+| [ADR-027](ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | Accepted           | Data Quality    | 2026-01-19 |
+| [ADR-028](ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | Accepted           | Configuration   | 2026-01-20 |
+| [ADR-029](ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | Accepted           | Data Modeling   | 2026-01-23 |
+| [ADR-030](ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | Accepted           | Data Fetching   | 2026-01-25 |
+| [ADR-031](ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | Data Loading    | 2026-01-26 |
+| [ADR-032](ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | HTTP/Networking | 2026-01-28 |
+| [ADR-033](ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | Data Quality    | 2026-02-06 |
+| [ADR-034](ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | Architecture    | 2026-02-15 |
+| [ADR-035](ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)   | Accepted           | Data Modeling   | 2026-02-17 |
 
 ## ADRs by Category
 
 ### Architecture (Core Patterns)
+
 - [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture (Bronze/Silver/Gold)
 - [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer Separation (DI)
 - [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition (God Object removal)
@@ -52,16 +54,19 @@ This directory contains Architecture Decision Records documenting significant ar
 - [ADR-034](ADR-034-schema-domain-pairs.md): Schema↔Domain Configuration Pairs — Domain frozen dataclasses vs Infrastructure Pydantic models
 
 ### Storage
+
 - [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet
 - [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract and Run ID
 - [ADR-013](ADR-013-async-storage-cleanup.md): Async Storage Cleanup
 
 ### Resilience & Error Handling
+
 - [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker Implementation
 - [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy
 - [ADR-032](ADR-032-unified-http-client.md): Unified HTTP Client Pattern — Centralized HTTP with rate limiting and retry
 
 ### Observability
+
 - [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports
 - [ADR-017](ADR-017-observability-architecture.md): Observability Architecture
 - [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement
@@ -69,35 +74,44 @@ This directory contains Architecture Decision Records documenting significant ar
 - [ADR-023](ADR-023-entity-type-patterns.md): Entity Type Patterns (transformer entity_type)
 
 ### Lifecycle Management
+
 - [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy
 - [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle
 
 ### Data Quality
+
 - [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation
 - [ADR-027](ADR-027-dq-rules-externalization.md): DQ Rules Externalization — Hierarchical DQ config
 - [ADR-033](ADR-033-publication-validation-strategy.md): Publication Metadata Validation Strategy — 5-level validation for publication data
 
 ### Domain Model
+
 - [ADR-004](ADR-004-pydantic-vs-dataclasses.md): Pydantic vs Dataclasses
 - [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates Adoption
 - [ADR-029](ADR-029-output-metadata-unification.md): Output Metadata Unification — Unified output metadata contracts
+- [ADR-035](ADR-035-json-field-typing-policy.md): JSON Field Typing Policy (Silver↔Gold)
 
 ### Data Fetching
+
 - [ADR-009](ADR-009-paginated-fetcher-mixin.md): PaginatedFetcherMixin Design
 - [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark Mechanism
 - [ADR-030](ADR-030-publication-pagination-strategy.md): Publication Pagination Strategy
 - [ADR-031](ADR-031-loading-strategy-formalization.md): Loading Strategy Formalization
 
 ### Deployment
+
 - [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment
 
 ### Locking
+
 - [ADR-003](ADR-003-in-memory-locking-strategy.md): In-Memory Locking (MemoryLock) — Local-Only locking strategy
 
 ### Reproducibility
+
 - [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes and Retries
 
 ### Configuration
+
 - [ADR-025](ADR-025-pipeline-config-unification.md): Pipeline Config Unification
 - [ADR-028](ADR-028-filter-rules-externalization.md): Filter Rules Externalization — Hierarchical filter config
 

--- a/docs/03-data-model/json-field-typing-inventory.md
+++ b/docs/03-data-model/json-field-typing-inventory.md
@@ -1,0 +1,60 @@
+# JSON Field Typing Inventory (Silver vs Gold)
+
+Scope: `src/bioetl/infrastructure/schemas/silver.py` и `src/bioetl/domain/contracts/gold/*.py`.
+
+| Field                        | Silver type kind              | Gold type kind                  | Status                         |
+| ---------------------------- | ----------------------------- | ------------------------------- | ------------------------------ |
+| `active_sites`               | canonical_string              | —                               | only one layer (manual review) |
+| `activity_properties`        | canonical_string              | —                               | only one layer (manual review) |
+| `affiliation_list`           | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `affiliation_structured`     | canonical_string              | —                               | only one layer (manual review) |
+| `all_mappings`               | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `alternative_id`             | native_list                   | native_object                   | consistent legacy (native)     |
+| `assay_classifications`      | canonical_string              | —                               | only one layer (manual review) |
+| `assay_parameters`           | canonical_string              | —                               | only one layer (manual review) |
+| `author_details`             | canonical_string              | —                               | only one layer (manual review) |
+| `author_h_indices`           | canonical_string              | —                               | only one layer (manual review) |
+| `author_orcids`              | —                             | canonical_string                | only one layer (manual review) |
+| `author_s2_ids`              | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `authors`                    | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `authors_with_affiliations`  | canonical_string              | —                               | only one layer (manual review) |
+| `binding_sites`              | canonical_string              | —                               | only one layer (manual review) |
+| `chembl_ids`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `chemicals`                  | canonical_string              | native_object                   | MISMATCH                       |
+| `citation_contexts`          | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `component_accessions`       | native_list                   | native_object                   | consistent legacy (native)     |
+| `component_descriptions`     | native_list                   | —                               | only one layer (manual review) |
+| `component_ids`              | native_list                   | native_object                   | consistent legacy (native)     |
+| `component_relationships`    | native_list                   | native_object                   | consistent legacy (native)     |
+| `component_types`            | native_list                   | native_object                   | consistent legacy (native)     |
+| `content_domain_domains`     | native_list                   | native_object                   | consistent legacy (native)     |
+| `cross_references`           | —                             | canonical_string                | only one layer (manual review) |
+| `databanks`                  | canonical_string              | native_object                   | MISMATCH                       |
+| `domains`                    | canonical_string              | —                               | only one layer (manual review) |
+| `drugbank_ids`               | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `features_json`              | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `gene_names`                 | native_list                   | native_object                   | consistent legacy (native)     |
+| `gene_symbols`               | canonical_string              | native_object                   | MISMATCH                       |
+| `go_terms`                   | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `grants`                     | —                             | canonical_string                | only one layer (manual review) |
+| `institution_country_codes`  | native_list                   | native_object                   | consistent legacy (native)     |
+| `institution_ids`            | native_list                   | native_object                   | consistent legacy (native)     |
+| `interpro_xrefs`             | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `issn_list`                  | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `pdb_xrefs`                  | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `pfam_xrefs`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `pipeline_stages`            | —                             | canonical_string                | only one layer (manual review) |
+| `primary_topic`              | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `protein_classification_ids` | native_list                   | native_object                   | consistent legacy (native)     |
+| `protein_classifications`    | canonical_string              | —                               | only one layer (manual review) |
+| `publication_type`           | —                             | native_object                   | only one layer (manual review) |
+| `publication_type_list`      | canonical_string              | —                               | only one layer (manual review) |
+| `publication_types`          | canonical_string, native_list | canonical_string, native_object | MISMATCH                       |
+| `reactome_xrefs`             | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `references`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `ror_ids`                    | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `subject_keywords`           | native_list                   | native_object                   | consistent legacy (native)     |
+| `subject_mesh`               | native_list                   | native_object                   | consistent legacy (native)     |
+| `subject_topics`             | canonical_string              | canonical_string                | consistent (canonical string)  |
+| `target_components`          | —                             | canonical_string                | only one layer (manual review) |
+| `variant_sequence_json`      | canonical_string              | canonical_string                | consistent (canonical string)  |


### PR DESCRIPTION
### Motivation

- Eliminate drift and type mismatches for JSON-like fields observed between Silver schemas and Gold Pandera contracts by selecting a single canonical representation.
- Align strict Gold validation with a deterministic JSON typing policy so `strict_gold_validation=True` produces repeatable Pandera checks and fewer provider-specific edge cases.
- Provide a documented migration path and inventory to safely backfill legacy native list/object fields without surprising downstream consumers.

### Description

- Added a JSON Field Typing Policy to `docs/00-project/RULES.md` enforcing canonical JSON strings for JSON-like fields and the canonical serialization rule (`json.dumps(..., sort_keys=True, separators=(',', ':'), ensure_ascii=True)`).
- Extended `ADR-018` (`docs/02-architecture/decisions/ADR-018-gold-strict-validation.md`) to reference the JSON typing policy and require `Series[str]` for JSON-like fields when `strict_gold_validation=True`.
- Introduced a new ADR `ADR-035` (`docs/02-architecture/decisions/ADR-035-json-field-typing-policy.md`) that records the decision, breaking impact, backfill strategy and Delta migration steps for converting legacy native list/object fields.
- Produced an inventory of JSON-like fields and type status across Silver vs Gold at `docs/03-data-model/json-field-typing-inventory.md` and updated the ADR index (`docs/02-architecture/decisions/README.md`) and RULES version (`docs/00-project/RULES.md`).
- Files changed: `docs/00-project/RULES.md`, `docs/02-architecture/decisions/ADR-018-gold-strict-validation.md`, `docs/02-architecture/decisions/ADR-035-json-field-typing-policy.md` (new), `docs/02-architecture/decisions/README.md`, `docs/03-data-model/json-field-typing-inventory.md` (new).

### Testing

- Ran `git diff --check` style/consistency check which passed.
- Executed the repository pre-commit checks: `mdformat` auto-edited markdown (reported as a failure and was fixed by applying formatting edits), `pip-audit` was not available in the environment (tooling issue), and repository policy checker `check-root-vcr-cassettes` reported existing root-level VCR cassette files unrelated to these docs changes; these findings are tooling/repo-policy signals that must be addressed separately.
- Verified that the documentation files renderable sections were inserted and the ADR inventory file (`docs/03-data-model/json-field-typing-inventory.md`) was written to disk and contains the field-by-field status for manual review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489c69f50832489c563cbe1cae379)