### PR TITLE
docs: add 2026 target schema governance and ADR-035

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ______________________________________________________________________
 - **Deterministic Writes**: Reproducible outputs and deterministic retries ([ADR-014](docs/02-architecture/decisions/ADR-014-deterministic-writes.md)).
 - **Observability by Design**: Metrics, tracing, and logging ports ([ADR-017](docs/02-architecture/decisions/ADR-017-observability-architecture.md)).
 - **Unified HTTP Client**: Standardized rate limiting, retry, and telemetry ([ADR-032](docs/02-architecture/decisions/ADR-032-unified-http-client.md)).
-- **Strict Governance**: Comprehensive rules for schema evolution, data contracts, and operational procedures.
+- **Strict Governance**: Comprehensive rules for schema evolution, data contracts, and operational procedures, including governance-gate severity (`blocking` / `warning`) classification.
 
 ## Architecture Overview
 
@@ -74,15 +74,18 @@ The domain layer implements Domain-Driven Design patterns:
 
 ## Documentation
 
-| Document                                                  | Description                                 |
-| --------------------------------------------------------- | ------------------------------------------- |
-| [API Reference](docs/04-reference/api/index.md)           | Full API documentation with mkdocstrings    |
-| [Architecture Decisions](docs/02-architecture/decisions/) | 34 ADRs explaining design choices           |
-| [Ubiquitous Language](docs/00-project/glossary.md)        | Domain terminology and canonical naming     |
-| [RULES.md](docs/00-project/RULES.md)                      | Project governance and requirements (v5.19) |
-| [Project Map](docs/00-project/00-map.md)                  | Documentation navigator and code map        |
-| [CLI Reference](docs/04-reference/cli.md)                 | Command-line interface documentation        |
-| [Operations Runbooks](docs/05-operations/runbooks/)       | Incident response and procedures            |
+| Document                                                                                   | Description                                                 |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| [API Reference](docs/04-reference/api/index.md)                                            | Full API documentation with mkdocstrings                    |
+| [Architecture Decisions](docs/02-architecture/decisions/)                                  | 35 ADRs explaining design choices                           |
+| [Ubiquitous Language](docs/00-project/glossary.md)                                         | Domain terminology and canonical naming                     |
+| [RULES.md](docs/00-project/RULES.md)                                                       | Project governance and requirements (v5.21)                 |
+| [Schema Governance](docs/02-architecture/Schema-Governance.md)                             | Lifecycle, drift handling, contract versioning, SCD2 matrix |
+| [ADR-035](docs/02-architecture/decisions/ADR-035-target-schema-architecture-2026.md)       | Target Schema Architecture 2026 roadmap and risk model      |
+| [Governance Gate Severity](docs/02-architecture/Schema-Governance.md#scd2-decision-matrix) | `blocking` vs `warning` classification policy               |
+| [Project Map](docs/00-project/00-map.md)                                                   | Documentation navigator and code map                        |
+| [CLI Reference](docs/04-reference/cli.md)                                                  | Command-line interface documentation                        |
+| [Operations Runbooks](docs/05-operations/runbooks/)                                        | Incident response and procedures                            |
 
 ## Quick Start
 
@@ -179,13 +182,14 @@ bioetl checkpoint list
 - Keep machine-consumed reference datasets under semantic paths in `data/` (for example, `data/input/reference/`).
 - Keep optional human-facing spreadsheet copies under `docs/reference/`.
 - Unified publication classifier canonical format is CSV at `data/input/reference/unified_classification.csv`; Excel is optional documentation copy at `docs/reference/unified_classification.xlsx`.
+
 ### Local diagnostic artifacts
 
 Локальные диагностические файлы (например, `git_commit_*.txt`, `*_gitshow_err.txt`, `log_test.txt`) не должны храниться в корне репозитория и не коммитятся в Git.
 
-* Временные диагностические дампы сохраняйте в `tmp/`.
-* Логи локальных запусков сохраняйте в `logs/`.
-* Для ad-hoc команд используйте явное перенаправление (`> logs/<name>.log 2>&1` или `> tmp/<name>.txt 2>&1`).
+- Временные диагностические дампы сохраняйте в `tmp/`.
+- Логи локальных запусков сохраняйте в `logs/`.
+- Для ad-hoc команд используйте явное перенаправление (`> logs/<name>.log 2>&1` или `> tmp/<name>.txt 2>&1`).
 
 ### Testing
 
@@ -284,7 +288,7 @@ Access the docs at `http://localhost:8000`.
 │   ├── 02-architecture/      # Layer docs, diagrams, ADRs (34 decisions)
 │   ├── 00-project/
 │   │   ├── glossary.md       # Ubiquitous Language glossary
-│   │   └── RULES.md          # Project governance (v5.19)
+│   │   └── RULES.md          # Project governance (v5.21)
 │   └── ...
 ├── src/
 │   └── bioetl/

--- a/docs/00-project/ARCHITECTURE_AUDIT_2026-02-16.md
+++ b/docs/00-project/ARCHITECTURE_AUDIT_2026-02-16.md
@@ -5,35 +5,56 @@
 **Branch**: `claude/bioetl-architecture-audit-PC7Qu`
 **Auditor**: Automated architecture audit
 
----
+______________________________________________________________________
+
+## Part 0. Target State Sync (2026-02-17)
+
+Target state for schema governance synchronized with documentation baseline:
+
+- Added canonical schema governance document: `docs/02-architecture/Schema-Governance.md`.
+- Added ADR-035 (`Target Schema Architecture 2026`) with 3-phase roadmap.
+- Updated `README.md` references for governance gate and `blocking` / `warning` taxonomy.
+- Updated `RULES.md` to include §2.10 with target-state schema governance requirements.
+
+### Compliance Delta
+
+| Area                | Previous state (2026-02-16)      | Target state (2026-02-17)                           |
+| ------------------- | -------------------------------- | --------------------------------------------------- |
+| Schema lifecycle    | Implicit, spread across sections | Explicit lifecycle with governance gate             |
+| Drift severity      | Mentioned in DQ/error contexts   | Standardized `blocking` vs `warning` classification |
+| Contract versioning | Present in appendix workflows    | Elevated to target-state MUST policy                |
+| SCD2 decisioning    | Implemented in Gold mode         | Formal decision matrix documented                   |
+| ADR coverage        | ADR-001..034                     | ADR-001..035                                        |
+
+______________________________________________________________________
 
 ## Part 1. Objective Metrics
 
-| Metric | Command / Method | Value |
-|--------|-----------------|-------|
-| Test coverage | `pytest --cov=src/bioetl --cov-report=term` | **90.63%** |
-| Tests passed | `pytest tests/` | **11693 passed**, 1 failed, 234 skipped |
-| mypy errors | `mypy src/bioetl --strict` | **1** (unused `type: ignore` in `memory_monitor.py:146`) |
-| Circular imports | `python -c "from bioetl.domain import *"` | **PASS** |
-| Class count | `grep -r "^class " src/ --include="*.py" \| wc -l` | **911** |
-| Python file count | `find src/ -name "*.py" \| wc -l` | **559** |
-| Total LOC (src/bioetl) | `wc -l src/bioetl/**/*.py` | **116,062** |
-| Average module size | 116,062 / 534 | **~217 lines** |
-| TODO/FIXME/HACK | `grep -rE "(TODO\|FIXME\|XXX\|HACK)" src/` | **0** |
-| print() in production code | `grep -r "print(" src/bioetl --include="*.py"` | **0** |
-| Hardcoded secrets | `grep -rE "(api_key\|password\|secret)\s*=" src/` | **0** real violations (14 matches are parameter names, not literal values) |
-| Port/Protocol count | Protocols in `domain/ports/` | **38** |
-| `@runtime_checkable` count | decorators in `domain/ports/` | **38** (100%) |
-| ADR documents | `ls docs/02-architecture/decisions/` | **34** (ADR-001 through ADR-034) |
-| VCR cassettes | `find tests/fixtures/vcr -type f` | **136** |
-| Unit test files | `find tests -name "*.py" -path "*/unit/*"` | **408** |
-| Architecture test files | `find tests -name "*.py" -path "*/architecture/*"` | **53** |
-| Contract test files | `find tests -name "*.py" -path "*/contract/*"` | **13** |
-| Integration test files | `find tests -name "*.py" -path "*/integration/*"` | **49** |
-| E2E test files | `find tests -name "*.py" -path "*/e2e/*"` | **24** |
-| Security test files | `find tests -name "*.py" -path "*/security/*"` | **4** |
+| Metric                     | Command / Method                                   | Value                                                                      |
+| -------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------- |
+| Test coverage              | `pytest --cov=src/bioetl --cov-report=term`        | **90.63%**                                                                 |
+| Tests passed               | `pytest tests/`                                    | **11693 passed**, 1 failed, 234 skipped                                    |
+| mypy errors                | `mypy src/bioetl --strict`                         | **1** (unused `type: ignore` in `memory_monitor.py:146`)                   |
+| Circular imports           | `python -c "from bioetl.domain import *"`          | **PASS**                                                                   |
+| Class count                | `grep -r "^class " src/ --include="*.py" \| wc -l` | **911**                                                                    |
+| Python file count          | `find src/ -name "*.py" \| wc -l`                  | **559**                                                                    |
+| Total LOC (src/bioetl)     | `wc -l src/bioetl/**/*.py`                         | **116,062**                                                                |
+| Average module size        | 116,062 / 534                                      | **~217 lines**                                                             |
+| TODO/FIXME/HACK            | `grep -rE "(TODO\|FIXME\|XXX\|HACK)" src/`         | **0**                                                                      |
+| print() in production code | `grep -r "print(" src/bioetl --include="*.py"`     | **0**                                                                      |
+| Hardcoded secrets          | `grep -rE "(api_key\|password\|secret)\s*=" src/`  | **0** real violations (14 matches are parameter names, not literal values) |
+| Port/Protocol count        | Protocols in `domain/ports/`                       | **38**                                                                     |
+| `@runtime_checkable` count | decorators in `domain/ports/`                      | **38** (100%)                                                              |
+| ADR documents              | `ls docs/02-architecture/decisions/`               | **34** (ADR-001 through ADR-034)                                           |
+| VCR cassettes              | `find tests/fixtures/vcr -type f`                  | **136**                                                                    |
+| Unit test files            | `find tests -name "*.py" -path "*/unit/*"`         | **408**                                                                    |
+| Architecture test files    | `find tests -name "*.py" -path "*/architecture/*"` | **53**                                                                     |
+| Contract test files        | `find tests -name "*.py" -path "*/contract/*"`     | **13**                                                                     |
+| Integration test files     | `find tests -name "*.py" -path "*/integration/*"`  | **49**                                                                     |
+| E2E test files             | `find tests -name "*.py" -path "*/e2e/*"`          | **24**                                                                     |
+| Security test files        | `find tests -name "*.py" -path "*/security/*"`     | **4**                                                                      |
 
----
+______________________________________________________________________
 
 ## Part 2. Category Evaluation
 
@@ -43,20 +64,21 @@
 
 All import boundary checks passed with **zero violations**:
 
-| Check | Result |
-|-------|--------|
-| Domain -> Infrastructure | 0 violations |
-| Domain -> Application | 0 violations |
-| Domain -> Composition | 0 violations |
-| Domain -> Interfaces | 0 violations |
-| Application -> Infrastructure | 0 violations |
-| Application -> Composition | 0 violations (1 match is a comment: `src/bioetl/application/pipelines/__init__.py:13`) |
-| Application -> Interfaces | 0 violations |
-| Infrastructure -> Application | 0 violations |
-| Infrastructure -> Composition | 0 violations |
-| Infrastructure -> Interfaces | 0 violations |
+| Check                         | Result                                                                                 |
+| ----------------------------- | -------------------------------------------------------------------------------------- |
+| Domain -> Infrastructure      | 0 violations                                                                           |
+| Domain -> Application         | 0 violations                                                                           |
+| Domain -> Composition         | 0 violations                                                                           |
+| Domain -> Interfaces          | 0 violations                                                                           |
+| Application -> Infrastructure | 0 violations                                                                           |
+| Application -> Composition    | 0 violations (1 match is a comment: `src/bioetl/application/pipelines/__init__.py:13`) |
+| Application -> Interfaces     | 0 violations                                                                           |
+| Infrastructure -> Application | 0 violations                                                                           |
+| Infrastructure -> Composition | 0 violations                                                                           |
+| Infrastructure -> Interfaces  | 0 violations                                                                           |
 
 **Additional checks:**
+
 - `structlog` usage: Only in `infrastructure/observability/` (3 files) and `composition/bootstrap_logger.py` (1 file) - all allowed locations per rules
 - No I/O in domain layer (regex matches in `domain/locking.py` and `domain/models/metadata.py` are false positives - docstrings/attribute names containing `.write_`)
 - No `Factory()` calls in application or domain layers
@@ -64,9 +86,10 @@ All import boundary checks passed with **zero violations**:
 - `import-linter` configured as dependency for CI enforcement
 
 **Evidence:**
+
 - Architecture is enforced both at test level (`tests/architecture/` with 53 test files) and via `import-linter` + `pytest-archon`
 
----
+______________________________________________________________________
 
 ### 2. Contracts and Ports (Weight: 12%)
 
@@ -74,42 +97,45 @@ All import boundary checks passed with **zero violations**:
 
 **38 Protocol-based ports** defined in `src/bioetl/domain/ports/`:
 
-| Port | File | @runtime_checkable |
-|------|------|-------------------|
-| `DataSourcePort` | `data_source.py` | Yes |
-| `FilterableDataSourcePort` | `data_source.py` | Yes |
-| `StoragePort` | `storage.py` | Yes |
-| `LockPort` | `locking.py` | Yes |
-| `LoggerPort` | `observability.py` | Yes |
-| `TracingPort` | `observability.py` | Yes |
-| `MetricsPort` | `observability.py` | Yes |
-| `DQMonitorPort` | `observability.py` | Yes |
-| `CircuitBreakerPort` | `resilience.py` | Yes |
-| `RateLimiterPort` | `resilience.py` | Yes |
-| `QuarantinePort` | `quarantine.py` | Yes |
-| `CheckpointPort` | `checkpoint.py` | Yes |
-| `PiiHasherPort` | `pii.py` | Yes |
-| `HealthCheckPort` | `health_check.py` | Yes |
-| `AuditPort` | `audit.py` | Yes |
-| ... (23 more) | various | All Yes |
+| Port                       | File               | @runtime_checkable |
+| -------------------------- | ------------------ | ------------------ |
+| `DataSourcePort`           | `data_source.py`   | Yes                |
+| `FilterableDataSourcePort` | `data_source.py`   | Yes                |
+| `StoragePort`              | `storage.py`       | Yes                |
+| `LockPort`                 | `locking.py`       | Yes                |
+| `LoggerPort`               | `observability.py` | Yes                |
+| `TracingPort`              | `observability.py` | Yes                |
+| `MetricsPort`              | `observability.py` | Yes                |
+| `DQMonitorPort`            | `observability.py` | Yes                |
+| `CircuitBreakerPort`       | `resilience.py`    | Yes                |
+| `RateLimiterPort`          | `resilience.py`    | Yes                |
+| `QuarantinePort`           | `quarantine.py`    | Yes                |
+| `CheckpointPort`           | `checkpoint.py`    | Yes                |
+| `PiiHasherPort`            | `pii.py`           | Yes                |
+| `HealthCheckPort`          | `health_check.py`  | Yes                |
+| `AuditPort`                | `audit.py`         | Yes                |
+| ... (23 more)              | various            | All Yes            |
 
 **Key findings:**
+
 - 100% of ports use `@runtime_checkable` decorator
 - All external dependencies are abstracted through Protocol ports
 - Health check methods present across all HTTP adapters (17 files in `infrastructure/adapters/` contain `health_check`)
 - A dedicated `HealthCheckMixin` in `infrastructure/adapters/health_check_mixin.py` ensures consistency
 
----
+______________________________________________________________________
 
 ### 3. Medallion Architecture (Weight: 12%)
 
 **Score: 10/10**
 
 **Bronze layer:**
+
 - JSONL+zstd format used (Bronze writer in `infrastructure/storage/`)
 - Append-only, immutable design
 
 **Silver layer:**
+
 - Delta Lake fully implemented via `deltalake` library
 - `DeltaTable`, `write_deltalake` used extensively in `infrastructure/storage/silver_writer.py`
 - Merge operations supported via `SilverWriteMode.MERGE`
@@ -117,12 +143,14 @@ All import boundary checks passed with **zero violations**:
 - 19+ Pandera schemas defined in `domain/schemas/` for Silver validation
 
 **Gold layer:**
+
 - Delta Lake used in `infrastructure/storage/gold_writer.py`
 - Gold contracts defined in `domain/contracts/gold/` (chembl.py, pubchem.py, publications.py, uniprot.py, composite.py)
 - Strict validation via Pandera `DataFrameModel` schemas
 - SCD2 support via `GoldWriteMode.SCD2`
 
 **Medallion policy** (`domain/medallion.py`):
+
 - `Layer` enum: BRONZE, SILVER, GOLD
 - `WriteMode` enum: APPEND, MERGE, OVERWRITE
 - `SilverWriteMode`: MERGE, APPEND, DELETE
@@ -130,16 +158,18 @@ All import boundary checks passed with **zero violations**:
 - Clear policies enforced per `RunType` (REBUILD/BACKFILL/INCREMENTAL)
 
 **Retention and VACUUM:**
+
 - `infrastructure/storage/retention_manager.py` implements Delta Lake retention with VACUUM operations
 - Time-travel support via `DeltaTable` version/timestamp loading
 
----
+______________________________________________________________________
 
 ### 4. Error Handling and Circuit Breaker (Weight: 10%)
 
 **Score: 10/10**
 
 **Error classification** (three-tier hierarchy in `domain/exceptions/`):
+
 - `CriticalError`: LockLostError, LockAcquisitionError, PolicyViolationError, InvalidStateError, InfrastructureError, etc.
 - `RecoverableError`: NetworkError, TimeoutError, RateLimitError, CircuitBreakerOpenError, RetryExhaustedError, ApiError, StorageError
 - `DataQualityError`: ValidationError, SchemaViolationError, MissingRequiredFieldError, InvalidDataFormatError
@@ -147,32 +177,37 @@ All import boundary checks passed with **zero violations**:
 **Error classifier** (`domain/error_classifier.py`): Classifies errors into categories for appropriate handling.
 
 **Circuit breaker:**
+
 - `CircuitBreakerPort` protocol in `domain/ports/resilience.py`
 - Implementation in `infrastructure/adapters/http/circuit_breaker.py`
 - Decorator pattern in `infrastructure/adapters/decorators/circuit_breaker.py`
 - `CircuitBreakerOpenError` exception for open state signaling
 
 **Retry pattern:**
+
 - Decorator in `infrastructure/adapters/decorators/retry.py`
 - Error handling mixin in `infrastructure/adapters/error_handling.py` (117 lines of logic, 30 branches)
 - `RetryExhaustedError` for giving up after max attempts
 
 **Metrics integration:**
+
 - Prometheus metrics in `infrastructure/observability/prometheus_metrics.py`
 - Observable circuit breaker state changes
 
----
+______________________________________________________________________
 
 ### 5. Locking and Concurrency (Weight: 10%)
 
 **Score: 9/10**
 
 **Lock implementation:**
+
 - `LockPort` protocol in `domain/ports/locking.py` with full contract: `acquire()`, `release()`, `heartbeat()`, `validate_fencing_token()`
 - `MemoryLock` in `infrastructure/locking/memory_lock.py` (sufficient per ADR-010: local-only deployment)
 - `LockManager` in `application/core/lock_manager.py` orchestrates full lifecycle
 
 **Heartbeat:**
+
 - `HeartbeatTask` in `application/core/heartbeat.py`
 - Background async loop sends periodic heartbeats
 - Configurable interval: `heartbeat_interval` (default 30s, range 5-60s)
@@ -180,31 +215,36 @@ All import boundary checks passed with **zero violations**:
 - Graceful stop on pipeline completion
 
 **Fencing token:**
+
 - `FencingToken` type in `domain/locking.py`
 - `LockContext` dataclass with `fencing_token` field
 - `validate_fencing_token()` method on both port and implementation
 - `LockContextHolder` for thread-safe token management
 
 **Configuration:**
+
 - `LockConfig` in `application/core/config.py` with `heartbeat_interval`, `lock_ttl`
 - Auto-computed `safe_ttl = lock_ttl or heartbeat_interval * 3`
 
 **Minor gap (-1):**
+
 - Only `MemoryLock` implementation exists (no Redis/distributed lock). While this is by design (ADR-010), the architecture supports future distributed lock implementations via the `LockPort` protocol.
 
----
+______________________________________________________________________
 
 ### 6. Validation and Data Quality (Weight: 10%)
 
 **Score: 10/10**
 
 **Pandera schemas:**
+
 - 44 files reference Pandera across the codebase
 - Silver schemas in `domain/schemas/` for all entity types: ChEMBL (activity, assay, cell_line, compound_record, molecule, publication, target, etc.), PubChem, PubMed, UniProt, Crossref, OpenAlex, Semantic Scholar
 - Gold contracts in `domain/contracts/gold/` for all providers
 - Base schema with common validation in `domain/schemas/base.py`
 
 **Quarantine mechanism:**
+
 - `QuarantinePort` protocol in `domain/ports/quarantine.py`
 - Quarantine aggregate in `domain/aggregates/quarantine_entry.py`
 - `QuarantineManager` in `application/core/quarantine_manager.py`
@@ -213,6 +253,7 @@ All import boundary checks passed with **zero violations**:
 - Quarantine CLI commands in `interfaces/cli/commands/quarantine.py`
 
 **DQ monitoring:**
+
 - `DQMonitorPort` protocol for metrics
 - DQ report service in `application/services/dq_report_service.py`
 - DQ metrics calculator in `domain/services/dq_metrics_calculator.py`
@@ -220,18 +261,20 @@ All import boundary checks passed with **zero violations**:
 - Externalized DQ rules (ADR-027)
 
 **Content hash / deduplication:**
+
 - 65 files reference `content_hash`/`hash_record`/`dedup`
 - Identity service in `domain/services/identity_service.py`
 - Deduplication logic in `application/composite/deduplication.py`
 - Content hash in entities via `domain/entities/base.py`
 
----
+______________________________________________________________________
 
 ### 7. Logging and Observability (Weight: 8%)
 
 **Score: 10/10**
 
 **Structured logging:**
+
 - `LoggerPort` protocol in `domain/ports/observability.py`
 - `UnifiedLogger` implementation in `infrastructure/observability/unified_logger.py`
 - `structlog` only imported in infrastructure/composition (never in domain/application/interfaces)
@@ -240,22 +283,25 @@ All import boundary checks passed with **zero violations**:
 - Bootstrap logger in `composition/bootstrap_logger.py`
 
 **Observability ports:**
+
 - `TracingPort` for distributed tracing
 - `MetricsPort` for metrics collection
 - `DQMonitorPort` for data quality metrics
 - All ports have NoOp implementations for graceful degradation
 
 **Prometheus metrics:**
+
 - Implementation in `infrastructure/observability/prometheus_metrics.py`
 - Metrics server in `infrastructure/observability/server.py`
 - Pipeline metrics, DQ metrics, circuit breaker metrics
 
 **Tracing:**
+
 - OpenTelemetry integration (API + SDK + OTLP exporter in dependencies)
 - Tracing enforcement architecture test (`tests/architecture/test_tracing_enforcement.py`)
 - ADR-022 for tracing NoOp strategy
 
----
+______________________________________________________________________
 
 ### 8. Testing (Weight: 8%)
 
@@ -264,6 +310,7 @@ All import boundary checks passed with **zero violations**:
 **Coverage:** 90.63% (exceeds 85% threshold)
 
 **Test structure:**
+
 - Unit tests: 408 files
 - Architecture tests: 53 files (import boundaries, column order, code formatting, env var centralization, tracing enforcement)
 - Contract tests: 13 files (schema contracts, API contracts)
@@ -279,16 +326,18 @@ All import boundary checks passed with **zero violations**:
 **Golden/contract tests:** Present in `tests/contract/silver_schemas/` for field types, naming conventions, and validations
 
 **Minor gap (-1):**
+
 - 1 test failure: `tests/architecture/test_code_formatting.py::TestCodeFormatting::test_ruff_formatting_src` (formatting drift)
 - 234 tests skipped (mainly live API tests requiring `BIOETL_LIVE_API_TESTS=true`, and schema-specific skips)
 
----
+______________________________________________________________________
 
 ### 9. Security and Secrets (Weight: 8%)
 
 **Score: 10/10**
 
 **Secrets management:**
+
 - All secrets use `pydantic.SecretStr` (`infrastructure/config/_base.py:221-253`)
 - `.env` files in `.gitignore` (lines 68-70)
 - `get_secret_value()` used for runtime access (5 call sites, all in composition/infrastructure)
@@ -296,6 +345,7 @@ All import boundary checks passed with **zero violations**:
 - No hardcoded credential values in codebase
 
 **PII hashing:**
+
 - `PiiHasherPort` protocol in `domain/ports/pii.py`
 - SHA256 implementation in `infrastructure/security/pii_hasher.py`
 - Salt rotation support: `current_salt` + `next_salt` + `rotation_active`
@@ -304,16 +354,18 @@ All import boundary checks passed with **zero violations**:
 - Unicode normalization before hashing
 
 **Security testing:**
+
 - 4 security test files in `tests/security/`
 - `bandit` in dev dependencies for SAST
 
----
+______________________________________________________________________
 
 ### 10. Documentation and Maintainability (Weight: 7%)
 
 **Score: 9/10**
 
 **ADR (Architecture Decision Records):** 34 ADRs (ADR-001 through ADR-034) covering:
+
 - ADR-001: Delta Lake vs Parquet
 - ADR-002: Medallion Architecture
 - ADR-003: In-Memory Locking Strategy
@@ -333,27 +385,28 @@ All import boundary checks passed with **zero violations**:
 **Gold contracts:** Data contracts defined in `domain/contracts/gold/` for all entity types.
 
 **Minor gap (-1):**
+
 - `run_id` binding is present but limited to 5 files (35 occurrences). Could be more pervasive across logging call sites.
 
----
+______________________________________________________________________
 
 ## Part 3. Summary
 
 ### 3.1. Score Table
 
-| # | Category | Weight | Score | Weighted | Key Findings |
-|---|----------|--------|-------|----------|--------------|
-| 1 | Layered Architecture | 15% | 10 | 1.50 | Zero import violations, enforced by tests + import-linter |
-| 2 | Contracts and Ports | 12% | 10 | 1.20 | 38 protocols, 100% @runtime_checkable |
-| 3 | Medallion Architecture | 12% | 10 | 1.20 | Full Bronze/Silver/Gold with Delta Lake, zero raw Parquet |
-| 4 | Error Handling & CB | 10% | 10 | 1.00 | Three-tier classification, CB + retry + metrics |
-| 5 | Locking & Concurrency | 10% | 9 | 0.90 | Full lifecycle (heartbeat + fencing), MemoryLock only |
-| 6 | Validation & DQ | 10% | 10 | 1.00 | Pandera schemas for all entities, quarantine, content hash |
-| 7 | Logging & Observability | 8% | 10 | 0.80 | UnifiedLogger, Prometheus, OpenTelemetry, zero prints |
-| 8 | Testing | 8% | 9 | 0.72 | 90.63% coverage, VCR, snapshots, architecture tests |
-| 9 | Security & Secrets | 8% | 10 | 0.80 | SecretStr, PII hashing with salt rotation, bandit |
-| 10 | Documentation | 7% | 9 | 0.63 | 34 ADRs, active CHANGELOG, Gold contracts |
-| **Total** | | **100%** | | **9.75** | |
+| #         | Category                | Weight   | Score | Weighted | Key Findings                                               |
+| --------- | ----------------------- | -------- | ----- | -------- | ---------------------------------------------------------- |
+| 1         | Layered Architecture    | 15%      | 10    | 1.50     | Zero import violations, enforced by tests + import-linter  |
+| 2         | Contracts and Ports     | 12%      | 10    | 1.20     | 38 protocols, 100% @runtime_checkable                      |
+| 3         | Medallion Architecture  | 12%      | 10    | 1.20     | Full Bronze/Silver/Gold with Delta Lake, zero raw Parquet  |
+| 4         | Error Handling & CB     | 10%      | 10    | 1.00     | Three-tier classification, CB + retry + metrics            |
+| 5         | Locking & Concurrency   | 10%      | 9     | 0.90     | Full lifecycle (heartbeat + fencing), MemoryLock only      |
+| 6         | Validation & DQ         | 10%      | 10    | 1.00     | Pandera schemas for all entities, quarantine, content hash |
+| 7         | Logging & Observability | 8%       | 10    | 0.80     | UnifiedLogger, Prometheus, OpenTelemetry, zero prints      |
+| 8         | Testing                 | 8%       | 9     | 0.72     | 90.63% coverage, VCR, snapshots, architecture tests        |
+| 9         | Security & Secrets      | 8%       | 10    | 0.80     | SecretStr, PII hashing with salt rotation, bandit          |
+| 10        | Documentation           | 7%       | 9     | 0.63     | 34 ADRs, active CHANGELOG, Gold contracts                  |
+| **Total** |                         | **100%** |       | **9.75** |                                                            |
 
 ### 3.2. Interpretation
 
@@ -361,7 +414,7 @@ All import boundary checks passed with **zero violations**:
 
 The BioETL codebase demonstrates exceptional architectural discipline. The layered architecture is perfectly enforced with zero import boundary violations. All external dependencies are abstracted through 38 Protocol-based ports, each with `@runtime_checkable` validation. The Medallion architecture is fully implemented using Delta Lake (no raw Parquet), with comprehensive Pandera validation schemas across all entity types.
 
----
+______________________________________________________________________
 
 ### 3.3. Refactoring Plan
 
@@ -378,7 +431,7 @@ The BioETL codebase demonstrates exceptional architectural discipline. The layer
 **Criterion**: `pytest tests/architecture/test_code_formatting.py` passes
 **Effort**: S (minutes)
 
----
+______________________________________________________________________
 
 #### [P3] Fix unused type:ignore comment
 
@@ -393,7 +446,7 @@ The BioETL codebase demonstrates exceptional architectural discipline. The layer
 **Criterion**: `mypy --strict src/bioetl/` reports 0 errors
 **Effort**: S (minutes)
 
----
+______________________________________________________________________
 
 #### [P3] Expand run_id binding in logging
 
@@ -408,7 +461,7 @@ The BioETL codebase demonstrates exceptional architectural discipline. The layer
 **Criterion**: All log output includes `run_id` field
 **Effort**: S (hours)
 
----
+______________________________________________________________________
 
 #### [P3] Add distributed lock implementation (future)
 
@@ -423,7 +476,7 @@ The BioETL codebase demonstrates exceptional architectural discipline. The layer
 **Criterion**: `RedisLock` passes same test suite as `MemoryLock`
 **Effort**: M (days)
 
----
+______________________________________________________________________
 
 ### 3.4. Roadmap
 
@@ -446,60 +499,60 @@ The BioETL codebase demonstrates exceptional architectural discipline. The layer
 
 **Expected score change**: 9.90 -> 10.00
 
----
+______________________________________________________________________
 
 ## Part 4. Regression Control Metrics
 
-| Metric | Threshold | Command | Blocks PR |
-|--------|-----------|---------|-----------|
-| Test coverage | >= 85% | `pytest --cov=src/bioetl --cov-fail-under=85` | Yes |
-| mypy errors | 0 | `mypy --strict src/bioetl/ 2>&1 \| grep -c "error:"` | Yes |
-| Circular imports | 0 | `python -c "from bioetl.domain import *"` | Yes |
-| Layer violations (domain->infra) | 0 | `grep -r "from bioetl.infrastructure" src/bioetl/domain/` | Yes |
-| Layer violations (domain->app) | 0 | `grep -r "from bioetl.application" src/bioetl/domain/` | Yes |
-| Layer violations (app->infra) | 0 | `grep -r "from bioetl.infrastructure" src/bioetl/application/` | Yes |
-| Layer violations (infra->app) | 0 | `grep -r "from bioetl.application" src/bioetl/infrastructure/` | Yes |
-| Layer violations (infra->comp) | 0 | `grep -r "from bioetl.composition" src/bioetl/infrastructure/` | Yes |
-| print() in production | 0 | `grep -r "print(" src/bioetl --include="*.py"` | Yes |
-| structlog in domain/app | 0 | `grep -r "import structlog" src/bioetl/domain/ src/bioetl/application/` | Yes |
-| TODO/FIXME | 0 | `grep -rE "(TODO\|FIXME\|XXX\|HACK)" src/` | No (warning) |
-| Ruff formatting | 0 diffs | `ruff format --check src/` | Yes |
-| Architecture tests | 100% pass | `pytest tests/architecture/ -v` | Yes |
-| Import linter | 0 violations | `lint-imports` | Yes |
-| Security scan (bandit) | 0 high/critical | `bandit -r src/bioetl/` | Yes |
-| Detect-secrets | 0 new secrets | `detect-secrets scan --baseline .secrets.baseline` | Yes |
+| Metric                           | Threshold       | Command                                                                 | Blocks PR    |
+| -------------------------------- | --------------- | ----------------------------------------------------------------------- | ------------ |
+| Test coverage                    | >= 85%          | `pytest --cov=src/bioetl --cov-fail-under=85`                           | Yes          |
+| mypy errors                      | 0               | `mypy --strict src/bioetl/ 2>&1 \| grep -c "error:"`                    | Yes          |
+| Circular imports                 | 0               | `python -c "from bioetl.domain import *"`                               | Yes          |
+| Layer violations (domain->infra) | 0               | `grep -r "from bioetl.infrastructure" src/bioetl/domain/`               | Yes          |
+| Layer violations (domain->app)   | 0               | `grep -r "from bioetl.application" src/bioetl/domain/`                  | Yes          |
+| Layer violations (app->infra)    | 0               | `grep -r "from bioetl.infrastructure" src/bioetl/application/`          | Yes          |
+| Layer violations (infra->app)    | 0               | `grep -r "from bioetl.application" src/bioetl/infrastructure/`          | Yes          |
+| Layer violations (infra->comp)   | 0               | `grep -r "from bioetl.composition" src/bioetl/infrastructure/`          | Yes          |
+| print() in production            | 0               | `grep -r "print(" src/bioetl --include="*.py"`                          | Yes          |
+| structlog in domain/app          | 0               | `grep -r "import structlog" src/bioetl/domain/ src/bioetl/application/` | Yes          |
+| TODO/FIXME                       | 0               | `grep -rE "(TODO\|FIXME\|XXX\|HACK)" src/`                              | No (warning) |
+| Ruff formatting                  | 0 diffs         | `ruff format --check src/`                                              | Yes          |
+| Architecture tests               | 100% pass       | `pytest tests/architecture/ -v`                                         | Yes          |
+| Import linter                    | 0 violations    | `lint-imports`                                                          | Yes          |
+| Security scan (bandit)           | 0 high/critical | `bandit -r src/bioetl/`                                                 | Yes          |
+| Detect-secrets                   | 0 new secrets   | `detect-secrets scan --baseline .secrets.baseline`                      | Yes          |
 
----
+______________________________________________________________________
 
 ## Appendix A. Codebase Statistics
 
-| Metric | Value |
-|--------|-------|
-| Total classes | 911 |
-| Total Python files (src/) | 559 |
-| Total Python files (src/bioetl/) | 534 |
-| Total LOC (src/bioetl/) | 116,062 |
-| Average module size | ~217 lines |
-| Port protocols | 38 |
-| ADR documents | 34 |
-| VCR cassettes | 136 |
-| Entity types supported | 7 providers (ChEMBL, PubChem, PubMed, UniProt, Crossref, OpenAlex, Semantic Scholar) |
-| Pandera schemas | 44 files |
-| Gold contracts | 8 files |
-| Test files (total) | 583 |
+| Metric                           | Value                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| Total classes                    | 911                                                                                  |
+| Total Python files (src/)        | 559                                                                                  |
+| Total Python files (src/bioetl/) | 534                                                                                  |
+| Total LOC (src/bioetl/)          | 116,062                                                                              |
+| Average module size              | ~217 lines                                                                           |
+| Port protocols                   | 38                                                                                   |
+| ADR documents                    | 34                                                                                   |
+| VCR cassettes                    | 136                                                                                  |
+| Entity types supported           | 7 providers (ChEMBL, PubChem, PubMed, UniProt, Crossref, OpenAlex, Semantic Scholar) |
+| Pandera schemas                  | 44 files                                                                             |
+| Gold contracts                   | 8 files                                                                              |
+| Test files (total)               | 583                                                                                  |
 
 ## Appendix B. Architecture Enforcement Stack
 
-| Tool | Purpose | Configuration |
-|------|---------|---------------|
-| `import-linter` | Layer boundary enforcement | `pyproject.toml` |
-| `pytest-archon` | Architecture test framework | `tests/architecture/` |
-| `mypy --strict` | Type safety | `pyproject.toml [tool.mypy]` |
-| `ruff` | Linting + formatting | `pyproject.toml [tool.ruff]` |
-| `bandit` | Security analysis (SAST) | dev dependency |
-| `detect-secrets` | Secret detection | dev dependency |
-| `vulture` | Dead code detection | dev dependency |
-| `xenon`/`radon` | Code complexity | dev dependency |
-| `pandera` | DataFrame schema validation | `domain/schemas/` |
-| `syrupy` | Snapshot testing | `tests/snapshots/` |
-| `vcrpy` | HTTP cassette recording | `tests/fixtures/vcr/` |
+| Tool             | Purpose                     | Configuration                |
+| ---------------- | --------------------------- | ---------------------------- |
+| `import-linter`  | Layer boundary enforcement  | `pyproject.toml`             |
+| `pytest-archon`  | Architecture test framework | `tests/architecture/`        |
+| `mypy --strict`  | Type safety                 | `pyproject.toml [tool.mypy]` |
+| `ruff`           | Linting + formatting        | `pyproject.toml [tool.ruff]` |
+| `bandit`         | Security analysis (SAST)    | dev dependency               |
+| `detect-secrets` | Secret detection            | dev dependency               |
+| `vulture`        | Dead code detection         | dev dependency               |
+| `xenon`/`radon`  | Code complexity             | dev dependency               |
+| `pandera`        | DataFrame schema validation | `domain/schemas/`            |
+| `syrupy`         | Snapshot testing            | `tests/snapshots/`           |
+| `vcrpy`          | HTTP cassette recording     | `tests/fixtures/vcr/`        |

--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -1,6 +1,6 @@
 # BioETL: Правила Проекта
 
-*Версия: 5.19 (Statistics Update), 2026-02-16*
+*Версия: 5.21 (Target Schema Architecture 2026), 2026-02-17*
 
 ## Введение (Quick Reference)
 
@@ -62,7 +62,9 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие критические порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
@@ -72,6 +74,7 @@
 
   > **Текущее состояние:** Все 38 портов декорированы `@runtime_checkable` (100% coverage).
   > Минимальное требование — 4 критических порта выше; остальные декорированы для единообразия.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -164,7 +167,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -244,19 +247,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -274,6 +278,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -335,6 +340,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -506,6 +512,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -564,6 +571,50 @@ _run_id → _run_id → pipeline_run_id
 
 - Сохранять оригинальные имена в Silver (упрощает отладку)
 - Применять бизнес-имена только в Gold (`_run_id` → `pipeline_run_id`, `pmid` → `pubmed_id`)
+
+### 2.10. Target Schema Architecture 2026 (Governance Gate)
+
+См. [Schema Governance](../02-architecture/Schema-Governance.md) и [ADR-035](../02-architecture/decisions/ADR-035-target-schema-architecture-2026.md).
+
+#### 2.10.1 Schema Lifecycle (MUST)
+
+Любое изменение схемы MUST проходить этапы: Draft -> Review -> Governance Gate -> Release -> Deprecation/Removal.
+
+#### 2.10.2 Drift Classification (MUST)
+
+Результат governance-gate MUST быть классифицирован:
+
+- **blocking**: блокирует публикацию Gold до обновления контракта/миграции.
+- **warning**: не блокирует релиз, но требует тикет и SLA на обработку.
+
+#### 2.10.3 Contract Versioning (MUST)
+
+Схемы должны использовать SemVer-подобную классификацию:
+
+- MAJOR — breaking contract,
+- MINOR — additive backward-compatible changes,
+- PATCH — non-breaking metadata/constraint updates.
+
+Breaking changes MUST сопровождаться ADR и планом миграции.
+
+#### 2.10.4 PK & Partition Strategy (SHOULD)
+
+- Business PK SHOULD оставаться стабильным и независимым от content hash.
+- Silver/Gold partition keys SHOULD иметь ограниченную кардинальность.
+- Использование UUID/hash как partition key MUST NOT применяться без отдельного ADR-исключения.
+
+#### 2.10.5 JSON Typing Standard (MUST)
+
+- Пропуски и неизвестные значения MUST кодироваться как `null` (sentinel values запрещены).
+- Даты MUST быть в формате `YYYY-MM-DD`, timestamps — ISO-8601 UTC.
+- Нормализация перед hash/checks MUST включать trim строк, округление float, NaN/Inf -> null.
+
+#### 2.10.6 SCD2 Decision Matrix (MUST)
+
+Для Gold-изменений решение MUST приниматься через SCD2-матрицу:
+
+- изменение, ведущее к потере семантики/данных -> `blocking`;
+- аддитивное изменение без потери историчности -> `warning`.
 
 ## 3. Обработка Ошибок и Наблюдаемость
 
@@ -922,7 +973,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1024,11 +1077,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1163,11 +1216,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1222,6 +1275,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1352,20 +1406,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1397,14 +1451,14 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
@@ -1535,10 +1589,12 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-035](02-architecture/decisions/ADR-035-target-schema-architecture-2026.md)    | Target Schema Architecture 2026          | Accepted           | 2026-02-17 |
 
 ## История Изменений (Changelog)
 
+- **5.21** (2026-02-17): Target Schema Architecture 2026. Добавлена §2.10 (Schema Lifecycle, Drift Classification, Contract Versioning, PK/Partition Strategy, JSON Typing Standard, SCD2 Decision Matrix). Добавлен ADR-035 в реестр (Приложение F).
 - **5.20** (2026-02-17): Audit Sync. Future annotations (497→501, 93.8%). Тест-функций (`def test_`): ~9,442; параметризованных кейсов (`pytest --collect-only`): ~11,985. Python-файлов (~1,114→~1,161). Исправлен .importlinter gap (infrastructure→composition). Архивирован orphaned ADR-030. TYPE-002 `Any` justification — 21 инстанс.
 - **5.19** (2026-02-16): Documentation Sync. Файлов кода (517→534), future annotations (481→497, 93.1%). ADR-034 (Schema↔Domain Configuration Pairs) добавлен в реестр. Тестов (~7,090→~11,985). Python-файлов (~1,094→~1,114). Синхронизация 00-map.md, CLAUDE.md, 00-overview.md, decisions/README.md.
 - **5.18** (2026-02-15): Statistics Update. Обновлены числовые данные по результатам аудита 2026-02-14: файлов кода (499→517), future annotations (468→481), Int→Float coercion occurrences (~34→~88), publication field groups (94→106), LOC для ChemblAdapter (517→975), GoldWriter (593→946), PreflightService (527→818).

--- a/docs/02-architecture/Schema-Governance.md
+++ b/docs/02-architecture/Schema-Governance.md
@@ -1,0 +1,103 @@
+# Schema Governance
+
+*Status: Target state baseline (2026).*
+
+## Schema Lifecycle
+
+Schema lifecycle for Bronze/Silver/Gold is standardized as a gated flow:
+
+1. **Draft**
+   - Schema is authored in provider/entity contract files.
+   - Validation examples and backward-compatibility notes are mandatory.
+1. **Review**
+   - Architecture + data governance review confirms medallion compliance and naming rules.
+   - Changes are classified as `backward-compatible` or `breaking`.
+1. **Pre-release verification (governance gate)**
+   - Contract checks, fixture replay, and drift simulation are executed.
+   - Gate emits `blocking` or `warning` findings.
+1. **Release**
+   - Schema version and changelog are published together.
+   - Rollout strategy is selected (dual-write, shadow-read, or direct cutover).
+1. **Deprecation / Removal**
+   - Deprecated fields keep a migration window.
+   - Removal requires version bump and explicit ADR reference.
+
+## Drift Handling
+
+Drift management separates detection from enforcement:
+
+- **Bronze**: drift is tolerated (append-only raw capture).
+- **Silver**: soft enforcement — unknown/changed fields trigger drift events, not immediate stop.
+- **Gold**: strict enforcement — unresolved drift is treated as a release-blocking contract mismatch.
+
+Drift workflow:
+
+1. Detect drift (`new_field`, `type_change`, `nullability_change`, `enum_expansion`).
+1. Classify severity:
+   - `blocking`: destructive or ambiguous change (e.g., type narrowing).
+   - `warning`: additive or safely coercible change.
+1. Route action:
+   - warning → ticket + SLA.
+   - blocking → stop Gold publish until schema contract is updated.
+
+## Contract Versioning
+
+Versioning policy for schema contracts:
+
+- **MAJOR**: incompatible contract (rename, type incompatibility, semantic change).
+- **MINOR**: backward-compatible additive changes.
+- **PATCH**: metadata, docs, constraints tightening without consumer break.
+
+Additional rules:
+
+- Contract version is declared per entity.
+- Breaking changes require ADR and migration plan.
+- Gold contract version MUST be traceable to Silver source contract version.
+
+## PK & Partition Strategy
+
+Primary key and partition rules for target-state schema design:
+
+- PK MUST represent stable business identity (`provider_id` + optional natural discriminator).
+- Content hash MUST represent version identity (record state), not business identity.
+- Silver partitioning SHOULD use bounded cardinality keys (`year`, `month`, `entity_type`).
+- Gold partitioning SHOULD align with primary query access patterns, avoiding high-cardinality UUID/hash partition keys.
+
+Recommended constraints:
+
+- Avoid partition keys with expected cardinality >50k.
+- Use Z-ORDER / clustering for high-cardinality filters instead of deep partition fan-out.
+
+## JSON Typing Standard
+
+Canonical JSON typing baseline for cross-provider normalization:
+
+- Integer-like optional fields in analytical schemas: nullable numeric representation compatible with dataframe engines.
+- Floating point values normalized with bounded precision.
+- Date values serialized as `YYYY-MM-DD`.
+- Timestamp values serialized as ISO-8601 UTC.
+- Booleans are strict (`true` / `false`), no string booleans.
+- Missing or unknown values represented as `null` (sentinel values are forbidden).
+
+Normalization before content-hash or contract checks:
+
+- trim strings,
+- round floats to agreed precision,
+- map NaN/Inf to `null`,
+- exclude runtime metadata fields from hash comparison.
+
+## SCD2 Decision Matrix
+
+| Change type                        | Business meaning            | SCD2 action                                                | Gate class |
+| ---------------------------------- | --------------------------- | ---------------------------------------------------------- | ---------- |
+| Descriptive attribute update       | Normal historical evolution | New version row (`valid_from` / `valid_to`)                | warning    |
+| Identity key change                | Potential entity remap      | Manual review + migration                                  | blocking   |
+| Type narrowing / incompatible cast | Contract break risk         | Block publish until migration approved                     | blocking   |
+| Additive nullable attribute        | Non-breaking extension      | Keep current row; write new value on next version boundary | warning    |
+| Enum expansion                     | Usually additive            | Accept with monitoring                                     | warning    |
+| Enum contraction                   | Potential data loss         | Require impact analysis and migration                      | blocking   |
+
+Decision rule:
+
+- If change can cause historical reinterpretation or data loss, classify as `blocking`.
+- If change is additive and preserves historical semantics, classify as `warning`.

--- a/docs/02-architecture/decisions/ADR-035-target-schema-architecture-2026.md
+++ b/docs/02-architecture/decisions/ADR-035-target-schema-architecture-2026.md
@@ -1,0 +1,86 @@
+# ADR-035: Target Schema Architecture 2026
+
+- **Status**: Accepted
+- **Date**: 2026-02-17
+- **Related**: ADR-002, ADR-014, ADR-018, ADR-034
+
+## Context
+
+By 2026, BioETL requires a single target-state schema governance model that aligns:
+
+- Medallion contracts (Bronze tolerant, Silver controlled, Gold strict),
+- SCD Type 2 historical guarantees,
+- deterministic hashing and replay behavior,
+- and explicit release gating for schema drift.
+
+Existing controls are distributed across multiple rules and ADRs. This ADR formalizes the target architecture and implementation roadmap.
+
+## Decision
+
+BioETL adopts a **Target Schema Architecture 2026** with:
+
+1. Unified schema lifecycle governance gate (`blocking` vs `warning`).
+1. Explicit contract versioning policy (MAJOR/MINOR/PATCH per entity contract).
+1. Canonical PK/content-hash separation and partition policy.
+1. JSON typing standard used by validation, hashing, and schema diffs.
+1. Mandatory SCD2 decision matrix for Gold model evolution.
+
+## Roadmap (3 phases)
+
+### Phase 1 — Foundation (Q1 2026)
+
+- Publish `Schema-Governance.md` as normative architecture reference.
+- Add governance gate outputs into CI artifact set.
+- Standardize change classification (`blocking`, `warning`) in docs and release checklist.
+
+### Phase 2 — Enforcement (Q2 2026)
+
+- Enforce contract semantic versioning in schema change pipeline.
+- Add automated drift classifier with deterministic severity mapping.
+- Add mandatory SCD2 decision checks for Gold-breaking changes.
+
+### Phase 3 — Optimization (Q3 2026)
+
+- Add trend monitoring for drift volume and warning debt.
+- Tune partition strategy with observed workload patterns.
+- Automate migration plan generation for MAJOR version changes.
+
+## Impact Matrix
+
+| Area                 | Positive impact                                                       | Cost / tradeoff                                        |
+| -------------------- | --------------------------------------------------------------------- | ------------------------------------------------------ |
+| Data Reliability     | Lower risk of silent schema breakages in Gold                         | More pre-release checks and slower approval path       |
+| Operability          | Clear `blocking`/`warning` semantics for on-call and release managers | Requires team alignment on severity taxonomy           |
+| Performance          | Better partition discipline reduces metadata overhead                 | May require repartition migrations for existing tables |
+| Developer Experience | Predictable contract evolution path and fewer ad-hoc reviews          | Additional documentation and versioning duties per PR  |
+| Governance           | Traceable and auditable schema decisions                              | More ADR/update overhead for MAJOR changes             |
+
+## Risk Assessment
+
+| Risk                                             | Probability | Impact | Mitigation                                                     |
+| ------------------------------------------------ | ----------- | ------ | -------------------------------------------------------------- |
+| Over-classification as `blocking` slows delivery | Medium      | Medium | Start with conservative warning defaults and calibrate monthly |
+| Inconsistent version bump decisions across teams | Medium      | High   | Provide versioning checklist and CI validation hooks           |
+| Drift alert fatigue from additive changes        | High        | Medium | Batch warning alerts and enforce warning debt SLA              |
+| Migration complexity for legacy schemas          | Medium      | High   | Phase rollout by provider/entity and keep rollback plans       |
+| Documentation drift from implementation          | Medium      | Medium | Add docs sync check in release gate                            |
+
+## Consequences
+
+### Positive
+
+- Target-state schema governance becomes explicit and auditable.
+- Gold layer evolution receives uniform SCD2 and contract controls.
+- Architecture audit and RULES now share a single schema target narrative.
+
+### Negative
+
+- Governance workflow introduces additional process overhead.
+- Initial rollout may require refactoring of historical schema metadata.
+
+## Related ADRs
+
+- [ADR-002](ADR-002-medallion-architecture.md): Medallion architecture baseline.
+- [ADR-014](ADR-014-deterministic-writes.md): Deterministic behaviors for replay/hash logic.
+- [ADR-018](ADR-018-gold-strict-validation.md): Strict Gold contract enforcement.
+- [ADR-034](ADR-034-schema-domain-pairs.md): Schema/domain split and compatibility constraints.

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -4,64 +4,70 @@ This directory contains Architecture Decision Records documenting significant ar
 
 ## ADR Index
 
-| ADR | Title | Status | Category | Date |
-|-----|-------|--------|----------|------|
-| [ADR-001](ADR-001-delta-lake-vs-parquet.md) | Delta Lake vs Parquet | Accepted | Storage | 2025-05-20 |
-| [ADR-002](ADR-002-medallion-architecture.md) | Medallion Architecture | Accepted | Architecture | 2025-05-20 |
-| [ADR-003](ADR-003-in-memory-locking-strategy.md) | In-Memory Locking (MemoryLock) | Accepted (Revised) | Locking | 2025-12-23 |
-| [ADR-004](ADR-004-pydantic-vs-dataclasses.md) | Pydantic vs Dataclasses | Accepted | Data Modeling | 2025-05-20 |
-| [ADR-005](ADR-005-composition-layer-separation.md) | Composition Layer Separation | Accepted | Architecture | 2025-12-15 |
-| [ADR-006](ADR-006-logger-metrics-ports.md) | Logger and Metrics Ports | Accepted | Observability | 2025-12-18 |
-| [ADR-007](ADR-007-circuit-breaker-implementation.md) | Circuit Breaker Implementation | Accepted | Resilience | 2025-12-22 |
-| [ADR-008](ADR-008-graceful-shutdown-strategy.md) | Graceful Shutdown Strategy | Accepted | Lifecycle | 2025-12-22 |
-| [ADR-009](ADR-009-paginated-fetcher-mixin.md) | PaginatedFetcherMixin Design | Accepted | Data Fetching | 2025-12-22 |
-| [ADR-010](ADR-010-local-only-deployment.md) | Local-Only Deployment | Accepted | Deployment | 2025-12-23 |
-| [ADR-011](ADR-011-remove-watermark-mechanism.md) | Remove Watermark Mechanism | Accepted | Data Loading | 2025-12-23 |
-| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID | Accepted | Storage | 2025-12-23 |
-| [ADR-013](ADR-013-async-storage-cleanup.md) | Async Storage Cleanup | Accepted | Storage | 2025-12-24 |
-| [ADR-014](ADR-014-deterministic-writes.md) | Deterministic Writes and Retries | Accepted | Reproducibility | 2025-12-24 |
-| [ADR-015](ADR-015-pipeline-services-lifecycle.md) | Pipeline Services Lifecycle | Accepted | Lifecycle | 2025-12-24 |
-| [ADR-016](ADR-016-error-handling-strategy.md) | Error Handling Strategy | Accepted | Resilience | 2025-12-26 |
-| [ADR-017](ADR-017-observability-architecture.md) | Observability Architecture | Accepted | Observability | 2025-12-26 |
-| [ADR-018](ADR-018-gold-strict-validation.md) | Gold Strict Validation | Accepted | Data Quality | 2025-12-26 |
-| [ADR-019](ADR-019-observability-port-enforcement.md) | Observability Port Enforcement | Accepted | Observability | 2025-12-26 |
-| [ADR-020](ADR-020-basepipeline-decomposition.md) | BasePipeline Decomposition | Accepted | Architecture | 2025-12-16 |
-| [ADR-021](ADR-021-ddd-aggregates-adoption.md) | DDD Aggregates Adoption | Accepted | Domain Model | 2025-12-29 |
-| [ADR-022](ADR-022-tracing-noop.md) | NoOp Tracing for Local-Only | Accepted | Observability | 2025-12-30 |
-| [ADR-023](ADR-023-entity-type-patterns.md) | Entity Type Patterns | Accepted | Observability | 2026-01-06 |
-| [ADR-024](ADR-024-entity-naming-unification.md) | Entity Naming Unification | Accepted | Architecture | 2026-01-07 |
-| [ADR-025](ADR-025-pipeline-config-unification.md) | Pipeline Config Unification | Accepted | Configuration | 2026-01-14 |
-| [ADR-026](ADR-026-composite-pipeline-pattern.md) | Composite Pipeline Pattern | Accepted | Architecture | 2026-01-15 |
-| [ADR-027](ADR-027-dq-rules-externalization.md) | DQ Rules Externalization | Accepted | Data Quality | 2026-01-19 |
-| [ADR-028](ADR-028-filter-rules-externalization.md) | Filter Rules Externalization | Accepted | Configuration | 2026-01-20 |
-| [ADR-029](ADR-029-output-metadata-unification.md) | Output Metadata Unification | Accepted | Data Modeling | 2026-01-23 |
-| [ADR-030](ADR-030-publication-pagination-strategy.md) | Publication Pagination Strategy | Accepted | Data Fetching | 2026-01-25 |
-| [ADR-031](ADR-031-loading-strategy-formalization.md) | Loading Strategy Formalization | Accepted | Data Loading | 2026-01-26 |
-| [ADR-032](ADR-032-unified-http-client.md) | Unified HTTP Client Pattern | Accepted | HTTP/Networking | 2026-01-28 |
-| [ADR-033](ADR-033-publication-validation-strategy.md) | Publication Metadata Validation Strategy | Proposed | Data Quality | 2026-02-06 |
-| [ADR-034](ADR-034-schema-domain-pairs.md) | Schema↔Domain Configuration Pairs | Accepted | Architecture | 2026-02-15 |
+| ADR                                                     | Title                                    | Status             | Category        | Date       |
+| ------------------------------------------------------- | ---------------------------------------- | ------------------ | --------------- | ---------- |
+| [ADR-001](ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | Storage         | 2025-05-20 |
+| [ADR-002](ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | Architecture    | 2025-05-20 |
+| [ADR-003](ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | Locking         | 2025-12-23 |
+| [ADR-004](ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | Accepted           | Data Modeling   | 2025-05-20 |
+| [ADR-005](ADR-005-composition-layer-separation.md)      | Composition Layer Separation             | Accepted           | Architecture    | 2025-12-15 |
+| [ADR-006](ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                 | Accepted           | Observability   | 2025-12-18 |
+| [ADR-007](ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation           | Accepted           | Resilience      | 2025-12-22 |
+| [ADR-008](ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy               | Accepted           | Lifecycle       | 2025-12-22 |
+| [ADR-009](ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design             | Accepted           | Data Fetching   | 2025-12-22 |
+| [ADR-010](ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | Accepted           | Deployment      | 2025-12-23 |
+| [ADR-011](ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism               | Accepted           | Data Loading    | 2025-12-23 |
+| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID        | Accepted           | Storage         | 2025-12-23 |
+| [ADR-013](ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | Accepted           | Storage         | 2025-12-24 |
+| [ADR-014](ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries         | Accepted           | Reproducibility | 2025-12-24 |
+| [ADR-015](ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | Accepted           | Lifecycle       | 2025-12-24 |
+| [ADR-016](ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | Resilience      | 2025-12-26 |
+| [ADR-017](ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | Observability   | 2025-12-26 |
+| [ADR-018](ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | Data Quality    | 2025-12-26 |
+| [ADR-019](ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | Observability   | 2025-12-26 |
+| [ADR-020](ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | Architecture    | 2025-12-16 |
+| [ADR-021](ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | Domain Model    | 2025-12-29 |
+| [ADR-022](ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only              | Accepted           | Observability   | 2025-12-30 |
+| [ADR-023](ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | Accepted           | Observability   | 2026-01-06 |
+| [ADR-024](ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | Accepted           | Architecture    | 2026-01-07 |
+| [ADR-025](ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | Accepted           | Configuration   | 2026-01-14 |
+| [ADR-026](ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | Accepted           | Architecture    | 2026-01-15 |
+| [ADR-027](ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | Accepted           | Data Quality    | 2026-01-19 |
+| [ADR-028](ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | Accepted           | Configuration   | 2026-01-20 |
+| [ADR-029](ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | Accepted           | Data Modeling   | 2026-01-23 |
+| [ADR-030](ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | Accepted           | Data Fetching   | 2026-01-25 |
+| [ADR-031](ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | Data Loading    | 2026-01-26 |
+| [ADR-032](ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | HTTP/Networking | 2026-01-28 |
+| [ADR-033](ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | Data Quality    | 2026-02-06 |
+| [ADR-034](ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | Architecture    | 2026-02-15 |
+| [ADR-035](ADR-035-target-schema-architecture-2026.md)   | Target Schema Architecture 2026          | Accepted           | Architecture    | 2026-02-17 |
 
 ## ADRs by Category
 
 ### Architecture (Core Patterns)
+
 - [ADR-002](ADR-002-medallion-architecture.md): Medallion Architecture (Bronze/Silver/Gold)
 - [ADR-005](ADR-005-composition-layer-separation.md): Composition Layer Separation (DI)
 - [ADR-020](ADR-020-basepipeline-decomposition.md): BasePipeline Decomposition (God Object removal)
 - [ADR-024](ADR-024-entity-naming-unification.md): Entity Naming Unification
 - [ADR-026](ADR-026-composite-pipeline-pattern.md): Composite Pipeline Pattern
 - [ADR-034](ADR-034-schema-domain-pairs.md): Schema↔Domain Configuration Pairs — Domain frozen dataclasses vs Infrastructure Pydantic models
+- [ADR-035](ADR-035-target-schema-architecture-2026.md): Target Schema Architecture 2026 — unified lifecycle, drift gates, and SCD2 governance
 
 ### Storage
+
 - [ADR-001](ADR-001-delta-lake-vs-parquet.md): Delta Lake vs Parquet
 - [ADR-012](ADR-012-storage-clear-contract-and-run-id.md): Storage Clear Contract and Run ID
 - [ADR-013](ADR-013-async-storage-cleanup.md): Async Storage Cleanup
 
 ### Resilience & Error Handling
+
 - [ADR-007](ADR-007-circuit-breaker-implementation.md): Circuit Breaker Implementation
 - [ADR-016](ADR-016-error-handling-strategy.md): Error Handling Strategy
 - [ADR-032](ADR-032-unified-http-client.md): Unified HTTP Client Pattern — Centralized HTTP with rate limiting and retry
 
 ### Observability
+
 - [ADR-006](ADR-006-logger-metrics-ports.md): Logger and Metrics Ports
 - [ADR-017](ADR-017-observability-architecture.md): Observability Architecture
 - [ADR-019](ADR-019-observability-port-enforcement.md): Observability Port Enforcement
@@ -69,35 +75,43 @@ This directory contains Architecture Decision Records documenting significant ar
 - [ADR-023](ADR-023-entity-type-patterns.md): Entity Type Patterns (transformer entity_type)
 
 ### Lifecycle Management
+
 - [ADR-008](ADR-008-graceful-shutdown-strategy.md): Graceful Shutdown Strategy
 - [ADR-015](ADR-015-pipeline-services-lifecycle.md): Pipeline Services Lifecycle
 
 ### Data Quality
+
 - [ADR-018](ADR-018-gold-strict-validation.md): Gold Strict Validation
 - [ADR-027](ADR-027-dq-rules-externalization.md): DQ Rules Externalization — Hierarchical DQ config
 - [ADR-033](ADR-033-publication-validation-strategy.md): Publication Metadata Validation Strategy — 5-level validation for publication data
 
 ### Domain Model
+
 - [ADR-004](ADR-004-pydantic-vs-dataclasses.md): Pydantic vs Dataclasses
 - [ADR-021](ADR-021-ddd-aggregates-adoption.md): DDD Aggregates Adoption
 - [ADR-029](ADR-029-output-metadata-unification.md): Output Metadata Unification — Unified output metadata contracts
 
 ### Data Fetching
+
 - [ADR-009](ADR-009-paginated-fetcher-mixin.md): PaginatedFetcherMixin Design
 - [ADR-011](ADR-011-remove-watermark-mechanism.md): Remove Watermark Mechanism
 - [ADR-030](ADR-030-publication-pagination-strategy.md): Publication Pagination Strategy
 - [ADR-031](ADR-031-loading-strategy-formalization.md): Loading Strategy Formalization
 
 ### Deployment
+
 - [ADR-010](ADR-010-local-only-deployment.md): Local-Only Deployment
 
 ### Locking
+
 - [ADR-003](ADR-003-in-memory-locking-strategy.md): In-Memory Locking (MemoryLock) — Local-Only locking strategy
 
 ### Reproducibility
+
 - [ADR-014](ADR-014-deterministic-writes.md): Deterministic Writes and Retries
 
 ### Configuration
+
 - [ADR-025](ADR-025-pipeline-config-unification.md): Pipeline Config Unification
 - [ADR-028](ADR-028-filter-rules-externalization.md): Filter Rules Externalization — Hierarchical filter config
 


### PR DESCRIPTION
### Motivation

- Provide a single, normative target-state for schema governance covering lifecycle, drift handling, contract versioning, PK/partition strategy, JSON typing and SCD2 decisioning. 
- Make the governance gate explicit so Gold publishing has deterministic `blocking` vs `warning` semantics and a clear rollout roadmap. 
- Surface the new target state in top-level docs and the architecture audit so reviewers and CI can reference a canonical policy. 

### Description

- Added a new normative document `docs/02-architecture/Schema-Governance.md` with sections: `Schema Lifecycle`, `Drift Handling`, `Contract Versioning`, `PK & Partition Strategy`, `JSON Typing Standard`, and `SCD2 Decision Matrix`.
- Added ADR `ADR-035: Target Schema Architecture 2026` at `docs/02-architecture/decisions/ADR-035-target-schema-architecture-2026.md` containing a 3-phase roadmap, impact matrix and risk assessment.
- Updated top-level documentation to reference the governance gate and severity taxonomy by changing `README.md` to include links to the new Schema Governance page and ADR-035 and updating the RULES version/ADR count.
- Synchronized project governance artifacts by updating `docs/00-project/RULES.md`, adding a §2.10 Target Schema Architecture subsection, updating `docs/00-project/ARCHITECTURE_AUDIT_2026-02-16.md` with a "Target State Sync" block, and adding ADR-035 to `docs/02-architecture/decisions/README.md`.

### Testing

- Verified presence and cross-references with a targeted search: `rg -n "Schema-Governance|ADR-035|2.10|blocking|warning"` across the updated docs (search completed and references found).
- Executed repository pre-commit checks which surfaced formatting/validation issues: `mdformat` made changes to Markdown content (hook modified files), `pip-audit` hook failed due to missing `pip-audit` binary in the environment, and the `check-root-vcr-cassettes` hook reported existing root-level VCR cassette files (policy failure). 
- Confirmed working tree state and that the new/updated documentation files exist at the intended paths (`docs/02-architecture/Schema-Governance.md`, `docs/02-architecture/decisions/ADR-035-target-schema-architecture-2026.md`, plus updated `README.md`, `docs/00-project/RULES.md`, `docs/00-project/ARCHITECTURE_AUDIT_2026-02-16.md`, and `docs/02-architecture/decisions/README.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489ec97008324b5adc7206684dd2e)