### PR TITLE
ci: enforce Silver contract snapshot export+diff merge gate

### DIFF
--- a/.github/workflows/contract-snapshot-diff.yml
+++ b/.github/workflows/contract-snapshot-diff.yml
@@ -1,0 +1,60 @@
+name: Contract Snapshot Diff Check
+
+on:
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - 'src/bioetl/domain/schemas/**'
+      - 'tests/contract/silver_schemas/snapshots/**'
+      - 'scripts/verify_silver_contract_snapshots.py'
+      - '.github/workflows/contract-snapshot-diff.yml'
+  push:
+    branches: [main, master, develop]
+    paths:
+      - 'src/bioetl/domain/schemas/**'
+      - 'tests/contract/silver_schemas/snapshots/**'
+      - 'scripts/verify_silver_contract_snapshots.py'
+      - '.github/workflows/contract-snapshot-diff.yml'
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  contract-snapshot-diff:
+    name: Contract Snapshot Diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Install dependencies
+        run: uv sync --extra tests
+
+      - name: Export contracts and verify tracked JSON snapshots
+        run: uv run python scripts/verify_silver_contract_snapshots.py
+
+  contract-snapshot-diff-status:
+    name: Contract Snapshot Diff Status
+    runs-on: ubuntu-latest
+    needs: [contract-snapshot-diff]
+    if: always()
+
+    steps:
+      - name: Check contract snapshot diff result
+        run: |
+          if [[ "${{ needs.contract-snapshot-diff.result }}" != "success" ]]; then
+            echo "::error::Contract snapshot diff check failed"
+            exit 1
+          fi
+          echo "::notice::Contract snapshot diff check passed"

--- a/README.md
+++ b/README.md
@@ -179,13 +179,14 @@ bioetl checkpoint list
 - Keep machine-consumed reference datasets under semantic paths in `data/` (for example, `data/input/reference/`).
 - Keep optional human-facing spreadsheet copies under `docs/reference/`.
 - Unified publication classifier canonical format is CSV at `data/input/reference/unified_classification.csv`; Excel is optional documentation copy at `docs/reference/unified_classification.xlsx`.
+
 ### Local diagnostic artifacts
 
 Локальные диагностические файлы (например, `git_commit_*.txt`, `*_gitshow_err.txt`, `log_test.txt`) не должны храниться в корне репозитория и не коммитятся в Git.
 
-* Временные диагностические дампы сохраняйте в `tmp/`.
-* Логи локальных запусков сохраняйте в `logs/`.
-* Для ad-hoc команд используйте явное перенаправление (`> logs/<name>.log 2>&1` или `> tmp/<name>.txt 2>&1`).
+- Временные диагностические дампы сохраняйте в `tmp/`.
+- Логи локальных запусков сохраняйте в `logs/`.
+- Для ad-hoc команд используйте явное перенаправление (`> logs/<name>.log 2>&1` или `> tmp/<name>.txt 2>&1`).
 
 ### Testing
 
@@ -246,6 +247,22 @@ The project uses `pytest` for testing, split into Unit, Integration, and Archite
   ```bash
   make arch-test
   ```
+
+### Contract Snapshot Merge Gate
+
+Silver schema snapshot contracts are protected by CI workflow `Contract Snapshot Diff Check`.
+
+- The workflow regenerates contract JSON from current schema models and compares against tracked files in `tests/contract/silver_schemas/snapshots/`.
+- The merge-blocking status check is **`Contract Snapshot Diff Status`**.
+- Any difference in `name`, `type`, `nullable`, or `description` fails CI.
+
+To refresh snapshots after an intentional schema change:
+
+```bash
+python scripts/verify_silver_contract_snapshots.py --write
+```
+
+Blocking policy details are documented in `docs/05-operations/verification/contract-snapshot-diff-policy.md`.
 
 ### Code Quality
 

--- a/docs/05-operations/verification/contract-snapshot-diff-policy.md
+++ b/docs/05-operations/verification/contract-snapshot-diff-policy.md
@@ -1,0 +1,53 @@
+# Contract Snapshot Diff Blocking Policy
+
+## Purpose
+
+This policy defines the merge gate for Silver schema contract snapshots.
+
+The CI workflow `.github/workflows/contract-snapshot-diff.yml` regenerates schema JSON contracts from current Pandera models and compares the generated output with repository-tracked snapshots in `tests/contract/silver_schemas/snapshots/`.
+
+## Blocking Rule
+
+A pull request is **blocked from merge** when the job **Contract Snapshot Diff Status** is not green.
+
+The check fails when regenerated contract JSON differs from tracked files, including changes in:
+
+- `name` (field addition/removal)
+- `type`
+- `nullable`
+- `description`
+
+## Required Status Check Configuration
+
+Branch protection for `main`/`master`/`develop` MUST include:
+
+- **Required status check**: `Contract Snapshot Diff Status`
+
+This status check is emitted by the summary job in `.github/workflows/contract-snapshot-diff.yml` and is the canonical check to require at merge time.
+
+## Developer Workflow
+
+When CI reports a contract diff:
+
+1. Regenerate snapshots locally:
+
+   ```bash
+   python scripts/verify_silver_contract_snapshots.py --write
+   ```
+
+1. Review the diff and validate downstream impact.
+
+1. Commit updated snapshot JSON files.
+
+1. Ensure `Contract Snapshot Diff Status` passes.
+
+## CI Diff Summary Output
+
+On mismatch, CI emits a human-readable summary grouped by:
+
+- `name`
+- `type`
+- `nullable`
+- `description`
+
+This summary is produced by `scripts/verify_silver_contract_snapshots.py`.

--- a/scripts/verify_silver_contract_snapshots.py
+++ b/scripts/verify_silver_contract_snapshots.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Verify Silver schema contract snapshots are in sync."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+
+@dataclass(frozen=True)
+class FieldChange:
+    """Represents a field-level schema change."""
+
+    schema_name: str
+    field_name: str
+    attribute: str
+    expected: str
+    actual: str
+
+
+def _load_schema_registry() -> tuple[dict[str, Any], Callable[[Any], dict[str, Any]]]:
+    """Load schema registry utilities from test contract module."""
+    project_root = Path(__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    module = importlib.import_module("tests.contract.silver_schemas.conftest")
+    schemas = cast(dict[str, Any], module.SILVER_SCHEMAS)
+    extractor = cast(Callable[[Any], dict[str, Any]], module.extract_field_metadata)
+    return schemas, extractor
+
+
+def _write_line(text: str) -> None:
+    """Write a line to stdout."""
+    sys.stdout.write(f"{text}\n")
+
+
+def _canonicalize(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Normalize snapshot representation for stable comparison."""
+    canonical = json.loads(json.dumps(snapshot, sort_keys=True, ensure_ascii=False))
+    return cast(dict[str, Any], canonical)
+
+
+def _load_snapshot(path: Path) -> dict[str, Any] | None:
+    """Load an existing snapshot file, if present."""
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    return cast(dict[str, Any], loaded)
+
+
+def _generate_snapshot(
+    schema_name: str,
+    schemas: dict[str, Any],
+    extractor: Callable[[Any], dict[str, Any]],
+) -> dict[str, Any]:
+    """Generate snapshot metadata for a schema."""
+    schema_cls = schemas[schema_name]
+    return extractor(schema_cls)
+
+
+def _collect_diffs(
+    schema_name: str, expected: dict[str, Any], actual: dict[str, Any]
+) -> dict[str, list[FieldChange] | list[str]]:
+    """Collect field-level differences grouped by requested dimensions."""
+    expected_fields = set(expected.keys())
+    actual_fields = set(actual.keys())
+
+    added = sorted(actual_fields - expected_fields)
+    removed = sorted(expected_fields - actual_fields)
+
+    type_changes: list[FieldChange] = []
+    nullable_changes: list[FieldChange] = []
+    description_changes: list[FieldChange] = []
+
+    for field_name in sorted(expected_fields & actual_fields):
+        expected_field = expected[field_name]
+        actual_field = actual[field_name]
+
+        if expected_field.get("dtype") != actual_field.get("dtype"):
+            type_changes.append(
+                FieldChange(
+                    schema_name=schema_name,
+                    field_name=field_name,
+                    attribute="type",
+                    expected=str(expected_field.get("dtype")),
+                    actual=str(actual_field.get("dtype")),
+                )
+            )
+
+        if expected_field.get("nullable") != actual_field.get("nullable"):
+            nullable_changes.append(
+                FieldChange(
+                    schema_name=schema_name,
+                    field_name=field_name,
+                    attribute="nullable",
+                    expected=str(expected_field.get("nullable")),
+                    actual=str(actual_field.get("nullable")),
+                )
+            )
+
+        if expected_field.get("description") != actual_field.get("description"):
+            description_changes.append(
+                FieldChange(
+                    schema_name=schema_name,
+                    field_name=field_name,
+                    attribute="description",
+                    expected=str(expected_field.get("description", "")),
+                    actual=str(actual_field.get("description", "")),
+                )
+            )
+
+    return {
+        "name": [
+            *[f"+ {field}" for field in added],
+            *[f"- {field}" for field in removed],
+        ],
+        "type": type_changes,
+        "nullable": nullable_changes,
+        "description": description_changes,
+    }
+
+
+def _render_summary(diffs_by_schema: dict[str, dict[str, list[Any]]]) -> str:
+    """Render a human-readable diff summary grouped by field attributes."""
+    lines: list[str] = [
+        "Silver contract snapshot diff detected.",
+        "Grouped summary (name/type/nullable/description):",
+    ]
+
+    for schema_name in sorted(diffs_by_schema):
+        schema_diffs = diffs_by_schema[schema_name]
+        lines.append(f"\nSchema: {schema_name}")
+
+        name_changes = schema_diffs["name"]
+        lines.append("  name:")
+        if name_changes:
+            for item in name_changes:
+                lines.append(f"    {item}")
+        else:
+            lines.append("    (no changes)")
+
+        for key in ["type", "nullable", "description"]:
+            raw_changes = schema_diffs[key]
+            changes = [
+                change for change in raw_changes if isinstance(change, FieldChange)
+            ]
+            lines.append(f"  {key}:")
+            if changes:
+                for change in changes:
+                    lines.append(
+                        f"    {change.field_name}: expected={change.expected!r}, actual={change.actual!r}"
+                    )
+            else:
+                lines.append("    (no changes)")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Verify Silver schema contract snapshots are up to date."
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        default="tests/contract/silver_schemas/snapshots",
+        help="Directory with tracked snapshot JSON files.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write regenerated snapshots to tracked files instead of checking only.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run verification/export flow."""
+    args = parse_args()
+    schemas, extractor = _load_schema_registry()
+
+    snapshot_dir = Path(args.snapshot_dir)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    diffs: dict[str, dict[str, list[Any]]] = {}
+
+    for schema_name in sorted(schemas.keys()):
+        generated = _canonicalize(_generate_snapshot(schema_name, schemas, extractor))
+        snapshot_path = snapshot_dir / f"{schema_name}_schema.json"
+
+        if args.write:
+            with snapshot_path.open("w", encoding="utf-8") as handle:
+                json.dump(
+                    generated, handle, indent=2, sort_keys=True, ensure_ascii=False
+                )
+                handle.write("\n")
+
+        tracked = _load_snapshot(snapshot_path)
+        if tracked is None:
+            diffs[schema_name] = {
+                "name": ["snapshot file missing"],
+                "type": [],
+                "nullable": [],
+                "description": [],
+            }
+            continue
+
+        tracked_canonical = _canonicalize(tracked)
+        if tracked_canonical != generated:
+            diffs[schema_name] = _collect_diffs(
+                schema_name=schema_name,
+                expected=tracked_canonical,
+                actual=generated,
+            )
+
+    if diffs:
+        _write_line(_render_summary(diffs))
+        _write_line(
+            "\nRun `python scripts/verify_silver_contract_snapshots.py --write` and commit updates."
+        )
+        return 1
+
+    _write_line("Silver contract snapshots are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure Silver schema JSON contracts are regenerated and verified in CI so schema drift is detected before merge.
- Fail PRs when regenerated contract JSON diverges from repository-tracked snapshots to prevent unnoticed breaking schema changes.
- Provide a clear, human-readable summary of contract diffs grouped by `name/type/nullable/description` to speed review and remediation.
- Document the required status check and the developer remediation workflow for transparency and enforcement.

### Description
- Added CI workflow `.github/workflows/contract-snapshot-diff.yml` that regenerates Silver schema snapshots and reports a summary job named `Contract Snapshot Diff Status` for branch-protection wiring. 
- Added `scripts/verify_silver_contract_snapshots.py` which deterministically regenerates snapshots, compares them to tracked JSON, emits a grouped human-readable diff by `name`, `type`, `nullable`, and `description`, returns non-zero on differences, and supports `--write` to refresh snapshots. 
- Added operational policy `docs/05-operations/verification/contract-snapshot-diff-policy.md` documenting the blocking rule and remediation steps and updated `README.md` with the merge-gate guidance and local regeneration command (`python scripts/verify_silver_contract_snapshots.py --write`).
- Committed the new workflow, script, policy doc, and README changes and formatted/linted the new script to meet project standards.

### Testing
- Ran the verification script locally with `uv run python scripts/verify_silver_contract_snapshots.py` which reported snapshots up to date and exited 0. 
- Ran static checks `uv run ruff check scripts/verify_silver_contract_snapshots.py` and `uv run mypy scripts/verify_silver_contract_snapshots.py`, both completed successfully after fixes. 
- Ensured `ruff format`/hooks and repository pre-commit checks were exercised during commit and adjusted files until all configured checks passed. 
- The CI workflow was added and is intended to be configured as a required status check `Contract Snapshot Diff Status` for the `main`/`master`/`develop` branches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948a09fc08832493fa01de7f5a77aa)