### PR TITLE
docs: formalize content-hash contract and add hash-stability regression tests

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -62,7 +62,9 @@
 Интерфейсы определяются в пакете `domain/ports/` через `typing.Protocol`:
 
 - **Design-time**: `mypy --strict` проверяет соответствие типов во время сборки. Основной механизм контроля.
+
 - **Runtime Boundary**: Следующие критические порты **SHOULD** быть `@runtime_checkable` для boundary validation в composition layer:
+
   - `DataSourcePort` — для проверки адаптеров при регистрации
   - `FilterableDataSourcePort` — для проверки расширенных адаптеров
   - `HealthCheckPort` — для проверки health-check capability
@@ -72,6 +74,7 @@
 
   > **Текущее состояние:** Все 38 портов декорированы `@runtime_checkable` (100% coverage).
   > Минимальное требование — 4 критических порта выше; остальные декорированы для единообразия.
+
 - **Импорт**: Порты **MUST** импортироваться из фасада (`from bioetl.domain.ports import ...`), а не из внутренних модулей. Проверяется архитектурным тестом.
 
 ```python
@@ -164,7 +167,7 @@ class MyAdapter:
 ### 2.2. Политика Дрейфа Схемы (Schema Drift)
 
 | Уровень  | Условие                                  |
-|----------|------------------------------------------|
+| -------- | ---------------------------------------- |
 | Info     | Новые поля (любое количество)            |
 | Critical | Пропавшее обязательное поле / смена типа |
 
@@ -244,19 +247,20 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 Единая таблица `common.quarantine` для всех сущностей.
 
-- `ingestion_ts` (Timestamp): Время инцидента. [Код: `QuarantineEntry._created_at`]
+- `ingestion_ts` (Timestamp): Время инцидента. \[Код: `QuarantineEntry._created_at`\]
 
-- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). [Код: `QuarantineEntry._pipeline_name`]
+- `pipeline` (String): Имя пайплайна (напр., `chembl_activity`). \[Код: `QuarantineEntry._pipeline_name`\]
 
-- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). [Код: `QuarantineEntry._error_code`]
+- `error_code` (String): Тип ошибки (напр., `SCHEMA_VIOLATION`). \[Код: `QuarantineEntry._error_code`\]
 
-- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). [Код: `QuarantineEntry._payload`]
+- `payload` (JSON/Text): Сырая запись (**Truncated to 64KB**). \[Код: `QuarantineEntry._payload`\]
 
-- `payload_hash` (String): Для дедупликации ошибок. [Код: `QuarantineEntry._payload_hash`]
+- `payload_hash` (String): Для дедупликации ошибок. \[Код: `QuarantineEntry._payload_hash`\]
 
-- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. [Код: `QuarantineEntry._batch_id` (BatchID)]
+- `bronze_batch_id` (UUID): Ссылка на пакет исходных данных. \[Код: `QuarantineEntry._batch_id` (BatchID)\]
 
 - `dq_status` (String): `NEW` | `UNDER_REVIEW` | `IGNORED` | `REPROCESSED` | `EXPIRED`.
+
   - `NEW`: Только что создана, ждёт разбора.
   - `UNDER_REVIEW`: Анализируется оператором.
   - `IGNORED`: Разобрана и признана неактуальной.
@@ -274,6 +278,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Причина**: Pandas/Polars исторически не поддерживали nullable integers без специального типа `Int64` (с заглавной I). Float — единственный способ представить `int + NULL` без потери данных для больших значений. `NaN` используется для отсутствующих значений.
 
 <!-- Updated: was ~34, now ~88 (audit 2026-02-14) -->
+
 **Затронутые поля (~88 occurrences)**:
 
 > **Примечание**: Для получения актуального числа occurrences:
@@ -335,6 +340,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 > (`configs/sources/{provider}.yaml`), а не непосредственно в pipeline config.
 > Pipeline config ссылается на источник через convention-based resolution
 > (`source_file: ../../sources/{provider}.yaml`) или явно через поле `data_schema_file`.
+
 - **Hybrid**: Incremental ежедневно + Full еженедельно для обеспечения консистентности.
 
 ### 2.8. Генерация ID Сущности (Entity ID)
@@ -362,6 +368,46 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 **Исключения**: Из расчета хэша исключаются технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`.
 
 - **Детекция Коллизий**: При upsert проверять `_source_record_id`; если отличается — конфликт, логировать обе записи.
+
+#### 2.8.2. Content Hash (Formal Contract)
+
+**Input set**
+
+- `provider: str` — идентификатор источника (`chembl`, `pubchem`, `uniprot`, ...).
+- `record: dict[str, Any]` — бизнес-запись после ETL mapping.
+- `exclude_none: bool` — политика для полей со значением `None`.
+
+**Canonicalization rules (MUST):**
+
+1. `NaN`/`Inf` → `null` (`None`).
+1. Все `float` значения → `round(value, 10)`.
+1. `datetime` и `date` → строка `YYYY-MM-DD`.
+1. `str` → `strip()` (обрезка пробелов по краям).
+1. `dict`/`list` → рекурсивная нормализация вложенных значений.
+
+**None policy:**
+
+- `exclude_none=false` (default): поля `key: null` включаются в canonical JSON и влияют на hash.
+- `exclude_none=true`: поля `key: null` удаляются перед сериализацией и не влияют на hash.
+
+**Sorting/canonical JSON requirements (MUST):**
+
+- `json.dumps(..., sort_keys=True, separators=(',', ':'), ensure_ascii=True)`.
+- Выходная строка JSON не должна содержать пробелы между токенами.
+- Порядок ключей должен быть лексикографическим и детерминированным.
+
+**Excluded fields list (MUST NOT affect hash):**
+
+- `_ingestion_ts`
+- `_run_id`
+- `_run_type`
+- `_source_batch_id`
+- `_index`
+- `_dq_*` (все DQ-технические поля; текущие: `_dq_warn`, `_dq_error`)
+
+**Формула:**
+
+`content_hash = sha256(provider + canonical_json_dumps(normalized_record))`
 
 ### 2.9. Composite Pipelines
 
@@ -506,6 +552,7 @@ merge:
 | `TRASH`                         | Внутренние, избыточные, low-value       | **Нет**           |
 
 <!-- Updated: was 94, now 106 (audit 2026-02-14) -->
+
 **Конфигурация:** `configs/composite/field_groups/publication.yaml` — 106 базовых полей, маппинг на провайдерские колонки.
 
 **Доменные модели** (`domain/composite/field_groups.py`):
@@ -922,7 +969,9 @@ from __future__ import annotations
 > **Исключение**: `__init__.py` файлы, содержащие только re-exports (`from ... import ...`)
 > и `__all__`, **MAY** опускать `from __future__ import annotations`, так как
 > они не содержат type annotations, требующих отложенной эвалюации.
+
 <!-- Updated: was 497/534 (93.1%), now 501/534 (93.8%); was 37, now 33 (audit 2026-02-17) -->
+
 > Текущее состояние: 501 из 534 файлов (93.8%) содержат импорт;
 > 33 файла без импорта — все `__init__.py` (re-export only).
 
@@ -1024,11 +1073,11 @@ async with services:  # __aenter__ инициализирует ресурсы
 
 #### 5.5.1. Detailed DR Procedures (Runbook)
 
-| Сценарий                      | Действие                                                                                                                                                                         |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver). |
+| Сценарий                      | Действие                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Повреждение Bronze/Silver** | 1. Остановить пайплайны. 2. Восстановить локальное хранилище из backup (point-in-time restore). 3. Перезапустить пайплайны с флагом `--run-type rebuild` (если затронут Silver).      |
 | **Потеря чекпоинта**          | Удалить файл чекпоинта: `data/output/checkpoints/{pipeline_name}.json`, затем запустить `--run-type rebuild` (приведет к дубликатам в Bronze, но дедупликация в Silver исправит это). |
-| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                       |
+| **Отказ региона AWS**         | Переключение DNS на Failover Region. Развертывание Infrastructure-as-Code (Terraform) в резервном регионе.                                                                            |
 
 ### 5.6. Среды (Environments)
 
@@ -1163,11 +1212,11 @@ PipelineRunner.run() создаёт PipelineObserver напрямую вмест
 
 <!-- Updated: was 527 LOC / 8 методов, now 818 LOC / 21 метод (audit 2026-02-14) -->
 
-| ❌ Неверно                      | ✅ Верно                                                                                                           |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ❌ Неверно                      | ✅ Верно                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | "PreflightService — god object" | "PreflightService (`preflight_service.py`, 818 LOC, 21 метод) имеет 4 публичных метода с единой ответственностью" |
-| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                         |
-| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                      |
+| "Компонент перегружен"          | "Компонент (`file.py`, N строк) содержит M методов, делегирует K сервисам"                                        |
+| "Нет валидации X"               | "Валидация X отсутствует в `file.py` (проверено grep по 'X')"                                                     |
 
 #### 7.1.4. Типичные Ложные Выводы
 
@@ -1222,6 +1271,7 @@ grep "ChemblAdapter\|GoldWriter\|PreflightService" docs/archived/refactoring-pla
 **Контрпримеры (НЕ монолиты, несмотря на размер):**
 
 <!-- Updated: ChemblAdapter was 517→975; GoldWriter was 593→946; PreflightService was 527→818 (audit 2026-02-14) -->
+
 - `ChemblAdapter` (975 LOC): Делегирует 4 компонентам, когезивная ответственность
 - `GoldWriter` (946 LOC): Делегирует `CsvExporter`, `AuditPort`, режимы записи когезивны
 - `PreflightService` (818 LOC): 21 метод с единой ответственностью (preflight validation)
@@ -1352,20 +1402,20 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 
 **Маппинг entity → API resource** (`_NON_PUBLICATION_ENTITY_MAPPING`):
 
-| Entity Type        | API Resource             | Primary Key              |
-| ------------------ | ------------------------ | ------------------------ |
-| `activity`         | `activity`               | `activity_id`            |
-| `assay`            | `assay`                  | `assay_chembl_id`        |
-| `assay_parameters` | `assay`                  | *(composite)*            |
-| `cell_line`        | `cell_line`              | `cell_chembl_id`         |
-| `compound`         | `molecule`               | `molecule_chembl_id`     |
-| `compound_record`  | `compound_record`        | `record_id`              |
-| `molecule`         | `molecule`               | `molecule_chembl_id`     |
-| `protein_class`    | `protein_classification` | `protein_class_id`       |
-| `publication`      | `document`               | `document_chembl_id`     |
-| `target`           | `target`                 | `target_chembl_id`       |
-| `target_component` | `target_component`       | `component_id`           |
-| `tissue`           | `tissue`                 | `tissue_chembl_id`       |
+| Entity Type        | API Resource             | Primary Key          |
+| ------------------ | ------------------------ | -------------------- |
+| `activity`         | `activity`               | `activity_id`        |
+| `assay`            | `assay`                  | `assay_chembl_id`    |
+| `assay_parameters` | `assay`                  | *(composite)*        |
+| `cell_line`        | `cell_line`              | `cell_chembl_id`     |
+| `compound`         | `molecule`               | `molecule_chembl_id` |
+| `compound_record`  | `compound_record`        | `record_id`          |
+| `molecule`         | `molecule`               | `molecule_chembl_id` |
+| `protein_class`    | `protein_classification` | `protein_class_id`   |
+| `publication`      | `document`               | `document_chembl_id` |
+| `target`           | `target`                 | `target_chembl_id`   |
+| `target_component` | `target_component`       | `component_id`       |
+| `tissue`           | `tissue`                 | `tissue_chembl_id`   |
 
 **Query parameters** (формируются в `ChemblAdapter._build_params()`):
 
@@ -1397,14 +1447,14 @@ URL-адреса для ChEMBL формируются в `infrastructure/adapter
 | **P2** | Падение второстепенного пайплайна                | 8 часов     | 24 часа            |
 | **P3** | Warning / DQ аномалии                            | 24 часа     | Next Sprint        |
 
-| Ошибка                 | Симптом                                        | Действие                                                          |
-| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
-| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                    |
-| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                         |
-| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR            |
+| Ошибка                 | Симптом                                        | Действие                                                                                                |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Auth failure           | `401 Unauthorized` в логах                     | Проверить/обновить `BIOETL_{PROVIDER}_API_KEY`                                                          |
+| Rate limit exhausted   | `429` + пик `errors_total{type="recoverable"}` | Уменьшить `requests_per_second` в конфиге                                                               |
+| Schema mismatch (Gold) | Pipeline fail + `schema_violations` > 0        | Проверить изменения API; обновить Gold-схему через ADR                                                  |
 | Stale checkpoint       | Warning при старте                             | `--resume` для продолжения или удалить файл `data/output/checkpoints/{pipeline_name}.json` для рестарта |
-| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа      |
-| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`        |
+| >20% DQ errors         | Batch fail                                     | Проверить источник; возможно API вернул ошибку в теле ответа                                            |
+| Lock timeout           | Alert "Lock expired"                           | Проверить зомби-процессы; `make release-lock PIPELINE=...`                                              |
 
 ## Приложение D: Схема Конфигурации Пайплайна
 
@@ -1535,7 +1585,7 @@ fields:
 | [ADR-031](02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
 | [ADR-032](02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
 | [ADR-033](02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)              | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
+| [ADR-034](02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 
 ## История Изменений (Changelog)
 

--- a/docs/02-architecture/decisions/ADR-029-output-metadata-unification.md
+++ b/docs/02-architecture/decisions/ADR-029-output-metadata-unification.md
@@ -9,19 +9,19 @@
 
 Bronze/Silver/Gold Medallion layers использовали разные структуры для `output`-метаданных в sidecar-файлах:
 
-| Layer | Класс | Поля |
-|-------|-------|------|
-| Bronze | `OutputMetadata` | `total_records`, `total_bytes`, `files`, `format`, `compression` |
-| Silver | `SilverOutputMetadata` | `record_count`, `content_hash` |
-| Gold | `GoldOutputMetadata` | `record_count`, `partition_count`, `total_bytes`, `format` |
+| Layer  | Класс                  | Поля                                                             |
+| ------ | ---------------------- | ---------------------------------------------------------------- |
+| Bronze | `OutputMetadata`       | `total_records`, `total_bytes`, `files`, `format`, `compression` |
+| Silver | `SilverOutputMetadata` | `record_count`, `content_hash`                                   |
+| Gold   | `GoldOutputMetadata`   | `record_count`, `partition_count`, `total_bytes`, `format`       |
 
 ### Проблемы
 
 1. **Несогласованное именование**: `total_records` vs `record_count`
-2. **Отсутствует общий контракт**: Усложняет downstream-аналитику и мониторинг
-3. **Пропущенные поля**: `total_bytes` отсутствует в Silver
-4. **Нет timestamps записи**: Отсутствуют `write_started_at`/`write_completed_at`
-5. **Дублирование delta_version**: В Silver версии есть в `DeltaMetrics`, но не в output
+1. **Отсутствует общий контракт**: Усложняет downstream-аналитику и мониторинг
+1. **Пропущенные поля**: `total_bytes` отсутствует в Silver
+1. **Нет timestamps записи**: Отсутствуют `write_started_at`/`write_completed_at`
+1. **Дублирование delta_version**: В Silver версии есть в `DeltaMetrics`, но не в output
 
 ## Decision
 
@@ -39,7 +39,9 @@ class BaseOutputMetadata(BaseModel):
     total_bytes: int = Field(ge=0, description="Total size in bytes")
     content_hash: str | None = Field(description="SHA256 hash for change detection")
     write_started_at: datetime | None = Field(description="Write start timestamp")
-    write_completed_at: datetime | None = Field(description="Write completion timestamp")
+    write_completed_at: datetime | None = Field(
+        description="Write completion timestamp"
+    )
 
     @computed_field
     @property
@@ -55,9 +57,11 @@ class BronzeOutputExt(BaseModel):
     format: str = "jsonl+zstd"
     compression: str = "zstd"
 
+
 class SilverOutputExt(BaseModel):
     delta_version_before: int | None
     delta_version_after: int | None
+
 
 class GoldOutputExt(BaseModel):
     partition_count: int = 0
@@ -68,21 +72,94 @@ class GoldOutputExt(BaseModel):
 
 ```python
 class BronzeMetadata(BaseModel):
-    output: BaseOutputMetadata          # Unified base
-    output_ext: BronzeOutputExt         # Layer-specific
+    output: BaseOutputMetadata  # Unified base
+    output_ext: BronzeOutputExt  # Layer-specific
+
 
 class SilverMetadata(BaseModel):
-    output: BaseOutputMetadata          # Unified base
-    output_ext: SilverOutputExt         # Layer-specific
+    output: BaseOutputMetadata  # Unified base
+    output_ext: SilverOutputExt  # Layer-specific
+
 
 class GoldMetadata(BaseModel):
-    output: BaseOutputMetadata          # Unified base
-    output_ext: GoldOutputExt           # Layer-specific
+    output: BaseOutputMetadata  # Unified base
+    output_ext: GoldOutputExt  # Layer-specific
 ```
 
 ### Metadata Schema Version Bump
 
 Версия metadata schema увеличена с `1.0` до `1.1` для всех слоёв.
+
+### Formal Specification: Content Hash Algorithm (Normative)
+
+Данная спецификация фиксирует алгоритм из RULES §2.8/§2.8.1 как формальный контракт для
+`output.content_hash` и всех downstream-потребителей.
+
+#### Inputs
+
+- `provider: str` — идентификатор провайдера (`chembl`, `pubchem`, ...).
+- `record: Mapping[str, JSONValue]` — запись до сериализации.
+- `exclude_none: bool = false` — политика включения `null`-полей в хэш.
+
+#### Excluded Field Set
+
+Из входного `record` перед нормализацией **MUST** исключаться поля:
+
+1. Точные имена: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`.
+1. DQ-поля: любой ключ, удовлетворяющий шаблону `_dq_*`.
+
+#### Canonicalization Rules
+
+После удаления excluded-полей значения **MUST** быть нормализованы рекурсивно:
+
+1. `float`:
+   - если `isnan(v)` или `isinf(v)` → `null`;
+   - иначе `round(v, 10)`.
+1. `datetime` → `YYYY-MM-DD` (date-part only).
+1. `date` → `YYYY-MM-DD`.
+1. `str` → `strip()`.
+1. `dict`/`list` → рекурсивная нормализация всех дочерних значений.
+
+#### None Policy
+
+- Если `exclude_none=false` (default), поля со значением `null` **MUST** сохраняться в
+  canonical JSON.
+- Если `exclude_none=true`, поля со значением `null` **MUST** удаляться до сериализации.
+
+#### Canonical JSON Requirements
+
+Нормализованный объект **MUST** сериализоваться как canonical JSON с параметрами:
+
+- `sort_keys=true`
+- `separators=(',', ':')` (без пробелов)
+- `ensure_ascii=true`
+
+#### Hash Function
+
+Итоговый digest **MUST** вычисляться по формуле:
+
+```text
+content_hash = sha256( provider || canonical_json )
+```
+
+где `||` — конкатенация строк UTF-8 без разделителя.
+
+#### Reference Pseudocode
+
+```text
+function generate_content_hash(provider, record, exclude_none=false):
+    filtered = remove_excluded_fields(record)
+    normalized = normalize_recursive(filtered)
+    if exclude_none:
+        normalized = drop_none_fields(normalized)
+    canonical_json = json.dumps(
+        normalized,
+        sort_keys=true,
+        separators=(',', ':'),
+        ensure_ascii=true,
+    )
+    return sha256_hex(provider + canonical_json)
+```
 
 ### Backward Compatibility
 
@@ -111,15 +188,15 @@ class OutputMetadata(BaseModel):
 ### Positive
 
 1. **Unified analytics**: Все слои экспортируют одинаковые базовые метрики
-2. **Duration tracking**: `write_duration_ms` доступен через computed field
-3. **Change detection**: `content_hash` доступен на всех слоях
-4. **Monitoring consistency**: Prometheus/Grafana dashboards могут использовать единый набор метрик
-5. **Type safety**: `extra="forbid"` предотвращает случайные поля
+1. **Duration tracking**: `write_duration_ms` доступен через computed field
+1. **Change detection**: `content_hash` доступен на всех слоях
+1. **Monitoring consistency**: Prometheus/Grafana dashboards могут использовать единый набор метрик
+1. **Type safety**: `extra="forbid"` предотвращает случайные поля
 
 ### Negative
 
 1. **Breaking change**: Существующий код использующий `output.total_records` (Bronze) требует обновления
-2. **Schema migration**: Существующие sidecar-файлы v1.0 не совместимы с v1.1
+1. **Schema migration**: Существующие sidecar-файлы v1.0 не совместимы с v1.1
 
 ### Neutral
 
@@ -131,21 +208,26 @@ class OutputMetadata(BaseModel):
 ### Files Modified
 
 **Domain Models:**
-- `src/bioetl/domain/models/metadata.py` — BaseOutputMetadata, *OutputExt классы
+
+- `src/bioetl/domain/models/metadata.py` — BaseOutputMetadata, \*OutputExt классы
 
 **DTOs:**
+
 - `src/bioetl/domain/ports/metadata_coordinator.py` — Добавлены `version_before`, `total_bytes`, `partition_count`
 
 **Services:**
-- `src/bioetl/composition/services/metadata_coordinator.py` — Обновлены create_*_metadata методы
+
+- `src/bioetl/composition/services/metadata_coordinator.py` — Обновлены create\_\*\_metadata методы
 
 **Infrastructure:**
-- `src/bioetl/infrastructure/storage/bronze_writer.py` — _build_full_bronze_metadata
+
+- `src/bioetl/infrastructure/storage/bronze_writer.py` — \_build_full_bronze_metadata
 - `src/bioetl/infrastructure/storage/metadata_builder.py` — Silver/Gold builders
 
 ### JSON Output Format
 
 **Before (v1.0):**
+
 ```json
 {
   "output": {
@@ -157,6 +239,7 @@ class OutputMetadata(BaseModel):
 ```
 
 **After (v1.1):**
+
 ```json
 {
   "output": {
@@ -178,7 +261,7 @@ class OutputMetadata(BaseModel):
 
 ### Unit Tests
 
-- `tests/unit/domain/models/test_metadata_output.py` — BaseOutputMetadata, *OutputExt
+- `tests/unit/domain/models/test_metadata_output.py` — BaseOutputMetadata, \*OutputExt
 
 ### Architecture Tests
 

--- a/docs/04-reference/contracts/README.md
+++ b/docs/04-reference/contracts/README.md
@@ -1,0 +1,55 @@
+# Contracts Reference
+
+Этот раздел фиксирует контракты данных и требования к их стабильности для Bronze/Silver/Gold.
+
+## Hash Stability Guarantees
+
+Контракт стабильности `content_hash` обязателен для всех pipeline, использующих SCD Type 2 и дедупликацию.
+
+### Determinism Guarantees
+
+При неизменных `provider`, `record`, `exclude_none` функция генерации хэша **MUST** возвращать одинаковый
+64-символьный hex SHA256 digest.
+
+### Invariance Guarantees
+
+`content_hash` **MUST** быть инвариантен к:
+
+- перестановке ключей в `dict` (за счет `sort_keys=True`);
+- служебным полям `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`;
+- `NaN`/`Inf` (нормализуются в `null`);
+- избыточным пробелам в строках по краям (`strip()`).
+
+### Controlled Variance Guarantees
+
+`content_hash` **MUST** изменяться, если меняются бизнес-значения после canonicalization.
+
+Дополнительно:
+
+- `float` значения сравниваются в нормализованной форме `round(value, 10)`;
+- политика `exclude_none` является частью контракта вызова:
+  - `exclude_none=false`: `null` участвует в хэше;
+  - `exclude_none=true`: `null` исключается из хэш-входа.
+
+### Canonical JSON Contract
+
+Перед SHA256 сериализация **MUST** использовать:
+
+```python
+json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+```
+
+Итоговая формула:
+
+```text
+sha256(provider + canonical_json)
+```
+
+### Regression Coverage
+
+Стабильность хэша проверяется регрессионной матрицей в unit-тестах доменного слоя:
+
+- key-order permutation;
+- string trim behavior;
+- float precision normalization;
+- NaN/Inf normalization.

--- a/tests/unit/domain/test_transformations.py
+++ b/tests/unit/domain/test_transformations.py
@@ -168,6 +168,42 @@ class TestGenerateContentHash:
 
 
 @pytest.mark.unit
+class TestContentHashStabilityRegressionMatrix:
+    """Regression matrix for canonical content hash stability."""
+
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            pytest.param(
+                {"a": 1, "b": 2, "nested": {"x": 1, "y": 2}},
+                {"nested": {"y": 2, "x": 1}, "b": 2, "a": 1},
+                id="key-order-permutation",
+            ),
+            pytest.param(
+                {"name": "  aspirin  ", "code": "\tCHEMBL1\n"},
+                {"name": "aspirin", "code": "CHEMBL1"},
+                id="string-trim",
+            ),
+            pytest.param(
+                {"value": 1.1234567890123},
+                {"value": 1.1234567890},
+                id="float-precision-rounding",
+            ),
+            pytest.param(
+                {"score": float("nan"), "limit": float("inf")},
+                {"score": None, "limit": None},
+                id="nan-inf-normalization",
+            ),
+        ],
+    )
+    def test_hash_stability_matrix(self, left, right):
+        """Hashes remain stable for equivalent canonical forms."""
+        left_hash = generate_content_hash(left, "chembl")
+        right_hash = generate_content_hash(right, "chembl")
+        assert left_hash == right_hash
+
+
+@pytest.mark.unit
 class TestGenerateEntityId:
     """Test entity ID generation."""
 


### PR DESCRIPTION
### Motivation

- Provide a normative, machine-readable specification for `content_hash` to remove ambiguity and ensure downstream consumers can rely on deterministic behavior. 
- Capture canonicalization and exclusion rules (NaN/Inf, float rounding, string trimming, excluded meta-fields, `exclude_none` policy, canonical JSON) in architecture and project rules documentation. 
- Add explicit regression coverage to guard against accidental hash instability across common transformation variants (key order, whitespace, float precision, NaN/Inf).

### Description

- Added a formal, normative specification of the content-hash algorithm to ADR-029 in `docs/02-architecture/decisions/ADR-029-output-metadata-unification.md` including inputs, excluded-field set, canonicalization rules, `exclude_none` policy, canonical JSON requirements, hash formula and pseudocode. 
- Extended `docs/00-project/RULES.md` with a new `2.8.2. Content Hash (Formal Contract)` section that records the same mandatory rules (input set, canonicalization, sorting/JSON params, excluded fields such as `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`). 
- Added `docs/04-reference/contracts/README.md` with `Hash Stability Guarantees` summarizing determinism, invariance properties and canonical JSON contract. 
- Added a regression matrix unit test `TestContentHashStabilityRegressionMatrix` to `tests/unit/domain/test_transformations.py` that verifies hash stability for key-order permutations, string trimming, float rounding, and NaN/Inf normalization.

### Testing

- Ran Python byte-compile check: `python -m py_compile tests/unit/domain/test_transformations.py src/bioetl/domain/transformations.py` which succeeded. 
- Attempted to run the unit tests with `pytest tests/unit/domain/test_transformations.py -q`, but test collection/execution could not be completed in this environment due to missing runtime test dependencies (initially `hypothesis` and test plugins, and finally `pandas`), so a full run was not possible here. 
- The new regression test is included and expected to pass in CI once standard test dependencies are available in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489f094848324978b8666a7f99882)