### PR TITLE
Schema parity: block PK nullable mismatches, add nullable-int guards, and auto-generate JSON typing inventory

### DIFF
--- a/.github/workflows/schema-governance.yml
+++ b/.github/workflows/schema-governance.yml
@@ -9,6 +9,8 @@ on:
       - 'src/bioetl/infrastructure/schemas/**'
       - 'src/tools/scripts/generate_contracts.py'
       - 'src/tools/verify_schema_parity.py'
+      - 'src/tools/generate_json_field_typing_inventory.py'
+      - 'docs/03-data-model/json-field-typing-inventory.md'
       - '.github/workflows/schema-governance.yml'
   pull_request:
     paths:
@@ -17,6 +19,8 @@ on:
       - 'src/bioetl/infrastructure/schemas/**'
       - 'src/tools/scripts/generate_contracts.py'
       - 'src/tools/verify_schema_parity.py'
+      - 'src/tools/generate_json_field_typing_inventory.py'
+      - 'docs/03-data-model/json-field-typing-inventory.md'
       - '.github/workflows/schema-governance.yml'
 
 permissions:
@@ -64,10 +68,9 @@ jobs:
           "
 
   schema-parity:
-    name: Schema Parity + PK Coverage (non-blocking)
+    name: Schema Parity + PK Coverage (blocking)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -85,7 +88,13 @@ jobs:
         run: uv sync --extra dev
 
       - name: Verify schema parity (Domain → Silver → Gold)
-        run: uv run python src/tools/verify_schema_parity.py
+        run: uv run python src/tools/verify_schema_parity.py --mode blocking
+
+      - name: Rebuild JSON field typing inventory
+        run: uv run python src/tools/generate_json_field_typing_inventory.py
+
+      - name: Ensure JSON field typing inventory is up-to-date
+        run: git diff --exit-code docs/03-data-model/json-field-typing-inventory.md
 
   schema-governance-status:
     name: Schema Governance Status

--- a/docs/03-data-model/json-field-typing-inventory.md
+++ b/docs/03-data-model/json-field-typing-inventory.md
@@ -1,60 +1,289 @@
-# JSON Field Typing Inventory (Silver vs Gold)
+# JSON Field Typing Inventory (Bronze -> Silver -> Gold)
 
-Scope: `src/bioetl/infrastructure/schemas/silver.py` и `src/bioetl/domain/contracts/gold/*.py`.
+Scope: inferred Bronze CSV samples + Silver Pandera + Silver PyArrow + Gold contracts.
 
-| Field                        | Silver type kind              | Gold type kind                  | Status                         |
-| ---------------------------- | ----------------------------- | ------------------------------- | ------------------------------ |
-| `active_sites`               | canonical_string              | —                               | only one layer (manual review) |
-| `activity_properties`        | canonical_string              | —                               | only one layer (manual review) |
-| `affiliation_list`           | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `affiliation_structured`     | canonical_string              | —                               | only one layer (manual review) |
-| `all_mappings`               | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `alternative_id`             | native_list                   | native_object                   | consistent legacy (native)     |
-| `assay_classifications`      | canonical_string              | —                               | only one layer (manual review) |
-| `assay_parameters`           | canonical_string              | —                               | only one layer (manual review) |
-| `author_details`             | canonical_string              | —                               | only one layer (manual review) |
-| `author_h_indices`           | canonical_string              | —                               | only one layer (manual review) |
-| `author_orcids`              | —                             | canonical_string                | only one layer (manual review) |
-| `author_s2_ids`              | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `authors`                    | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `authors_with_affiliations`  | canonical_string              | —                               | only one layer (manual review) |
-| `binding_sites`              | canonical_string              | —                               | only one layer (manual review) |
-| `chembl_ids`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `chemicals`                  | canonical_string              | native_object                   | MISMATCH                       |
-| `citation_contexts`          | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `component_accessions`       | native_list                   | native_object                   | consistent legacy (native)     |
-| `component_descriptions`     | native_list                   | —                               | only one layer (manual review) |
-| `component_ids`              | native_list                   | native_object                   | consistent legacy (native)     |
-| `component_relationships`    | native_list                   | native_object                   | consistent legacy (native)     |
-| `component_types`            | native_list                   | native_object                   | consistent legacy (native)     |
-| `content_domain_domains`     | native_list                   | native_object                   | consistent legacy (native)     |
-| `cross_references`           | —                             | canonical_string                | only one layer (manual review) |
-| `databanks`                  | canonical_string              | native_object                   | MISMATCH                       |
-| `domains`                    | canonical_string              | —                               | only one layer (manual review) |
-| `drugbank_ids`               | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `features_json`              | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `gene_names`                 | native_list                   | native_object                   | consistent legacy (native)     |
-| `gene_symbols`               | canonical_string              | native_object                   | MISMATCH                       |
-| `go_terms`                   | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `grants`                     | —                             | canonical_string                | only one layer (manual review) |
-| `institution_country_codes`  | native_list                   | native_object                   | consistent legacy (native)     |
-| `institution_ids`            | native_list                   | native_object                   | consistent legacy (native)     |
-| `interpro_xrefs`             | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `issn_list`                  | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `pdb_xrefs`                  | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `pfam_xrefs`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `pipeline_stages`            | —                             | canonical_string                | only one layer (manual review) |
-| `primary_topic`              | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `protein_classification_ids` | native_list                   | native_object                   | consistent legacy (native)     |
-| `protein_classifications`    | canonical_string              | —                               | only one layer (manual review) |
-| `publication_type`           | —                             | native_object                   | only one layer (manual review) |
-| `publication_type_list`      | canonical_string              | —                               | only one layer (manual review) |
-| `publication_types`          | canonical_string, native_list | canonical_string, native_object | MISMATCH                       |
-| `reactome_xrefs`             | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `references`                 | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `ror_ids`                    | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `subject_keywords`           | native_list                   | native_object                   | consistent legacy (native)     |
-| `subject_mesh`               | native_list                   | native_object                   | consistent legacy (native)     |
-| `subject_topics`             | canonical_string              | canonical_string                | consistent (canonical string)  |
-| `target_components`          | —                             | canonical_string                | only one layer (manual review) |
-| `variant_sequence_json`      | canonical_string              | canonical_string                | consistent (canonical string)  |
+| Field                           | Bronze inferred      | Silver Pandera              | Silver PyArrow                  | Gold contract                  |
+| ------------------------------- | -------------------- | --------------------------- | ------------------------------- | ------------------------------ |
+| `_ingestion_ts`                 | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `_lookup_method`                | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `_original_id`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `_run_id`                       | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `_run_type`                     | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `_source`                       | `unknown` (nullable) | —                           | `string` (nullable)             | `str` (not-null)               |
+| `_source_batch_id`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `abstract`                      | `null` (nullable)    | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `accession`                     | \`null               | string\` (nullable)         | `str` (not-null)                | `string` (nullable)            |
+| `acetylation`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `action_type`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `action_type_description`       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `action_type_parent_type`       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `active_sites`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `activity_comment`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `activity_id`                   | `integer` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `activity_properties`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `activity_regulation`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `affiliation_list`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `affiliation_structured`        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `aidx`                          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `all_mappings`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `alternative_id`                | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `alternative_products`          | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `assay_category`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_cell_type`               | \`integer            | null                        | string\` (nullable)             | `str` (nullable)               |
+| `assay_classifications`         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_description`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_group`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_id`                      | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `assay_organism`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_parameters`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_pref_name`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_strain`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_subcellular_fraction`    | \`null               | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `assay_test_type`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_tissue`                  | \`null               | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `assay_type`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_type_description`        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_variant_accession`       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `assay_variant_mutation`        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `atc_classifications`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_details`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_h_indices`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_keys`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_openalex_ids`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_orcids`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `author_s2_ids`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `authors`                       | \`null               | string\` (nullable)         | `str` (nullable)                | —                              |
+| `authors_with_affiliations`     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `bao_endpoint`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `bao_format`                    | `string` (nullable)  | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `bao_label`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `binding_sites`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `biophysicochemical_properties` | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `canonical_smiles`              | \`array              | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `catalytic_activity`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `caution`                       | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `cell_description`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cell_id`                       | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `cell_name`                     | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `cell_source_organism`          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cell_source_tissue`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cell_type`                     | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `cellosaurus_id`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cellular_component`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `chembl_ids`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `chembl_release`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `chemicals`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `citation_contexts`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `citation_subset`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cl_lincs_id`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `clo_id`                        | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `cofactors`                     | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `comments`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `component_accessions`          | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `component_descriptions`        | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | —                              |
+| `component_ids`                 | `unknown` (nullable) | `str` (nullable)            | `list<item: int64>` (nullable)  | `str` (nullable)               |
+| `component_relationships`       | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `component_type`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `component_types`               | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `compound_key`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `compound_name`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `confidence_description`        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `content_domain_domains`        | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `content_hash`                  | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `country`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `creation_date`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `cross_references`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `data_validity_comment`         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `data_validity_description`     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `databanks`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `date_completed`                | `unknown` (nullable) | `datetime64[ns]` (nullable) | `string` (nullable)             | `str` (nullable)               |
+| `date_revised`                  | `unknown` (nullable) | `datetime64[ns]` (nullable) | `string` (nullable)             | `str` (nullable)               |
+| `dblp_id`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `definition`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `description`                   | \`array              | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `disease_involvement`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `disulfide_bond`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `doi`                           | `string` (nullable)  | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `domains`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `drugbank_ids`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `efo_id`                        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `entity_id`                     | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `entry_name`                    | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (nullable)               |
+| `entry_type`                    | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `features_json`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `flag`                          | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `function_comment`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `gene_names`                    | `unknown` (nullable) | —                           | `list<item: string>` (nullable) | `str` (nullable)               |
+| `gene_orf_names`                | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `gene_primary`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `gene_symbols`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `gene_synonyms`                 | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `genus`                         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `glycosylation`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `go_terms`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `grants`                        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `guidetopharmacology_ids`       | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `helm_notation`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `hierarchy_active_chembl_id`    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `hierarchy_child_chembl_id`     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `hierarchy_parent_chembl_id`    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `inchi`                         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `inchi_key`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `induction`                     | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `institution_country_codes`     | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `institution_ids`               | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `interpro_xrefs`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `intramembrane`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `isoform_ids`                   | \`null               | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `isoform_names`                 | \`integer            | null                        | string\` (nullable)             | `str` (nullable)               |
+| `isoform_synonyms`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `isomeric_smiles`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `issn`                          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `issn_electronic`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `issn_list`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `issn_print`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `issue`                         | \`integer            | null\` (nullable)           | —                               | `string` (nullable)            |
+| `iupac_name`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `journal`                       | \`null               | string\` (nullable)         | `str` (nullable)                | `string` (nullable)            |
+| `journal_iso_abbrev`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `journal_issn_type`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `journal_name_short`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `keywords`                      | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `language`                      | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `license_url`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `lineage`                       | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `lipidation`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `logp_method`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `mag_id`                        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `mapping_status`                | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `medline_pgn`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `mesh_id`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `mid`                           | `unknown` (nullable) | `str` (nullable)            | —                               | `str` (nullable)               |
+| `modified_residue`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `molecular_formula`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecular_function`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `molecule_hierarchy`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_id`                   | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `molecule_pref_name`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_properties`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_species`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_structures`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_synonyms`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `molecule_type`                 | `string` (nullable)  | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `nlm_unique_id`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `oa_status`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `open_access_url`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `openalex_id`                   | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `organism`                      | `string` (nullable)  | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `organism_common`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `organism_scientific`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `page_first`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `page_last`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `page_range`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `paper_id`                      | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `parent_molecule_id`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pathway`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pdb_xrefs`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pfam_xrefs`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pharmaceutical_use`            | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `phosphorylation`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `phylum`                        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `pii`                           | `unknown` (nullable) | `str` (nullable)            | —                               | `str` (nullable)               |
+| `pipeline_stages`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pmc_id`                        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `pmid`                          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pref_name`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `primary_topic`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `propeptide`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `protein_alternative_names`     | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `protein_class_desc`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `protein_classification_ids`    | \`integer            | string\` (nullable)         | `str` (nullable)                | `list<item: int64>` (nullable) |
+| `protein_classifications`       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `protein_ec_numbers`            | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `protein_existence`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `protein_name`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `protein_short_names`           | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `pub_date`                      | `unknown` (nullable) | —                           | `string` (nullable)             | —                              |
+| `publication_class`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `publication_date`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publication_doi`               | `unknown` (nullable) | —                           | —                               | `str` (nullable)               |
+| `publication_id`                | `string` (nullable)  | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `publication_pmc_id`            | `unknown` (nullable) | —                           | —                               | `str` (nullable)               |
+| `publication_pmid`              | `unknown` (nullable) | —                           | —                               | `str` (nullable)               |
+| `publication_status`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publication_subclass`          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `publication_type`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publication_type_list`         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publication_type_unified`      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `publication_types`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `published`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `published_online`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `published_print`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publisher`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `publisher_id`                  | `unknown` (nullable) | `str` (nullable)            | —                               | `str` (nullable)               |
+| `pubmed_id1`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `pubmed_id2`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `qualifier`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `qudt_units`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `reaction_ec_numbers`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `reactions`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `reactome_xrefs`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `references`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `relation`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `relationship_description`      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `relationship_type`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `ro3_pass`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `ror_ids`                       | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `secondary_accessions`          | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `sequence`                      | `unknown` (nullable) | `str` (not-null)            | —                               | —                              |
+| `sequence_checksum`             | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `short_name`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `signal_peptide`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `similarity_comment`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `src_assay_id`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `src_compound_id`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `standard_inchi`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `standard_relation`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `standard_text_value`           | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `standard_type`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `standard_units`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `structure_type`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `subcellular_location`          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `subject_fields`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `subject_keywords`              | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `subject_mesh`                  | `unknown` (nullable) | `str` (nullable)            | `list<item: string>` (nullable) | `str` (nullable)               |
+| `subject_topics`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `subunit`                       | `unknown` (nullable) | `str` (nullable)            | —                               | —                              |
+| `superkingdom`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `target_component_synonyms`     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `target_component_xrefs`        | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `target_components`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `target_id`                     | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `target_organism`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `target_pref_name`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `target_type`                   | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `term`                          | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `term_type`                     | `unknown` (nullable) | `str` (not-null)            | `string` (nullable)             | `str` (not-null)               |
+| `text_value`                    | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `tissue_id`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `tissue_specificity`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `title`                         | \`array              | null                        | string\` (nullable)             | `str` (nullable)               |
+| `tldr`                          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `topology`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `transmembrane`                 | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `type`                          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (not-null)               |
+| `ubiquitination`                | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | —                              |
+| `uniprot_accession`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `uniprot_entry_name`            | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `units`                         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `uo_units`                      | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `usan_stem`                     | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `usan_stem_definition`          | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `usan_substem`                  | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_accession`             | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_isoform`               | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_mutation`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_organism`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_sequence`              | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `variant_sequence_json`         | `unknown` (nullable) | `str` (nullable)            | `string` (nullable)             | `str` (nullable)               |
+| `volume`                        | \`integer            | null\` (nullable)           | `str` (nullable)                | `string` (nullable)            |

--- a/src/tools/generate_json_field_typing_inventory.py
+++ b/src/tools/generate_json_field_typing_inventory.py
@@ -1,0 +1,375 @@
+"""Generate JSON field typing inventory (Bronze -> Silver -> Gold)."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bioetl.domain.contracts import (
+    ChEMBLActivityGoldSchema,
+    ChEMBLAssayGoldSchema,
+    ChEMBLAssayParametersGoldSchema,
+    ChEMBLCellLineGoldSchema,
+    ChEMBLCompoundRecordGoldSchema,
+    ChEMBLDocumentGoldSchema,
+    ChEMBLDocumentSimilarityGoldSchema,
+    ChEMBLDocumentTermGoldSchema,
+    ChEMBLMoleculeGoldSchema,
+    ChEMBLProteinClassGoldSchema,
+    ChEMBLTargetComponentGoldSchema,
+    ChEMBLTargetGoldSchema,
+    CrossRefPublicationGoldSchema,
+    OpenAlexPublicationGoldSchema,
+    PubChemCompoundGoldSchema,
+    PubMedPublicationGoldSchema,
+    SemanticScholarPublicationGoldSchema,
+    UniProtIDMappingGoldSchema,
+    UniProtProteinGoldSchema,
+)
+from bioetl.domain.schemas.chembl.activity import ActivitySchema
+from bioetl.domain.schemas.chembl.assay import AssaySchema
+from bioetl.domain.schemas.chembl.assay_parameters import AssayParametersSchema
+from bioetl.domain.schemas.chembl.cell_line import CellLineSchema
+from bioetl.domain.schemas.chembl.compound_record import CompoundRecordSchema
+from bioetl.domain.schemas.chembl.molecule import MoleculeSchema
+from bioetl.domain.schemas.chembl.protein_classification import (
+    ProteinClassificationSchema,
+)
+from bioetl.domain.schemas.chembl.publication import ChemblPublicationSchema
+from bioetl.domain.schemas.chembl.publication_similarity import (
+    PublicationSimilaritySchema,
+)
+from bioetl.domain.schemas.chembl.publication_term import PublicationTermSchema
+from bioetl.domain.schemas.chembl.target import TargetSchema
+from bioetl.domain.schemas.chembl.target_component import TargetComponentSchema
+from bioetl.domain.schemas.crossref.publication import PublicationEnrichedSchema
+from bioetl.domain.schemas.openalex.publication import OpenAlexPublicationSchema
+from bioetl.domain.schemas.pubchem.compound import PubchemMoleculeSchema
+from bioetl.domain.schemas.pubmed.publication import PubMedPublicationSchema
+from bioetl.domain.schemas.semanticscholar.publication import (
+    SemanticScholarPublicationSchema,
+)
+from bioetl.domain.schemas.uniprot.idmapping import IDMappingSchema
+from bioetl.domain.schemas.uniprot.protein import UniprotTargetSchema
+from bioetl.infrastructure.schemas.silver import (
+    CHEMBL_ACTIVITY_SCHEMA,
+    CHEMBL_ASSAY_PARAMETERS_SCHEMA,
+    CHEMBL_ASSAY_SCHEMA,
+    CHEMBL_CELL_LINE_SCHEMA,
+    CHEMBL_COMPOUND_RECORD_SCHEMA,
+    CHEMBL_DOCUMENT_SIMILARITY_SCHEMA,
+    CHEMBL_DOCUMENT_TERM_SCHEMA,
+    CHEMBL_MOLECULE_SCHEMA,
+    CHEMBL_PROTEIN_CLASS_SCHEMA,
+    CHEMBL_PUBLICATION_SCHEMA,
+    CHEMBL_TARGET_COMPONENT_SCHEMA,
+    CHEMBL_TARGET_SCHEMA,
+    CROSSREF_PUBLICATION_SCHEMA,
+    OPENALEX_PUBLICATION_SCHEMA,
+    PUBCHEM_COMPOUND_SCHEMA,
+    PUBMED_PUBLICATION_SCHEMA,
+    SEMANTICSCHOLAR_PUBLICATION_SCHEMA,
+    UNIPROT_ID_MAPPING_SCHEMA,
+    UNIPROT_PROTEIN_SCHEMA,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = PROJECT_ROOT / "docs/03-data-model/json-field-typing-inventory.md"
+
+
+@dataclass(frozen=True)
+class SchemaBundle:
+    """Bundle all layers for a pipeline schema."""
+
+    name: str
+    pandera_silver: type
+    pyarrow_silver: Any
+    gold_contract: type
+    bronze_csv: str | None
+
+
+SCHEMA_BUNDLES: tuple[SchemaBundle, ...] = (
+    SchemaBundle(
+        "chembl_activity",
+        ActivitySchema,
+        CHEMBL_ACTIVITY_SCHEMA,
+        ChEMBLActivityGoldSchema,
+        "data/input/activity.csv",
+    ),
+    SchemaBundle(
+        "chembl_assay",
+        AssaySchema,
+        CHEMBL_ASSAY_SCHEMA,
+        ChEMBLAssayGoldSchema,
+        "data/input/assay.csv",
+    ),
+    SchemaBundle(
+        "chembl_assay_parameters",
+        AssayParametersSchema,
+        CHEMBL_ASSAY_PARAMETERS_SCHEMA,
+        ChEMBLAssayParametersGoldSchema,
+        None,
+    ),
+    SchemaBundle(
+        "chembl_cell_line",
+        CellLineSchema,
+        CHEMBL_CELL_LINE_SCHEMA,
+        ChEMBLCellLineGoldSchema,
+        "data/input/cell.csv",
+    ),
+    SchemaBundle(
+        "chembl_compound_record",
+        CompoundRecordSchema,
+        CHEMBL_COMPOUND_RECORD_SCHEMA,
+        ChEMBLCompoundRecordGoldSchema,
+        "data/input/compound_record.csv",
+    ),
+    SchemaBundle(
+        "chembl_document",
+        ChemblPublicationSchema,
+        CHEMBL_PUBLICATION_SCHEMA,
+        ChEMBLDocumentGoldSchema,
+        "data/input/publication.csv",
+    ),
+    SchemaBundle(
+        "chembl_document_similarity",
+        PublicationSimilaritySchema,
+        CHEMBL_DOCUMENT_SIMILARITY_SCHEMA,
+        ChEMBLDocumentSimilarityGoldSchema,
+        None,
+    ),
+    SchemaBundle(
+        "chembl_document_term",
+        PublicationTermSchema,
+        CHEMBL_DOCUMENT_TERM_SCHEMA,
+        ChEMBLDocumentTermGoldSchema,
+        None,
+    ),
+    SchemaBundle(
+        "chembl_molecule",
+        MoleculeSchema,
+        CHEMBL_MOLECULE_SCHEMA,
+        ChEMBLMoleculeGoldSchema,
+        "data/input/molecule.csv",
+    ),
+    SchemaBundle(
+        "chembl_protein_class",
+        ProteinClassificationSchema,
+        CHEMBL_PROTEIN_CLASS_SCHEMA,
+        ChEMBLProteinClassGoldSchema,
+        "data/input/protein_classification.csv",
+    ),
+    SchemaBundle(
+        "chembl_target",
+        TargetSchema,
+        CHEMBL_TARGET_SCHEMA,
+        ChEMBLTargetGoldSchema,
+        "data/input/target.csv",
+    ),
+    SchemaBundle(
+        "chembl_target_component",
+        TargetComponentSchema,
+        CHEMBL_TARGET_COMPONENT_SCHEMA,
+        ChEMBLTargetComponentGoldSchema,
+        "data/input/target_component.csv",
+    ),
+    SchemaBundle(
+        "pubchem_compound",
+        PubchemMoleculeSchema,
+        PUBCHEM_COMPOUND_SCHEMA,
+        PubChemCompoundGoldSchema,
+        None,
+    ),
+    SchemaBundle(
+        "pubmed_publication",
+        PubMedPublicationSchema,
+        PUBMED_PUBLICATION_SCHEMA,
+        PubMedPublicationGoldSchema,
+        "data/input/pubmed.csv",
+    ),
+    SchemaBundle(
+        "crossref_publication",
+        PublicationEnrichedSchema,
+        CROSSREF_PUBLICATION_SCHEMA,
+        CrossRefPublicationGoldSchema,
+        "data/input/dois.csv",
+    ),
+    SchemaBundle(
+        "openalex_publication",
+        OpenAlexPublicationSchema,
+        OPENALEX_PUBLICATION_SCHEMA,
+        OpenAlexPublicationGoldSchema,
+        "data/input/publication.csv",
+    ),
+    SchemaBundle(
+        "semanticscholar_publication",
+        SemanticScholarPublicationSchema,
+        SEMANTICSCHOLAR_PUBLICATION_SCHEMA,
+        SemanticScholarPublicationGoldSchema,
+        "data/input/publication.csv",
+    ),
+    SchemaBundle(
+        "uniprot_protein",
+        UniprotTargetSchema,
+        UNIPROT_PROTEIN_SCHEMA,
+        UniProtProteinGoldSchema,
+        "data/input/protein.csv",
+    ),
+    SchemaBundle(
+        "uniprot_idmapping",
+        IDMappingSchema,
+        UNIPROT_ID_MAPPING_SCHEMA,
+        UniProtIDMappingGoldSchema,
+        None,
+    ),
+)
+
+
+def _infer_scalar_type(raw: str) -> str:
+    text = raw.strip()
+    if not text:
+        return "null"
+    if text.lower() in {"true", "false"}:
+        return "boolean"
+    if text.startswith("["):
+        return "array"
+    if text.startswith("{"):
+        return "object"
+    try:
+        int(text)
+        return "integer"
+    except ValueError:
+        pass
+    try:
+        float(text)
+        return "float"
+    except ValueError:
+        return "string"
+
+
+def _kind(dtype: str) -> str:
+    value = dtype.lower()
+    if "list" in value or "array" in value:
+        return "native_list"
+    if "object" in value or "dict" in value:
+        return "native_object"
+    if "str" in value or "string" in value:
+        return "canonical_string"
+    return "scalar"
+
+
+def _fmt(dtype: str, nullable: bool | None) -> str:
+    if not dtype:
+        return "—"
+    if nullable is None:
+        return f"`{dtype}`"
+    nullable_text = "nullable" if nullable else "not-null"
+    return f"`{dtype}` ({nullable_text})"
+
+
+def build_inventory() -> str:
+    bronze_types: dict[str, set[str]] = defaultdict(set)
+    bronze_nullable: dict[str, bool] = defaultdict(bool)
+
+    for bundle in SCHEMA_BUNDLES:
+        if bundle.bronze_csv is None:
+            continue
+        csv_path = PROJECT_ROOT / bundle.bronze_csv
+        if not csv_path.exists():
+            continue
+        with csv_path.open(encoding="utf-8", newline="") as file_obj:
+            reader = csv.DictReader(file_obj)
+            for row in reader:
+                for field, value in row.items():
+                    inferred = _infer_scalar_type(value or "")
+                    bronze_types[field].add(inferred)
+                    if inferred == "null":
+                        bronze_nullable[field] = True
+
+    rows: dict[str, tuple[str, str, str, str]] = {}
+    for bundle in SCHEMA_BUNDLES:
+        pandera_columns = bundle.pandera_silver.to_schema().columns
+        pyarrow_fields = {field.name: field for field in bundle.pyarrow_silver}
+        gold_columns = bundle.gold_contract.to_schema().columns
+
+        field_names = set(pandera_columns) | set(pyarrow_fields) | set(gold_columns)
+        for field_name in sorted(field_names):
+            pandera_dtype = (
+                str(pandera_columns[field_name].dtype)
+                if field_name in pandera_columns
+                else ""
+            )
+            pyarrow_dtype = (
+                str(pyarrow_fields[field_name].type)
+                if field_name in pyarrow_fields
+                else ""
+            )
+            gold_dtype = (
+                str(gold_columns[field_name].dtype)
+                if field_name in gold_columns
+                else ""
+            )
+
+            kinds = {_kind(pandera_dtype), _kind(pyarrow_dtype), _kind(gold_dtype)}
+            if not kinds.intersection(
+                {"canonical_string", "native_list", "native_object"}
+            ):
+                continue
+
+            bronze_type = "|".join(sorted(bronze_types.get(field_name, {"unknown"})))
+            rows[field_name] = (
+                _fmt(bronze_type, bronze_nullable.get(field_name, True)),
+                _fmt(
+                    pandera_dtype,
+                    pandera_columns[field_name].nullable
+                    if field_name in pandera_columns
+                    else None,
+                ),
+                _fmt(
+                    pyarrow_dtype,
+                    pyarrow_fields[field_name].nullable
+                    if field_name in pyarrow_fields
+                    else None,
+                ),
+                _fmt(
+                    gold_dtype,
+                    gold_columns[field_name].nullable
+                    if field_name in gold_columns
+                    else None,
+                ),
+            )
+
+    lines = [
+        "# JSON Field Typing Inventory (Bronze -> Silver -> Gold)",
+        "",
+        "Scope: inferred Bronze CSV samples + Silver Pandera + Silver PyArrow + Gold contracts.",
+        "",
+        "| Field | Bronze inferred | Silver Pandera | Silver PyArrow | Gold contract |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+
+    for field_name in sorted(rows):
+        bronze, pandera, pyarrow, gold = rows[field_name]
+        lines.append(f"| `{field_name}` | {bronze} | {pandera} | {pyarrow} | {gold} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    content = build_inventory()
+    args.output.write_text(content, encoding="utf-8")
+    print(f"Updated {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tools/verify_schema_parity.py
+++ b/src/tools/verify_schema_parity.py
@@ -256,6 +256,13 @@ def check_schema_pair(pair: SchemaPair) -> tuple[list[str], list[str]]:
                 f"{pair.name}: PK '{primary_key}' is nullable in Gold schema"
             )
 
+        if silver_fields[primary_key].nullable != gold_columns[primary_key].nullable:
+            blocking.append(
+                f"{pair.name}: PK '{primary_key}' nullable mismatch "
+                f"(Silver={silver_fields[primary_key].nullable}, "
+                f"Gold={gold_columns[primary_key].nullable})"
+            )
+
     return blocking, warnings
 
 

--- a/tests/contract/silver_schemas/test_field_types.py
+++ b/tests/contract/silver_schemas/test_field_types.py
@@ -17,6 +17,16 @@ from tests.contract.silver_schemas.conftest import (
 )
 
 
+def _has_nullable_int_dtype_guard(annotation_repr: str, dtype_repr: str) -> bool:
+    """Return True when nullable-int annotation has explicit pandas dtype guard."""
+    if "int" not in dtype_repr.lower():
+        return True
+
+    has_nullable_union = "None" in annotation_repr or "Optional" in annotation_repr
+    has_nullable_int_dtype = "Int64Dtype" in annotation_repr
+    return has_nullable_union and has_nullable_int_dtype
+
+
 @pytest.mark.contracts
 @pytest.mark.no_api
 class TestFieldTypes:
@@ -235,6 +245,75 @@ class TestFieldTypes:
                 )
                 + "\n\nUse Series[bool] for boolean fields."
             )
+
+    @pytest.mark.parametrize(
+        "schema_name,guard_fields",
+        [
+            ("chembl_publication", {"src_id"}),
+            ("pubmed_publication", {"pub_month", "pub_day", "author_count"}),
+            (
+                "semanticscholar_publication",
+                {"corpus_id", "influential_citation_count"},
+            ),
+            (
+                "chembl_molecule",
+                {
+                    "hba_count",
+                    "hbd_count",
+                    "rotatable_bond_count",
+                    "ro5_violation_count",
+                    "heavy_atom_count",
+                    "aromatic_ring_count",
+                },
+            ),
+        ],
+    )
+    def test_nullable_int_fields_have_explicit_dtype_guard(
+        self, schema_name: str, guard_fields: set[str]
+    ) -> None:
+        """Critical nullable-int fields MUST keep explicit pandas Int64 dtype guard."""
+        schema_class = SILVER_SCHEMAS[schema_name]
+        schema_model = schema_class.to_schema()
+        annotations = schema_class.__annotations__
+
+        violations: list[str] = []
+        for field_name in sorted(guard_fields):
+            col_schema = schema_model.columns[field_name]
+            dtype_repr = str(col_schema.dtype)
+            annotation_repr = str(annotations.get(field_name, ""))
+            if not _has_nullable_int_dtype_guard(annotation_repr, dtype_repr):
+                violations.append(
+                    f"{field_name}: dtype={dtype_repr}, annotation={annotation_repr}"
+                )
+
+        if violations:
+            pytest.fail(
+                f"{schema_name}: nullable-int fields must have explicit dtype guard:\n"
+                + "\n".join(f"  - {item}" for item in violations)
+                + "\n\nUse: Series[pd.Int64Dtype] | None = pa.Field(nullable=True)"
+            )
+
+
+@pytest.mark.contracts
+@pytest.mark.no_api
+class TestNullableIntGuardRegression:
+    """Regression tests for nullable-int dtype guard helper."""
+
+    @pytest.mark.parametrize(
+        "annotation_repr,dtype_repr,expected",
+        [
+            ("Series[pd.Int64Dtype] | None", "int64", True),
+            ("Optional[Series[pd.Int64Dtype]]", "int64", True),
+            ("Series[int] | None", "int64", False),
+            ("Series[pd.Int64Dtype]", "int64", False),
+            ("Series[str] | None", "string", True),
+        ],
+    )
+    def test_has_nullable_int_dtype_guard(
+        self, annotation_repr: str, dtype_repr: str, expected: bool
+    ) -> None:
+        """Guard helper must detect nullable-int annotations reliably."""
+        assert _has_nullable_int_dtype_guard(annotation_repr, dtype_repr) is expected
 
 
 @pytest.mark.contracts


### PR DESCRIPTION
### Motivation

- Provide an auditable 4-layer typing matrix (Bronze inferred → Pandera → PyArrow → Gold) to keep JSON-like field typing documented and in sync. 
- Prevent subtle regressions around nullable integer types by requiring an explicit pandas nullable-int dtype guard in Pandera annotations. 
- Treat Silver↔Gold primary-key nullable mismatches as blocking so CI surfaces contract drift earlier. 

### Description

- Added a generator `src/tools/generate_json_field_typing_inventory.py` that inspects Bronze CSV samples, Silver Pandera models, Silver PyArrow schemas, and Gold Pandera contracts and writes `docs/03-data-model/json-field-typing-inventory.md` in a 4-column matrix format. 
- Hardened parity checks in `src/tools/verify_schema_parity.py` to treat primary key nullable mismatch (Silver vs Gold) as a blocking error. 
- Introduced nullable-int dtype guard logic and focused tests in `tests/contract/silver_schemas/test_field_types.py` (helper `_has_nullable_int_dtype_guard`, critical-field checks, and regression cases). 
- Updated schema governance CI `.github/workflows/schema-governance.yml` to run parity in blocking mode, regenerate the JSON typing inventory, and fail the job if the inventory doc is out of date. 

### Testing

- Ran the focused contract tests for the new nullable-int guard: `PYTHONPATH=src uv run pytest tests/contract/silver_schemas/test_field_types.py -k "nullable_int" -q`, which passed. 
- Executed the generator: `PYTHONPATH=src uv run python src/tools/generate_json_field_typing_inventory.py --output /tmp/json-field-typing-inventory.md`, which produced an updated markdown output successfully. 
- Ran parity check in blocking mode: `PYTHONPATH=src uv run python src/tools/verify_schema_parity.py --mode blocking`, which failed as expected against the current codebase due to existing Silver↔Gold schema differences (the stricter check surfaced multiple blocking mismatches to be addressed separately).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552197fe88324a754213647e78d57)