### PR TITLE
Require and validate `schema_file` for pipelines; populate empty schema configs and add CI check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra tracing --extra performance
 
+      - name: Validate pipeline configs + schema links (blocking)
+        run: uv run python scripts/validate_pipeline_configs.py
+
       - name: Smoke check (dependencies + core imports)
         run: uv run pytest tests/smoke/ -v --tb=short
 

--- a/configs/_schema/pipeline.json
+++ b/configs/_schema/pipeline.json
@@ -1791,12 +1791,19 @@
       "default": null,
       "description": "Explicit loading strategy for the pipeline. 'full_scan_only': Each run performs full scan, checkpoint resume disabled. See ADR-031.",
       "title": "Loading Strategy"
+    },
+    "schema_file": {
+      "description": "Required path to schema config file relative to pipeline config. Example: ../../schemas/chembl/activity.yaml",
+      "minLength": 1,
+      "title": "Schema File",
+      "type": "string"
     }
   },
   "required": [
     "pipeline_name",
     "provider",
     "entity_type",
+    "schema_file",
     "primary_keys",
     "silver_table"
   ],

--- a/configs/pipelines/chembl/activity.yaml
+++ b/configs/pipelines/chembl/activity.yaml
@@ -16,6 +16,7 @@
 pipeline_name: chembl_activity
 provider: chembl
 entity_type: activity
+schema_file: ../../schemas/chembl/activity.yaml
 version: "1.2.0"
 description: "Extract biological activity records from ChEMBL API"
 

--- a/configs/pipelines/chembl/assay.yaml
+++ b/configs/pipelines/chembl/assay.yaml
@@ -10,6 +10,7 @@
 pipeline_name: chembl_assay
 provider: chembl
 entity_type: assay
+schema_file: ../../schemas/chembl/assay.yaml
 version: "1.2.0"
 description: "Extract bioassay definitions from ChEMBL API"
 

--- a/configs/pipelines/chembl/assay_parameters.yaml
+++ b/configs/pipelines/chembl/assay_parameters.yaml
@@ -7,6 +7,7 @@
 pipeline_name: chembl_assay_parameters
 provider: chembl
 entity_type: assay_parameters
+schema_file: ../../schemas/chembl/assay_parameters.yaml
 version: "1.2.0"
 description: "Extract experimental assay parameters from ChEMBL API"
 

--- a/configs/pipelines/chembl/cell_line.yaml
+++ b/configs/pipelines/chembl/cell_line.yaml
@@ -6,6 +6,7 @@
 pipeline_name: chembl_cell_line
 provider: chembl
 entity_type: cell_line
+schema_file: ../../schemas/chembl/cell_line.yaml
 version: "1.2.0"
 description: "Extract cell lines from ChEMBL API"
 

--- a/configs/pipelines/chembl/compound_record.yaml
+++ b/configs/pipelines/chembl/compound_record.yaml
@@ -9,6 +9,7 @@
 pipeline_name: chembl_compound_record
 provider: chembl
 entity_type: compound_record
+schema_file: ../../schemas/chembl/compound_record.yaml
 version: "1.2.0"
 description: "Extract compound records from ChEMBL API"
 

--- a/configs/pipelines/chembl/molecule.yaml
+++ b/configs/pipelines/chembl/molecule.yaml
@@ -6,6 +6,7 @@
 pipeline_name: chembl_molecule
 provider: chembl
 entity_type: molecule
+schema_file: ../../schemas/chembl/molecule.yaml
 version: "1.2.0"
 description: "Extract molecules/compounds from ChEMBL API"
 

--- a/configs/pipelines/chembl/protein_class.yaml
+++ b/configs/pipelines/chembl/protein_class.yaml
@@ -7,6 +7,7 @@
 pipeline_name: chembl_protein_class
 provider: chembl
 entity_type: protein_class
+schema_file: ../../schemas/chembl/protein_class.yaml
 version: "1.2.0"
 description: "ChEMBL Protein Classification hierarchy (enzyme classes, receptor types, etc.)"
 

--- a/configs/pipelines/chembl/publication.yaml
+++ b/configs/pipelines/chembl/publication.yaml
@@ -7,6 +7,7 @@
 pipeline_name: chembl_publication
 provider: chembl
 entity_type: publication
+schema_file: ../../schemas/chembl/publication.yaml
 version: "2.1.0"
 description: "Extract scientific publications from ChEMBL API"
 

--- a/configs/pipelines/chembl/publication_similarity.yaml
+++ b/configs/pipelines/chembl/publication_similarity.yaml
@@ -7,6 +7,7 @@
 pipeline_name: chembl_publication_similarity
 provider: chembl
 entity_type: publication_similarity
+schema_file: ../../schemas/chembl/publication_similarity.yaml
 version: "2.1.0"
 description: "Extract publication similarity data (Tanimoto coefficients) from ChEMBL API"
 

--- a/configs/pipelines/chembl/publication_term.yaml
+++ b/configs/pipelines/chembl/publication_term.yaml
@@ -8,6 +8,7 @@
 pipeline_name: chembl_publication_term
 provider: chembl
 entity_type: publication_term
+schema_file: ../../schemas/chembl/publication_term.yaml
 version: "2.1.0"
 description: "Extract publication terms (MeSH, keywords) from ChEMBL Publication records"
 

--- a/configs/pipelines/chembl/subcellular_fraction.yaml
+++ b/configs/pipelines/chembl/subcellular_fraction.yaml
@@ -9,6 +9,7 @@
 pipeline_name: chembl_subcellular_fraction
 provider: chembl
 entity_type: subcellular_fraction
+schema_file: ../../schemas/chembl/subcellular_fraction.yaml
 version: "1.0.0"
 description: "Extract unique subcellular fractions from ChEMBL Assay records"
 

--- a/configs/pipelines/chembl/target.yaml
+++ b/configs/pipelines/chembl/target.yaml
@@ -6,6 +6,7 @@
 pipeline_name: chembl_target
 provider: chembl
 entity_type: target
+schema_file: ../../schemas/chembl/target.yaml
 version: "1.2.0"
 description: "Extract biological targets from ChEMBL API"
 

--- a/configs/pipelines/chembl/target_component.yaml
+++ b/configs/pipelines/chembl/target_component.yaml
@@ -6,6 +6,7 @@
 pipeline_name: chembl_target_component
 provider: chembl
 entity_type: target_component
+schema_file: ../../schemas/chembl/target_component.yaml
 version: "1.2.0"
 description: "ChEMBL Target Components (protein sequences, etc.)"
 

--- a/configs/pipelines/chembl/tissue.yaml
+++ b/configs/pipelines/chembl/tissue.yaml
@@ -6,6 +6,7 @@
 pipeline_name: chembl_tissue
 provider: chembl
 entity_type: tissue
+schema_file: ../../schemas/chembl/tissue.yaml
 version: "1.0.0"
 description: "Extract tissues from ChEMBL API"
 

--- a/configs/pipelines/crossref/publication.yaml
+++ b/configs/pipelines/crossref/publication.yaml
@@ -7,6 +7,7 @@
 pipeline_name: crossref_publication
 provider: crossref
 entity_type: publication
+schema_file: ../../schemas/crossref/publication.yaml
 version: "1.2.0"
 description: "Enrich publication records with CrossRef metadata via DOI resolution"
 

--- a/configs/pipelines/openalex/publication.yaml
+++ b/configs/pipelines/openalex/publication.yaml
@@ -9,6 +9,7 @@
 pipeline_name: openalex_publication
 provider: openalex
 entity_type: publication
+schema_file: ../../schemas/openalex/publication.yaml
 version: "1.2.0"
 description: "Batch DOI resolution via OpenAlex with title fallback"
 

--- a/configs/pipelines/pubchem/compound.yaml
+++ b/configs/pipelines/pubchem/compound.yaml
@@ -6,6 +6,7 @@
 pipeline_name: pubchem_compound
 provider: pubchem
 entity_type: compound
+schema_file: ../../schemas/pubchem/compound.yaml
 version: "1.2.0"
 description: "Pipeline for ingesting PubChem compounds"
 

--- a/configs/pipelines/pubmed/publication.yaml
+++ b/configs/pipelines/pubmed/publication.yaml
@@ -8,6 +8,7 @@
 pipeline_name: pubmed_publication
 provider: pubmed
 entity_type: publication
+schema_file: ../../schemas/pubmed/publication.yaml
 version: "1.2.0"
 description: "Extract publication metadata from PubMed via Entrez API"
 

--- a/configs/pipelines/semanticscholar/publication.yaml
+++ b/configs/pipelines/semanticscholar/publication.yaml
@@ -9,6 +9,7 @@
 pipeline_name: semanticscholar_publication
 provider: semanticscholar
 entity_type: publication
+schema_file: ../../schemas/semanticscholar/publication.yaml
 version: "1.2.0"
 description: "Batch DOI resolution via Semantic Scholar with title fallback"
 

--- a/configs/pipelines/uniprot/idmapping.yaml
+++ b/configs/pipelines/uniprot/idmapping.yaml
@@ -10,6 +10,7 @@
 pipeline_name: uniprot_idmapping
 provider: uniprot
 entity_type: idmapping
+schema_file: ../../schemas/uniprot/idmapping.yaml
 version: "1.1.0"
 description: "Maps ChEMBL target IDs to UniProt accessions via UniProt ID Mapping API"
 

--- a/configs/pipelines/uniprot/protein.yaml
+++ b/configs/pipelines/uniprot/protein.yaml
@@ -10,6 +10,7 @@
 pipeline_name: uniprot_protein
 provider: uniprot
 entity_type: protein
+schema_file: ../../schemas/uniprot/protein.yaml
 version: "1.2.0"
 description: "Pipeline for ingesting UniProt proteins"
 

--- a/configs/schemas/chembl/activity.yaml
+++ b/configs/schemas/chembl/activity.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - activity_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/assay.yaml
+++ b/configs/schemas/chembl/assay.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - assay_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/assay_parameters.yaml
+++ b/configs/schemas/chembl/assay_parameters.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - assay_param_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/cell_line.yaml
+++ b/configs/schemas/chembl/cell_line.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - cell_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/compound_record.yaml
+++ b/configs/schemas/chembl/compound_record.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - record_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/molecule.yaml
+++ b/configs/schemas/chembl/molecule.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - molecule_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/protein_class.yaml
+++ b/configs/schemas/chembl/protein_class.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - protein_class_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/publication_similarity.yaml
+++ b/configs/schemas/chembl/publication_similarity.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - sim_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/publication_term.yaml
+++ b/configs/schemas/chembl/publication_term.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - entity_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/subcellular_fraction.yaml
+++ b/configs/schemas/chembl/subcellular_fraction.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - entity_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/target.yaml
+++ b/configs/schemas/chembl/target.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - target_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/target_component.yaml
+++ b/configs/schemas/chembl/target_component.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - component_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/chembl/tissue.yaml
+++ b/configs/schemas/chembl/tissue.yaml
@@ -4,26 +4,34 @@
 version: "1.0.0"
 entity: tissue
 
-# Column groups must be a list of {name, fields} objects
 column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source
+      - _ingestion_ts
   - name: identifiers
     fields:
       - tissue_id
-  - name: core_metadata
+  - name: business
     fields:
       - pref_name
-  - name: ontology_references
-    fields:
       - bto_id
       - caloha_id
       - efo_id
       - uberon_id
 
-# All business fields for Gold layer
-gold_columns:
-  - tissue_id
-  - pref_name
-  - bto_id
-  - caloha_id
-  - efo_id
-  - uberon_id
+silver:
+  include_groups:
+    - system
+    - identifiers
+    - business
+
+gold:
+  include_groups:
+    - system
+    - identifiers
+    - business

--- a/configs/schemas/pubchem/compound.yaml
+++ b/configs/schemas/pubchem/compound.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - molecule_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/uniprot/idmapping.yaml
+++ b/configs/schemas/uniprot/idmapping.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - target_id
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/configs/schemas/uniprot/protein.yaml
+++ b/configs/schemas/uniprot/protein.yaml
@@ -1,1 +1,27 @@
-column_groups: []
+column_groups:
+- name: system
+  fields:
+  - entity_id
+  - content_hash
+  - _run_id
+  - _run_type
+  - _source
+  - _ingestion_ts
+- name: identifiers
+  fields:
+  - accession
+- name: business
+  pattern: ^(?!_|.*_id$).+
+silver:
+  include_groups:
+  - system
+  - identifiers
+  - business
+gold:
+  include_groups:
+  - system
+  - identifiers
+  - business
+  exclude_fields:
+  - '*_raw'
+  - _dq_*

--- a/docs/04-reference/pipelines/README.md
+++ b/docs/04-reference/pipelines/README.md
@@ -36,13 +36,13 @@ ______________________________________________________________________
 
 ### Composite Pipelines (5)
 
-| #   | Pipeline ID             | Provider  | Entity      | Spec                                         |
-| --- | ----------------------- | --------- | ----------- | -------------------------------------------- |
-| 22  | `composite_publication` | Composite | publication | [Spec](composite/01-publication-spec.md)     |
-| 23  | `composite_molecule`    | Composite | molecule    | [Spec](composite/02-molecule-spec.md)        |
-| 24  | `composite_target`      | Composite | target      | [Spec](composite/03-target-spec.md)          |
-| 25  | `composite_activity`    | Composite | activity    | *Spec pending*                               |
-| 26  | `composite_assay`       | Composite | assay       | *Spec pending*                               |
+| #   | Pipeline ID             | Provider  | Entity      | Spec                                     |
+| --- | ----------------------- | --------- | ----------- | ---------------------------------------- |
+| 22  | `composite_publication` | Composite | publication | [Spec](composite/01-publication-spec.md) |
+| 23  | `composite_molecule`    | Composite | molecule    | [Spec](composite/02-molecule-spec.md)    |
+| 24  | `composite_target`      | Composite | target      | [Spec](composite/03-target-spec.md)      |
+| 25  | `composite_activity`    | Composite | activity    | *Spec pending*                           |
+| 26  | `composite_assay`       | Composite | assay       | *Spec pending*                           |
 
 ______________________________________________________________________
 
@@ -91,7 +91,33 @@ ______________________________________________________________________
 
 ## Schema Files
 
-Provider schemas live in `src/bioetl/domain/schemas/` and Gold contracts in `src/bioetl/domain/contracts/gold/`.
+Each provider pipeline references an explicit schema config via `schema_file` in `configs/pipelines/*/*.yaml`.
+
+| Pipeline config                                        | Schema config                                        |
+| ------------------------------------------------------ | ---------------------------------------------------- |
+| `configs/pipelines/chembl/activity.yaml`               | `configs/schemas/chembl/activity.yaml`               |
+| `configs/pipelines/chembl/assay.yaml`                  | `configs/schemas/chembl/assay.yaml`                  |
+| `configs/pipelines/chembl/assay_parameters.yaml`       | `configs/schemas/chembl/assay_parameters.yaml`       |
+| `configs/pipelines/chembl/cell_line.yaml`              | `configs/schemas/chembl/cell_line.yaml`              |
+| `configs/pipelines/chembl/compound_record.yaml`        | `configs/schemas/chembl/compound_record.yaml`        |
+| `configs/pipelines/chembl/molecule.yaml`               | `configs/schemas/chembl/molecule.yaml`               |
+| `configs/pipelines/chembl/protein_class.yaml`          | `configs/schemas/chembl/protein_class.yaml`          |
+| `configs/pipelines/chembl/publication.yaml`            | `configs/schemas/chembl/publication.yaml`            |
+| `configs/pipelines/chembl/publication_similarity.yaml` | `configs/schemas/chembl/publication_similarity.yaml` |
+| `configs/pipelines/chembl/publication_term.yaml`       | `configs/schemas/chembl/publication_term.yaml`       |
+| `configs/pipelines/chembl/subcellular_fraction.yaml`   | `configs/schemas/chembl/subcellular_fraction.yaml`   |
+| `configs/pipelines/chembl/target.yaml`                 | `configs/schemas/chembl/target.yaml`                 |
+| `configs/pipelines/chembl/target_component.yaml`       | `configs/schemas/chembl/target_component.yaml`       |
+| `configs/pipelines/chembl/tissue.yaml`                 | `configs/schemas/chembl/tissue.yaml`                 |
+| `configs/pipelines/crossref/publication.yaml`          | `configs/schemas/crossref/publication.yaml`          |
+| `configs/pipelines/openalex/publication.yaml`          | `configs/schemas/openalex/publication.yaml`          |
+| `configs/pipelines/pubchem/compound.yaml`              | `configs/schemas/pubchem/compound.yaml`              |
+| `configs/pipelines/pubmed/publication.yaml`            | `configs/schemas/pubmed/publication.yaml`            |
+| `configs/pipelines/semanticscholar/publication.yaml`   | `configs/schemas/semanticscholar/publication.yaml`   |
+| `configs/pipelines/uniprot/idmapping.yaml`             | `configs/schemas/uniprot/idmapping.yaml`             |
+| `configs/pipelines/uniprot/protein.yaml`               | `configs/schemas/uniprot/protein.yaml`               |
+
+Domain schema contracts remain in `src/bioetl/domain/schemas/` and Gold contracts in `src/bioetl/domain/contracts/gold/`.
 JSON contract exports are in `docs/contracts/gold/`.
 
 ______________________________________________________________________

--- a/scripts/validate_pipeline_configs.py
+++ b/scripts/validate_pipeline_configs.py
@@ -74,6 +74,57 @@ def validate_paths_hierarchy(config: dict[str, Any]) -> list[str]:
     return warnings
 
 
+def validate_schema_link(config: dict[str, Any], config_path: Path) -> list[str]:
+    """Validate required schema_file reference and non-empty schema config."""
+    errors: list[str] = []
+
+    schema_file = config.get("schema_file")
+    if not isinstance(schema_file, str) or not schema_file.strip():
+        errors.append("schema_file is required and must be a non-empty string")
+        return errors
+
+    schema_path = (config_path.parent / schema_file).resolve()
+    if not schema_path.exists():
+        errors.append(
+            f"schema_file does not exist: {schema_file} (resolved: {schema_path})"
+        )
+        return errors
+
+    schema = yaml.safe_load(schema_path.read_text()) or {}
+    groups = schema.get("column_groups")
+    if not isinstance(groups, list) or len(groups) == 0:
+        errors.append(f"schema_file has empty column_groups: {schema_file}")
+        return errors
+
+    names = {g.get("name") for g in groups if isinstance(g, dict)}
+    has_system = "system" in names
+    has_identifiers = any(
+        isinstance(name, str) and name.startswith("identifiers") for name in names
+    )
+    has_business = "business" in names or any(
+        isinstance(name, str)
+        and name != "system"
+        and not name.startswith("identifiers")
+        for name in names
+    )
+    if not (has_system and has_identifiers and has_business):
+        errors.append(
+            f"schema_file must contain system, identifiers*, and business groups: {schema_file}"
+        )
+
+    for layer in ("silver", "gold"):
+        layer_cfg = schema.get(layer)
+        include_groups = (
+            layer_cfg.get("include_groups") if isinstance(layer_cfg, dict) else None
+        )
+        if not isinstance(include_groups, list) or not include_groups:
+            errors.append(
+                f"schema_file missing non-empty {layer}.include_groups: {schema_file}"
+            )
+
+    return errors
+
+
 def validate_sort_by_present(config: dict[str, Any]) -> list[str]:
     """Check that sort_by is defined for determinism (ADR-014)."""
     warnings = []
@@ -127,6 +178,11 @@ def main() -> int:
         # Hierarchy and sort checks apply only to standard pipeline configs.
         if is_composite_config:
             continue
+
+        # schema_file linkage and non-empty schema config (blocking)
+        schema_errors = validate_schema_link(config, config_path)
+        for e in schema_errors:
+            errors.append(f"{config_path}: {e}")
 
         # Path hierarchy check
         path_warnings = validate_paths_hierarchy(config)

--- a/src/bioetl/infrastructure/config_loader.py
+++ b/src/bioetl/infrastructure/config_loader.py
@@ -10,7 +10,7 @@ Convention-based path resolution (ADR-029):
         - source_file: ../../sources/{provider}.yaml
         - dq_config_file: ../../quality/entities/{provider}/{entity_type}.yaml
         - filter_config_file: ../../filters/entities/{provider}/{entity_type}.yaml
-        - data_schema_file: ../../schemas/{provider}/{entity_type}.yaml
+        - schema_file: ../../schemas/{provider}/{entity_type}.yaml
 
     Sink Paths:
         - sink.bronze.path: data/output/bronze/{provider}/{entity_type}
@@ -79,7 +79,7 @@ def _apply_file_reference_defaults(
         f"../../filters/entities/{provider}/{entity_type}.yaml",
     )
     config.setdefault(
-        "data_schema_file",
+        "schema_file",
         f"../../schemas/{provider}/{entity_type}.yaml",
     )
     config.setdefault(
@@ -111,7 +111,7 @@ def _load_column_groups_config(
 
 
 def _load_data_schema_config(
-    config_path: Path, data_schema_file: str
+    config_path: Path, schema_file: str
 ) -> dict[str, Any] | None:
     """Load data schema configuration with layer-specific column definitions.
 
@@ -121,7 +121,7 @@ def _load_data_schema_config(
 
     Args:
         config_path: Path to pipeline config file.
-        data_schema_file: Relative path to data schema YAML.
+        schema_file: Relative path to data schema YAML.
 
     Returns:
         Dictionary with column_groups, silver, and gold keys, or None if empty.
@@ -129,11 +129,11 @@ def _load_data_schema_config(
     Raises:
         FileNotFoundError: If the resolved schema path does not exist.
     """
-    schema_path = (config_path.parent / data_schema_file).resolve()
+    schema_path = (config_path.parent / schema_file).resolve()
     if not schema_path.exists():
         raise FileNotFoundError(
             f"Data schema file not found: {schema_path} "
-            f"(resolved from '{data_schema_file}' relative to {config_path.parent})"
+            f"(resolved from '{schema_file}' relative to {config_path.parent})"
         )
 
     with open(schema_path, encoding="utf-8") as f:
@@ -521,6 +521,49 @@ def _merge_data_schema_into_config(
         config.setdefault("data_schema", {})["gold"] = data_schema["gold"]
 
 
+def _validate_schema_config(data_schema: dict[str, Any], schema_file: str) -> None:
+    """Validate schema configuration has required minimum structure.
+
+    Required:
+      - non-empty column_groups
+      - system/identifiers/business groups
+      - layer filters for silver and gold (non-empty include_groups)
+    """
+    groups = data_schema.get("column_groups") or []
+    if not isinstance(groups, list) or not groups:
+        raise ValueError(
+            f"schema_file '{schema_file}' must define non-empty column_groups"
+        )
+
+    group_names = {g.get("name") for g in groups if isinstance(g, dict)}
+    has_system = "system" in group_names
+    has_identifiers = any(
+        isinstance(name, str) and name.startswith("identifiers") for name in group_names
+    )
+    has_business = "business" in group_names or any(
+        isinstance(name, str)
+        and name != "system"
+        and not name.startswith("identifiers")
+        for name in group_names
+    )
+    if not (has_system and has_identifiers and has_business):
+        raise ValueError(
+            f"schema_file '{schema_file}' must contain system, identifiers*, and business groups"
+        )
+
+    for layer in ("silver", "gold"):
+        layer_cfg = data_schema.get(layer)
+        if not isinstance(layer_cfg, dict):
+            raise ValueError(
+                f"schema_file '{schema_file}' missing '{layer}' layer filter config"
+            )
+        include_groups = layer_cfg.get("include_groups")
+        if not isinstance(include_groups, list) or not include_groups:
+            raise ValueError(
+                f"schema_file '{schema_file}' must define non-empty {layer}.include_groups"
+            )
+
+
 def _load_column_groups_section(
     config: dict[str, Any],
     entity_config: dict[str, Any],
@@ -528,20 +571,30 @@ def _load_column_groups_section(
 ) -> None:
     """Load column groups from external file unless explicitly set inline.
 
-    Priority: explicit inline > data_schema_file > column_groups_file (legacy).
+    Priority: explicit inline > schema_file > data_schema_file > column_groups_file (legacy).
     """
     if "column_groups" in entity_config:
         return
 
-    if data_schema_file := config.get("data_schema_file"):
-        try:
-            data_schema = _load_data_schema_config(config_path, data_schema_file)
-        except FileNotFoundError:
-            pass  # Fall back to column_groups_file below
-        else:
-            if data_schema:
-                _merge_data_schema_into_config(config, data_schema)
-                return
+    schema_file = config.get("schema_file")
+    if isinstance(schema_file, str) and schema_file.strip():
+        data_schema = _load_data_schema_config(config_path, schema_file)
+        if data_schema:
+            _validate_schema_config(data_schema, schema_file)
+            _merge_data_schema_into_config(config, data_schema)
+            return
+
+    # Backward compatibility for deprecated data_schema_file field
+    deprecated_data_schema_file = config.get("data_schema_file")
+    if (
+        isinstance(deprecated_data_schema_file, str)
+        and deprecated_data_schema_file.strip()
+    ):
+        data_schema = _load_data_schema_config(config_path, deprecated_data_schema_file)
+        if data_schema:
+            _validate_schema_config(data_schema, deprecated_data_schema_file)
+            _merge_data_schema_into_config(config, data_schema)
+            return
 
     if column_groups_file := config.get("column_groups_file"):
         column_groups = _load_column_groups_config(config_path, column_groups_file)

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -660,9 +660,15 @@ class PipelineYamlConfig(BaseModel):
         default=None,
         description="Path to column group config file relative to pipeline config.",
     )
+    schema_file: str = Field(
+        ...,
+        min_length=1,
+        description="Required path to schema config file relative to pipeline config. "
+        "Example: ../../schemas/chembl/activity.yaml",
+    )
     data_schema_file: str | None = Field(
         default=None,
-        description="Path to data schema file with layer-specific columns (silver/gold).",
+        description="Deprecated alias for schema_file. Kept for backward compatibility.",
     )
 
     primary_keys: list[str] = Field(min_length=1)

--- a/tests/unit/infrastructure/test_config_loader_schema_path.py
+++ b/tests/unit/infrastructure/test_config_loader_schema_path.py
@@ -1,4 +1,4 @@
-"""Unit tests for data_schema_file path resolution in config_loader.
+"""Unit tests for schema_file path resolution in config_loader.
 
 Tests:
 - Convention-based default path: ../../schemas/{provider}/{entity_type}.yaml
@@ -20,24 +20,24 @@ from bioetl.infrastructure.config_loader import (
 
 
 @pytest.mark.unit
-class TestDataSchemaFileDefault:
-    """Verify convention-based default for data_schema_file."""
+class TestSchemaFileDefault:
+    """Verify convention-based default for schema_file."""
 
     def test_default_path_uses_two_parent_levels(self) -> None:
-        """Default data_schema_file must be ../../schemas/{provider}/{entity}.yaml."""
+        """Default schema_file must be ../../schemas/{provider}/{entity}.yaml."""
         config: dict[str, Any] = {}
         _apply_file_reference_defaults(config, "chembl", "molecule")
 
-        assert config["data_schema_file"] == "../../schemas/chembl/molecule.yaml"
+        assert config["schema_file"] == "../../schemas/chembl/molecule.yaml"
 
     def test_explicit_override_not_overwritten(self) -> None:
-        """Explicit data_schema_file in config must not be overwritten by default."""
+        """Explicit schema_file in config must not be overwritten by default."""
         config: dict[str, Any] = {
-            "data_schema_file": "custom/path/schema.yaml",
+            "schema_file": "custom/path/schema.yaml",
         }
         _apply_file_reference_defaults(config, "chembl", "molecule")
 
-        assert config["data_schema_file"] == "custom/path/schema.yaml"
+        assert config["schema_file"] == "custom/path/schema.yaml"
 
 
 @pytest.mark.unit
@@ -45,7 +45,7 @@ class TestLoadDataSchemaConfig:
     """Tests for _load_data_schema_config file resolution and loading."""
 
     def test_missing_file_raises_file_not_found_error(self, tmp_path: Path) -> None:
-        """Missing data_schema_file must raise FileNotFoundError."""
+        """Missing schema_file must raise FileNotFoundError."""
         config_path = tmp_path / "pipelines" / "chembl" / "molecule.yaml"
         config_path.parent.mkdir(parents=True)
         config_path.touch()
@@ -54,7 +54,7 @@ class TestLoadDataSchemaConfig:
             _load_data_schema_config(config_path, "../../schemas/chembl/molecule.yaml")
 
     def test_existing_file_loads_column_groups(self, tmp_path: Path) -> None:
-        """Existing data_schema_file with column_groups must load correctly."""
+        """Existing schema_file with column_groups must load correctly."""
         # Create pipeline config path
         config_path = tmp_path / "pipelines" / "chembl" / "molecule.yaml"
         config_path.parent.mkdir(parents=True)

--- a/tests/unit/infrastructure/test_schema_file_validation.py
+++ b/tests/unit/infrastructure/test_schema_file_validation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from bioetl.infrastructure.config_loader import _validate_schema_config
+
+
+@pytest.mark.unit
+def test_validate_schema_config_accepts_minimum_structure() -> None:
+    schema = {
+        "column_groups": [
+            {"name": "system", "fields": ["entity_id"]},
+            {"name": "identifiers", "fields": ["compound_id"]},
+            {"name": "business", "pattern": "^name$"},
+        ],
+        "silver": {"include_groups": ["system", "identifiers", "business"]},
+        "gold": {"include_groups": ["system", "identifiers"]},
+    }
+
+    _validate_schema_config(schema, "../../schemas/test/entity.yaml")
+
+
+@pytest.mark.unit
+def test_validate_schema_config_rejects_empty_column_groups() -> None:
+    schema = {
+        "column_groups": [],
+        "silver": {"include_groups": ["system"]},
+        "gold": {"include_groups": ["system"]},
+    }
+
+    with pytest.raises(ValueError, match="non-empty column_groups"):
+        _validate_schema_config(schema, "../../schemas/test/entity.yaml")


### PR DESCRIPTION
### Motivation
- Ensure every pipeline is explicitly bound to a concrete schema config and that schema files contain a minimum usable structure (so `cfg_schema` / column ordering is not empty). 
- Prevent pipelines without valid schema definitions from entering CI or runtime by making linkage declarative and blocking in validation.

### Description
- Populated previously-empty schema files (`configs/schemas/*/*.yaml` that had `column_groups: []`) with a minimal baseline of column groups (`system`, `identifiers`, `business`) plus `silver`/`gold` `include_groups` and sensible `gold.exclude_fields` (e.g. `*_raw`, `_dq_*`).
- Added a required `schema_file` field to pipeline configs and schema models: inserted `schema_file: ../../schemas/{provider}/{entity}.yaml` into provider pipeline YAMLs and made `schema_file` required in `PipelineYamlConfig` and `configs/_schema/pipeline.json`.
- Updated loader and validation logic to use the schema file: refactored `_load_data_schema_config(...)` to accept `schema_file`, added `_validate_schema_config(...)` which enforces non-empty `column_groups`, presence of `system` / `identifiers*` / `business` groups, and non-empty `silver`/`gold` `include_groups`; kept `data_schema_file` as a deprecated fallback for backward compatibility.
- Added blocking config validation in `scripts/validate_pipeline_configs.py`: `validate_schema_link(...)` now checks that `schema_file` exists and the schema meets the minimum requirements; hooked this into CI smoke-check step in `.github/workflows/tests.yml`.
- Updated reference docs `docs/04-reference/pipelines/README.md` with an explicit `pipeline config → schema config` table.
- Added unit tests: `tests/unit/infrastructure/test_schema_file_validation.py` for `_validate_schema_config` and adjusted existing loader path tests to `schema_file` naming.

### Testing
- Ran the pipeline config validator: `uv run python scripts/validate_pipeline_configs.py` and iterated until schema issues were fixed; the script reported warnings for `sort_by` where applicable but no blocking errors after schema fixes.
- Installed runtime dependency and re-ran the validator when needed: `uv pip install jsonschema` (was required for local validation).
- Unit tests executed: `uv run pytest tests/unit/infrastructure/test_config_loader_schema_path.py tests/unit/infrastructure/test_schema_file_validation.py -q` — all tests passed.
- Verified runtime loading: loaded a pipeline config to confirm linkage and merged groups via `from bioetl.infrastructure.config_loader import load_pipeline_config` and checked `cfg.schema_file` and `len(cfg.column_groups)` (returned expected values).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995521aa4a48324835e4f37ad135b64)