### PR TITLE
Add configurable key nullability policy for Silver merge/partition keys

### DIFF
--- a/configs/quality/entities/chembl/activity.yaml
+++ b/configs/quality/entities/chembl/activity.yaml
@@ -117,3 +117,12 @@ conditional_validations:
         min: 0.001
         max: 100000
         nullable: false
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: activity_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/assay.yaml
+++ b/configs/quality/entities/chembl/assay.yaml
@@ -64,3 +64,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: assay_id
+    key_type: merge
+    nullable: false
+  - field: assay_type
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/assay_parameters.yaml
+++ b/configs/quality/entities/chembl/assay_parameters.yaml
@@ -45,3 +45,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: assay_param_id
+    key_type: merge
+    nullable: false
+  - field: type
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/cell_line.yaml
+++ b/configs/quality/entities/chembl/cell_line.yaml
@@ -45,3 +45,12 @@ cross_field_validations: []
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: cell_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/compound_record.yaml
+++ b/configs/quality/entities/chembl/compound_record.yaml
@@ -50,3 +50,12 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: record_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/molecule.yaml
+++ b/configs/quality/entities/chembl/molecule.yaml
@@ -101,3 +101,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: molecule_id
+    key_type: merge
+    nullable: false
+  - field: molecule_type
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/protein_class.yaml
+++ b/configs/quality/entities/chembl/protein_class.yaml
@@ -53,3 +53,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: protein_class_id
+    key_type: merge
+    nullable: false
+  - field: class_level
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/publication.yaml
+++ b/configs/quality/entities/chembl/publication.yaml
@@ -118,3 +118,12 @@ conditional_validations:
         type: not_null
         nullable: false
         error_message: "Publications of type PUBLICATION must have a title"
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: publication_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/publication_similarity.yaml
+++ b/configs/quality/entities/chembl/publication_similarity.yaml
@@ -59,3 +59,12 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: sim_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/publication_term.yaml
+++ b/configs/quality/entities/chembl/publication_term.yaml
@@ -56,3 +56,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: entity_id
+    key_type: merge
+    nullable: false
+  - field: term_type
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/subcellular_fraction.yaml
+++ b/configs/quality/entities/chembl/subcellular_fraction.yaml
@@ -45,3 +45,12 @@ cross_field_validations: []
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: entity_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/chembl/target.yaml
+++ b/configs/quality/entities/chembl/target.yaml
@@ -71,3 +71,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: target_id
+    key_type: merge
+    nullable: false
+  - field: target_type
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/target_component.yaml
+++ b/configs/quality/entities/chembl/target_component.yaml
@@ -54,3 +54,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: component_id
+    key_type: merge
+    nullable: false
+  - field: organism
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/chembl/tissue.yaml
+++ b/configs/quality/entities/chembl/tissue.yaml
@@ -57,3 +57,12 @@ cross_field_validations: []
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: tissue_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/crossref/publication.yaml
+++ b/configs/quality/entities/crossref/publication.yaml
@@ -103,3 +103,12 @@ conditional_validations:
         type: not_null
         nullable: false
         error_message: "Journal and proceedings articles must have a title"
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: doi
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/openalex/publication.yaml
+++ b/configs/quality/entities/openalex/publication.yaml
@@ -127,3 +127,12 @@ conditional_validations:
         type: not_null
         nullable: false
         error_message: "Articles and reviews must have a title"
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: openalex_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/pubchem/compound.yaml
+++ b/configs/quality/entities/pubchem/compound.yaml
@@ -89,3 +89,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: molecule_id
+    key_type: merge
+    nullable: false
+  - field: batch_date
+    key_type: partition
+    nullable: false

--- a/configs/quality/entities/pubmed/publication.yaml
+++ b/configs/quality/entities/pubmed/publication.yaml
@@ -114,3 +114,12 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: pmid
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/semanticscholar/publication.yaml
+++ b/configs/quality/entities/semanticscholar/publication.yaml
@@ -107,3 +107,12 @@ conditional_validations:
         type: not_null
         nullable: false
         error_message: "Journal articles must have a title"
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: paper_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/uniprot/idmapping.yaml
+++ b/configs/quality/entities/uniprot/idmapping.yaml
@@ -59,3 +59,12 @@ conditional_validations:
         pattern: '^[A-Z0-9]{6,10}$'
         nullable: false
         error_message: "Found mappings must have UniProt accession"
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: target_id
+    key_type: merge
+    nullable: false

--- a/configs/quality/entities/uniprot/protein.yaml
+++ b/configs/quality/entities/uniprot/protein.yaml
@@ -137,3 +137,15 @@ cross_field_validations:
 # Conditional Validations
 # =============================================================================
 conditional_validations: []
+
+# =============================================================================
+# Key Nullability Policy for Silver writes
+# =============================================================================
+# Documented per pipeline: merge(primary) and partition key nullability.
+key_nullability:
+  - field: accession
+    key_type: merge
+    nullable: false
+  - field: organism
+    key_type: partition
+    nullable: false

--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -733,6 +733,16 @@ class BatchExecutor:
         gold_data = self._build_dataframe_from_records(self._gold_records_for_dq)
         primary_keys = list(self._config.table_config.primary_keys)
         soft_threshold, hard_threshold = self._get_dq_thresholds()
+        key_nullability_rules = None
+        if self._config.dq_config is not None:
+            key_nullability_rules = [
+                {
+                    "field": rule.field,
+                    "key_type": rule.key_type,
+                    "nullable": rule.nullable,
+                }
+                for rule in self._config.dq_config.key_nullability_rules
+            ]
 
         # Get current date for Bronze DQ report filename
         current_date_str = datetime.now(UTC).strftime("%Y-%m-%d")
@@ -762,6 +772,7 @@ class BatchExecutor:
             silver_input_count=self.records_fetched,
             silver_quarantined_count=self.records_quarantined,
             silver_output_path=self._config.silver_output_path,
+            silver_key_nullability_rules=key_nullability_rules,
             # Gold context
             gold_data=gold_data,
             gold_target_table=self._config.table_config.gold_table,

--- a/src/bioetl/application/core/batch_writer.py
+++ b/src/bioetl/application/core/batch_writer.py
@@ -319,9 +319,15 @@ class BatchWriter:
                 primary_keys=list(self._table_config.primary_keys),
                 schema=self._silver_schema,
                 mode=self._silver_mode,
+                partition_cols=list(self._table_config.partition_cols),
                 on_schema_mismatch=self._table_config.on_schema_mismatch,
                 column_order=column_order,
                 bronze_refs=bronze_refs,
+                key_nullability_rules=(
+                    list(self._config.dq_config.key_nullability_rules)
+                    if self._config.dq_config is not None
+                    else None
+                ),
             )
             self._end_span(span)
             return silver_result

--- a/src/bioetl/application/core/preflight_service.py
+++ b/src/bioetl/application/core/preflight_service.py
@@ -335,6 +335,7 @@ class _MedallionConfigValidator:
         errors.extend(
             self._validate_medallion_policy_consistency(runtime.run_type, policy)
         )
+        errors.extend(self._validate_key_nullability_policies())
 
         self._log_medallion_validation_result(errors, runtime)
         return errors
@@ -520,6 +521,27 @@ class _MedallionConfigValidator:
                         expected="False",
                         actual="True",
                         rule="RULES §2.1: INCREMENTAL MUST NOT clear Gold layer",
+                    )
+                )
+
+        return errors
+
+    def _validate_key_nullability_policies(self) -> list[ConfigValidationError]:
+        """Validate key nullability policy consistency for Silver write keys."""
+        errors: list[ConfigValidationError] = []
+
+        valid_keys = set(self._config.table.primary_keys) | set(
+            self._config.table.partition_cols
+        )
+
+        for rule in self._config.dq.key_nullability_rules:
+            if rule.field not in valid_keys:
+                errors.append(
+                    ConfigValidationError(
+                        field="dq.key_nullability",
+                        expected="rule field must be present in primary_keys or partition_cols",
+                        actual=rule.field,
+                        rule="DQ key policy: key_nullability rules apply only to merge/partition keys",
                     )
                 )
 

--- a/src/bioetl/application/services/dq/silver_analyzer.py
+++ b/src/bioetl/application/services/dq/silver_analyzer.py
@@ -62,6 +62,7 @@ class SilverDQAnalyzer:
         input_record_count: int | None,
         quarantined_count: int,
         previous_schema: dict[str, str] | None,
+        key_nullability_rules: list[dict[str, Any]] | None,
     ) -> tuple[dict[str, Any], int, int, int]:
         """Execute all enabled DQ checks and collect results.
 
@@ -141,6 +142,19 @@ class SilverDQAnalyzer:
                 hash_result.status, passed, failed, warnings
             )
 
+        if SilverDQCheckType.KEY_NULLABILITY in enabled_checks:
+            key_nullability_result = self._check_key_nullability(
+                df,
+                key_nullability_rules or [],
+            )
+            checks["key_nullability"] = key_nullability_result
+            passed, failed, warnings = update_counts(
+                DQCheckStatus(key_nullability_result["status"]),
+                passed,
+                failed,
+                warnings,
+            )
+
         return checks, passed, failed, warnings
 
     def _calculate_thresholds(
@@ -196,6 +210,7 @@ class SilverDQAnalyzer:
         input_record_count: int | None = None,
         quarantined_count: int = 0,
         previous_schema: dict[str, str] | None = None,
+        key_nullability_rules: list[dict[str, Any]] | None = None,
     ) -> SilverDQReport:
         """Analyze Silver data and generate DQ report.
 
@@ -233,6 +248,7 @@ class SilverDQAnalyzer:
             input_record_count=input_record_count,
             quarantined_count=quarantined_count,
             previous_schema=previous_schema,
+            key_nullability_rules=key_nullability_rules,
         )
 
         # Calculate thresholds
@@ -263,6 +279,38 @@ class SilverDQAnalyzer:
             thresholds=thresholds,
             summary=summary,
         )
+
+    def _check_key_nullability(
+        self,
+        df: pl.DataFrame,
+        key_nullability_rules: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Check nullability for configured merge/partition keys."""
+        violations: list[dict[str, Any]] = []
+
+        for rule in key_nullability_rules:
+            if rule.get("nullable", False):
+                continue
+            field = str(rule.get("field", ""))
+            key_type = str(rule.get("key_type", "merge"))
+            if field not in df.columns:
+                continue
+            null_count = int(df[field].null_count())
+            if null_count > 0:
+                violations.append(
+                    {
+                        "field": field,
+                        "key_type": key_type,
+                        "null_count": null_count,
+                    }
+                )
+
+        status = DQCheckStatus.FAIL if violations else DQCheckStatus.PASS
+        return {
+            "status": status.value,
+            "violations": violations,
+            "rules_checked": len(key_nullability_rules),
+        }
 
     def _check_record_count(
         self,

--- a/src/bioetl/application/services/dq_report_service.py
+++ b/src/bioetl/application/services/dq_report_service.py
@@ -128,6 +128,7 @@ class DQReportContext:
     silver_quarantined_count: int = 0
     silver_previous_schema: dict[str, str] | None = None
     silver_output_path: str | None = None
+    silver_key_nullability_rules: list[dict[str, Any]] | None = None
 
     # Gold context
     gold_data: Any | None = None  # Any: pl.DataFrame (avoids polars import)
@@ -422,6 +423,7 @@ class DQReportService:
                 input_record_count=context.silver_input_count,
                 quarantined_count=context.silver_quarantined_count,
                 previous_schema=context.silver_previous_schema,
+                key_nullability_rules=context.silver_key_nullability_rules,
             )
 
             # Write report - use context output_path if provided, else config

--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -27,6 +27,7 @@ from bioetl.infrastructure.storage.silver_writer import SilverWriter
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from bioetl.domain.config import KeyNullabilityRule
     from bioetl.domain.models.metadata import SourceMetadata
     from bioetl.domain.types import ArrowSchema, BatchID, RunID, RunType
 
@@ -113,6 +114,7 @@ class StorageAdapter:
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
         column_order: list[str] | None = None,
         bronze_refs: list[BronzeWriteResult] | None = None,
+        key_nullability_rules: list[KeyNullabilityRule] | None = None,
     ) -> SilverWriteResult | None:
         """Write transformed records to Silver layer.
 
@@ -147,6 +149,7 @@ class StorageAdapter:
             on_schema_mismatch=on_schema_mismatch,
             column_order=column_order,
             bronze_refs=bronze_refs,
+            key_nullability_rules=key_nullability_rules,
         )
 
     async def write_gold(

--- a/src/bioetl/domain/config/__init__.py
+++ b/src/bioetl/domain/config/__init__.py
@@ -30,7 +30,7 @@ from bioetl.domain.config._converters import (
     freeze_sequences,
     resolve_loading_strategy,
 )
-from bioetl.domain.config.dq import DQConfig, DQReportConfig
+from bioetl.domain.config.dq import DQConfig, DQReportConfig, KeyNullabilityRule
 from bioetl.domain.config.memory import MemoryConfig
 from bioetl.domain.config.pipeline import PipelineConfig
 from bioetl.domain.config.runtime import RuntimeConfig
@@ -45,23 +45,17 @@ from bioetl.domain.config.validation import (
 
 __all__ = [
     "DEFAULT_VALIDATION_CONFIG",
-    # Validation
     "ConditionalValidation",
     "CrossFieldValidation",
-    # Data Quality
     "DQConfig",
     "DQReportConfig",
     "FieldValidation",
-    # Memory
+    "KeyNullabilityRule",
     "MemoryConfig",
-    # Pipeline
     "PipelineConfig",
-    # Runtime
     "RuntimeConfig",
-    # Table
     "TableConfig",
     "ValidationConfig",
-    # Converters (public utilities)
     "convert_write_mode",
     "freeze_sequences",
     "resolve_loading_strategy",

--- a/src/bioetl/domain/config/dq.py
+++ b/src/bioetl/domain/config/dq.py
@@ -36,6 +36,21 @@ class DQReportConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class KeyNullabilityRule:
+    """Nullability rule for key fields used by Silver writes.
+
+    Attributes:
+        field: Field name.
+        key_type: Key role in Silver writes.
+        nullable: Whether null is allowed for this key field.
+    """
+
+    field: str
+    key_type: Literal["merge", "partition"]
+    nullable: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class DQConfig:
     """Configuration for Data Quality thresholds and validations.
 
@@ -60,6 +75,7 @@ class DQConfig:
     conditional_validations: tuple[ConditionalValidation, ...] = ()
     invalid_record_policy: Literal["quarantine", "skip", "fail"] = "quarantine"
     report: DQReportConfig = field(default_factory=DQReportConfig)
+    key_nullability_rules: tuple[KeyNullabilityRule, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate threshold invariants on creation."""
@@ -69,7 +85,12 @@ class DQConfig:
         )
         freeze_sequences(
             self,
-            ("field_validations", "cross_field_validations", "conditional_validations"),
+            (
+                "field_validations",
+                "cross_field_validations",
+                "conditional_validations",
+                "key_nullability_rules",
+            ),
         )
 
     @staticmethod

--- a/src/bioetl/domain/ports/dq_report.py
+++ b/src/bioetl/domain/ports/dq_report.py
@@ -103,6 +103,7 @@ class SilverDQAnalyzerPort(Protocol):
         input_record_count: int | None = None,
         quarantined_count: int = 0,
         previous_schema: dict[str, str] | None = None,
+        key_nullability_rules: list[dict[str, Any]] | None = None,
     ) -> SilverDQReport:
         """Analyze Silver data and generate DQ report.
 

--- a/src/bioetl/domain/ports/storage.py
+++ b/src/bioetl/domain/ports/storage.py
@@ -25,6 +25,7 @@ from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 from bioetl.domain.value_objects.silver_result import SilverWriteResult
 
 if TYPE_CHECKING:
+    from bioetl.domain.config import KeyNullabilityRule
     from bioetl.domain.models.metadata import SourceMetadata
 
 
@@ -86,6 +87,7 @@ class StoragePort(Protocol):
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
         column_order: list[str] | None = None,
         bronze_refs: list[BronzeWriteResult] | None = None,
+        key_nullability_rules: list[KeyNullabilityRule] | None = None,
     ) -> SilverWriteResult | None:
         """Write transformed records to the Silver layer.
 

--- a/src/bioetl/domain/value_objects/dq_report.py
+++ b/src/bioetl/domain/value_objects/dq_report.py
@@ -72,6 +72,7 @@ class SilverDQCheckType(StrEnum):
     SCHEMA_DRIFT = "schema_drift"
     DEDUPLICATION_STATS = "deduplication_stats"
     CONTENT_HASH_INTEGRITY = "content_hash_integrity"
+    KEY_NULLABILITY = "key_nullability"
 
 
 # =============================================================================

--- a/src/bioetl/infrastructure/config/dq_config_loader.py
+++ b/src/bioetl/infrastructure/config/dq_config_loader.py
@@ -268,6 +268,10 @@ class DQConfigLoader:
                 result.pop("conditional_validations")
             )
 
+        if "key_nullability_rules" in result:
+            result.setdefault("key_nullability", [])
+            result["key_nullability"].extend(result.pop("key_nullability_rules"))
+
         return result
 
 

--- a/src/bioetl/infrastructure/schemas/dq_config.py
+++ b/src/bioetl/infrastructure/schemas/dq_config.py
@@ -26,6 +26,7 @@ from bioetl.domain.config import CrossFieldValidation as DomainCrossFieldValidat
 from bioetl.domain.config import DQConfig as DomainDQConfig
 from bioetl.domain.config import DQReportConfig as DomainDQReportConfig
 from bioetl.domain.config import FieldValidation as DomainFieldValidation
+from bioetl.domain.config import KeyNullabilityRule as DomainKeyNullabilityRule
 from bioetl.infrastructure.schemas.pipeline_config import (
     ConditionalValidationConfig,
     CrossFieldValidationConfig,
@@ -79,6 +80,19 @@ class ThresholdsConfig(BaseModel):
                 f"soft_fail ({self.soft_fail}) must be < hard_fail ({self.hard_fail})"
             )
         return self
+
+
+class KeyNullabilityRuleConfig(BaseModel):
+    """Nullability policy for Silver merge/partition keys."""
+
+    field: str = Field(description="Field name")
+    key_type: Literal["merge", "partition"] = Field(
+        description="Key role in Silver write strategy"
+    )
+    nullable: bool = Field(
+        default=False,
+        description="Whether null values are allowed for this key field",
+    )
 
 
 class DQConfigFile(BaseModel):
@@ -177,6 +191,11 @@ class DQConfigFile(BaseModel):
     entity_cross_field_validations: list[CrossFieldValidationConfig] = Field(
         default_factory=list,
         description="Cross-field validations from entity config",
+    )
+
+    key_nullability: list[KeyNullabilityRuleConfig] = Field(
+        default_factory=list,
+        description="Nullability rules for merge/partition key fields",
     )
 
     # Conditional validations
@@ -283,6 +302,14 @@ class DQConfigFile(BaseModel):
             conditional_validations=conditional_validations,
             invalid_record_policy=self.invalid_record_policy,
             report=report_config,
+            key_nullability_rules=tuple(
+                DomainKeyNullabilityRule(
+                    field=rule.field,
+                    key_type=rule.key_type,
+                    nullable=rule.nullable,
+                )
+                for rule in self.key_nullability
+            ),
         )
 
 

--- a/src/bioetl/infrastructure/schemas/dq_report_config.py
+++ b/src/bioetl/infrastructure/schemas/dq_report_config.py
@@ -102,6 +102,7 @@ class SilverDQReportConfig(BaseModel):
             SilverDQCheckType.VALUE_DISTRIBUTION.value,
             SilverDQCheckType.SCHEMA_DRIFT.value,
             SilverDQCheckType.DEDUPLICATION_STATS.value,
+            SilverDQCheckType.KEY_NULLABILITY.value,
         ],
         description="List of DQ checks to perform",
     )

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -53,6 +53,7 @@ from bioetl.infrastructure.storage.base_delta_writer import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bioetl.domain.config import KeyNullabilityRule
     from bioetl.domain.ports import (
         AuditPort,
         LoggerPort,
@@ -371,6 +372,49 @@ class SilverWriter(BaseDeltaWriter):
                     missing=optional_missing,
                 )
 
+    def _validate_key_nullability(
+        self,
+        records: list[dict[str, Any]],
+        primary_keys: list[str],
+        partition_cols: list[str] | None,
+        key_nullability_rules: list[KeyNullabilityRule] | None,
+        table_name: str,
+    ) -> None:
+        """Validate nullability policy for merge and partition keys."""
+        if not records or not key_nullability_rules:
+            return
+
+        rules = {(rule.field, rule.key_type): rule for rule in key_nullability_rules}
+
+        def collect_violations(
+            field: str,
+            key_type: Literal["merge", "partition"],
+        ) -> int:
+            rule = rules.get((field, key_type))
+            if rule is None or rule.nullable:
+                return 0
+            return sum(1 for record in records if record.get(field) is None)
+
+        violations: list[tuple[str, str, int]] = []
+
+        for key in primary_keys:
+            if count := collect_violations(key, "merge"):
+                violations.append((key, "merge", count))
+
+        for key in partition_cols or []:
+            if count := collect_violations(key, "partition"):
+                violations.append((key, "partition", count))
+
+        if violations:
+            details = [
+                f"{key_type}:{field} null_count={count}"
+                for field, key_type, count in violations
+            ]
+            raise ValueError(
+                "Key nullability policy violation for table "
+                f"'{table_name}': {'; '.join(details)}"
+            )
+
     def _validate_silver_pandera(
         self, records: list[dict[str, Any]], table_name: str
     ) -> None:
@@ -529,6 +573,7 @@ class SilverWriter(BaseDeltaWriter):
         on_schema_mismatch: Literal["error", "evolve", "ignore"] = "error",
         column_order: list[str] | None = None,
         bronze_refs: list[BronzeWriteResult] | None = None,
+        key_nullability_rules: list[KeyNullabilityRule] | None = None,
     ) -> SilverWriteResult | None:
         """Write normalized records to Silver layer (Delta Lake merge/upsert).
 
@@ -578,6 +623,13 @@ class SilverWriter(BaseDeltaWriter):
             self._enforce_write_policy(validated_mode, table_name)
 
             self._validate_records(records, table_name, schema)
+            self._validate_key_nullability(
+                records,
+                primary_keys,
+                partition_cols,
+                key_nullability_rules,
+                table_name,
+            )
 
             # Validate records using Pandera schema (if configured)
             self._validate_silver_pandera(records, table_name)

--- a/tests/unit/infrastructure/config/test_dq_config_loader.py
+++ b/tests/unit/infrastructure/config/test_dq_config_loader.py
@@ -98,6 +98,11 @@ entity_cross_field_validations:
       - field_a
       - field_b
     condition: all_present
+
+key_nullability:
+  - field: entity_id
+    key_type: merge
+    nullable: false
 """
     )
 
@@ -142,6 +147,8 @@ class TestDQConfigLoaderBasics:
         assert len(config.field_validations) == 4
         # Cross-field from entity
         assert len(config.cross_field_validations) == 1
+        assert len(config.key_nullability_rules) == 1
+        assert config.key_nullability_rules[0].field == "entity_id"
 
 
 class TestDQConfigLoaderMerge:
@@ -229,6 +236,29 @@ class TestDQConfigLoaderInlineOverrides:
 
         field_names = [fv.field for fv in config.field_validations]
         assert "inline_field" in field_names
+
+    def test_inline_override_key_nullability_rules(
+        self, loader: DQConfigLoader
+    ) -> None:
+        """Inline key nullability rules should be normalized and merged."""
+        config = loader.load(
+            "test_provider",
+            "test_entity",
+            inline_overrides={
+                "key_nullability_rules": [
+                    {
+                        "field": "partition_col",
+                        "key_type": "partition",
+                        "nullable": True,
+                    }
+                ]
+            },
+        )
+
+        rules = {
+            (r.field, r.key_type, r.nullable) for r in config.key_nullability_rules
+        }
+        assert ("partition_col", "partition", True) in rules
 
 
 class TestDQConfigLoaderCaching:

--- a/tests/unit/infrastructure/storage/test_silver_writer_key_nullability.py
+++ b/tests/unit/infrastructure/storage/test_silver_writer_key_nullability.py
@@ -1,0 +1,103 @@
+"""Tests for SilverWriter key nullability policy validation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pyarrow as pa
+import pytest
+
+from bioetl.domain.config import KeyNullabilityRule
+from bioetl.infrastructure.observability.noop_logger import NoOpLogger
+from bioetl.infrastructure.storage.silver_writer import SilverWriter
+
+
+@pytest.mark.unit
+class TestSilverWriterKeyNullability:
+    """Validate merge/partition key nullability policies."""
+
+    @pytest.mark.asyncio
+    async def test_non_nullable_merge_key_rejects_null(self) -> None:
+        """Non-null merge key policy must reject records with null merge key."""
+        writer = SilverWriter(base_path="/tmp/silver", logger=NoOpLogger())
+        writer._dispatch_write = AsyncMock()  # type: ignore[method-assign,assignment]
+
+        records = [
+            {
+                "entity_id": None,
+                "region": "eu",
+                "_run_id": "run-1",
+                "_run_type": "incremental",
+                "_source_batch_id": "batch-1",
+                "_ingestion_ts": "2025-01-01T00:00:00Z",
+            }
+        ]
+        schema = pa.schema(
+            [
+                pa.field("entity_id", pa.string()),
+                pa.field("region", pa.string()),
+                pa.field("_run_id", pa.string()),
+                pa.field("_run_type", pa.string()),
+                pa.field("_source_batch_id", pa.string()),
+                pa.field("_ingestion_ts", pa.string()),
+            ]
+        )
+
+        with pytest.raises(ValueError, match="Key nullability policy violation"):
+            await writer.write_silver(
+                table_name="test_table",
+                records=records,
+                primary_keys=["entity_id"],
+                schema=schema,
+                partition_cols=["region"],
+                key_nullability_rules=[
+                    KeyNullabilityRule(
+                        field="entity_id", key_type="merge", nullable=False
+                    )
+                ],
+            )
+
+    @pytest.mark.asyncio
+    async def test_nullable_partition_key_allows_null(self) -> None:
+        """Nullable partition key policy should allow null partition values."""
+        writer = SilverWriter(base_path="/tmp/silver", logger=NoOpLogger())
+
+        writer._dispatch_write = AsyncMock()  # type: ignore[method-assign,assignment]
+        writer._dispatch_write.return_value = None
+        writer._get_current_delta_version = AsyncMock(return_value=None)  # type: ignore[assignment]
+        writer._get_table_schema = AsyncMock(return_value=None)  # type: ignore[assignment]
+
+        records = [
+            {
+                "entity_id": "e1",
+                "region": None,
+                "_run_id": "run-1",
+                "_run_type": "incremental",
+                "_source_batch_id": "batch-1",
+                "_ingestion_ts": "2025-01-01T00:00:00Z",
+            }
+        ]
+        schema = pa.schema(
+            [
+                pa.field("entity_id", pa.string()),
+                pa.field("region", pa.string()),
+                pa.field("_run_id", pa.string()),
+                pa.field("_run_type", pa.string()),
+                pa.field("_source_batch_id", pa.string()),
+                pa.field("_ingestion_ts", pa.string()),
+            ]
+        )
+
+        result = await writer.write_silver(
+            table_name="test_table",
+            records=records,
+            primary_keys=["entity_id"],
+            schema=schema,
+            partition_cols=["region"],
+            key_nullability_rules=[
+                KeyNullabilityRule(field="entity_id", key_type="merge", nullable=False),
+                KeyNullabilityRule(field="region", key_type="partition", nullable=True),
+            ],
+        )
+
+        assert result is not None


### PR DESCRIPTION
### Motivation
- Make nullability of Silver-layer merge (primary) and partition keys explicit and enforceable to prevent silent corruption during merges/partitions. 
- Surface key nullability policy in external DQ configs (`configs/quality/entities/...`) and include it in generated DQ reports for observability.
- Enforce policy early in pipeline execution (preflight) to fail fast when configs reference invalid keys.

### Description
- Introduced domain model `KeyNullabilityRule` and added `key_nullability_rules` to `DQConfig` to hold per-entity key nullability policy, and re-exported it in `bioetl.domain.config`.
- Added Pydantic schema `KeyNullabilityRuleConfig` and mapping in `DQConfigFile.to_domain()` so `key_nullability:` YAML in `configs/quality/entities/...` becomes `DQConfig.key_nullability_rules`.
- Wired policy through the stack: `BatchWriter` now passes `key_nullability_rules` to `StoragePort.write_silver` → `StorageAdapter.write_silver` → `SilverWriter.write_silver` signature accepts `key_nullability_rules`.
- Implemented pre-write enforcement in `SilverWriter` via `_validate_key_nullability(...)` that raises `ValueError` when a non-nullable merge/partition key contains `null` values in the batch, invoked before Pandera validation and write dispatch.
- Added preflight consistency check `_validate_key_nullability_policies()` in `PreflightService._MedallionConfigValidator` to ensure configured `key_nullability` rules reference keys present in `primary_keys` or `partition_cols`.
- Extended DQ reporting: new `SilverDQCheckType.KEY_NULLABILITY`, the default Silver report checks include it, `DQReportContext` carries `silver_key_nullability_rules`, and `SilverDQAnalyzer` implements `_check_key_nullability()` to report violations in the Silver DQ report.
- Added `key_nullability:` sections to `configs/quality/entities/...` for pipeline-backed entities (documents merge/partition nullability rules) and added unit tests: `tests/unit/infrastructure/config/test_dq_config_loader.py` (loads/normalizes rules) and `tests/unit/infrastructure/storage/test_silver_writer_key_nullability.py` (SilverWriter enforcement).

### Testing
- Ran `python -m compileall` over the modified modules and new tests to ensure syntax/byte-compile correctness; this completed successfully across the changed files.
- Attempted to run targeted `pytest` for the new/modified unit tests, but test execution in this environment was blocked by the pytest configuration/plugin mismatch (`PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope`), so unit tests were not executed here.
- Pre-commit checks (auto-formatters) were exercised during development and formatting fixes applied; some external checks (type checks / environment tools) surfaced issues that were addressed where possible, but full pre-commit validation requiring environment binaries (e.g., `pip-audit`) could not be completed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552d8626883249d6cba1187633890)