### PR TITLE
Populate external schema column_groups from Pandera models and add CI guard

### DIFF
--- a/configs/schemas/chembl/activity.yaml
+++ b/configs/schemas/chembl/activity.yaml
@@ -1,1 +1,90 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - activity_id
+      - assay_id
+      - molecule_id
+      - target_id
+      - publication_id
+      - standard_relation
+      - standard_value
+      - standard_units
+      - standard_type
+      - standard_flag
+      - pchembl_value
+      - data_validity_comment
+      - activity_comment
+      - potential_duplicate
+      - bao_endpoint
+      - uo_units
+      - qudt_units
+      - src_id
+      - record_id
+      - type
+      - relation
+      - value
+      - units
+      - text_value
+      - standard_text_value
+      - upper_value
+      - standard_upper_value
+      - toid
+      - manual_curation_flag
+      - original_activity_id
+      - data_validity_description
+      - ligand_efficiency_bei
+      - ligand_efficiency_le
+      - ligand_efficiency_lle
+      - ligand_efficiency_sei
+      - action_type
+      - action_type_description
+      - action_type_parent_type
+      - activity_properties
+      - canonical_smiles
+      - molecule_pref_name
+      - parent_molecule_id
+      - target_pref_name
+      - target_organism
+      - target_taxonomy_id
+      - assay_type
+      - assay_description
+      - assay_variant_accession
+      - assay_variant_mutation
+      - bao_format
+      - bao_label
+      - journal
+      - publication_doi
+      - publication_pmid
+      - publication_pmc_id
+      - publication_year
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/assay.yaml
+++ b/configs/schemas/chembl/assay.yaml
@@ -1,1 +1,71 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - assay_id
+      - description
+      - assay_type
+      - assay_type_description
+      - assay_test_type
+      - assay_category
+      - assay_group
+      - assay_organism
+      - assay_taxonomy_id
+      - assay_strain
+      - assay_tissue
+      - assay_cell_type
+      - assay_subcellular_fraction
+      - target_id
+      - relationship_type
+      - relationship_description
+      - confidence_score
+      - confidence_description
+      - src_id
+      - src_assay_id
+      - publication_id
+      - assay_pref_name
+      - score
+      - cell_id
+      - tissue_id
+      - bao_format
+      - bao_label
+      - aidx
+      - variant_accession
+      - variant_isoform
+      - variant_mutation
+      - variant_organism
+      - variant_sequence
+      - variant_taxonomy_id
+      - variant_sequence_json
+      - assay_classifications
+      - assay_parameters
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/assay_parameters.yaml
+++ b/configs/schemas/chembl/assay_parameters.yaml
@@ -1,1 +1,47 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - assay_param_id
+      - assay_id
+      - type
+      - relation
+      - value
+      - units
+      - text_value
+      - comments
+      - standard_type
+      - standard_relation
+      - standard_value
+      - standard_units
+      - standard_text_value
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/cell_line.yaml
+++ b/configs/schemas/chembl/cell_line.yaml
@@ -1,1 +1,45 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - cell_id
+      - cell_name
+      - cell_description
+      - cell_source_tissue
+      - cell_source_organism
+      - cell_source_taxonomy_id
+      - cell_type
+      - cellosaurus_id
+      - clo_id
+      - cl_lincs_id
+      - efo_id
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/compound_record.yaml
+++ b/configs/schemas/chembl/compound_record.yaml
@@ -1,1 +1,41 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - record_id
+      - molecule_id
+      - publication_id
+      - src_id
+      - compound_key
+      - compound_name
+      - src_compound_id
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/molecule.yaml
+++ b/configs/schemas/chembl/molecule.yaml
@@ -1,1 +1,86 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - molecule_id
+      - pref_name
+      - max_phase
+      - structure_type
+      - molecule_type
+      - first_approval
+      - therapeutic_flag
+      - oral
+      - parenteral
+      - topical
+      - black_box_warning
+      - natural_product
+      - first_in_class
+      - prodrug
+      - inorganic_flag
+      - polymer_flag
+      - withdrawn_flag
+      - chirality
+      - dosed_ingredient
+      - availability_type
+      - usan_year
+      - usan_stem
+      - usan_substem
+      - usan_stem_definition
+      - helm_notation
+      - molecule_species
+      - hierarchy_parent_chembl_id
+      - hierarchy_active_chembl_id
+      - hierarchy_child_chembl_id
+      - logp
+      - logp_method
+      - mw_freebase
+      - molecular_weight
+      - hba_count
+      - hbd_count
+      - polar_surface_area
+      - rotatable_bond_count
+      - ro5_violation_count
+      - heavy_atom_count
+      - aromatic_ring_count
+      - qed_score
+      - molecular_formula
+      - ro3_pass
+      - canonical_smiles
+      - standard_inchi
+      - inchi_key
+      - molecule_hierarchy
+      - molecule_properties
+      - molecule_structures
+      - molecule_synonyms
+      - cross_references
+      - atc_classifications
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/protein_class.yaml
+++ b/configs/schemas/chembl/protein_class.yaml
@@ -1,1 +1,44 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - protein_class_id
+      - parent_id
+      - replaced_by
+      - pref_name
+      - short_name
+      - protein_class_desc
+      - definition
+      - class_level
+      - sort_order
+      - downgraded
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/publication_similarity.yaml
+++ b/configs/schemas/chembl/publication_similarity.yaml
@@ -1,1 +1,43 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - sim_id
+      - doc_1
+      - doc_2
+      - pubmed_id1
+      - pubmed_id2
+      - tid_tani
+      - mol_tani
+      - avg_tani
+      - max_tani
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/publication_term.yaml
+++ b/configs/schemas/chembl/publication_term.yaml
@@ -1,1 +1,39 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - publication_id
+      - term
+      - term_type
+      - mesh_id
+      - qualifier
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/subcellular_fraction.yaml
+++ b/configs/schemas/chembl/subcellular_fraction.yaml
@@ -1,1 +1,39 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - assay_subcellular_fraction
+      - assay_id
+      - target_id
+      - assay_type
+      - assay_organism
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/target.yaml
+++ b/configs/schemas/chembl/target.yaml
@@ -1,1 +1,52 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - target_id
+      - target_type
+      - pref_name
+      - taxonomy_id
+      - organism
+      - species_group_flag
+      - description
+      - downgraded
+      - target_components
+      - cross_references
+      - pipeline_stages
+      - target_component_synonyms
+      - component_accessions
+      - component_descriptions
+      - primary_component_id
+      - component_ids
+      - component_types
+      - component_relationships
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/chembl/target_component.yaml
+++ b/configs/schemas/chembl/target_component.yaml
@@ -1,1 +1,45 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - component_id
+      - accession
+      - component_type
+      - description
+      - organism
+      - taxonomy_id
+      - target_component_synonyms
+      - target_component_xrefs
+      - protein_classifications
+      - protein_classification_id
+      - protein_classification_ids
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/pubchem/compound.yaml
+++ b/configs/schemas/pubchem/compound.yaml
@@ -1,1 +1,74 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - molecule_id
+      - canonical_smiles
+      - isomeric_smiles
+      - inchi
+      - inchi_key
+      - molecular_formula
+      - iupac_name
+      - molecular_weight
+      - exact_mass
+      - monoisotopic_mass
+      - xlogp
+      - tpsa
+      - complexity
+      - charge
+      - heavy_atom_count
+      - h_bond_donor_count
+      - h_bond_acceptor_count
+      - rotatable_bond_count
+      - atom_stereo_count
+      - defined_atom_stereo_count
+      - undefined_atom_stereo_count
+      - bond_stereo_count
+      - defined_bond_stereo_count
+      - undefined_bond_stereo_count
+      - isotope_atom_count
+      - covalent_unit_count
+      - volume_3d
+      - conformer_count_3d
+      - feature_acceptor_count_3d
+      - feature_donor_count_3d
+      - feature_anion_count_3d
+      - feature_cation_count_3d
+      - feature_ring_count_3d
+      - feature_hydrophobe_count_3d
+      - effective_rotor_count_3d
+      - conformer_rmsd_3d
+      - x_steric_quadrupole_3d
+      - y_steric_quadrupole_3d
+      - z_steric_quadrupole_3d
+      - feature_count_3d
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/uniprot/idmapping.yaml
+++ b/configs/schemas/uniprot/idmapping.yaml
@@ -1,1 +1,48 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - target_id
+      - uniprot_accession
+      - mapping_status
+      - uniprot_entry_name
+      - organism_scientific
+      - organism_common
+      - taxonomy_id
+      - protein_name
+      - gene_primary
+      - sequence_length
+      - sequence_mass
+      - reviewed
+      - annotation_score
+      - all_mappings
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/configs/schemas/uniprot/protein.yaml
+++ b/configs/schemas/uniprot/protein.yaml
@@ -1,1 +1,116 @@
-column_groups: []
+column_groups:
+  - name: system
+    fields:
+      - entity_id
+      - content_hash
+      - _run_id
+      - _run_type
+      - _source_batch_id
+      - _ingestion_ts
+      - _index
+
+  - name: business
+    fields:
+      - accession
+      - entry_name
+      - entry_type
+      - secondary_accessions
+      - protein_name
+      - protein_short_names
+      - protein_alternative_names
+      - protein_ec_numbers
+      - flag
+      - gene_primary
+      - gene_synonyms
+      - gene_orf_names
+      - organism_scientific
+      - organism_common
+      - taxonomy_id
+      - lineage
+      - sequence
+      - sequence_length
+      - sequence_mass
+      - sequence_checksum
+      - sequence_modified
+      - entry_version
+      - entry_created
+      - entry_modified
+      - reviewed
+      - protein_existence
+      - annotation_score
+      - function_comment
+      - catalytic_activity
+      - activity_regulation
+      - subunit
+      - pathway
+      - subcellular_location
+      - tissue_specificity
+      - alternative_products
+      - disease_involvement
+      - pharmaceutical_use
+      - similarity_comment
+      - caution
+      - cofactors
+      - biophysicochemical_properties
+      - induction
+      - go_terms
+      - drugbank_ids
+      - chembl_ids
+      - guidetopharmacology_ids
+      - pdb_xrefs
+      - interpro_xrefs
+      - pfam_xrefs
+      - reactome_xrefs
+      - superkingdom
+      - phylum
+      - genus
+      - molecular_function
+      - cellular_component
+      - features_json
+      - domains
+      - binding_sites
+      - active_sites
+      - keywords
+      - topology
+      - transmembrane
+      - intramembrane
+      - signal_peptide
+      - propeptide
+      - glycosylation
+      - lipidation
+      - disulfide_bond
+      - modified_residue
+      - phosphorylation
+      - acetylation
+      - ubiquitination
+      - isoform_names
+      - isoform_ids
+      - isoform_synonyms
+      - reactions
+      - reaction_ec_numbers
+      - cross_reference_count
+      - feature_count
+      - keyword_count
+      - publication_count
+      - isoform_count
+
+  - name: dq
+    pattern: "^_dq_"
+
+silver:
+  include_groups:
+    - system
+    - business
+    - dq
+  exclude_fields: []
+  alias_policy: preserve
+
+gold:
+  include_groups:
+    - system
+    - business
+  exclude_fields:
+    - _dq_*
+    - _source_batch_id
+    - _index
+  alias_policy: canonical

--- a/tests/architecture/test_pipeline_external_schema_non_empty.py
+++ b/tests/architecture/test_pipeline_external_schema_non_empty.py
@@ -1,0 +1,66 @@
+"""Architecture guard: registered pipelines must use non-empty external schema files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from bioetl.composition.factories.pipeline_factories import PIPELINE_CONFIGS
+
+_SCHEMA_REF_RE = re.compile(r"^\s*data_schema_file:\s*(.+?)\s*$", re.MULTILINE)
+_EMPTY_COLUMN_GROUPS_RE = re.compile(r"^\s*column_groups:\s*\[\s*\]\s*$", re.MULTILINE)
+
+
+@pytest.mark.architecture
+class TestPipelineExternalSchemaNotEmpty:
+    """Ensure external schema files are not empty placeholders."""
+
+    def test_registered_pipeline_schema_files_are_not_empty(self) -> None:
+        """Every PIPELINE_CONFIGS entry must resolve to a non-empty external schema file."""
+        failures: list[str] = []
+
+        for pipeline in PIPELINE_CONFIGS:
+            pipeline_path = (
+                Path("configs")
+                / "pipelines"
+                / pipeline.provider
+                / (f"{pipeline.entity_type}.yaml")
+            )
+            if not pipeline_path.exists():
+                failures.append(
+                    f"{pipeline.pipeline_name}: missing pipeline config {pipeline_path}"
+                )
+                continue
+
+            text = pipeline_path.read_text(encoding="utf-8")
+            match = _SCHEMA_REF_RE.search(text)
+            if match:
+                raw_ref = match.group(1).strip().strip("\"'")
+                schema_path = (pipeline_path.parent / raw_ref).resolve()
+            else:
+                schema_path = (
+                    pipeline_path.parent
+                    / f"../../schemas/{pipeline.provider}/{pipeline.entity_type}.yaml"
+                ).resolve()
+
+            if not schema_path.exists():
+                failures.append(
+                    f"{pipeline.pipeline_name}: schema file not found {schema_path}"
+                )
+                continue
+
+            schema_text = schema_path.read_text(encoding="utf-8")
+            if _EMPTY_COLUMN_GROUPS_RE.search(schema_text):
+                failures.append(
+                    f"{pipeline.pipeline_name}: schema {schema_path} has empty column_groups"
+                )
+                continue
+
+            if "column_groups:" not in schema_text:
+                failures.append(
+                    f"{pipeline.pipeline_name}: schema {schema_path} misses column_groups"
+                )
+
+        assert not failures, "\n".join(failures)


### PR DESCRIPTION
### Motivation
- Replace placeholder external schema files that used `column_groups: []` with explicit, actionable group definitions so pipeline merging/ordering logic has deterministic field sets. 
- Ensure layer-specific (silver/gold) policies (include/exclude/alias) are available for medallion processing and downstream ordering/merge behavior. 
- Prevent regressions by adding a CI architecture test that disallows empty external schema files for pipelines registered in `PIPELINE_CONFIGS`.

### Description
- Replaced `column_groups: []` with explicit `column_groups` (groups: `system`, `business`, `dq`) and populated `business` fields by extracting field names from the corresponding Pandera schemas in `src/bioetl/domain/schemas/...` for the following external schema files (15 files): `configs/schemas/chembl/*.yaml`, `configs/schemas/pubchem/compound.yaml`, and `configs/schemas/uniprot/*.yaml`.
- Added layer-specific sections to each updated schema file: a `silver` section with `include_groups`, `exclude_fields`, and `alias_policy: preserve`, and a `gold` section with `include_groups`, `exclude_fields` (e.g. `_dq_*`, `_source_batch_id`, `_index`), and `alias_policy: canonical`.
- Implemented a new CI architecture test `tests/architecture/test_pipeline_external_schema_non_empty.py` which iterates `PIPELINE_CONFIGS`, resolves each pipeline's `data_schema_file` (or convention-based schema path), and asserts the referenced external schema exists, contains `column_groups:`, and is not a placeholder `column_groups: []`.

### Testing
- Verified absence of placeholder files with an `rg` check (no occurrences of `column_groups: []`) which succeeded. 
- Validated the new test file compiles with `python -m py_compile tests/architecture/test_pipeline_external_schema_non_empty.py` which succeeded.
- Attempted to run the new test under the local pytest environment; collection failed due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so full pytest execution was not completed locally; the new test is designed to run in CI where the test matrix and plugins are expected to match repository configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552b9f7208324831571f99821b03e)