### PR TITLE
Add DQ rule provenance to reports and metadata traceability

### DIFF
--- a/src/bioetl/application/services/dq/_checks_business.py
+++ b/src/bioetl/application/services/dq/_checks_business.py
@@ -101,6 +101,7 @@ def check_business_rules(
     rules_failed = 0
 
     for rule in rules:
+        column = rule.get("column")
         try:
             passed, violations = _evaluate_single_rule(df, rule)
         except Exception:
@@ -120,6 +121,11 @@ def check_business_rules(
                 description=rule.get("description", ""),
                 passed=passed,
                 violations=violations,
+                config_path=rule.get("config_path"),
+                layer=rule.get("layer", "gold"),
+                field=rule.get("field", column),
+                severity=rule.get("severity", "error"),
+                decision=rule.get("decision", "pass" if passed else "fail"),
             )
         )
 

--- a/src/bioetl/composition/services/metadata_coordinator.py
+++ b/src/bioetl/composition/services/metadata_coordinator.py
@@ -277,6 +277,10 @@ class MetadataCoordinator:
             if input_data.dq_metrics
             else DQSummary(total_records=rec_count, valid_records=rec_count)
         )
+        if input_data.dq_rule_provenance:
+            dq_summary = dq_summary.model_copy(
+                update={"rule_provenance": input_data.dq_rule_provenance}
+            )
 
         # Calculate duration if both timestamps provided
         duration_seconds = (

--- a/src/bioetl/domain/models/metadata.py
+++ b/src/bioetl/domain/models/metadata.py
@@ -584,6 +584,13 @@ class DQSummary(BaseModel):
     data_freshness_hours: float | None = Field(
         default=None, description="Data freshness in hours"
     )
+    rule_provenance: list[dict[str, str | None]] = Field(
+        default_factory=list,
+        description=(
+            "DQ rule provenance entries with rule_id, config_path, layer, "
+            "field, severity, and decision"
+        ),
+    )
 
     @property
     def null_rates(self) -> dict[str, float]:

--- a/src/bioetl/domain/ports/metadata_coordinator.py
+++ b/src/bioetl/domain/ports/metadata_coordinator.py
@@ -68,6 +68,7 @@ class SilverMetadataInput:
         transform_version: Optional semver version of transform applied.
         transform_steps: Optional list of transform step names applied.
         dq_report_path: Optional path to generated DQ report for cross-reference.
+        dq_rule_provenance: Optional DQ rule provenance entries for traceability.
         partition_by: Partition columns used for the Delta table.
         governance: Optional governance metadata from pipeline config.
         started_at: UTC timestamp when Silver write started.
@@ -86,6 +87,7 @@ class SilverMetadataInput:
     transform_version: str | None = None
     transform_steps: tuple[str, ...] | None = None
     dq_report_path: str | None = None
+    dq_rule_provenance: list[dict[str, str | None]] | None = None
     partition_by: list[str] | None = None
     governance: GovernanceMetadata | None = None
     started_at: datetime | None = None

--- a/src/bioetl/domain/value_objects/dq_report.py
+++ b/src/bioetl/domain/value_objects/dq_report.py
@@ -296,6 +296,11 @@ class BusinessRuleResult:
     description: str
     passed: bool
     violations: int | None  # None indicates unknown (e.g., exception during check)
+    config_path: str | None = None
+    layer: str | None = None
+    field: str | None = None
+    severity: str | None = None
+    decision: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/integration/test_dq_report_integration.py
+++ b/tests/integration/test_dq_report_integration.py
@@ -9,7 +9,7 @@ Tests the end-to-end flow of DQ report generation including:
 from __future__ import annotations
 
 import json
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -335,6 +335,67 @@ class TestDQReportIntegration:
             )
             is True
         )
+
+    @pytest.mark.asyncio
+    async def test_gold_dq_report_includes_rule_provenance_traceability(
+        self,
+        tmp_path: Path,
+        mock_logger: MagicMock,
+        dq_context: DQReportContext,
+    ) -> None:
+        """Gold DQ report JSON should include business rule provenance fields."""
+        import polars as pl
+
+        context = DQReportContext(
+            run_id=dq_context.run_id,
+            pipeline_name=dq_context.pipeline_name,
+            timestamp=dq_context.timestamp,
+            provider="chembl",
+            entity="activity",
+            gold_data=pl.DataFrame({"value": [-1.0, 2.0]}),
+            gold_target_table="chembl.activity",
+            gold_required_fields=["value"],
+            gold_business_rules=[
+                {
+                    "rule_id": "R_TRACE_01",
+                    "name": "non_negative",
+                    "column": "value",
+                    "condition": "range",
+                    "min": 0,
+                    "config_path": "configs/quality/entities/chembl/activity.yaml",
+                    "layer": "gold",
+                    "field": "value",
+                    "severity": "error",
+                    "decision": "quarantine",
+                }
+            ],
+            dq_soft_threshold=0.05,
+            dq_hard_threshold=0.20,
+        )
+
+        service = DQReportService(
+            logger=mock_logger,
+            gold_analyzer=DQServicesFactory.create_gold_analyzer(),
+            report_writer=DQServicesFactory.create_report_writer(tmp_path, mock_logger),
+        )
+
+        result = await service.generate_reports(
+            context=context,
+            gold_config=GoldDQReportConfig(enabled=True, format="json"),
+        )
+
+        assert result.gold_report_path is not None
+        report_content = json.loads(result.gold_report_path.read_text())
+        rules = report_content["checks"]["business_rules"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["rule_id"] == "R_TRACE_01"
+        assert (
+            rules[0]["config_path"] == "configs/quality/entities/chembl/activity.yaml"
+        )
+        assert rules[0]["layer"] == "gold"
+        assert rules[0]["field"] == "value"
+        assert rules[0]["severity"] == "error"
+        assert rules[0]["decision"] == "quarantine"
 
 
 @pytest.mark.integration

--- a/tests/unit/application/services/dq/test_gold_analyzer.py
+++ b/tests/unit/application/services/dq/test_gold_analyzer.py
@@ -33,11 +33,11 @@ from bioetl.application.services.dq._checks_statistical import (
     check_anomaly_detection,
     check_statistical_profile,
 )
-from bioetl.application.services.dq.gold_analyzer import GoldDQAnalyzer
 from bioetl.application.services.dq.dq_report_builders import (
     convert_value,
     update_counts,
 )
+from bioetl.application.services.dq.gold_analyzer import GoldDQAnalyzer
 from bioetl.domain.value_objects.dq_report import (
     DQCheckStatus,
     DQReportStatus,
@@ -341,6 +341,37 @@ class TestBusinessRulesCheck:
         result = check_business_rules(df, rules)
 
         assert result.rules_failed == 1
+
+    def test_business_rules_include_provenance_fields(self) -> None:
+        """Business rules should preserve provenance and decision fields."""
+        df = pl.DataFrame({"value": [-1.0, 2.0]})
+        rules = [
+            {
+                "rule_id": "R_TRACE_01",
+                "name": "non_negative",
+                "column": "value",
+                "condition": "range",
+                "min": 0,
+                "config_path": "configs/quality/entities/chembl/activity.yaml",
+                "layer": "gold",
+                "field": "value",
+                "severity": "error",
+                "decision": "quarantine",
+            }
+        ]
+
+        result = check_business_rules(df, rules)
+
+        assert result.rules_failed == 1
+        rule_result = result.rules[0]
+        assert rule_result.rule_id == "R_TRACE_01"
+        assert (
+            rule_result.config_path == "configs/quality/entities/chembl/activity.yaml"
+        )
+        assert rule_result.layer == "gold"
+        assert rule_result.field == "value"
+        assert rule_result.severity == "error"
+        assert rule_result.decision == "quarantine"
 
     def test_business_rules_empty(self) -> None:
         """Business rules check passes when no rules specified."""

--- a/tests/unit/application/services/test_metadata_coordinator.py
+++ b/tests/unit/application/services/test_metadata_coordinator.py
@@ -16,9 +16,7 @@ from bioetl.composition.services.metadata_coordinator import (
     MetadataCoordinator,
     SilverMetadataInput,
 )
-from bioetl.domain.ports.metadata_coordinator import SilverRef
-from bioetl.domain.medallion import GoldWriteMode, SilverWriteMode
-from bioetl.domain.medallion import Layer
+from bioetl.domain.medallion import GoldWriteMode, Layer, SilverWriteMode
 from bioetl.domain.models.metadata import (
     BronzeMetadata,
     GoldMetadata,
@@ -29,6 +27,7 @@ from bioetl.domain.models.metadata import (
     SilverMetadata,
     SourceMetadata,
 )
+from bioetl.domain.ports.metadata_coordinator import SilverRef
 from bioetl.domain.types import BatchID, RunID, RunType
 from bioetl.domain.value_objects.run_context import RunContext
 
@@ -445,6 +444,34 @@ class TestSilverMetadata:
         assert metadata.delta.primary_key == ["id"]
         assert metadata.delta.version_after == 10
         assert metadata.delta.rows_inserted == 10
+
+    def test_silver_metadata_includes_rule_provenance(
+        self, coordinator: MetadataCoordinator
+    ) -> None:
+        """Silver metadata should include DQ rule provenance when provided."""
+        records = [{"id": 1}]
+        provenance = [
+            {
+                "rule_id": "R_TRACE_01",
+                "config_path": "configs/quality/entities/chembl/activity.yaml",
+                "layer": "gold",
+                "field": "value",
+                "severity": "error",
+                "decision": "quarantine",
+            }
+        ]
+
+        input_data = SilverMetadataInput(
+            table_path="/data/silver/chembl/activity",
+            records=records,
+            primary_keys=["id"],
+            mode=SilverWriteMode.MERGE,
+            dq_rule_provenance=provenance,
+        )
+
+        metadata = coordinator.create_silver_metadata(input_data)
+
+        assert metadata.dq_summary.rule_provenance == provenance
 
     def test_silver_mode_to_operation_mapping(
         self, coordinator: MetadataCoordinator


### PR DESCRIPTION
### Motivation

- Capture provenance for business-rule evaluations so DQ reports and metadata sidecars record where rules came from and what decision was made for traceability and audit.
- Surface rule-level traceability in the Silver metadata sidecar so downstream consumers and governance tools can correlate DQ failures with originating config files and decisions.
- Add regression coverage to prevent regressions in DQ traceability.

### Description

- Extended the business-rule result object by adding provenance and decision fields to `BusinessRuleResult`: `config_path`, `layer`, `field`, `severity`, and `decision` (in addition to existing `rule_id`).
- Populated those provenance fields in `check_business_rules()` (Gold analyzer checks) using values from the input rule dict with sensible defaults when fields are absent.
- Added `rule_provenance: list[dict[str, str | None]]` to `DQSummary` in metadata models to carry rule provenance entries.
- Extended `SilverMetadataInput` with `dq_rule_provenance` and updated `MetadataCoordinator.create_silver_metadata()` to copy `dq_rule_provenance` into `dq_summary.rule_provenance` when present.
- Added tests: unit test for business-rule provenance preservation, unit test for Silver metadata propagation of provenance, and an integration test that asserts provenance fields appear in generated Gold DQ report JSON.

### Testing

- Ran unit tests: `tests/unit/application/services/dq/test_gold_analyzer.py::TestBusinessRulesCheck::test_business_rules_include_provenance_fields` — PASSED.
- Ran unit tests: `tests/unit/application/services/test_metadata_coordinator.py::TestSilverMetadata::test_silver_metadata_includes_rule_provenance` — PASSED.
- Compilation check: `python -m compileall` across modified modules — PASSED.
- Added integration test `tests/integration/test_dq_report_integration.py::TestDQReportIntegration::test_gold_dq_report_includes_rule_provenance_traceability` but full integration run in this execution environment required additional external test dependencies and CI pre-commit helpers; those environment-level blockers prevented a reliable local full-suite integration run here (test added and exercised in CI expected to run in project environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552701ddc832493327f7a28614086)