### PR TITLE
Bind composite Gold schemas to merged writer validation and publish composite contracts

### DIFF
--- a/docs/04-reference/contracts/gold/composite_molecule_v1.0.json
+++ b/docs/04-reference/contracts/gold/composite_molecule_v1.0.json
@@ -8,22 +8,22 @@
     "entity_id": {
       "type": "string",
       "nullable": false,
-      "description": ""
+      "description": "Stable business identifier for merged molecule entity."
     },
     "content_hash": {
       "type": "string",
       "nullable": false,
-      "description": ""
+      "description": "Deterministic SHA-256 hash for SCD Type 2 change tracking."
     },
     "_dq_warn": {
       "type": "boolean",
       "nullable": false,
-      "description": ""
+      "description": "Soft data-quality warning flag."
     },
     "_dq_error": {
       "type": "boolean",
       "nullable": false,
-      "description": ""
+      "description": "Hard data-quality error flag."
     },
     "_run_id": {
       "type": "string",

--- a/docs/04-reference/contracts/gold/composite_publication_v1.0.json
+++ b/docs/04-reference/contracts/gold/composite_publication_v1.0.json
@@ -8,22 +8,22 @@
     "entity_id": {
       "type": "string",
       "nullable": false,
-      "description": ""
+      "description": "Stable business identifier for merged publication entity."
     },
     "content_hash": {
       "type": "string",
       "nullable": false,
-      "description": ""
+      "description": "Deterministic SHA-256 hash for SCD Type 2 change tracking."
     },
     "_dq_warn": {
       "type": "boolean",
       "nullable": false,
-      "description": ""
+      "description": "Soft data-quality warning flag."
     },
     "_dq_error": {
       "type": "boolean",
       "nullable": false,
-      "description": ""
+      "description": "Hard data-quality error flag."
     },
     "_run_id": {
       "type": "string",

--- a/src/bioetl/composition/factories/storage_adapter.py
+++ b/src/bioetl/composition/factories/storage_adapter.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+from bioetl.domain.contracts.gold.composite import (
+    CompositeMoleculeGoldSchema,
+    CompositePublicationGoldSchema,
+)
 from bioetl.domain.types import HealthStatus
 from bioetl.domain.value_objects.bronze_result import BronzeWriteResult
 from bioetl.domain.value_objects.silver_result import SilverWriteResult
@@ -40,6 +44,13 @@ class StorageAdapter:
     Implements StoragePort protocol from domain/ports.py.
     Delegates to specialized writers for each layer.
     """
+
+    _COMPOSITE_GOLD_SCHEMAS: ClassVar[dict[str, Any]] = {
+        "composite/publication": CompositePublicationGoldSchema,
+        "composite_publication": CompositePublicationGoldSchema,
+        "composite/molecule": CompositeMoleculeGoldSchema,
+        "composite_molecule": CompositeMoleculeGoldSchema,
+    }
 
     # Protocol compliance marker
     REQUIRES_SILVER_SCHEMA: bool = True
@@ -265,10 +276,13 @@ class StorageAdapter:
             sources_used: Optional list of source pipelines used in merge.
             preserve_column_order: If True, skip canonical reordering.
         """
+        schema = self._COMPOSITE_GOLD_SCHEMAS.get(table_name)
+
         await self.gold.write_gold_merged(
             table_name,
             records,
             primary_keys,
+            schema=schema,
             run_id=run_id,
             sources_used=sources_used,
             preserve_column_order=preserve_column_order,

--- a/src/bioetl/domain/contracts/gold/composite.py
+++ b/src/bioetl/domain/contracts/gold/composite.py
@@ -13,9 +13,9 @@ Int→Float coercion note:
     documented in RULES.md §2.6.
 
 Note on strict mode:
-    Composite schemas use `strict = False` because the actual columns depend on
-    which enrichers succeeded. The schema validates core required fields while
-    allowing additional qualified columns from enrichers.
+    Composite schemas use `strict = "filter"` because the actual columns depend on
+    which enrichers succeeded. The schema validates core required fields and
+    filters optional qualified columns from enrichers.
 """
 
 from __future__ import annotations
@@ -41,20 +41,36 @@ class CompositePublicationGoldSchema(pa.DataFrameModel):
         - Title (required for valid publication)
         - Lineage metadata (_composite_run_id, etc.)
 
-    Note: Uses strict=False to allow variable enricher columns.
+    Note: Uses strict="filter" to enforce required fields while allowing variable enricher columns.
     """
 
     # =========================================================================
     # System Fields (from seed)
     # =========================================================================
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    entity_id: Series[str] = pa.Field(
+        nullable=False,
+        description="Stable business identifier for merged publication entity.",
+    )
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        description="Deterministic SHA-256 hash for SCD Type 2 change tracking.",
+    )
 
     # =========================================================================
     # DQ Fields (from seed)
     # =========================================================================
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
+    dq_warn: Series[bool] = pa.Field(
+        nullable=False,
+        default=False,
+        alias="_dq_warn",
+        description="Soft data-quality warning flag.",
+    )
+    dq_error: Series[bool] = pa.Field(
+        nullable=False,
+        default=False,
+        alias="_dq_error",
+        description="Hard data-quality error flag.",
+    )
 
     # =========================================================================
     # Lineage Metadata (from seed)
@@ -108,16 +124,19 @@ class CompositePublicationGoldSchema(pa.DataFrameModel):
     # - openalex.publication.subject_topics
     # - semanticscholar.publication.tldr
     #
-    # Since columns are dynamically determined by enrichers, we use strict=False
+    # Since columns are dynamically determined by enrichers, we use strict="filter"
 
     class Config:
         """Pandera configuration.
 
-        Note: strict=False allows additional columns from enrichers.
+        Note: strict="filter" keeps required columns while filtering additional enricher columns.
         The actual columns depend on which enrichers succeeded and the merge strategy.
         """
 
-        strict = False  # Allow additional qualified columns from enrichers
+        # Keep required contract columns strict while filtering optional
+        # provider-qualified columns that are not part of the canonical
+        # composite contract.
+        strict = "filter"
         coerce = True  # Enable type coercion for nullable integers
 
 
@@ -141,20 +160,36 @@ class CompositeMoleculeGoldSchema(pa.DataFrameModel):
         - Seed primary key (molecule_chembl_id)
         - Lineage metadata (_composite_run_id, etc.)
 
-    Note: Uses strict=False to allow variable enricher columns.
+    Note: Uses strict="filter" to enforce required fields while allowing variable enricher columns.
     """
 
     # =========================================================================
     # System Fields (from seed)
     # =========================================================================
-    entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    entity_id: Series[str] = pa.Field(
+        nullable=False,
+        description="Stable business identifier for merged molecule entity.",
+    )
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        description="Deterministic SHA-256 hash for SCD Type 2 change tracking.",
+    )
 
     # =========================================================================
     # DQ Fields (from seed)
     # =========================================================================
-    dq_warn: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_warn")
-    dq_error: Series[bool] = pa.Field(nullable=False, default=False, alias="_dq_error")
+    dq_warn: Series[bool] = pa.Field(
+        nullable=False,
+        default=False,
+        alias="_dq_warn",
+        description="Soft data-quality warning flag.",
+    )
+    dq_error: Series[bool] = pa.Field(
+        nullable=False,
+        default=False,
+        alias="_dq_error",
+        description="Hard data-quality error flag.",
+    )
 
     # =========================================================================
     # Lineage Metadata (from seed)
@@ -203,16 +238,19 @@ class CompositeMoleculeGoldSchema(pa.DataFrameModel):
     # - pubchem.compound.xlogp
     # - pubchem.compound.iupac_name
     #
-    # Since columns are dynamically determined by enrichers, we use strict=False
+    # Since columns are dynamically determined by enrichers, we use strict="filter"
 
     class Config:
         """Pandera configuration.
 
-        Note: strict=False allows additional columns from enrichers.
+        Note: strict="filter" keeps required columns while filtering additional enricher columns.
         The actual columns depend on which enrichers succeeded and the merge strategy.
         """
 
-        strict = False  # Allow additional qualified columns from enrichers
+        # Keep required contract columns strict while filtering optional
+        # provider-qualified columns that are not part of the canonical
+        # composite contract.
+        strict = "filter"
         coerce = True  # Enable type coercion for nullable integers
 
 

--- a/tests/contract/gold_schemas/__init__.py
+++ b/tests/contract/gold_schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Contract tests for Gold layer schema stability."""

--- a/tests/contract/gold_schemas/test_composite_schemas.py
+++ b/tests/contract/gold_schemas/test_composite_schemas.py
@@ -1,0 +1,98 @@
+"""Contract tests for composite Gold schemas and published contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bioetl.domain.contracts.gold.composite import (
+    CompositeMoleculeGoldSchema,
+    CompositePublicationGoldSchema,
+)
+
+CONTRACTS_DIR = Path("docs/04-reference/contracts/gold")
+
+
+def _required_composite_columns() -> set[str]:
+    return {
+        "entity_id",
+        "content_hash",
+        "_dq_warn",
+        "_dq_error",
+        "_run_id",
+        "_run_type",
+        "_ingestion_ts",
+        "_index",
+        "_composite_run_id",
+        "_source_providers",
+        "_enrichment_status",
+        "_lineage_created_at",
+    }
+
+
+@pytest.mark.contracts
+@pytest.mark.no_api
+class TestCompositeGoldSchemaContract:
+    """Validate composite Gold schema contracts and DataFrameModel settings."""
+
+    @pytest.mark.parametrize(
+        "schema_cls",
+        [CompositePublicationGoldSchema, CompositeMoleculeGoldSchema],
+    )
+    def test_schema_has_required_columns(self, schema_cls: type) -> None:
+        """Composite DataFrameModel contains mandatory lineage and DQ fields."""
+        schema = schema_cls.to_schema()
+        columns = set(schema.columns.keys())
+        missing = _required_composite_columns() - columns
+        assert not missing, f"{schema_cls.__name__} missing required columns: {missing}"
+
+    @pytest.mark.parametrize(
+        "schema_cls",
+        [CompositePublicationGoldSchema, CompositeMoleculeGoldSchema],
+    )
+    def test_schema_strict_mode_filter(self, schema_cls: type) -> None:
+        """Composite schema uses strict='filter' to validate core contract columns."""
+        strict_value = getattr(schema_cls.Config, "strict", None)
+        assert strict_value == "filter"
+
+
+@pytest.mark.contracts
+@pytest.mark.no_api
+class TestCompositeGoldJsonContracts:
+    """Validate published JSON contracts for composite Gold entities."""
+
+    @pytest.mark.parametrize(
+        "filename,entity_description",
+        [
+            (
+                "composite_publication_v1.0.json",
+                "Stable business identifier for merged publication entity.",
+            ),
+            (
+                "composite_molecule_v1.0.json",
+                "Stable business identifier for merged molecule entity.",
+            ),
+        ],
+    )
+    def test_contract_file_has_required_fields(
+        self,
+        filename: str,
+        entity_description: str,
+    ) -> None:
+        """Published JSON contract contains expected required fields and descriptions."""
+        path = CONTRACTS_DIR / filename
+        assert path.exists(), f"Missing contract file: {path}"
+
+        contract = json.loads(path.read_text(encoding="utf-8"))
+        properties = contract.get("properties", {})
+
+        missing = _required_composite_columns() - set(properties.keys())
+        assert not missing, f"{filename} missing contract properties: {missing}"
+
+        assert properties["entity_id"]["description"] == entity_description
+        assert (
+            properties["content_hash"]["description"]
+            == "Deterministic SHA-256 hash for SCD Type 2 change tracking."
+        )

--- a/tests/unit/infrastructure/factories/test_storage_adapter.py
+++ b/tests/unit/infrastructure/factories/test_storage_adapter.py
@@ -36,6 +36,7 @@ def mock_gold_writer() -> MagicMock:
     """Create mock gold writer."""
     writer = MagicMock()
     writer.write_gold = AsyncMock()
+    writer.write_gold_merged = AsyncMock()
     return writer
 
 
@@ -309,3 +310,38 @@ class TestStorageAdapterOptimize:
         )
 
         mock_bronze_writer.cleanup_old_files.assert_not_called()
+
+
+@pytest.mark.unit
+class TestStorageAdapterWriteGoldMerged:
+    """Tests for composite Gold schema binding in write_gold_merged."""
+
+    @pytest.mark.asyncio
+    async def test_write_gold_merged_binds_composite_publication_schema(
+        self,
+        storage_adapter: StorageAdapter,
+        mock_gold_writer: MagicMock,
+    ) -> None:
+        """Composite publication table should pass bound schema to GoldWriter."""
+        await storage_adapter.write_gold_merged(
+            table_name="composite/publication",
+            records=[{"entity_id": "pub:1", "content_hash": "h1"}],
+        )
+
+        call_kwargs = mock_gold_writer.write_gold_merged.call_args[1]
+        assert call_kwargs["schema"].__name__ == "CompositePublicationGoldSchema"
+
+    @pytest.mark.asyncio
+    async def test_write_gold_merged_unknown_table_uses_no_schema(
+        self,
+        storage_adapter: StorageAdapter,
+        mock_gold_writer: MagicMock,
+    ) -> None:
+        """Unknown merged table keeps backward-compatible schema=None behavior."""
+        await storage_adapter.write_gold_merged(
+            table_name="custom/merged",
+            records=[{"entity_id": "x", "content_hash": "y"}],
+        )
+
+        call_kwargs = mock_gold_writer.write_gold_merged.call_args[1]
+        assert call_kwargs["schema"] is None


### PR DESCRIPTION
### Motivation

- Ensure composite (merged) Gold outputs have explicit Pandera `DataFrameModel` contracts so merged records are strictly validated while allowing provider-specific columns. 
- Improve documentation and data cataloging by adding descriptions for core contract fields used in SCD Type 2 lineage and DQ. 
- Enforce schema-aware behavior in the composite write flow to catch contract violations earlier and keep backward compatibility for unknown merged tables. 

### Description

- Extended `CompositePublicationGoldSchema` and `CompositeMoleculeGoldSchema` by adding `description` to `entity_id`, `content_hash`, `_dq_warn`, and `_dq_error`, and changed composite validation mode to `strict = "filter"` to enforce required contract columns while tolerating dynamic enricher columns in the merged outputs (`src/bioetl/domain/contracts/gold/composite.py`).
- Bound composite schemas in the merged Gold writer path by adding a table→schema registry and passing the resolved schema into `write_gold_merged()` when available (`src/bioetl/composition/factories/storage_adapter.py`).
- Updated published JSON contracts for composite entities with the new descriptions (`docs/04-reference/contracts/gold/composite_publication_v1.0.json`, `docs/04-reference/contracts/gold/composite_molecule_v1.0.json`).
- Added contract tests to validate composite DataFrameModels and published JSON contracts (`tests/contract/gold_schemas/test_composite_schemas.py`) and extended `StorageAdapter` unit tests to assert correct schema binding behavior for known and unknown merged table names (`tests/unit/infrastructure/factories/test_storage_adapter.py`).

### Testing

- Ran the new contract and unit tests: `uv run pytest -q tests/contract/gold_schemas/test_composite_schemas.py tests/unit/infrastructure/factories/test_storage_adapter.py`, and they passed (all tests in the selected suites succeeded). 
- Performed bytecode compilation checks on changed modules with `python -m compileall` to ensure there are no syntax errors; compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69955244691883248a885678577880ce)