### PR TITLE
Exclude technical `_` metadata from content-hash identity; add canonical policy and tests

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -424,7 +424,7 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 - **Dates**: Приводятся к единому ISO-формату `YYYY-MM-DD`.
 - **Strings**: Удаление пробелов по краям (`strip()`).
 
-**Исключения**: Из расчета хэша исключаются технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`.
+**Исключения**: Из расчета хэша исключаются технические мета-поля, включая все поля с префиксом `_` (например: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`, `_source_batch_id`, `_index`, `_lookup_method`, `_original_id`, `_source`).
 
 - **Детекция Коллизий**: При upsert проверять `_source_record_id`; если отличается — конфликт, логировать обе записи.
 
@@ -1131,7 +1131,7 @@ async with services:  # __aenter__ инициализирует ресурсы
 1. **Time Source**: `datetime.now()` **MUST NOT** вызываться в `infrastructure` слое (за исключением мониторинга реального времени). Все временные метки (`ingestion_ts`, `processing_ts`) **MUST** генерироваться в `Application` слое (`PipelineContext.started_at`) и передаваться вниз.
 1. **Retry Jitter**: При `deterministic=True`, jitter **MUST** вычисляться детерминистично (на основе хэша попытки и URL). Реализация: `domain/resilience.py:RetryConfig.calculate_delay()` использует MD5-based jitter.
 1. **Ordering**: Запись в Delta Lake **MUST** происходить после сортировки данных по Primary Keys (Silver) или Business Keys (Gold).
-1. **Content Hash**: Исключать из расчёта хэша технические мета-поля: `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`. Реализация: `domain/constants.py:META_FIELDS` (re-exported через `domain/transformations.py`).
+1. **Content Hash**: Исключать из расчёта хэша технические мета-поля. Canonical policy: см. `docs/02-architecture/policies/content-hash-identity-policy.md`; все поля с префиксом `_` исключаются из identity/hash (включая `_ingestion_ts`, `_run_id`, `_run_type`, `_source_batch_id`, `_index`, `_dq_*`, `_lookup_method`, `_original_id`, `_source`). Реализация: `domain/constants.py:META_FIELDS` + `domain/transformations.py:_should_include_field()`.
 
 #### Архитектурные Тесты Детерминизма
 

--- a/docs/02-architecture/policies/content-hash-identity-policy.md
+++ b/docs/02-architecture/policies/content-hash-identity-policy.md
@@ -1,0 +1,57 @@
+# Content Hash Identity Policy (Canonical)
+
+**Status:** Active canonical policy
+**Owner:** Architecture / Domain
+**Last updated:** 2026-02-18
+
+## Scope
+
+This document is the single canonical policy for determining which fields affect
+`content_hash` and identity in BioETL.
+
+Cross-reference:
+
+- RULES.md §2.8.1, §6.1
+- ADR-014 (determinism context)
+- `src/bioetl/domain/constants.py` (`META_FIELDS`)
+- `src/bioetl/domain/transformations.py` (`_should_include_field`)
+
+## Canonical Rule
+
+`content_hash` is computed as:
+
+`sha256(provider + canonical_json_dumps(normalized_record))`
+
+Before hashing:
+
+1. Normalize values (`NaN/Inf -> null`, float rounding, date ISO, string strip).
+1. Exclude all technical metadata fields from identity.
+
+### Metadata exclusion policy (MUST)
+
+A field **MUST NOT** affect identity/hash if its name starts with `_`.
+
+This includes (non-exhaustive):
+
+- `_ingestion_ts`
+- `_run_id`
+- `_run_type`
+- `_dq_warn`, `_dq_error`, `_dq_*`
+- `_source_batch_id`
+- `_index`
+- `_lookup_method`
+- `_original_id`
+- `_source`
+- Future technical fields like `_new_field`
+
+## Rationale
+
+1. Prevents identity churn from operational metadata.
+1. Preserves deterministic identity under schema drift when new technical fields
+   are introduced.
+1. Keeps dedup/version semantics tied to business content only.
+
+## Contract tests
+
+- Property-based determinism: metadata-only changes keep hash stable.
+- Schema drift contract: adding new `_` fields keeps hash stable.

--- a/src/bioetl/domain/constants.py
+++ b/src/bioetl/domain/constants.py
@@ -21,5 +21,8 @@ META_FIELDS: frozenset[str] = frozenset(
         "_dq_error",
         "_source_batch_id",
         "_index",
+        "_lookup_method",
+        "_original_id",
+        "_source",
     }
 )

--- a/src/bioetl/domain/transformations.py
+++ b/src/bioetl/domain/transformations.py
@@ -85,7 +85,7 @@ _NORMALIZE_DISPATCH = (
 # Any: record field type varies
 def _should_include_field(key: str, value: Any, exclude_none: bool) -> bool:
     """Check if field should be included in hash calculation."""
-    if key in META_FIELDS:
+    if key.startswith("_") or key in META_FIELDS:
         return False
     return not (exclude_none and value is None)
 

--- a/tests/contract/test_content_hash_schema_drift_contract.py
+++ b/tests/contract/test_content_hash_schema_drift_contract.py
@@ -1,0 +1,56 @@
+"""Contract tests for content hash behavior under schema drift.
+
+These tests codify the forward-compatibility contract for identity:
+adding technical underscore-prefixed fields must not change content hash.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.transformations import detect_schema_drift, generate_content_hash
+from bioetl.domain.types import DriftLevel
+
+
+@pytest.mark.contracts
+@pytest.mark.no_api
+class TestContentHashSchemaDriftContract:
+    """Contracts for hash stability when schema evolves."""
+
+    def test_hash_stable_when_new_underscore_field_added(self) -> None:
+        """Adding a new technical '_' field MUST NOT alter content hash."""
+        base_record = {
+            "entity_id": "CHEMBL25",
+            "title": "Aspirin",
+            "value": 42,
+        }
+        drifted_record = {
+            **base_record,
+            "_new_technical_field": "schema-drift-v2",
+        }
+
+        base_hash = generate_content_hash(base_record, "chembl")
+        drifted_hash = generate_content_hash(drifted_record, "chembl")
+
+        assert base_hash == drifted_hash
+
+    def test_schema_drift_remains_informational_for_added_underscore_fields(
+        self,
+    ) -> None:
+        """Adding optional technical fields should remain informational drift."""
+        old_schema = {"entity_id", "title", "value"}
+        new_schema = {
+            *old_schema,
+            "_new_technical_field",
+            "_yet_another_meta",
+        }
+
+        level, details = detect_schema_drift(
+            old_schema=old_schema,
+            new_schema=set(new_schema),
+            required_fields={"entity_id"},
+        )
+
+        assert level == DriftLevel.INFO
+        assert "_new_technical_field" in details["added_fields"]
+        assert "_yet_another_meta" in details["added_fields"]

--- a/tests/unit/domain/services/test_identity_service.py
+++ b/tests/unit/domain/services/test_identity_service.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from datetime import date, datetime
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from bioetl.domain.services.identity_service import META_FIELDS, IdentityService
 
@@ -118,6 +120,9 @@ class TestMetaFieldExclusion:
             "_dq_error",
             "_source_batch_id",
             "_index",
+            "_lookup_method",
+            "_original_id",
+            "_source",
         ],
     )
     def test_meta_field_excluded_from_hash(self, meta_field: str) -> None:
@@ -142,8 +147,59 @@ class TestMetaFieldExclusion:
             "_dq_error",
             "_source_batch_id",
             "_index",
+            "_lookup_method",
+            "_original_id",
+            "_source",
         }
         assert META_FIELDS == expected
+
+    @pytest.mark.hypothesis
+    @given(
+        business_record=st.dictionaries(
+            keys=st.text(
+                min_size=1,
+                max_size=20,
+                alphabet=st.characters(
+                    blacklist_characters="_",
+                    blacklist_categories=("Cs",),
+                ),
+            ),
+            values=st.one_of(
+                st.none(),
+                st.booleans(),
+                st.integers(),
+                st.floats(allow_nan=False, allow_infinity=False),
+                st.text(),
+            ),
+            max_size=10,
+        ),
+        meta_value=st.one_of(
+            st.none(),
+            st.booleans(),
+            st.integers(),
+            st.floats(allow_nan=False, allow_infinity=False),
+            st.text(),
+        ),
+    )
+    def test_hash_is_stable_when_only_metadata_changes(
+        self,
+        business_record: dict[str, object],
+        meta_value: object,
+    ) -> None:
+        """Metadata-only mutations MUST NOT alter content hash."""
+        service = IdentityService()
+        base_hash = service.compute_content_hash("test", business_record)
+
+        augmented = {
+            **business_record,
+            "_lookup_method": "doi",
+            "_original_id": "pmid:123",
+            "_source": "pubmed",
+            "_future_meta_field": meta_value,
+        }
+        augmented_hash = service.compute_content_hash("test", augmented)
+
+        assert base_hash == augmented_hash
 
 
 class TestCanonicalJSON:


### PR DESCRIPTION
### Motivation
- Prevent identity churn caused by operational/ingestion metadata and make content identity deterministic under schema drift. 
- Ensure canonical policy and implementation match RULES/ADRs (determinism requirements for content hash). 
- Provide forward-compatibility so newly added technical `_` fields (future schema drift) do not change entity identity. 

### Description
- Added `_lookup_method`, `_original_id`, and `_source` to `META_FIELDS` to explicitly document known technical metadata excluded from hash (`src/bioetl/domain/constants.py`).
- Hardened inclusion logic in `normalize_for_hash()` so any field with a leading underscore is ignored for identity (`src/bioetl/domain/transformations.py:_should_include_field`).
- Synced documentation by updating `docs/00-project/RULES.md` and adding a canonical policy file `docs/02-architecture/policies/content-hash-identity-policy.md` that states the policy: all `_`-prefixed fields MUST be excluded from content-hash/identity.
- Added tests: a Hypothesis property-based test ensuring metadata-only mutations do not change the hash (`tests/unit/domain/services/test_identity_service.py`), and a contract test asserting hash stability when new underscore-prefixed fields are introduced (`tests/contract/test_content_hash_schema_drift_contract.py`).

### Testing
- Ran targeted unit/property tests with `uv run pytest tests/unit/domain/services/test_identity_service.py -q` and the suite passed (property-based determinism assertions succeeded). 
- Ran the transformations unit tests with `uv run pytest tests/unit/domain/test_transformations.py -q` and they passed. 
- Ran the new contract tests with `uv run pytest tests/contract/test_content_hash_schema_drift_contract.py -q` and they passed. 
- Note: a direct `pytest` run in this container produced a config-related warning (`asyncio_default_fixture_loop_scope`) from the environment, but the targeted `uv` test runs above exercised and validated the added behavior successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699552c6e6408324ae796a5fc3a8dba0)