### PR TITLE
Add publication_type validation for SemanticScholar publications

### DIFF
--- a/configs/quality/entities/semanticscholar/publication.yaml
+++ b/configs/quality/entities/semanticscholar/publication.yaml
@@ -57,6 +57,15 @@ field_validations:
     nullable: true
     error_message: "Publication year out of valid range"
 
+  - field: publication_type
+    type: pattern
+    # After normalization: pipe-delimited canonical kebab-case values
+    # e.g. "journal-article", "journal-article|review", "book-chapter|other"
+    pattern: '^[a-z][a-z0-9-]+(\|[a-z][a-z0-9-]+)*$'
+    nullable: true
+    severity: warn
+    error_message: "Unexpected publication_type format after normalization"
+
   - field: citations_received
     type: range
     min: 0


### PR DESCRIPTION
## Summary
Added validation rules for the `publication_type` field in the SemanticScholar publication quality configuration to ensure proper formatting of normalized publication type values.

## Key Changes
- Added a new pattern-based validation for the `publication_type` field that enforces:
  - Canonical kebab-case format for individual publication types (e.g., "journal-article", "book-chapter")
  - Support for pipe-delimited multiple types (e.g., "journal-article|review")
  - Field is nullable to accommodate missing values
  - Validation severity set to `warn` to flag formatting issues without blocking processing

## Implementation Details
- Pattern: `^[a-z][a-z0-9-]+(\|[a-z][a-z0-9-]+)*$`
  - Requires lowercase start character followed by alphanumeric or hyphen characters
  - Supports multiple pipe-separated values with the same format requirements
  - Ensures consistency in publication type representation after normalization

https://claude.ai/code/session_013NWaEmL4Lwq5mpVgzN5McU