### PR TITLE
Unify Bronze v1 path contract and enforce Silver partition validation

### DIFF
--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -128,11 +128,11 @@ class MyAdapter:
 
 ### 2.1. Архитектура Medallion
 
-| Уровень            | Формат           | Валидация                  | Хранение (Retention)                          | Идемпотентность                                                                                                        |
-| ------------------ | ---------------- | -------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Bronze** (Сырые) | **JSONL + zstd** | Мин./Нет                   | 90 дней hot -> Archive (local archive policy) | Path: `bronze/{provider}/{entity}/{date}/`. Append-only.                                                               |
-| **Silver** (Норм.) | **Delta Lake**   | Мягкая (учет дрейфа схемы) | Постоянно                                     | **Merge/Upsert**. Raw Parquet в Silver **MUST NOT** использоваться. Обязателен ACID. Time Travel — для Ops, не для DR. |
-| **Gold** (Витрины) | Delta Lake       | Строгая (`strict=True`)    | Постоянно                                     | Версионированные снимки (SCD Type 2) или партиционирование по дате.                                                    |
+| Уровень            | Формат           | Валидация                  | Хранение (Retention)                          | Идемпотентность                                                                                                             |
+| ------------------ | ---------------- | -------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Bronze** (Сырые) | **JSONL + zstd** | Мин./Нет                   | 90 дней hot -> Archive (local archive policy) | Path: `bronze/v1/{provider}/{entity}/{date}/` (legacy: `bronze/{provider}/{entity}/{date}/` read-only compat). Append-only. |
+| **Silver** (Норм.) | **Delta Lake**   | Мягкая (учет дрейфа схемы) | Постоянно                                     | **Merge/Upsert**. Raw Parquet в Silver **MUST NOT** использоваться. Обязателен ACID. Time Travel — для Ops, не для DR.      |
+| **Gold** (Витрины) | Delta Lake       | Строгая (`strict=True`)    | Постоянно                                     | Версионированные снимки (SCD Type 2) или партиционирование по дате.                                                         |
 
 #### 2.1.1. Silver Write Modes (Режимы Записи)
 
@@ -260,8 +260,8 @@ if self.runtime.run_type in (RunType.REBUILD, RunType.BACKFILL):
 
 | Уровень    | Стратегия партиционирования                   | Пример                                         |
 | ---------- | --------------------------------------------- | ---------------------------------------------- |
-| **Bronze** | По `ingestion_date` (YYYY-MM-DD)              | `bronze/chembl/activity/2025-05-20/`           |
-| **Silver** | По `source_date` или `entity_type`            | `silver/chembl/activity/year=2025/month=05/`   |
+| **Bronze** | По `ingestion_date` (YYYY-MM-DD)              | `bronze/v1/chembl/activity/2025-05-20/`        |
+| **Silver** | По `year` и `month` (`year=YYYY/month=MM`)    | `silver/chembl/activity/year=2025/month=05/`   |
 | **Gold**   | По use-case (часто по `target_id` или `date`) | `gold/activity_by_target/target_id=CHEMBL123/` |
 
 - **Soft Limits**: Warning при >10,000 партиций или >100 файлов в партиции.
@@ -1598,8 +1598,8 @@ fields:
 
 ## Приложение F: Реестр Architecture Decision Records (ADR)
 
-| ADR                                                                               | Название                                 | Статус             | Дата       |
-| --------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ | ---------- |
+| ADR                                                                                  | Название                                 | Статус             | Дата       |
+| ------------------------------------------------------------------------------------ | ---------------------------------------- | ------------------ | ---------- |
 | [ADR-001](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | 2025-05    |
 | [ADR-002](../02-architecture/decisions/ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | 2025-05    |
 | [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | 2025-12    |
@@ -1635,7 +1635,7 @@ fields:
 | [ADR-033](../02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
 | [ADR-034](../02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
 | [ADR-035](../02-architecture/decisions/ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)   | Accepted           | 2026-02-17 |
-| [ADR-036](../02-architecture/decisions/ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy           | Accepted           | 2026-02-18 |
+| [ADR-036](../02-architecture/decisions/ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy          | Accepted           | 2026-02-18 |
 
 ## История Изменений (Changelog)
 

--- a/docs/02-architecture/data-layers.md
+++ b/docs/02-architecture/data-layers.md
@@ -9,92 +9,102 @@
 Слой Bronze предназначен для хранения сырых данных в исходном формате, полученных от внешних провайдеров. Является неизменяемым (Append-only) источником истины для всех последующих пересчетов.
 
 ### 1.1. Формат и Хранение
-*   **Формат**: `JSONL` (JSON Lines), сжатый кодеком `zstd`.
-*   **Путь**: `data/output/bronze/{provider}/{entity}/{date}/`.
-    *   `{date}` — дата выгрузки (ingestion date), формат `YYYY-MM-DD`.
-*   **Схема**: Implicit (Схема источника). Файлы сохраняются "как есть", без валидации структуры содержимого, но с добавлением технических метаданных.
-*   **Правило**: Файлы в Bronze **НИКОГДА** не перезаписываются и не удаляются (кроме политики Retention для архивации).
+
+- **Формат**: `JSONL` (JSON Lines), сжатый кодеком `zstd`.
+- **Путь**: `data/output/bronze/v1/{provider}/{entity}/{date}/` (legacy layout `data/output/bronze/{provider}/{entity}/{date}/` поддерживается в compat-read режиме).
+  - `{date}` — дата выгрузки (ingestion date), формат `YYYY-MM-DD`.
+- **Схема**: Implicit (Схема источника). Файлы сохраняются "как есть", без валидации структуры содержимого, но с добавлением технических метаданных.
+- **Правило**: Файлы в Bronze **НИКОГДА** не перезаписываются и не удаляются (кроме политики Retention для архивации).
 
 ### 1.2. Метаданные (Wrapper)
+
 Каждая запись в Bronze оборачивается или дополняется техническими полями при сохранении:
 
-| Поле | Тип | Описание |
-|------|-----|----------|
-| `ingestion_ts` | Timestamp (UTC) | Время получения записи (в sidecar `.meta.json`). |
-| `run_id` | UUID | Идентификатор запуска пайплайна (в sidecar `.meta.json`). |
-| `batch_id` | UUID | Идентификатор пакета данных (в sidecar `.meta.json`). |
+| Поле           | Тип             | Описание                                                  |
+| -------------- | --------------- | --------------------------------------------------------- |
+| `ingestion_ts` | Timestamp (UTC) | Время получения записи (в sidecar `.meta.json`).          |
+| `run_id`       | UUID            | Идентификатор запуска пайплайна (в sidecar `.meta.json`). |
+| `batch_id`     | UUID            | Идентификатор пакета данных (в sidecar `.meta.json`).     |
 
 **Примечание**: Metadata хранится в отдельном sidecar-файле `.meta.json` на уровне файла, а не как per-record поля. Underscore-prefixed версии (`_ingestion_ts`, `_run_id`, `_source_batch_id`) появляются в Silver layer после трансформации.
 
 **Примечание**: Если источник возвращает массив JSON, он разбивается на отдельные строки (records).
 
 ### 1.3. Реализация (Code Reference)
-*   **Writer**: `src/bioetl/infrastructure/storage/bronze_writer.py`
-*   **Логика**:
-    1.  Получение батча данных от адаптера.
-    2.  Добавление метаданных.
-    3.  Сериализация в JSONL.
-    4.  Сжатие `zstd`.
-    5.  Загрузка в локальное хранилище с уникальным именем файла (обычно содержащим `run_id` и порядковый номер части).
 
----
+- **Writer**: `src/bioetl/infrastructure/storage/bronze_writer.py`
+- **Логика**:
+  1. Получение батча данных от адаптера.
+  1. Добавление метаданных.
+  1. Сериализация в JSONL.
+  1. Сжатие `zstd`.
+  1. Загрузка в локальное хранилище с уникальным именем файла (обычно содержащим `run_id` и порядковый номер части).
+
+______________________________________________________________________
 
 ## 2. Silver Layer (Нормализованные данные)
 
 Слой Silver содержит очищенные, нормализованные и дедуплицированные данные. Это основной аналитический слой.
 
 ### 2.1. Формат и Технологии
-*   **Формат**: Delta Lake (Parquet + Transaction Log).
-*   **Engine**: `delta-rs` (через библиотеку `deltalake` Python binding).
-*   **Путь**: `data/output/silver/{provider}/{entity}/[{partition_cols}/]` — партиционирование опционально, настраивается через `partition_by` в YAML конфиге пайплайна.
-*   **Протокол**: Версия протокола определяется defaults библиотеки deltalake.
+
+- **Формат**: Delta Lake (Parquet + Transaction Log).
+- **Engine**: `delta-rs` (через библиотеку `deltalake` Python binding).
+- **Путь**: `data/output/silver/{provider}/{entity}/year={YYYY}/month={MM}/`. Партиционирование Silver обязательно и должно задаваться как `partition_by: [year, month]`.
+- **Протокол**: Версия протокола определяется defaults библиотеки deltalake.
 
 ### 2.2. Схема и Валидация
+
 Валидация происходит **перед** записью в Silver. Используется библиотека `pandera`.
 
-*   **Контракты**: Определены в `src/bioetl/domain/schemas/{provider}.py`.
-*   **Обработка ошибок валидации**:
-    *   **Info/Warning** (например, новые поля или отсутствие необязательных): Данные пропускаются, но метаданные дрейфа схемы логируются.
-    *   **Data Quality Error** (нарушение типов, провал check-ов):
-        *   Soft Fail (<5%): Замена на `NULL` (если поле `nullable`) или пометка флагом `_dq_error`.
-        *   Hard Fail (>20%): Батч отклоняется, запись в Quarantine.
-    *   **Critical Schema Violation**: Исключение, остановка пайплайна.
+- **Контракты**: Определены в `src/bioetl/domain/schemas/{provider}.py`.
+- **Обработка ошибок валидации**:
+  - **Info/Warning** (например, новые поля или отсутствие необязательных): Данные пропускаются, но метаданные дрейфа схемы логируются.
+  - **Data Quality Error** (нарушение типов, провал check-ов):
+    - Soft Fail (\<5%): Замена на `NULL` (если поле `nullable`) или пометка флагом `_dq_error`.
+    - Hard Fail (>20%): Батч отклоняется, запись в Quarantine.
+  - **Critical Schema Violation**: Исключение, остановка пайплайна.
 
 ### 2.3. Нормализация
+
 Перед валидацией данные проходят стадию нормализации:
-1.  **Приведение типов**: Строки "123" -> Int 123, "TRUE" -> Boolean True.
-2.  **Очистка строк**: `strip()`, приведение к нижнему регистру (где применимо), удаление непечатных символов.
-3.  **Обработка NULL**:
-    *   Явные `NULL` сохраняются.
-    *   Пустые строки `""` преобразуются в `NULL` (для строковых полей, если это не имеет бизнес-смысла).
-    *   `NaN` (float) допустим, но строковые "NaN" преобразуются в `NULL`.
-    *   Sentinel values (например, -1 для ID) преобразуются в `NULL`.
-4.  **Даты**: Приведение всех дат к ISO 8601 (`YYYY-MM-DD`) и таймстемпов к UTC.
+
+1. **Приведение типов**: Строки "123" -> Int 123, "TRUE" -> Boolean True.
+1. **Очистка строк**: `strip()`, приведение к нижнему регистру (где применимо), удаление непечатных символов.
+1. **Обработка NULL**:
+   - Явные `NULL` сохраняются.
+   - Пустые строки `""` преобразуются в `NULL` (для строковых полей, если это не имеет бизнес-смысла).
+   - `NaN` (float) допустим, но строковые "NaN" преобразуются в `NULL`.
+   - Sentinel values (например, -1 для ID) преобразуются в `NULL`.
+1. **Даты**: Приведение всех дат к ISO 8601 (`YYYY-MM-DD`) и таймстемпов к UTC.
 
 ### 2.4. Дедупликация и Merge Strategy
+
 Silver слой использует стратегию **Merge/Upsert** для обеспечения идемпотентности.
 
-*   **Первичный ключ (Primary Key)**: Определяется для каждой сущности (например, `chembl_id`). Если естественного ключа нет, используется синтетический `content_hash`.
-*   **Логика Merge**:
-    *   Если запись с PK существует: Обновление (UPDATE).
-    *   Если запись не существует: Вставка (INSERT).
-*   **Приоритет обновлений (Conflict Resolution)**:
-    При конкурентных запусках (например, Backfill vs Incremental) используется поле `_run_type`.
-    Приоритет: `rebuild` > `backfill` > `incremental`.
-    *В коде*: Условный update в Delta Merge (см. `src/bioetl/infrastructure/storage/silver_writer.py`).
+- **Первичный ключ (Primary Key)**: Определяется для каждой сущности (например, `chembl_id`). Если естественного ключа нет, используется синтетический `content_hash`.
+- **Логика Merge**:
+  - Если запись с PK существует: Обновление (UPDATE).
+  - Если запись не существует: Вставка (INSERT).
+- **Приоритет обновлений (Conflict Resolution)**:
+  При конкурентных запусках (например, Backfill vs Incremental) используется поле `_run_type`.
+  Приоритет: `rebuild` > `backfill` > `incremental`.
+  *В коде*: Условный update в Delta Merge (см. `src/bioetl/infrastructure/storage/silver_writer.py`).
 
 ### 2.5. PII и Безопасность
-*   Поля, помеченные как чувствительные (PII), **ОБЯЗАНЫ** быть хэшированы перед записью в Silver.
-*   **Алгоритм**: `sha256(lowercase(value) + SALT)`.
-*   Соль управляется через Secrets Manager и ротируется (см. `RULES.md` §5.4.1).
+
+- Поля, помеченные как чувствительные (PII), **ОБЯЗАНЫ** быть хэшированы перед записью в Silver.
+- **Алгоритм**: `sha256(lowercase(value) + SALT)`.
+- Соль управляется через Secrets Manager и ротируется (см. `RULES.md` §5.4.1).
 
 ### 2.6. Партиционирование
-*   **Конфигурация**: Определяется через `partition_by` в `configs/pipelines/{provider}/{entity}.yaml`.
-*   **Примеры**: `["year", "month"]` (по дате), `["assay_type"]` (по типу сущности), `[]` (без партиционирования).
-*   **Стандарт**: По дате источника или по типу данных, если кардинальность низкая.
-*   **Z-ORDER**: Не применяется в Silver (обычно сортировка по ingestion time), так как основная цель — write throughput.
 
----
+- **Конфигурация**: Определяется через `partition_by` в `configs/pipelines/{provider}/{entity}.yaml`.
+- **Примеры**: `["year", "month"]` (контрактный и обязательный вариант для Silver).
+- **Стандарт**: Silver партиционируется только по `year/month` в формате `year=YYYY/month=MM`.
+- **Z-ORDER**: Не применяется в Silver (обычно сортировка по ingestion time), так как основная цель — write throughput.
+
+______________________________________________________________________
 
 ## 3. Gold Layer (Витрины данных)
 
@@ -104,58 +114,63 @@ Silver слой использует стратегию **Merge/Upsert** для 
 
 При переходе из Silver в Gold выполняется трансформация данных:
 
-*   **Фильтрация полей**: Метод `BaseTransformer.transform_for_gold()` (`base_transformer.py:456`) использует `GOLD_EXCLUDE_FIELDS` для фильтрации полей. В текущей версии `GOLD_EXCLUDE_FIELDS = frozenset()` (пустое множество) — все Silver-поля проходят в Gold без исключения.
-*   **Плоская структура**: Gold содержит только плоские (scalar) поля для оптимизации аналитических запросов.
-*   **Реализация**: `BaseTransformer.transform_for_gold()` метод с константой `GOLD_EXCLUDE_FIELDS` в `src/bioetl/application/core/base_transformer.py`.
+- **Фильтрация полей**: Метод `BaseTransformer.transform_for_gold()` (`base_transformer.py:456`) использует `GOLD_EXCLUDE_FIELDS` для фильтрации полей. В текущей версии `GOLD_EXCLUDE_FIELDS = frozenset()` (пустое множество) — все Silver-поля проходят в Gold без исключения.
+- **Плоская структура**: Gold содержит только плоские (scalar) поля для оптимизации аналитических запросов.
+- **Реализация**: `BaseTransformer.transform_for_gold()` метод с константой `GOLD_EXCLUDE_FIELDS` в `src/bioetl/application/core/base_transformer.py`.
 
 #### Пример: ChEMBL Molecule
 
-| Silver (JSON) | Gold (Flat) |
-|---------------|-------------|
-| `molecule_hierarchy` (JSON string) | `hierarchy_parent_chembl_id`, `hierarchy_active_chembl_id` |
+| Silver (JSON)                       | Gold (Flat)                                                                                                                                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `molecule_hierarchy` (JSON string)  | `hierarchy_parent_chembl_id`, `hierarchy_active_chembl_id`                                                                                                                               |
 | `molecule_properties` (JSON string) | `property_mw_freebase`, `property_alogp`, `property_hba`, `property_hbd`, `property_psa`, `property_rtb`, `property_ro5_violations`, `property_qed_weighted`, `property_full_molformula` |
-| `molecule_structures` (JSON string) | `structure_canonical_smiles`, `structure_standard_inchi`, `structure_standard_inchi_key` |
-| `molecule_synonyms` (JSON string) | *Excluded* |
-| `cross_references` (JSON string) | *Excluded* |
-| `atc_classifications` (JSON string) | *Excluded* |
+| `molecule_structures` (JSON string) | `structure_canonical_smiles`, `structure_standard_inchi`, `structure_standard_inchi_key`                                                                                                 |
+| `molecule_synonyms` (JSON string)   | *Excluded*                                                                                                                                                                               |
+| `cross_references` (JSON string)    | *Excluded*                                                                                                                                                                               |
+| `atc_classifications` (JSON string) | *Excluded*                                                                                                                                                                               |
 
 **Примечание**: Silver сохраняет полные JSON-данные для возможности восстановления и расследования (forensic retention).
 
 ### 3.2. Формат и Оптимизация
-*   **Формат**: Delta Lake.
-*   **Путь**: `data/output/gold/{provider}/{entity}/` (например, `data/output/gold/chembl/activity`).
-*   **Оптимизация чтения**:
-    *   **Z-ORDER Clustering**: Рекомендуется (не реализовано в текущей версии) по часто используемым предикатам фильтрации (например, `target_id`, `assay_type`).
-    *   **Compaction**: Регулярная (еженедельная) компрессия мелких файлов через `OPTIMIZE`.
+
+- **Формат**: Delta Lake.
+- **Путь**: `data/output/gold/{provider}/{entity}/` (например, `data/output/gold/chembl/activity`).
+- **Оптимизация чтения**:
+  - **Z-ORDER Clustering**: Рекомендуется (не реализовано в текущей версии) по часто используемым предикатам фильтрации (например, `target_id`, `assay_type`).
+  - **Compaction**: Регулярная (еженедельная) компрессия мелких файлов через `OPTIMIZE`.
 
 ### 3.3. Контракты Данных (Data Contracts)
+
 Gold слой имеет строгие публичные контракты.
-*   **Реестр**: JSON Schema файлы в `docs/04-reference/contracts/gold/`.
-*   **Стабильность**: Любое изменение схемы в Gold требует:
-    1.  Обновления JSON-контракта.
-    2.  Создания миграции или новой версии витрины (v2).
-    3.  Уведомления потребителей (Breaking Change Policy).
+
+- **Реестр**: JSON Schema файлы в `docs/04-reference/contracts/gold/`.
+- **Стабильность**: Любое изменение схемы в Gold требует:
+  1. Обновления JSON-контракта.
+  1. Создания миграции или новой версии витрины (v2).
+  1. Уведомления потребителей (Breaking Change Policy).
 
 ### 3.4. Агрегация и Бизнес-логика
-*   Джойны между разными сущностями (например, Activity + Molecule + Target).
-*   Вычисление производных метрик (AVG, SUM).
-*   Применение бизнес-фильтров (исключение отозванных статей, невалидных экспериментов).
+
+- Джойны между разными сущностями (например, Activity + Molecule + Target).
+- Вычисление производных метрик (AVG, SUM).
+- Применение бизнес-фильтров (исключение отозванных статей, невалидных экспериментов).
 
 ### 3.5. Управление жизненным циклом (Lifecycle)
-*   Данные в Gold часто перезаписываются полностью (`mode="overwrite"`) для партиций или всей таблицы при пересчете витрин.
-*   Retention: Постоянное хранение, пока актуальна бизнес-задача.
 
----
+- Данные в Gold часто перезаписываются полностью (`mode="overwrite"`) для партиций или всей таблицы при пересчете витрин.
+- Retention: Постоянное хранение, пока актуальна бизнес-задача.
+
+______________________________________________________________________
 
 ## Сводная таблица характеристик
 
-| Характеристика | Bronze | Silver | Gold |
-|:---|:---|:---|:---|
-| **Назначение** | Сырая выгрузка, Archive | Очищенные данные, Source of Truth | Аналитика, ML, Отчеты |
-| **Формат** | JSONL + zstd | Delta Lake | Delta Lake |
-| **Схема** | Schema-on-Read (Implicit) | Enforced (Pandera), Evolution | Strict (JSON Contracts) |
-| **Мутабельность** | Append-only (Immutable) | Upsert (Merge) | Overwrite / Upsert |
-| **Партиционирование** | Ingestion Date | Source Date / Entity Type | Business Dimensions |
-| **Оптимизация** | Сжатие | Partitioning | Z-ORDER, Optimize |
-| **PII** | Plain Text (Restricted Access) | Hashed + Salted | Aggregated / Excluded |
-| **Recovery** | Replay source | Rebuild from Bronze | Recompute from Silver |
+| Характеристика        | Bronze                         | Silver                            | Gold                    |
+| :-------------------- | :----------------------------- | :-------------------------------- | :---------------------- |
+| **Назначение**        | Сырая выгрузка, Archive        | Очищенные данные, Source of Truth | Аналитика, ML, Отчеты   |
+| **Формат**            | JSONL + zstd                   | Delta Lake                        | Delta Lake              |
+| **Схема**             | Schema-on-Read (Implicit)      | Enforced (Pandera), Evolution     | Strict (JSON Contracts) |
+| **Мутабельность**     | Append-only (Immutable)        | Upsert (Merge)                    | Overwrite / Upsert      |
+| **Партиционирование** | Ingestion Date                 | Source Date / Entity Type         | Business Dimensions     |
+| **Оптимизация**       | Сжатие                         | Partitioning                      | Z-ORDER, Optimize       |
+| **PII**               | Plain Text (Restricted Access) | Hashed + Salted                   | Aggregated / Excluded   |
+| **Recovery**          | Replay source                  | Rebuild from Bronze               | Recompute from Silver   |

--- a/docs/02-architecture/decisions/ADR-025-pipeline-config-unification.md
+++ b/docs/02-architecture/decisions/ADR-025-pipeline-config-unification.md
@@ -7,15 +7,16 @@
 ## Context
 
 Pipeline configs имели следующие проблемы:
+
 1. Плоские пути без иерархии `{provider}/{entity}`
-2. Отсутствие `sort_by` у 78% entity configs (нарушение ADR-014)
-3. Нестандартные `batch_size` без документации
-4. Отсутствие автоматической валидации конфигов
-5. Разрозненные DQ-правила без централизации
+1. Отсутствие `sort_by` у 78% entity configs (нарушение ADR-014)
+1. Нестандартные `batch_size` без документации
+1. Отсутствие автоматической валидации конфигов
+1. Разрозненные DQ-правила без централизации
 
 ## Decision
 
-### 1. Единый _base.yaml (v2.0.0)
+### 1. Единый \_base.yaml (v2.0.0)
 
 Файл `_base.yaml` является единым источником defaults для всех pipeline configs:
 
@@ -64,18 +65,20 @@ configs/
 data/output/{layer}/{provider}/{entity}/
 ```
 
-| Слой | Паттерн | Пример |
-|------|---------|--------|
-| Bronze | `data/output/bronze/{provider}/{entity}/` | `data/output/bronze/chembl/activity/` |
-| Silver | `data/output/silver/{provider}/{entity}/` | `data/output/silver/chembl/activity/` |
-| Gold | `data/output/gold/{provider}/{entity}/` | `data/output/gold/chembl/activity/` |
+| Слой   | Паттерн                                      | Пример                                   |
+| ------ | -------------------------------------------- | ---------------------------------------- |
+| Bronze | `data/output/bronze/v1/{provider}/{entity}/` | `data/output/bronze/v1/chembl/activity/` |
+| Silver | `data/output/silver/{provider}/{entity}/`    | `data/output/silver/chembl/activity/`    |
+| Gold   | `data/output/gold/{provider}/{entity}/`      | `data/output/gold/chembl/activity/`      |
 
 **Bronze file layout (contract):**
+
 ```
-data/output/bronze/{provider}/{entity}/{YYYY-MM-DD}/{filename}.jsonl.zst
+data/output/bronze/v1/{provider}/{entity}/{YYYY-MM-DD}/{filename}.jsonl.zst
 ```
 
 **CSV Export** использует тот же путь, что и Delta:
+
 ```yaml
 csv_export:
   path: "data/output/silver/chembl/activity"  # Рядом с Delta таблицей
@@ -116,6 +119,7 @@ python scripts/validate_pipeline_configs.py
 ```
 
 Schema проверяет:
+
 - **Обязательные поля**: `pipeline_name`, `provider`, `entity_type`, `version`, `primary_keys`, `silver_table`, `gold_table`, `sink`
 - **Формат `pipeline_name`**: `^[a-z]+_[a-z_]+$`
 - **Допустимые `provider`**: `chembl`, `pubchem`, `uniprot`, `pubmed`, `crossref`, `openalex`, `semanticscholar`
@@ -124,12 +128,12 @@ Schema проверяет:
 
 ### 5. Naming Conventions
 
-| Элемент | Паттерн | Пример |
-|---------|---------|--------|
-| `pipeline_name` | `<provider>_<entity>` | `chembl_activity` |
-| `silver_table` | `<provider>_<entity>` | `chembl_activity` |
-| `gold_table` | `<provider>_<entity>` | `chembl_activity` |
-| Config path | `configs/pipelines/<provider>/<entity>.yaml` | `configs/pipelines/chembl/activity.yaml` |
+| Элемент         | Паттерн                                      | Пример                                   |
+| --------------- | -------------------------------------------- | ---------------------------------------- |
+| `pipeline_name` | `<provider>_<entity>`                        | `chembl_activity`                        |
+| `silver_table`  | `<provider>_<entity>`                        | `chembl_activity`                        |
+| `gold_table`    | `<provider>_<entity>`                        | `chembl_activity`                        |
+| Config path     | `configs/pipelines/<provider>/<entity>.yaml` | `configs/pipelines/chembl/activity.yaml` |
 
 **Статус**: Консистентность по всем 21 entity configs + 5 composite (верифицировано 2026-02-17).
 
@@ -155,6 +159,7 @@ source:
 ```
 
 Entity configs ссылаются через `source_file`:
+
 ```yaml
 # configs/pipelines/chembl/activity.yaml
 source_file: ../../sources/chembl.yaml
@@ -174,9 +179,10 @@ configs/quality/
 ```
 
 Entity configs могут:
+
 1. Ссылаться на DQ файл: `dq_config_file: ../../quality/entities/chembl/activity.yaml`
-2. Определять inline правила в `dq_overrides:`
-3. Комбинировать оба подхода (inline overrides поверх файла)
+1. Определять inline правила в `dq_overrides:`
+1. Комбинировать оба подхода (inline overrides поверх файла)
 
 ```yaml
 # configs/pipelines/chembl/activity.yaml
@@ -195,12 +201,12 @@ dq_overrides:
 ### Positive
 
 1. **Единый источник defaults**: `_base.yaml` v2.0.0 — нет дублирования
-2. **Детерминизм выходных данных**: `sort_by` во всех 21 entity configs (ADR-014)
-3. **Автоматическая валидация**: Pydantic schemas валидируют структуру
-4. **Консистентные пути**: `{layer}/{provider}/{entity}` упрощает навигацию
-5. **Provider knowledge captured**: API limits, auth requirements в source configs
-6. **Иерархические DQ правила**: Централизация через `configs/quality/` (ADR-027)
-7. **Separation of concerns**: Source configs отделены от pipeline configs
+1. **Детерминизм выходных данных**: `sort_by` во всех 21 entity configs (ADR-014)
+1. **Автоматическая валидация**: Pydantic schemas валидируют структуру
+1. **Консистентные пути**: `{layer}/{provider}/{entity}` упрощает навигацию
+1. **Provider knowledge captured**: API limits, auth requirements в source configs
+1. **Иерархические DQ правила**: Централизация через `configs/quality/` (ADR-027)
+1. **Separation of concerns**: Source configs отделены от pipeline configs
 
 ### Negative
 
@@ -210,13 +216,14 @@ dq_overrides:
 ### Neutral
 
 1. **21 entity configs + 5 composite**: Все используют единый формат и наследование от `_base.yaml`
-2. **7 source configs**: Один на провайдера, DRY для API settings
+1. **7 source configs**: Один на провайдера, DRY для API settings
 
 ## Alternatives Considered
 
 ### A. YAML Anchors for Inheritance
 
 Use YAML anchors/aliases for config inheritance:
+
 ```yaml
 <<: *defaults
 pipeline_name: chembl_activity
@@ -244,18 +251,18 @@ pipeline_name: chembl_activity
 
 ## Compliance
 
-| Requirement | Status | Notes |
-|-------------|--------|-------|
-| `sink.silver.format: delta` | ✅ PASS | All configs inherit from `_base.yaml` |
-| `sink.silver.primary_key` | ✅ PASS | All 21 entity configs specify (auto-propagated) |
-| `sink.silver.sort_by` | ✅ PASS | All 21 entity configs (ADR-014, auto-propagated from primary_keys) |
-| `sink.gold.sort_by` | ✅ PASS | All 21 entity configs (ADR-014, auto-propagated from primary_keys) |
-| `dq_overrides` thresholds | ✅ PASS | 0.05/0.20 in `_base.yaml` defaults |
-| `circuit_breaker` settings | ✅ PASS | 5/300 in `_base.yaml` and source configs |
-| `rate_limit` per provider | ✅ PASS | In 7 source configs |
-| No hardcoded secrets | ✅ PASS | Uses `${ENV_VAR}` syntax where needed |
-| `pipeline_name` format | ✅ PASS | All match `^[a-z]+_[a-z_]+$` |
-| Hierarchical paths | ✅ PASS | All use `{layer}/{provider}/{entity}` |
+| Requirement                 | Status  | Notes                                                              |
+| --------------------------- | ------- | ------------------------------------------------------------------ |
+| `sink.silver.format: delta` | ✅ PASS | All configs inherit from `_base.yaml`                              |
+| `sink.silver.primary_key`   | ✅ PASS | All 21 entity configs specify (auto-propagated)                    |
+| `sink.silver.sort_by`       | ✅ PASS | All 21 entity configs (ADR-014, auto-propagated from primary_keys) |
+| `sink.gold.sort_by`         | ✅ PASS | All 21 entity configs (ADR-014, auto-propagated from primary_keys) |
+| `dq_overrides` thresholds   | ✅ PASS | 0.05/0.20 in `_base.yaml` defaults                                 |
+| `circuit_breaker` settings  | ✅ PASS | 5/300 in `_base.yaml` and source configs                           |
+| `rate_limit` per provider   | ✅ PASS | In 7 source configs                                                |
+| No hardcoded secrets        | ✅ PASS | Uses `${ENV_VAR}` syntax where needed                              |
+| `pipeline_name` format      | ✅ PASS | All match `^[a-z]+_[a-z_]+$`                                       |
+| Hierarchical paths          | ✅ PASS | All use `{layer}/{provider}/{entity}`                              |
 
 ## References
 
@@ -264,25 +271,25 @@ pipeline_name: chembl_activity
 - [ADR-027: DQ Rules Externalization](ADR-027-dq-rules-externalization.md) - Hierarchical DQ config
 - [03-file-policy.md](../../00-project-rules/03-file-policy.md) - File structure documentation
 - [04-extending-bioetl.md](../../00-project-rules/04-extending-bioetl.md) - Entity config template
-- [configs/pipelines/_base.yaml](../../../configs/pipelines/_base.yaml) - Unified Base Schema v2.0.0
+- [configs/pipelines/\_base.yaml](../../../configs/pipelines/_base.yaml) - Unified Base Schema v2.0.0
 - [Pipeline Pydantic Schema](../../../src/bioetl/infrastructure/schemas/pipeline_config.py) - Pydantic validation schema
 
 ## Changelog
 
-| Date | Author | Change |
-|------|--------|--------|
-| 2026-01-13 | Claude Code | Initial version |
-| 2026-01-14 | Claude Code | Added: Hierarchical paths `{layer}/{provider}/{entity}` |
-| 2026-01-14 | Claude Code | Added: Mandatory `sort_by` for ADR-014 compliance |
-| 2026-01-14 | Claude Code | Added: JSON Schema validation via `_schema.json` |
+| Date       | Author      | Change                                                                                    |
+| ---------- | ----------- | ----------------------------------------------------------------------------------------- |
+| 2026-01-13 | Claude Code | Initial version                                                                           |
+| 2026-01-14 | Claude Code | Added: Hierarchical paths `{layer}/{provider}/{entity}`                                   |
+| 2026-01-14 | Claude Code | Added: Mandatory `sort_by` for ADR-014 compliance                                         |
+| 2026-01-14 | Claude Code | Added: JSON Schema validation via `_schema.json`                                          |
 | 2026-01-19 | Claude Code | Fixed: Corrected file structure (`_base.yaml` is the defaults file, not `_defaults.yaml`) |
-| 2026-01-19 | Claude Code | Added: Source config separation (`configs/sources/`) |
-| 2026-01-19 | Claude Code | Added: Hierarchical DQ configuration reference (ADR-027) |
-| 2026-01-19 | Claude Code | Updated: Compliance matrix with verification status |
-| 2026-02-03 | Claude Code | Fixed: Config counts (19 entity + 2 composite = 21 total) |
-| 2026-02-03 | Claude Code | Added: Reference to ADR-026 for composite pipelines |
-| 2026-02-03 | Claude Code | Fixed: ChEMBL has 12 entity configs, pubmed uses publication.yaml |
-| 2026-02-17 | Claude Code | Fixed: Config counts (21 entity + 5 composite), ChEMBL has 14 entity configs |
-| 2026-02-17 | Claude Code | Fixed: DQ path `configs/dq/` → `configs/quality/` (consistent with ADR-027) |
-| 2026-02-17 | Claude Code | Fixed: Removed `_schema.json` reference (validation via Pydantic schemas) |
-| 2026-02-17 | Claude Code | Fixed: Composite directory listing (activity, assay, molecule, publication, target) |
+| 2026-01-19 | Claude Code | Added: Source config separation (`configs/sources/`)                                      |
+| 2026-01-19 | Claude Code | Added: Hierarchical DQ configuration reference (ADR-027)                                  |
+| 2026-01-19 | Claude Code | Updated: Compliance matrix with verification status                                       |
+| 2026-02-03 | Claude Code | Fixed: Config counts (19 entity + 2 composite = 21 total)                                 |
+| 2026-02-03 | Claude Code | Added: Reference to ADR-026 for composite pipelines                                       |
+| 2026-02-03 | Claude Code | Fixed: ChEMBL has 12 entity configs, pubmed uses publication.yaml                         |
+| 2026-02-17 | Claude Code | Fixed: Config counts (21 entity + 5 composite), ChEMBL has 14 entity configs              |
+| 2026-02-17 | Claude Code | Fixed: DQ path `configs/dq/` → `configs/quality/` (consistent with ADR-027)               |
+| 2026-02-17 | Claude Code | Fixed: Removed `_schema.json` reference (validation via Pydantic schemas)                 |
+| 2026-02-17 | Claude Code | Fixed: Composite directory listing (activity, assay, molecule, publication, target)       |

--- a/src/bioetl/application/core/preflight_service.py
+++ b/src/bioetl/application/core/preflight_service.py
@@ -330,6 +330,7 @@ class _MedallionConfigValidator:
         errors.extend(
             self._validate_path_uniqueness(bronze_path, silver_path, gold_path)
         )
+        errors.extend(self._validate_silver_partition_contract())
 
         policy = MedallionPolicy.for_run_type(runtime.run_type)
         errors.extend(
@@ -472,6 +473,30 @@ class _MedallionConfigValidator:
                     expected="unique paths for each layer",
                     actual=f"bronze_path == gold_path ({bronze_path})",
                     rule="Medallion Architecture: layers MUST have distinct paths",
+                )
+            )
+
+        return errors
+
+    def _validate_silver_partition_contract(self) -> list[ConfigValidationError]:
+        """Validate Silver partition contract year=YYYY/month=MM.
+
+        Silver path layout is represented physically by Delta partition columns,
+        producing directories year=YYYY/month=MM under provider/entity table path.
+        """
+        errors: list[ConfigValidationError] = []
+
+        partition_cols = list(self._config.table.partition_cols)
+        if not partition_cols:
+            return errors
+
+        if partition_cols != ["year", "month"]:
+            errors.append(
+                ConfigValidationError(
+                    field="table.partition_cols",
+                    expected="['year', 'month']",
+                    actual=str(partition_cols),
+                    rule="RULES §2.1: Silver path partitioning MUST be year=YYYY/month=MM",
                 )
             )
 

--- a/src/bioetl/infrastructure/config_loader.py
+++ b/src/bioetl/infrastructure/config_loader.py
@@ -13,7 +13,7 @@ Convention-based path resolution (ADR-029):
         - schema_file: ../../schemas/{provider}/{entity_type}.yaml
 
     Sink Paths:
-        - sink.bronze.path: data/output/bronze/{provider}/{entity_type}
+        - sink.bronze.path: data/output/bronze/v1/{provider}/{entity_type}
         - sink.silver.path: data/output/silver/{provider}/{entity_type}
         - sink.gold.path: data/output/gold/{provider}/{entity_type}
         - sink.silver.csv_export.path: {sink.silver.path}
@@ -169,7 +169,10 @@ def _apply_layer_defaults(
 
     Sets path and csv_export.path if not specified.
     """
-    layer.setdefault("path", f"data/output/{layer_name}/{provider}/{entity_type}")
+    if layer_name == "bronze":
+        layer.setdefault("path", f"data/output/bronze/v1/{provider}/{entity_type}")
+    else:
+        layer.setdefault("path", f"data/output/{layer_name}/{provider}/{entity_type}")
 
     # Auto-set csv_export path to match layer path
     csv_export = layer.setdefault("csv_export", {})

--- a/src/bioetl/infrastructure/storage/bronze_writer.py
+++ b/src/bioetl/infrastructure/storage/bronze_writer.py
@@ -4,7 +4,7 @@ Implements RULES.md §2.1.1 - Bronze Layer specifications.
 
 Requirements:
 - REQ-DATA-001: JSONL + zstd format
-- REQ-DATA-002: Path format bronze/{provider}/{entity}/{date}/
+- REQ-DATA-002: Path format bronze/v1/{provider}/{entity}/{date}/
 - REQ-DATA-003: Append-only writes
 - REQ-DATA-004: Atomic writes (via temp file + rename)
 
@@ -57,7 +57,9 @@ class BronzeWriter:
     COMPRESSION_CHUNK_SIZE = 256 * 1024
     COMPRESSION_LEVEL = 3
     COMPRESSION_THREADS = -1  # zstd: auto-detect available CPU cores
-    BRONZE_PATH_FORMAT = "{provider}/{entity}/{date}/{filename}"
+    BRONZE_LAYOUT_VERSION = "v1"
+    BRONZE_PATH_FORMAT = "v1/{provider}/{entity}/{date}/{filename}"
+    LEGACY_BRONZE_PATH_FORMAT = "{provider}/{entity}/{date}/{filename}"
     BRONZE_FILE_SUFFIX = ".jsonl.zst"
 
     def __init__(
@@ -74,6 +76,8 @@ class BronzeWriter:
         save_metadata: bool = False,
         metadata_coordinator: MetadataCoordinatorPort | None = None,
         flat_structure: bool = False,
+        legacy_layout: bool = False,
+        compat_read_legacy_layout: bool = True,
     ) -> None:
         """Initialize Bronze writer.
 
@@ -104,6 +108,10 @@ class BronzeWriter:
             flat_structure: If True, write directly to base_path/{date}/ without
                           adding {provider}/{entity}/ prefix. Use when base_path
                           already includes provider/entity path segments.
+            legacy_layout: If True, writes Bronze files using legacy path
+                         {provider}/{entity}/{date}/ without v1 prefix.
+            compat_read_legacy_layout: If True, list/cleanup operations read both
+                                     v1 and legacy Bronze layouts.
 
         Note:
             Lock validation is now performed at Application layer (BatchWriter)
@@ -136,6 +144,8 @@ class BronzeWriter:
             metadata_coordinator
         )
         self._flat_structure = flat_structure
+        self._legacy_layout = legacy_layout
+        self._compat_read_legacy_layout = compat_read_legacy_layout
 
     def _resolve_bronze_path(
         self, provider: str, entity: str, date_str: str, filename: str
@@ -143,7 +153,26 @@ class BronzeWriter:
         """Resolve Bronze file path based on flat_structure setting."""
         if self._flat_structure:
             return f"{date_str}/{filename}"
-        return f"{provider}/{entity}/{date_str}/{filename}"
+        if self._legacy_layout:
+            return self.LEGACY_BRONZE_PATH_FORMAT.format(
+                provider=provider,
+                entity=entity,
+                date=date_str,
+                filename=filename,
+            )
+        return self.BRONZE_PATH_FORMAT.format(
+            provider=provider,
+            entity=entity,
+            date=date_str,
+            filename=filename,
+        )
+
+    def _iter_provider_entity_prefixes(self, provider: str, entity: str) -> list[str]:
+        """Get provider/entity prefixes for current and legacy Bronze layouts."""
+        prefixes = [f"{self.BRONZE_LAYOUT_VERSION}/{provider}/{entity}"]
+        if self._compat_read_legacy_layout:
+            prefixes.append(f"{provider}/{entity}")
+        return prefixes
 
     def _validate_bronze_names(self, provider: str, entity: str) -> None:
         """Validate provider and entity names (alphanumeric + underscores only)."""
@@ -718,11 +747,19 @@ class BronzeWriter:
             else:
                 search_path = self.base_path
         else:
-            # Standard path format: {provider}/{entity}/{date}/
-            prefix = f"{provider}/{entity}/"
-            if date:
-                prefix = f"{prefix}{date.strftime('%Y-%m-%d')}/"
-            search_path = self.base_path / prefix
+            files: list[Path] = []
+            pattern = "batch_*.jsonl.zst" if date else "**/*.jsonl.zst"
+            for prefix in self._iter_provider_entity_prefixes(provider, entity):
+                search_path = self.base_path / prefix
+                if date:
+                    search_path = search_path / date.strftime("%Y-%m-%d")
+                if search_path.exists():
+                    files.extend(search_path.glob(pattern))
+
+            if not files:
+                return []
+
+            return sorted({str(p.relative_to(self.base_path)) for p in files})
 
         if not search_path.exists():
             return []
@@ -746,19 +783,25 @@ class BronzeWriter:
         if not self.base_path.exists():
             return []
 
-        pattern = f"{provider or '*'}/{entity or '*'}"
         old_dirs: list[Path] = []
 
-        # Use glob to filter provider/entity structure efficiently
-        for entity_dir in self.base_path.glob(pattern):
-            if not entity_dir.is_dir():
-                continue
+        prefixes = [f"{provider or '*'}/{entity or '*'}"]
+        if self._compat_read_legacy_layout:
+            prefixes.insert(
+                0, f"{self.BRONZE_LAYOUT_VERSION}/{provider or '*'}/{entity or '*'}"
+            )
 
-            for date_dir in entity_dir.iterdir():
-                if self._is_old_date_dir(date_dir, cutoff_str):
-                    old_dirs.append(date_dir)
+        for pattern in prefixes:
+            # Use glob to filter provider/entity structure efficiently
+            for entity_dir in self.base_path.glob(pattern):
+                if not entity_dir.is_dir():
+                    continue
 
-        return old_dirs
+                for date_dir in entity_dir.iterdir():
+                    if self._is_old_date_dir(date_dir, cutoff_str):
+                        old_dirs.append(date_dir)
+
+        return sorted(set(old_dirs))
 
     def _is_old_date_dir(self, path: Path, cutoff_str: str) -> bool:
         """Check if path is a date directory older than cutoff."""

--- a/tests/architecture/test_medallion_invariants.py
+++ b/tests/architecture/test_medallion_invariants.py
@@ -8,8 +8,8 @@ See docs/02-architecture/decisions/ADR-014-deterministic-writes.md
 
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 
 import pytest
 
@@ -108,7 +108,7 @@ class TestBronzeMetadataInvariants:
     ) -> None:
         """Bronze paths MUST include date partitioning.
 
-        Path format: bronze/{provider}/{entity}/{date}/
+        Path format: bronze/v1/{provider}/{entity}/{date}/
         """
         from unittest.mock import Mock
 
@@ -127,9 +127,11 @@ class TestBronzeMetadataInvariants:
             filename="batch_2026-01-21_123.jsonl.zst",
         )
         normalized = path.replace("\\", "/")
-        assert normalized == "chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"
+        assert (
+            normalized == "v1/chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"
+        )
         assert re.match(
-            r"^chembl/activity/\d{4}-\d{2}-\d{2}/.+\.jsonl\.zst$",
+            r"^v1/chembl/activity/\d{4}-\d{2}-\d{2}/.+\.jsonl\.zst$",
             normalized,
         )
 

--- a/tests/architecture/test_path_contracts.py
+++ b/tests/architecture/test_path_contracts.py
@@ -6,10 +6,13 @@ and documented in ADR-025.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
+from bioetl.application.core.preflight_service import _MedallionConfigValidator
 from bioetl.domain.ports import NoOpMetrics
 from bioetl.infrastructure.storage.bronze_writer import BronzeWriter
 from bioetl.infrastructure.storage.gold_writer import GoldWriter
@@ -18,7 +21,7 @@ from bioetl.infrastructure.storage.silver_writer import SilverWriter
 ADR_PATH = Path("docs/02-architecture/decisions/ADR-025-pipeline-config-unification.md")
 
 BRONZE_CONTRACT = (
-    "data/output/bronze/{provider}/{entity}/{YYYY-MM-DD}/{filename}.jsonl.zst"
+    "data/output/bronze/v1/{provider}/{entity}/{YYYY-MM-DD}/{filename}.jsonl.zst"
 )
 SILVER_CONTRACT = "data/output/silver/{provider}/{entity}/"
 GOLD_CONTRACT = "data/output/gold/{provider}/{entity}/"
@@ -54,10 +57,10 @@ def test_bronze_path_contract() -> None:
         filename="batch_2026-01-21_123.jsonl.zst",
     )
     normalized = path.replace("\\", "/")
-    assert normalized == "chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"
+    assert normalized == "v1/chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"
     assert normalized.endswith(BronzeWriter.BRONZE_FILE_SUFFIX)
     assert re.match(
-        r"^chembl/activity/\d{4}-\d{2}-\d{2}/.+\.jsonl\.zst$",
+        r"^v1/chembl/activity/\d{4}-\d{2}-\d{2}/.+\.jsonl\.zst$",
         normalized,
     )
 
@@ -76,3 +79,72 @@ def test_gold_path_contract() -> None:
     path = writer._resolve_table_path("chembl.activity")
     normalized = path.replace("\\", "/")
     assert normalized == "data/output/gold/chembl/activity"
+
+
+def test_bronze_legacy_layout_compatibility() -> None:
+    """Bronze legacy layout MAY be written in compatibility mode."""
+    writer = BronzeWriter(
+        base_path="data/output/bronze",
+        logger=Mock(),
+        metrics=NoOpMetrics(),
+        legacy_layout=True,
+    )
+    path = writer._resolve_bronze_path(
+        provider="chembl",
+        entity="activity",
+        date_str="2026-01-21",
+        filename="batch_2026-01-21_123.jsonl.zst",
+    )
+    assert (
+        path.replace("\\", "/")
+        == "chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"
+    )
+
+
+def test_silver_partition_contract_year_month() -> None:
+    """Silver partition contract MUST use year/month partition columns."""
+    cfg = SimpleNamespace(
+        table=SimpleNamespace(partition_cols=("year", "month"), primary_keys=()),
+        dq=SimpleNamespace(key_nullability_rules=()),
+    )
+    validator = _MedallionConfigValidator(config=cfg, logger=Mock())
+
+    errors = validator._validate_silver_partition_contract()
+    assert errors == []
+
+
+def test_silver_partition_contract_rejects_legacy_partitioning() -> None:
+    """Legacy partitioning MUST be rejected by preflight contract validation."""
+    cfg = SimpleNamespace(
+        table=SimpleNamespace(partition_cols=("source_date",), primary_keys=()),
+        dq=SimpleNamespace(key_nullability_rules=()),
+    )
+    validator = _MedallionConfigValidator(config=cfg, logger=Mock())
+
+    errors = validator._validate_silver_partition_contract()
+    assert len(errors) == 1
+    assert errors[0].field == "table.partition_cols"
+    assert "year=YYYY/month=MM" in errors[0].rule
+
+
+def test_bronze_compat_reader_finds_legacy_batches(tmp_path: Path) -> None:
+    """Compat-read mode MUST detect legacy Bronze batches."""
+    legacy_batch = (
+        tmp_path
+        / "chembl"
+        / "activity"
+        / "2026-01-21"
+        / "batch_2026-01-21_123.jsonl.zst"
+    )
+    legacy_batch.parent.mkdir(parents=True, exist_ok=True)
+    legacy_batch.write_bytes(b"stub")
+
+    writer = BronzeWriter(
+        base_path=tmp_path,
+        logger=Mock(),
+        metrics=NoOpMetrics(),
+        compat_read_legacy_layout=True,
+    )
+
+    batches = asyncio.run(writer.list_batches("chembl", "activity"))
+    assert batches == ["chembl/activity/2026-01-21/batch_2026-01-21_123.jsonl.zst"]


### PR DESCRIPTION
### Motivation
- Standardize Bronze file layout to a versioned contract to avoid ambiguity and enable future evolution of storage layouts. 
- Enforce a single Silver partitioning contract (`year=YYYY/month=MM`) so table layout and query patterns remain consistent across pipelines. 
- Provide a backward-compatibility shim so existing pipelines and tests that use the legacy Bronze layout continue to work during migration. 
- Keep code and documentation aligned so architecture docs reflect the implemented contracts.

### Description
- Bronze writer: updated path contract to `bronze/v1/{provider}/{entity}/{date}/` and introduced `BRONZE_LAYOUT_VERSION`, `LEGACY_BRONZE_PATH_FORMAT`, constructor flags `legacy_layout` and `compat_read_legacy_layout`, plus `_iter_provider_entity_prefixes` and updated `list_batches()`/`_find_old_date_dirs()` to support compat-read across v1 and legacy layouts (`src/bioetl/infrastructure/storage/bronze_writer.py`).
- Preflight validation: added `_validate_silver_partition_contract()` to `_MedallionConfigValidator` and integrated it into the medallion config validation flow to require `table.partition_cols == ["year", "month"]` when partitioning is configured (`src/bioetl/application/core/preflight_service.py`).
- Configuration defaults: made convention-based Bronze sink default use `data/output/bronze/v1/{provider}/{entity_type}` in `config_loader` so auto-computed paths follow the new contract (`src/bioetl/infrastructure/config_loader.py`).
- Documentation: updated `docs/00-project/RULES.md`, `docs/02-architecture/data-layers.md`, and `docs/02-architecture/decisions/ADR-025-pipeline-config-unification.md` to describe the `bronze/v1` contract, legacy compat-read behavior, and the Silver `year/month` partition requirement. 
- Tests: updated/added architecture tests under `tests/architecture/` to assert the Bronze v1 path, Silver partition contract, legacy Bronze compatibility, and updated invariant expectations (`tests/architecture/test_path_contracts.py`, `tests/architecture/test_medallion_invariants.py`).

### Testing
- Ran bytecode checks with `python -m py_compile` against the modified modules and related test files, which succeeded for the targeted files. 
- Attempted to run `pytest` on architecture and preflight tests, but full `pytest` execution could not complete in this environment due to a local pytest configuration/plugin mismatch (`PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope`).
- Ad-hoc runtime import attempts (via `PYTHONPATH=src python -c ...`) uncovered missing runtime test dependencies (notably `pandas`), preventing end-to-end test execution in the sandbox; unit-level compilation and static checks were used as validation instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997037571d08324bef8ae499a76da69)