### PR TITLE
chore(cleanup): remove impossible async-generator branches in adapters

### DIFF
--- a/src/bioetl/infrastructure/adapters/crossref/client.py
+++ b/src/bioetl/infrastructure/adapters/crossref/client.py
@@ -180,13 +180,11 @@ class CrossRefAdapter(BaseHttpAdapter):
         Raises:
             NotImplementedError: Always, as CrossRef doesn't support multi-field filtering.
         """
-        # AsyncIterator requires yield before raise for proper generator creation
-        if False:  # pragma: no cover
-            yield {}  # Required for AsyncIterator type signature
         raise NotImplementedError(
             "CrossRef API does not support multi-field filtering. "
             "Use fetch_filtered() with filter_field='doi' instead."
         )
+        yield {}  # pragma: no cover - keeps AsyncIterator contract
 
     async def fetch_filtered_with_fallback(
         self,

--- a/src/bioetl/infrastructure/adapters/filterable_mixin.py
+++ b/src/bioetl/infrastructure/adapters/filterable_mixin.py
@@ -73,14 +73,11 @@ class NotSupportedMultiFilterMixin:
         # Mark unused parameters
         del entity_type, filters, limit
 
-        # AsyncIterator requires yield before raise for proper generator creation
-        if False:  # pragma: no cover
-            yield {}  # Required for AsyncIterator type signature
-
         raise NotImplementedError(
             f"{self.provider_name} does not support multi-field filtering. "
             "Use fetch_filtered() with a single filter_field instead."
         )
+        yield {}  # pragma: no cover - keeps AsyncIterator contract
 
 
 class DelegatingFallbackMixin:

--- a/src/bioetl/infrastructure/adapters/openalex/client.py
+++ b/src/bioetl/infrastructure/adapters/openalex/client.py
@@ -250,13 +250,11 @@ class OpenAlexAdapter(BaseHttpAdapter):
         Raises:
             NotImplementedError: Always, as OpenAlex doesn't support multi-field filtering.
         """
-        # AsyncIterator requires yield before raise for proper generator creation
-        if False:  # pragma: no cover
-            yield {}  # Required for AsyncIterator type signature
         raise NotImplementedError(
             "OpenAlex adapter does not support multi-field filtering. "
             "Use fetch_filtered() with filter_field='doi' instead."
         )
+        yield {}  # pragma: no cover - keeps AsyncIterator contract
 
     async def _batch_doi_lookup(
         self,

--- a/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
@@ -361,12 +361,11 @@ class SemanticScholarAdapter(BaseHttpAdapter):
             NotImplementedError: Always, as S2 doesn't support multi-field filtering.
 
         """
-        if False:  # pragma: no cover
-            yield {}
         raise NotImplementedError(
             "Semantic Scholar adapter supports only DOI filtering. "
             "Use fetch_filtered() or fetch_filtered_with_fallback()."
         )
+        yield {}  # pragma: no cover - keeps AsyncIterator contract
 
     # =========================================================================
     # Internal methods

--- a/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py
@@ -640,14 +640,12 @@ class UniProtIDMappingClient(BaseHttpAdapter):
         Raises:
             NotImplementedError: Always, as this is not a data source.
         """
-        # AsyncIterator requires yield before raise for proper generator creation
-        if False:  # pragma: no cover
-            yield {}  # Required for AsyncIterator type signature
         raise NotImplementedError(
             "UniProtIDMappingClient is not a DataSourcePort. "
             "Use IDMappingDataSource for pipeline integration, "
             "or call map_ids() directly for ID mapping operations."
         )
+        yield {}  # pragma: no cover - keeps AsyncIterator contract
 
     def __repr__(self) -> str:
         """Return string representation."""


### PR DESCRIPTION
### Motivation
- Remove unreachable `if False` placeholder branches that were added only to satisfy async-generator typing and which produced static-analysis noise in several infrastructure adapters and mixins. 
- Preserve existing runtime behavior (`NotImplementedError`) while keeping `AsyncIterator` signatures intact for callers and type-checkers.

### Description
- Replaced impossible `if False: yield {}` patterns with a single unreachable `yield {}` after the `raise NotImplementedError` to keep the async-generator contract and reduce dead-code noise in `AsyncIterator` methods. 
- Files changed: `src/bioetl/infrastructure/adapters/crossref/client.py`, `src/bioetl/infrastructure/adapters/openalex/client.py`, `src/bioetl/infrastructure/adapters/semanticscholar/adapter.py`, `src/bioetl/infrastructure/adapters/uniprot/idmapping_client.py`, and `src/bioetl/infrastructure/adapters/filterable_mixin.py`.

### Testing
- Ran unit tests for adapters with `uv run python -m pytest tests/unit/infrastructure/adapters -q --tb=no` and they passed. 
- Ran architecture tests with `uv run python -m pytest tests/architecture/ -q --tb=no` and they passed. 
- Type-checking for the modified files with `uv run python -m mypy --strict <files>` returned no issues, and `uv run ruff check src/bioetl --select F401` returned no failures for the project scope run used during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d32f0dbcc832495deb4ffec36de87)