### PR TITLE
chore(cleanup): remove unused TYPE_CHECKING import and redundant no-op pass statements in infrastructure

### DIFF
--- a/src/bioetl/infrastructure/adapters/cached_bronze_data_source.py
+++ b/src/bioetl/infrastructure/adapters/cached_bronze_data_source.py
@@ -104,7 +104,6 @@ class CachedBronzeDataSource:
         exc_tb: TracebackType | None,
     ) -> None:
         """Exit async context manager (no-op for file-based source)."""
-        pass
 
     async def health_check(self) -> HealthStatus:
         """Check health of the cached Bronze data source.
@@ -115,7 +114,6 @@ class CachedBronzeDataSource:
 
     async def aclose(self) -> None:
         """Close the data source (no-op for file-based source)."""
-        pass
 
     def _parse_date(self, date_str: str | None) -> datetime | None:
         """Parse date string to datetime for list_batches filtering."""

--- a/src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py
+++ b/src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py
@@ -127,7 +127,6 @@ class CircuitBreakerDataSourceDecorator:
         # The circuit_breaker.call() method handles success recording
         # but since we're not using call(), we need to reset on success
         # For now, the adapter-level circuit breaker handles this
-        pass
 
     def _record_failure(self, exc: Exception) -> None:
         """Record failed operation to circuit breaker.

--- a/src/bioetl/infrastructure/schemas/base_schemas.py
+++ b/src/bioetl/infrastructure/schemas/base_schemas.py
@@ -22,9 +22,6 @@ from bioetl.domain.resilience import CircuitBreakerConfig as DomainCircuitBreake
 if TYPE_CHECKING:
     from bioetl.domain.filtering import GoldFilterConfig
     from bioetl.domain.filtering.input_config import (
-        FilterColumn as DomainFilterColumn,
-    )
-    from bioetl.domain.filtering.input_config import (
         InputFilterConfig as DomainInputFilterConfig,
     )
 

--- a/src/bioetl/infrastructure/storage/delta_reader.py
+++ b/src/bioetl/infrastructure/storage/delta_reader.py
@@ -191,4 +191,3 @@ class DeltaReader:
 
     async def aclose(self) -> None:
         """Gracefully close the reader (no-op, no persistent resources)."""
-        pass

--- a/src/bioetl/infrastructure/storage/metadata_writer.py
+++ b/src/bioetl/infrastructure/storage/metadata_writer.py
@@ -235,4 +235,3 @@ class MetadataWriter:
 
         No resources to release for filesystem-based writer.
         """
-        pass


### PR DESCRIPTION
### Motivation
- Remove small instances of dead/unused code in the infrastructure layer to reduce linter noise and make intent explicit. 
- Keep changes minimal and behavior-preserving while addressing high-confidence `autoflake` findings and simplifying no-op methods.

### Description
- Removed an unused `TYPE_CHECKING` import (`FilterColumn`) from `src/bioetl/infrastructure/schemas/base_schemas.py` to eliminate a false-positive unused-import report. 
- Deleted redundant `pass` statements from async no-op context/close methods in `src/bioetl/infrastructure/adapters/cached_bronze_data_source.py`, `src/bioetl/infrastructure/storage/delta_reader.py`, and `src/bioetl/infrastructure/storage/metadata_writer.py` to clean up trivial boilerplate. 
- Removed an unnecessary `pass` in `_record_success` in `src/bioetl/infrastructure/adapters/decorators/circuit_breaker.py` while keeping the documented no-op behavior. 
- All changes are behavior-preserving and confined to the infrastructure layer.

### Testing
- `autoflake --check` run against the modified files passed for the cleaned files (no unused-import/variable reports). ✅
- `pytest tests/architecture/ -q` passed (architecture boundary tests run and green). ✅
- `mypy --strict` run against the changed files succeeded (no new typing issues introduced). ✅
- Full-repo `mypy --strict` currently fails on pre-existing `unused-ignore` issues in files outside this change set, so the repo-level type check remains failing (unrelated to these edits). ❌
- Repository pre-commit hooks reported unrelated policy/tooling failures (missing auxiliary script and `pip-audit` binary and root-layout policy items) that are outside the scope of this change. ❌

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d32f0dbcc832495deb4ffec36de87)