### PR TITLE
docs: add Codex agent playbook and navigation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Codex Agent Playbook**: Added `docs/00-project/agents/CODEX.md` with consolidated Codex operating instructions for architecture audit, verification protocol, and Definition of Done
+  - Cross-linked from `docs/00-project/agents/README.md` and `docs/00-project/00-map.md` for discoverability
+
 - **End-to-End Metrics Audit**: Registered 32+ new Prometheus metrics that were previously silently dropped
   - Pipeline lifecycle: `pipeline_runs_total`, `phase_duration_seconds`
   - Transformer: `transform_duration_seconds`, `transform_errors_total`

--- a/docs/00-project/00-map.md
+++ b/docs/00-project/00-map.md
@@ -1,41 +1,39 @@
 # BioETL Project Navigator
 
-*Synced with RULES.md v5.21 | Last updated: 2026-02-21*
+*Synced with RULES.md v5.21 | Last updated: 2026-02-24*
 
-> **Documentation Update:** 2026-02-17
-> - Codebase metrics updated: 1,120 Python files (534 src + 586 tests), ~116,120 src LOC
-> - ADR count: 34 ADRs (ADR-001 through ADR-034)
-> - Pipeline configs: 26 configurations (21 single-source + 5 composite)
-> - YAML configs total: 121 (26 pipelines + 35 DQ + 34 filters + 26 schemas)
-> - Documentation files: 273 markdown files
-> - Adapter listing completed (all 7 providers)
-> - Diagrams: 50+ Mermaid source files
+> **Documentation Update:** 2026-02-24
+>
+> - Added Codex operational guidance in `docs/00-project/agents/CODEX.md` (architecture audit + implementation protocol)
+> - Added AI agent index page with explicit links to AGENT/CLAUDE/GEMINI/CODEX instructions
+> - Navigator quick links extended with AI agent guidance entry
 
 ## Quick Links
 
-| Need to...              | Go to                                                                  |
-|-------------------------|------------------------------------------------------------------------|
-| Understand the rules    | [RULES.md](RULES.md)                 |
-| Look up terminology     | [glossary.md](glossary.md)           |
-| Create a new pipeline   | [governance/04-extending-bioetl.md](governance/04-extending-bioetl.md)      |
+| Need to...              | Go to                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| Understand the rules    | [RULES.md](RULES.md)                                                                   |
+| Look up terminology     | [glossary.md](glossary.md)                                                             |
+| Create a new pipeline   | [governance/04-extending-bioetl.md](governance/04-extending-bioetl.md)                 |
 | Review a pipeline       | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md) |
-| Handle a prod error     | [runbooks/index.md](../05-operations/runbooks/index.md)                           |
-| Understand architecture | [00-overview.md](../02-architecture/00-overview.md)                  |
-| Check data contracts    | [chembl_activity_v1.0.json](../04-reference/contracts/gold/chembl_activity_v1.0.json)          |
+| Handle a prod error     | [runbooks/index.md](../05-operations/runbooks/index.md)                                |
+| Understand architecture | [00-overview.md](../02-architecture/00-overview.md)                                    |
+| Check data contracts    | [chembl_activity_v1.0.json](../04-reference/contracts/gold/chembl_activity_v1.0.json)  |
+| AI agent instructions   | [agents/README.md](agents/README.md)                                                   |
 
----
+______________________________________________________________________
 
 ## Language Policy
 
-| Category | Language | Examples |
-|----------|----------|----------|
-| **Public-facing** | English | README.md, CONTRIBUTING.md, CHANGELOG.md |
-| **User guides** | English | docs/03-guides/*, docs/04-reference/* |
-| **Internal governance** | Russian | RULES.md, AGENT.md, docs/00-project/governance/* |
-| **Architecture docs** | Russian | docs/02-architecture/* |
-| **Code comments** | Russian | Docstrings, inline comments |
+| Category                | Language | Examples                                          |
+| ----------------------- | -------- | ------------------------------------------------- |
+| **Public-facing**       | English  | README.md, CONTRIBUTING.md, CHANGELOG.md          |
+| **User guides**         | English  | docs/03-guides/*, docs/04-reference/*             |
+| **Internal governance** | Russian  | RULES.md, AGENT.md, docs/00-project/governance/\* |
+| **Architecture docs**   | Russian  | docs/02-architecture/\*                           |
+| **Code comments**       | Russian  | Docstrings, inline comments                       |
 
----
+______________________________________________________________________
 
 ## Documentation Structure
 
@@ -88,102 +86,102 @@ docs/
     └── ...
 ```
 
----
+______________________________________________________________________
 
 ## By Topic
 
 ### Getting Started
 
 1. [RULES.md](RULES.md) - Project rules (start here)
-2. [rules-summary.md](rules-summary.md) - Quick reference
-3. [04-extending-bioetl.md](governance/04-extending-bioetl.md) - Adding providers/pipelines
+1. [rules-summary.md](rules-summary.md) - Quick reference
+1. [04-extending-bioetl.md](governance/04-extending-bioetl.md) - Adding providers/pipelines
 
 ### Architecture
 
-| Document                                                                                     | Covers                                   | RULES.md |
-|----------------------------------------------------------------------------------------------|------------------------------------------|----------|
-| [system-context.md](../02-architecture/system-context.md)                                       | Entity models, IDs, relationships        | §2.8     |
-| [container-diagram.md](../02-architecture/container-diagram.md)                               | C4 Container, Docker services            | §5.6     |
-| [data-flow.md](../02-architecture/data-flow.md)                                                 | Ports & Adapters, layer responsibilities | §1.1     |
-| [05-composition-layer.md](../02-architecture/05-composition-layer.md)                           | Composition Root, DI, Factories          | §1.1     |
-| [ADR-001: Delta Lake](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)            | Storage engine choice                    | §2.1, §3 |
-| [ADR-002: Medallion](../02-architecture/decisions/ADR-002-medallion-architecture.md)            | Data layering pattern                    | §1       |
-| [ADR-003: In-Memory Locking](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md) | MemoryLock strategy                      | §6       |
-| [ADR-004: Pydantic](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)            | Validation approach                      | -        |
-| [ADR-005: Composition Layer](../02-architecture/decisions/ADR-005-composition-layer-separation.md) | DI and layer separation               | §1.1     |
-| [ADR-006: Logger/Metrics Ports](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)   | Port abstractions                        | §1.1     |
-| [ADR-007: Circuit Breaker](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) | Failure handling pattern               | §3.1.4   |
-| [ADR-008: Graceful Shutdown](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md) | SIGTERM/SIGINT handling                  | §5.3     |
-| [ADR-009: Paginated Fetcher](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)   | Pagination abstraction                   | App D    |
-| [ADR-010: Local-Only Deploy](../02-architecture/decisions/ADR-010-local-only-deployment.md)     | File-based deployment (no Docker)        | §5.6     |
-| [ADR-011: Watermark Removal](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md) | Simplified checkpoint model             | §2.4     |
-| [ADR-012: Storage Clear Contract](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage clear API, run-id injection | §2.1     |
-| [ADR-013: Async Storage Cleanup](../02-architecture/decisions/ADR-013-async-storage-cleanup.md) | MedallionLifecycleService pattern        | §2.1     |
-| [ADR-014: Deterministic Writes](../02-architecture/decisions/ADR-014-deterministic-writes.md)   | SCD2 ingestion-ts, reproducible writes   | §2.1     |
-| [ADR-015: Pipeline Services Lifecycle](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md) | Port lifecycle contracts       | §1.1     |
-| [ADR-016: Error Handling Strategy](../02-architecture/decisions/ADR-016-error-handling-strategy.md) | Unified error classification          | §3.1     |
-| [ADR-017: Observability Architecture](../02-architecture/decisions/ADR-017-observability-architecture.md) | Metrics, tracing, logging ports    | §5.1     |
-| [ADR-018: Gold Strict Validation](../02-architecture/decisions/ADR-018-gold-strict-validation.md) | Pandera Gold validation                | §2.7     |
-| [ADR-019: Observability Port Enforcement](../02-architecture/decisions/ADR-019-observability-port-enforcement.md) | REQ-OBS-001 compliance       | §5.1     |
-| [ADR-020: BasePipeline Decomposition](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md) | God Object refactoring       | §1.1     |
-| [ADR-021: DDD Aggregates](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md) | DDD aggregates adoption       | -        |
-| [ADR-022: Tracing NoOp](../02-architecture/decisions/ADR-022-tracing-noop.md) | NoOp for tracing              | -        |
-| [ADR-023: Entity Type Patterns](../02-architecture/decisions/ADR-023-entity-type-patterns.md) | Entity type patterns          | -        |
-| [ADR-024: Entity Naming Unification](../02-architecture/decisions/ADR-024-entity-naming-unification.md) | Entity naming unification     | -        |
-| [ADR-025: Pipeline Config Unification](../02-architecture/decisions/ADR-025-pipeline-config-unification.md) | Pipeline config unification   | -        |
-| [ADR-026: Composite Pipeline Pattern](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) | Composite pipeline pattern    | -        |
-| [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md) | Hierarchical DQ configuration | §3.1.2   |
-| [ADR-028: Filter Rules Externalization](../02-architecture/decisions/ADR-028-filter-rules-externalization.md) | Hierarchical filter configuration | App D   |
-| [ADR-029: Output Metadata Unification](../02-architecture/decisions/ADR-029-output-metadata-unification.md) | Unified output metadata contracts | §2.4    |
-| [ADR-030: Publication Pagination Strategy](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication pagination strategy | -       |
-| [ADR-031: Loading Strategy Formalization](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md) | Loading strategy formalization | -       |
-| [ADR-032: Unified HTTP Client](../02-architecture/decisions/ADR-032-unified-http-client.md) | Unified HTTP client pattern | App A   |
+| Document                                                                                                            | Covers                                   | RULES.md |
+| ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | -------- |
+| [system-context.md](../02-architecture/system-context.md)                                                           | Entity models, IDs, relationships        | §2.8     |
+| [container-diagram.md](../02-architecture/container-diagram.md)                                                     | C4 Container, Docker services            | §5.6     |
+| [data-flow.md](../02-architecture/data-flow.md)                                                                     | Ports & Adapters, layer responsibilities | §1.1     |
+| [05-composition-layer.md](../02-architecture/05-composition-layer.md)                                               | Composition Root, DI, Factories          | §1.1     |
+| [ADR-001: Delta Lake](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)                                | Storage engine choice                    | §2.1, §3 |
+| [ADR-002: Medallion](../02-architecture/decisions/ADR-002-medallion-architecture.md)                                | Data layering pattern                    | §1       |
+| [ADR-003: In-Memory Locking](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)                    | MemoryLock strategy                      | §6       |
+| [ADR-004: Pydantic](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)                                | Validation approach                      | -        |
+| [ADR-005: Composition Layer](../02-architecture/decisions/ADR-005-composition-layer-separation.md)                  | DI and layer separation                  | §1.1     |
+| [ADR-006: Logger/Metrics Ports](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)                       | Port abstractions                        | §1.1     |
+| [ADR-007: Circuit Breaker](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)                  | Failure handling pattern                 | §3.1.4   |
+| [ADR-008: Graceful Shutdown](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)                    | SIGTERM/SIGINT handling                  | §5.3     |
+| [ADR-009: Paginated Fetcher](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)                       | Pagination abstraction                   | App D    |
+| [ADR-010: Local-Only Deploy](../02-architecture/decisions/ADR-010-local-only-deployment.md)                         | File-based deployment (no Docker)        | §5.6     |
+| [ADR-011: Watermark Removal](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md)                    | Simplified checkpoint model              | §2.4     |
+| [ADR-012: Storage Clear Contract](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md)        | Storage clear API, run-id injection      | §2.1     |
+| [ADR-013: Async Storage Cleanup](../02-architecture/decisions/ADR-013-async-storage-cleanup.md)                     | MedallionLifecycleService pattern        | §2.1     |
+| [ADR-014: Deterministic Writes](../02-architecture/decisions/ADR-014-deterministic-writes.md)                       | SCD2 ingestion-ts, reproducible writes   | §2.1     |
+| [ADR-015: Pipeline Services Lifecycle](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md)         | Port lifecycle contracts                 | §1.1     |
+| [ADR-016: Error Handling Strategy](../02-architecture/decisions/ADR-016-error-handling-strategy.md)                 | Unified error classification             | §3.1     |
+| [ADR-017: Observability Architecture](../02-architecture/decisions/ADR-017-observability-architecture.md)           | Metrics, tracing, logging ports          | §5.1     |
+| [ADR-018: Gold Strict Validation](../02-architecture/decisions/ADR-018-gold-strict-validation.md)                   | Pandera Gold validation                  | §2.7     |
+| [ADR-019: Observability Port Enforcement](../02-architecture/decisions/ADR-019-observability-port-enforcement.md)   | REQ-OBS-001 compliance                   | §5.1     |
+| [ADR-020: BasePipeline Decomposition](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md)           | God Object refactoring                   | §1.1     |
+| [ADR-021: DDD Aggregates](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)                          | DDD aggregates adoption                  | -        |
+| [ADR-022: Tracing NoOp](../02-architecture/decisions/ADR-022-tracing-noop.md)                                       | NoOp for tracing                         | -        |
+| [ADR-023: Entity Type Patterns](../02-architecture/decisions/ADR-023-entity-type-patterns.md)                       | Entity type patterns                     | -        |
+| [ADR-024: Entity Naming Unification](../02-architecture/decisions/ADR-024-entity-naming-unification.md)             | Entity naming unification                | -        |
+| [ADR-025: Pipeline Config Unification](../02-architecture/decisions/ADR-025-pipeline-config-unification.md)         | Pipeline config unification              | -        |
+| [ADR-026: Composite Pipeline Pattern](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)           | Composite pipeline pattern               | -        |
+| [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)               | Hierarchical DQ configuration            | §3.1.2   |
+| [ADR-028: Filter Rules Externalization](../02-architecture/decisions/ADR-028-filter-rules-externalization.md)       | Hierarchical filter configuration        | App D    |
+| [ADR-029: Output Metadata Unification](../02-architecture/decisions/ADR-029-output-metadata-unification.md)         | Unified output metadata contracts        | §2.4     |
+| [ADR-030: Publication Pagination Strategy](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication pagination strategy          | -        |
+| [ADR-031: Loading Strategy Formalization](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md)   | Loading strategy formalization           | -        |
+| [ADR-032: Unified HTTP Client](../02-architecture/decisions/ADR-032-unified-http-client.md)                         | Unified HTTP client pattern              | App A    |
 
 ### Data Management
 
-| Topic            | Document                                                                                            | RULES.md |
-|------------------|-----------------------------------------------------------------------------------------------------|----------|
-| Medallion Layers | [data-flow.md](../02-architecture/data-flow.md)                                                        | §2.1     |
-| Schema Drift     | [RULES.md](RULES.md#22-обработка-дрейфа-схемы)   | §2.2     |
-| Data Lineage     | [system-context.md](../02-architecture/system-context.md)                                              | §2.3     |
-| Backfill/Replay  | [RULES.md](RULES.md#24-стратегия-backfill-и-replay)            | §2.4     |
-| Quarantine       | [RULES.md](RULES.md#26-dead-letter-queue--quarantine) | §2.6     |
-| Content Hash     | [system-context.md](../02-architecture/system-context.md)                                              | §2.8     |
+| Topic            | Document                                                                                                                                           | RULES.md |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Medallion Layers | [data-flow.md](../02-architecture/data-flow.md)                                                                                                    | §2.1     |
+| Schema Drift     | [RULES.md](RULES.md#22-%D0%BE%D0%B1%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D0%B4%D1%80%D0%B5%D0%B9%D1%84%D0%B0-%D1%81%D1%85%D0%B5%D0%BC%D1%8B) | §2.2     |
+| Data Lineage     | [system-context.md](../02-architecture/system-context.md)                                                                                          | §2.3     |
+| Backfill/Replay  | [RULES.md](RULES.md#24-%D1%81%D1%82%D1%80%D0%B0%D1%82%D0%B5%D0%B3%D0%B8%D1%8F-backfill-%D0%B8-replay)                                              | §2.4     |
+| Quarantine       | [RULES.md](RULES.md#26-dead-letter-queue--quarantine)                                                                                              | §2.6     |
+| Content Hash     | [system-context.md](../02-architecture/system-context.md)                                                                                          | §2.8     |
 
 ### Schema Documentation
 
-| Provider | Entity | Schema Document | RULES.md |
-|----------|--------|-----------------|----------|
-| ChEMBL | Activity | [activity-schema.md](../04-reference/schemas/domain/chembl/activity-schema.md) | §2.8 |
-| ChEMBL | Molecule | [molecule-schema.md](../04-reference/schemas/domain/chembl/molecule-schema.md) | §2.8 |
-| ChEMBL | Target | [target-schema.md](../04-reference/schemas/domain/chembl/target-schema.md) | §2.8 |
-| ChEMBL | Assay | [assay-schema.md](../04-reference/schemas/domain/chembl/assay-schema.md) | §2.8 |
+| Provider | Entity   | Schema Document                                                                | RULES.md |
+| -------- | -------- | ------------------------------------------------------------------------------ | -------- |
+| ChEMBL   | Activity | [activity-schema.md](../04-reference/schemas/domain/chembl/activity-schema.md) | §2.8     |
+| ChEMBL   | Molecule | [molecule-schema.md](../04-reference/schemas/domain/chembl/molecule-schema.md) | §2.8     |
+| ChEMBL   | Target   | [target-schema.md](../04-reference/schemas/domain/chembl/target-schema.md)     | §2.8     |
+| ChEMBL   | Assay    | [assay-schema.md](../04-reference/schemas/domain/chembl/assay-schema.md)       | §2.8     |
 
 ### Operations
 
-| Topic             | Document                                                                                          | RULES.md |
-|-------------------|---------------------------------------------------------------------------------------------------|----------|
-| Error Handling    | [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)         | §3.1     |
-| Circuit Breaker   | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)  | §3.1.4   |
-| Locking           | [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)      | §3.3     |
-| DQ Metrics        | [RULES.md](RULES.md#34-data-quality-метрики)                                    | §3.4     |
-| Graceful Shutdown | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)      | §5.3     |
-| DR Procedures     | [runbooks/index.md](../05-operations/runbooks/index.md)                            | §5.5     |
-| Cleanup           | [cleanup-policy.md](../03-guides/cleanup-policy.md)                                | §2.1.1   |
+| Topic             | Document                                                                          | RULES.md |
+| ----------------- | --------------------------------------------------------------------------------- | -------- |
+| Error Handling    | [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)        | §3.1     |
+| Circuit Breaker   | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) | §3.1.4   |
+| Locking           | [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)     | §3.3     |
+| DQ Metrics        | [RULES.md](RULES.md#34-data-quality-%D0%BC%D0%B5%D1%82%D1%80%D0%B8%D0%BA%D0%B8)   | §3.4     |
+| Graceful Shutdown | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)     | §5.3     |
+| DR Procedures     | [runbooks/index.md](../05-operations/runbooks/index.md)                           | §5.5     |
+| Cleanup           | [cleanup-policy.md](../03-guides/cleanup-policy.md)                               | §2.1.1   |
 
 ### Development
 
-| Topic            | Document                                                                                        | RULES.md |
-|------------------|-------------------------------------------------------------------------------------------------|----------|
-| Adding Providers | [add-new-source.md](../03-guides/add-new-source.md)                                                | App D    |
-| Adding Pipelines | [add-pipeline-existing-source.md](../03-guides/add-pipeline-existing-source.md)                    | App D    |
-| Pipeline Review  | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md)                          | §4.2     |
-| Testing          | [testing.md](../03-guides/testing.md)                                                              | §4.2     |
-| E2E Testing      | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)                           | §4.2.3   |
-| Date Handling    | [date-handling.md](../03-guides/date-handling.md)                                                  | §2.4     |
-| Code Style       | [RULES.md §4](RULES.md#4-качество-кода-и-тестирование)                                          | §4       |
+| Topic            | Document                                                                                                                                                                            | RULES.md |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Adding Providers | [add-new-source.md](../03-guides/add-new-source.md)                                                                                                                                 | App D    |
+| Adding Pipelines | [add-pipeline-existing-source.md](../03-guides/add-pipeline-existing-source.md)                                                                                                     | App D    |
+| Pipeline Review  | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md)                                                                                              | §4.2     |
+| Testing          | [testing.md](../03-guides/testing.md)                                                                                                                                               | §4.2     |
+| E2E Testing      | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)                                                                                                            | §4.2.3   |
+| Date Handling    | [date-handling.md](../03-guides/date-handling.md)                                                                                                                                   | §2.4     |
+| Code Style       | [RULES.md §4](RULES.md#4-%D0%BA%D0%B0%D1%87%D0%B5%D1%81%D1%82%D0%B2%D0%BE-%D0%BA%D0%BE%D0%B4%D0%B0-%D0%B8-%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5) | §4       |
 
----
+______________________________________________________________________
 
 ## Source Code Map
 
@@ -305,7 +303,7 @@ tests/
     └── vcr/                     # VCR cassettes for HTTP
 ```
 
----
+______________________________________________________________________
 
 ## Config Files Map
 
@@ -322,31 +320,31 @@ graph TD
     end
 ```
 
----
+______________________________________________________________________
 
 ## Key Files
 
-| File                                               | Purpose                   |
-|----------------------------------------------------|---------------------------|
-| `docs/00-project/RULES.md`                         | Master rules document     |
-| `docs/00-project/glossary.md`                      | Ubiquitous Language terminology |
-| `CHANGELOG.md`                                     | Version history           |
-| `configs/pipelines/{provider}/{entity}.yaml`       | Pipeline configuration    |
-| `src/bioetl/domain/ports/`                         | Protocol interfaces (package) |
-| `src/bioetl/composition/bootstrap-contexts.py`     | Composition root          |
-| `src/bioetl/infrastructure/config.py`              | Application settings      |
-| `docs/02-architecture/system-context.md`           | High-level system diagram |
-| `docs/04-reference/contracts/gold/{entity}.json`   | Gold data contracts       |
+| File                                             | Purpose                         |
+| ------------------------------------------------ | ------------------------------- |
+| `docs/00-project/RULES.md`                       | Master rules document           |
+| `docs/00-project/glossary.md`                    | Ubiquitous Language terminology |
+| `CHANGELOG.md`                                   | Version history                 |
+| `configs/pipelines/{provider}/{entity}.yaml`     | Pipeline configuration          |
+| `src/bioetl/domain/ports/`                       | Protocol interfaces (package)   |
+| `src/bioetl/composition/bootstrap-contexts.py`   | Composition root                |
+| `src/bioetl/infrastructure/config.py`            | Application settings            |
+| `docs/02-architecture/system-context.md`         | High-level system diagram       |
+| `docs/04-reference/contracts/gold/{entity}.json` | Gold data contracts             |
 
----
+______________________________________________________________________
 
 ### CI/CD & GitHub
 
-| Topic | Document | RULES.md |
-|-------|----------|----------|
-| GitHub Policy | [05-github-policy.md](governance/05-github-policy.md) | §4, §5 |
-| Contributing | [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) | — |
-| Security | [SECURITY.md](../../.github/SECURITY.md) | §5.4 |
+| Topic         | Document                                              | RULES.md |
+| ------------- | ----------------------------------------------------- | -------- |
+| GitHub Policy | [05-github-policy.md](governance/05-github-policy.md) | §4, §5   |
+| Contributing  | [CONTRIBUTING.md](../../.github/CONTRIBUTING.md)      | —        |
+| Security      | [SECURITY.md](../../.github/SECURITY.md)              | §5.4     |
 
 ## Related Resources
 
@@ -354,26 +352,26 @@ graph TD
 - **Issues**: Report bugs and feature requests
 - **CI/CD**: GitHub Actions workflows ([GitHub Policy](governance/05-github-policy.md))
 
----
+______________________________________________________________________
 
 ## Document Status
 
-| Document                 | Last Updated | Status                       |
-|--------------------------|--------------|------------------------------|
-| RULES.md                 | 2026-02-21   | v5.21 (Latest)               |
-| REQUIREMENTS.md          | 2026-02-21   | v1.5 (Local-Only sync)       |
-| glossary.md              | 2026-02-06   | v2.5 (Ubiquitous Language)   |
-| 00-map.md                | 2026-02-21   | v7.3 Audit remediation       |
-| rules-summary.md         | 2026-02-21   | v5.21 Synced                 |
-| TOOLS.md                 | 2026-02-21   | v2.1 Synced with RULES v5.21 |
-| 03-guides/               | 2026-01-20   | Consolidated (16 guides)     |
-| 03-development/          | 2026-01-26   | Config schema guidelines     |
-| ADR-001..034             | 2026-02-17   | All 34 ADRs documented       |
-| 05-operations/runbooks/  | 2026-01-04   | 16 active runbooks           |
-| domain/schemas/          | 2025-12-28   | ChEMBL schemas (4 entities)  |
-| audits/                  | 2026-02-17   | Consolidated (audit/ merged) |
-| 02-architecture/diagrams/| 2025-12-31   | 50+ Mermaid diagrams         |
+| Document                  | Last Updated | Status                       |
+| ------------------------- | ------------ | ---------------------------- |
+| RULES.md                  | 2026-02-21   | v5.21 (Latest)               |
+| REQUIREMENTS.md           | 2026-02-21   | v1.5 (Local-Only sync)       |
+| glossary.md               | 2026-02-06   | v2.5 (Ubiquitous Language)   |
+| 00-map.md                 | 2026-02-21   | v7.3 Audit remediation       |
+| rules-summary.md          | 2026-02-21   | v5.21 Synced                 |
+| TOOLS.md                  | 2026-02-21   | v2.1 Synced with RULES v5.21 |
+| 03-guides/                | 2026-01-20   | Consolidated (16 guides)     |
+| 03-development/           | 2026-01-26   | Config schema guidelines     |
+| ADR-001..034              | 2026-02-17   | All 34 ADRs documented       |
+| 05-operations/runbooks/   | 2026-01-04   | 16 active runbooks           |
+| domain/schemas/           | 2025-12-28   | ChEMBL schemas (4 entities)  |
+| audits/                   | 2026-02-17   | Consolidated (audit/ merged) |
+| 02-architecture/diagrams/ | 2025-12-31   | 50+ Mermaid diagrams         |
 
----
+______________________________________________________________________
 
 *Last updated: 2026-02-21. Audit remediation (P0+P1) applied.*

--- a/docs/00-project/agents/CODEX.md
+++ b/docs/00-project/agents/CODEX.md
@@ -1,0 +1,209 @@
+# CODEX.md — Пользовательские инструкции для Codex (BioETL Architecture Auditor)
+
+*Версия: 1.0 (консолидировано из веток `codex/develop-user-instructions-for-codex*`) | Основано на `docs/00-project/RULES.md`, `AGENT.md`, `CLAUDE.md`, `GEMINI.md` | Дата: 2026-02-24*
+
+## 1) Роль и цель
+
+Ты — **Architecture Auditor + Implementation Engineer** проекта BioETL.
+
+**Цель по умолчанию:**
+
+1. Выполнить задачу пользователя.
+1. Сохранить архитектурную целостность (Hexagonal + DDD + Medallion).
+1. Не допускать ложноположительных выводов: каждое утверждение подтверждать кодом.
+
+**Ключевой принцип:** ни одного архитектурного утверждения без проверки (файл + строки + команда).
+
+______________________________________________________________________
+
+## 2) Обязательный контекст перед работой
+
+Перед изменениями/аудитом обязательно сверяться с:
+
+1. `docs/00-project/RULES.md` (источник требований RFC 2119),
+1. `docs/00-project/agents/AGENT.md`,
+1. `docs/00-project/agents/CLAUDE.md`,
+1. `docs/00-project/agents/GEMINI.md`,
+1. `docs/00-project/agents/memory.md`,
+1. `docs/00-project/agents/orchestration/ORCHESTRATION.md` (для сложных задач).
+
+Если уверенность недостаточна — помечай **Requires Manual Review**, а не делай предположений.
+
+______________________________________________________________________
+
+## 3) Критический архитектурный контекст
+
+### 3.1 Deployment (ADR-010)
+
+Проект **local-only по дизайну**. Это валидная целевая модель.
+
+- Locking: `MemoryLock` (TTL 90s, heartbeat 30s)
+- Storage: локальное `data/`
+- Не требовать Docker/Redis без явного требования задачи
+
+### 3.2 Слои
+
+- `domain/` — чистая бизнес-логика и порты, без I/O
+- `application/` — use-cases и orchestration
+- `infrastructure/` — адаптеры
+- `composition/` — composition root / DI / factories
+- `interfaces/` — CLI и entrypoints
+
+### 3.3 Medallion
+
+- Bronze: JSONL + zstd (append-only)
+- Silver: **только Delta Lake** (merge/upsert)
+- Gold: Delta/Parquet по политике слоя
+
+______________________________________________________________________
+
+## 4) Что считать нарушением
+
+### MUST (критические)
+
+1. Нарушение границ слоёв (по `RULES.md`/архитектурным тестам).
+1. I/O в `domain` (`httpx/requests/open()/print()` и т.п.).
+1. Hardcoded secrets/credentials.
+1. Sentinel values (`-1`, `"N/A"`) вместо `None`.
+1. Raw Parquet в Silver вместо Delta Lake.
+1. Отсутствие type annotations в публичном API.
+1. `print()` вместо структурированного логирования.
+
+### SHOULD (умеренные)
+
+1. Нет docstrings у публичных сущностей.
+1. Нарушения naming conventions.
+1. Логи без `run_id` в pipeline-контексте.
+1. Блокирующий I/O в async-коде.
+
+______________________________________________________________________
+
+## 5) Валидные паттерны (НЕ считать нарушением)
+
+- `param: T | None = None` в DI/конфигурации.
+- NoOp-реализации (`NoOpTracing`, `NoOpMetrics`).
+- Backward-compatible re-export/shims.
+- Большие файлы при корректном делегировании.
+- Graceful degradation.
+- CLI user confirmations.
+- `MemoryLock` для local-only сценария.
+
+______________________________________________________________________
+
+## 6) Обязательный протокол верификации
+
+Перед **каждым** архитектурным выводом:
+
+1. Найти конкретный файл и диапазон строк.
+1. Прочитать реализацию, не только сигнатуры.
+1. Проверить делегирование (большой файл ≠ god object).
+1. Проверить фактические импорты.
+1. Проверить связанные тесты.
+
+Рекомендуемые команды:
+
+```bash
+wc -l src/bioetl/path/to/file.py
+grep -c "def \|async def " src/bioetl/path/to/file.py
+grep -n "self\._.*\." src/bioetl/path/to/file.py | head -20
+grep "^from\|^import" src/bioetl/path/to/file.py
+find tests/ -name "test_*.py" -exec grep -l "ClassName" {} \;
+uv run python -m pytest tests/architecture/ -v
+uv run python -m mypy --strict src/bioetl/
+```
+
+______________________________________________________________________
+
+## 7) Формат отчёта аудита
+
+Используй RFC 2119-семантику и уровни:
+
+- **Critical (P1)** = MUST violation
+- **Moderate (P2)** = SHOULD deviation
+- **Informational (P3)** = MAY / рекомендация
+
+Шаблон finding:
+
+````markdown
+## [SEVERITY] Finding title
+
+**Location**: `src/.../file.py:42-56`
+**Rule**: RULES.md §X.Y
+
+**Evidence**:
+```python
+# реальный фрагмент кода
+```
+
+**Impact**: ...
+
+**Recommendation**:
+```python
+# исправленный вариант
+```
+
+**Verification command**: `...`
+````
+
+Шаблон summary:
+
+```markdown
+# Architecture Audit Report
+Date: YYYY-MM-DD
+Scope: ...
+
+## Executive Summary
+- Total findings: X
+- Critical (MUST): Y
+- Moderate (SHOULD): Z
+- Informational (MAY): W
+
+## Critical Findings
+## Moderate Findings
+## Positive Observations
+## Verification Log
+```
+
+______________________________________________________________________
+
+## 8) Domain-specific проверки BioETL
+
+1. **Content hash**: `sha256(provider + canonical_json_dumps(record))`
+1. Нормализация до hash:
+   - NaN/Inf → `null`
+   - float → `round(val, 10)`
+   - date → `YYYY-MM-DD`
+   - string → `strip()`
+   - исключить: `_ingestion_ts`, `_run_id`, `_run_type`, `_dq_*`
+1. DQ thresholds:
+   - > 5% ошибок → warning
+   - > 20% ошибок → fail batch
+1. Circuit breaker:
+   - trigger: 5 ошибок подряд
+   - open: 5 минут
+   - recovery: half-open + 1 probe
+1. Locking (local-only): `MemoryLock`, TTL 90s, heartbeat 30s, max duration 4h
+
+______________________________________________________________________
+
+## 9) Anti-pattern checklist
+
+- Layer boundary violations
+- I/O в domain
+- Hardcoded secrets
+- Sentinel values вместо `None`
+- `print()` вместо logging
+- Нет type annotations в public API
+- Blocking I/O в async
+- Raw Parquet в Silver
+- HTTP-тесты без VCR
+- Секреты в VCR-кассетах
+
+______________________________________________________________________
+
+## 10) Definition of Done для Codex
+
+1. Изменения соответствуют слоям, DI и Data Layer требованиям.
+1. Тесты/проверки выполнены (или ограничение среды явно зафиксировано).
+1. Документация обновлена при изменении поведения/контрактов.
+1. В отчёте нет недоказанных утверждений.

--- a/docs/00-project/agents/README.md
+++ b/docs/00-project/agents/README.md
@@ -1,1 +1,19 @@
 # AI Agents Context
+
+Этот каталог содержит профильные инструкции для разных AI-ассистентов, используемых в BioETL.
+
+## Available Agent Guides
+
+| Agent         | File                                                             | Purpose                                                   |
+| ------------- | ---------------------------------------------------------------- | --------------------------------------------------------- |
+| Jules         | [AGENT.md](AGENT.md)                                             | Основной инженерный гайд и workflow выполнения задач      |
+| Claude Code   | [CLAUDE.md](CLAUDE.md)                                           | Практики для Claude при работе с репозиторием             |
+| Gemini        | [GEMINI.md](GEMINI.md)                                           | Профильный набор правил и ограничений для Gemini          |
+| Codex         | [CODEX.md](CODEX.md)                                             | Инструкции Architecture Auditor + Implementation Engineer |
+| Shared memory | [memory.md](memory.md)                                           | Краткая оперативная память по проекту                     |
+| Orchestration | [orchestration/ORCHESTRATION.md](orchestration/ORCHESTRATION.md) | Порядок взаимодействия субагентов и артефакты             |
+
+## Notes
+
+- `RULES.md` остаётся canonical source всех RFC 2119 требований.
+- При конфликте инструкций приоритет: System/Developer/User > локальные инструкции агента.


### PR DESCRIPTION
### Motivation

- Provide a dedicated, discoverable playbook for the Codex Architecture Auditor role to standardize verification and implementation workflows across the repository.
- Make AI-agent guidance easier to find by adding an index entry and navigator update so contributors can follow a single, consistent protocol when performing audits or doc-driven changes.

### Description

- Added the Codex playbook at `docs/00-project/agents/CODEX.md` containing role, verification protocol, audit report templates, anti-pattern checklist, and Definition of Done (file: `docs/00-project/agents/CODEX.md`, lines 1-209). 
- Expanded the agents index from a placeholder to a usable index and linked the new playbook in `docs/00-project/agents/README.md` (file: `docs/00-project/agents/README.md`, lines 1-19).
- Updated the project navigator `docs/00-project/00-map.md` to include the documentation update note and a quick link to the agents index (file: `docs/00-project/00-map.md`, lines 3-23).
- Recorded the change in `CHANGELOG.md` under Unreleased to document the addition (file: `CHANGELOG.md`, lines 8-14).

### Testing

- Verified formatting and diffs with `git diff --check`, which passed before committing. 
- Ran repository pre-commit hooks during commit attempts; hooks reported `mdformat` auto-fixes and environment-related failures (`pip-audit` missing, root-layout checks), so layout and links were adjusted (moved `CODEX.md` to `docs/00-project/agents/`) and commits were finalized after fixes; final commit created successfully (commit `36a885d`).
- No unit/integration tests were run as this is a documentation-only change; no code behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3366dfa48324a8055b269d8d20c7)