### PR TITLE
docs: add 2026-02-24 code duplication analysis report

### DIFF
--- a/docs/99-archive/reports/code-duplication-analysis-2026-02-24.md
+++ b/docs/99-archive/reports/code-duplication-analysis-2026-02-24.md
@@ -1,141 +1,170 @@
-# Отчёт: Анализ дублирования кода BioETL
+# Architecture Audit Report — Code Duplication Consolidation
 
-**Дата**: 2026-02-24
-**Ветка**: main
+Date: 2026-02-24  
+Scope: `src/bioetl/application/**`, `src/bioetl/infrastructure/adapters/**`, зависимые factory/tests  
+Requested branches: `codex/analyze-code-duplication-and-extract-logic`, `codex/analyze-code-duplication-and-extract-logic-qds3s7`, `codex/analyze-code-duplication-and-extract-logic-n50rpx`
 
 ## Executive Summary
 
-- Проанализировано: 25 transformer-модулей в `src/bioetl/application` (по паттерну `*transformer*.py`) и mixin/base-компоненты в `src/bioetl/infrastructure/adapters`.
-- Обнаружено категорий потенциального дублирования: **2** (обе — низкий приоритет, P3/P4).
-- Оценка потенциального сокращения: **~55-75 LOC** без изменения бизнес-семантики.
-- Критических (MUST) нарушений архитектуры не обнаружено: дублирование локализовано в «шаблонном» glue-коде поверх уже существующих базовых классов.
+- Total findings: **2**
+- Critical (MUST): **0**
+- Moderate (SHOULD): **0**
+- Informational (MAY): **2**
+- Потенциальное сокращение шаблонного кода: **~55-120 LOC** (без изменения business semantics).
 
-## 1. Карты зависимостей
+## Consolidation Status (requested branches)
 
-## Карта зависимостей для publication transformer constructors (`__init__` passthrough)
+- `git branch --all` в текущем окружении содержит только рабочую ветку (`work`), без запрошенных веток.
+- Поэтому выполнена консолидация по **доступным артефактам и исходному коду** с пометкой:
+  - **Requires Manual Review**: сверка с отсутствующими branch refs при их публикации/доступе.
 
-### Импортёры
+## Dependency Maps (RULES §14 protocol)
 
-- `src/bioetl/composition/factories/pipeline_factories.py`: импортирует все 4 publication transformers для регистрации пайплайнов.
-- `src/bioetl/composition/factories/transformer_factory.py`: импортирует те же классы для DI-фабрики.
-- `src/bioetl/application/pipelines/{openalex,crossref,pubmed,semanticscholar}/__init__.py`: re-export классов.
+### Map A — publication transformer constructors (`__init__` passthrough)
 
-### Пользователи
+#### Importers
 
-- DI-регистрация через `transformer_class=...` в `pipeline_factories.py`.
-- Архитектурные тесты сигнатур в `tests/architecture/test_transformer_signatures.py`.
+- `src/bioetl/composition/factories/pipeline_factories.py` — импортирует publication transformers и регистрирует их как `transformer_class`.
+- `src/bioetl/composition/factories/transformer_factory.py` — импортирует те же классы для DI-фабрики.
+- `src/bioetl/application/pipelines/{openalex,crossref,pubmed,semanticscholar}/__init__.py` — re-export.
 
-### Тесты
+#### Users
 
-- `tests/unit/application/pipelines/openalex/test_transformer.py`
-- `tests/unit/application/pipelines/semanticscholar/test_transformer.py`
-- `tests/unit/pipelines/pubmed/test_pubmed_transformer.py`
-- `tests/integration/test_cross_provider_doi_normalization.py`
-- `tests/architecture/test_transformer_signatures.py`
+- `tests/architecture/test_transformer_signatures.py` — валидирует сигнатуры и inheritance.
+- Unit/integration tests публикационных трансформеров (OpenAlex/CrossRef/PubMed/S2).
 
-### Порядок миграции
+#### Migration Order
 
-1. Сначала обновить `BasePublicationTransformer` (ввести class-level defaults для provider/entity).
-1. Затем упростить `__init__` в OpenAlex/CrossRef/S2 (PubMed оставить отдельным из-за stateful init).
-1. Затем обновить архитектурные тесты сигнатур (если меняется конструктор).
-1. Затем прогнать unit/integration тесты публикационных трансформеров.
+1. Сначала обновить `BasePublicationTransformer` (если вводятся class-level defaults).
+2. Затем упростить `__init__` в OpenAlex/CrossRef/S2.
+3. PubMed оставить отдельным (stateful init).
+4. Обновить architecture tests сигнатур.
 
-______________________________________________________________________
+### Map B — selector hooks (`_get_primary_id_field`, `_get_entity_class`)
 
-## Карта зависимостей для selector-методов (`_get_primary_id_field`, `_get_entity_class`)
+#### Importers / Users
 
-### Импортёры
+- `BasePublicationTransformer._transform_impl()` вызывает `_get_primary_id_field()` и `_get_entity_class()` в Template Method потоке.
 
-- Непрямо используются через наследование в `BasePublicationTransformer._transform_impl()`.
-
-### Пользователи
-
-- `src/bioetl/application/pipelines/common/base_publication_transformer.py` вызывает оба selector-hook метода в общем потоке трансформации.
-
-### Тесты
+#### Tests
 
 - `tests/unit/application/pipelines/common/test_base_publication_transformer.py`
 - `tests/architecture/test_transformer_signatures.py`
 
-### Порядок миграции
+#### Migration Order
 
-1. Ввести class attrs (например `PRIMARY_ID_FIELD`, `ENTITY_CLASS`) в `BasePublicationTransformer`.
-1. Перевести 4 publication transformers на декларативные атрибуты.
-1. Удалить однотипные hook-методы там, где это не ломает typing/mypy.
-1. Прогнать unit-тесты base/publication и архитектурные проверки.
+1. Ввести class attrs в base (`PRIMARY_ID_FIELD`, `ENTITY_CLASS`) опционально.
+2. Перевести publication transformers на декларативные attrs.
+3. Сохранить backward-compatible hooks в переходный период.
 
-## 2. Верифицированные дублирования
+## Findings
 
-### 2.1 Повторяющиеся passthrough-конструкторы в publication transformers
+## [Informational (P3)] Repeated passthrough `__init__` in publication transformers
 
-**Наблюдение:** в `OpenAlexPublicationTransformer`, `CrossRefPublicationTransformer`, `SemanticScholarPublicationTransformer` конструкторы практически идентичны: одинаковые параметры DI и прямой `super().__init__(...)` без добавления состояния.
+**Location**:
+- `src/bioetl/application/pipelines/openalex/transformer.py:83-122`
+- `src/bioetl/application/pipelines/crossref/transformer.py:68-107`
+- `src/bioetl/application/pipelines/semanticscholar/transformer.py:83-122`
+- Counter-example: `src/bioetl/application/pipelines/pubmed/transformer.py:88-130`
 
-**Доказательства (файлы):**
+**Rule**: DRY optimization opportunity (MAY), not an architecture violation.
 
-- `openalex/transformer.py` — `__init__` только проксирует параметры в `super()`.
-- `crossref/transformer.py` — тот же паттерн.
-- `semanticscholar/transformer.py` — тот же паттерн.
-- Контрпример: `pubmed/transformer.py` после `super()` добавляет состояние (`_cached_xml_root`, extractors), поэтому это **не** дублирование.
+**Evidence**:
 
-**Оценка объёма:** ~18-24 LOC на класс × 3 класса = ~54-72 LOC.
+```python
+# openalex
+super().__init__(
+    provider,
+    entity_type=entity_type,
+    tracer=tracer,
+    metrics=metrics,
+    silver_filters=silver_filters,
+    gold_filters=gold_filters,
+    identity_service=identity_service,
+    pii_hasher=pii_hasher,
+    data_normalizer=data_normalizer,
+    contract_policy=contract_policy,
+)
+```
 
-**Рекомендуемый родительский объект:** расширить `BasePublicationTransformer` class-level defaults (`DEFAULT_PROVIDER`, `DEFAULT_ENTITY_TYPE`) и оставить возможность override через kwargs.
+```python
+# pubmed (semantic difference)
+super().__init__(...)
+self._cached_xml_root = None
+self._author_extractor = AuthorExtractor()
+self._date_extractor = DateExtractor()
+```
 
-**Приоритет:** P3 (Informational).
+**Impact**: низкий; снижает только boilerplate, не меняет runtime поведение.
 
-______________________________________________________________________
+**Recommendation**:
 
-### 2.2 Повторяющиеся selector-hook методы в publication transformers
+```python
+# BasePublicationTransformer (possible)
+DEFAULT_PROVIDER: ClassVar[str]
+DEFAULT_ENTITY_TYPE: ClassVar[str] = "publication"
+```
 
-**Наблюдение:** методы `_get_primary_id_field()` и `_get_entity_class()` в 4 publication transformers однотипны и часто являются константным `return`.
+Сократить passthrough-конструкторы только там, где нет provider-specific state.
 
-**Доказательства (файлы):**
+**Verification command**:  
+`rg "def __init__\(" src/bioetl/application/pipelines/{openalex,crossref,semanticscholar,pubmed}/transformer.py -n`
 
-- OpenAlex: `return "openalex_id"`, `return OpenAlexPublicationEntity`.
-- CrossRef: `return "doi"`, `return CrossRefPublicationEntity`.
-- PubMed: `return "pmid"`, `return PubMedPublicationEntity`.
-- SemanticScholar: `return "paper_id"`, `return SemanticScholarPublicationEntity`.
+---
 
-**Оценка объёма:** ~4-6 LOC × 2 метода × 4 класса = ~32-48 LOC.
+## [Informational (P3)] Repeated selector hook methods in publication transformers
 
-**Рекомендуемый родительский объект:** декларативная конфигурация в `BasePublicationTransformer` через class attrs:
+**Location**:
+- OpenAlex: `src/bioetl/application/pipelines/openalex/transformer.py:293-309`
+- CrossRef: `src/bioetl/application/pipelines/crossref/transformer.py:240-256`
+- PubMed: `src/bioetl/application/pipelines/pubmed/transformer.py:503-519`
+- SemanticScholar: `src/bioetl/application/pipelines/semanticscholar/transformer.py:272-288`
+- Hook usage in base flow: `src/bioetl/application/pipelines/common/base_publication_transformer.py:202-203`
 
-- `PRIMARY_ID_FIELD: ClassVar[str]`
-- `ENTITY_CLASS: ClassVar[type[BaseEntity]]`
+**Rule**: Template Method hook valid by design; DRY reduction optional.
 
-**Приоритет:** P4 (низкий), так как выигрыш в LOC небольшой и текущая читаемость приемлемая.
+**Evidence**:
 
-## 3. Паттерны НЕ являющиеся дублированием
+```python
+# repeated pattern
+return "openalex_id"  # or doi/pmid/paper_id
+return OpenAlexPublicationEntity  # provider-specific entity class
+```
 
-1. **`_extract_business_data()` в разных трансформерах** — валидный Template Method hook (provider-specific extraction).
-1. **Большой `BaseTransformer`** не является признаком god object автоматически: это orchestration-ядро, а не business-логика провайдера.
-1. **Health-check логика в адаптерах** уже централизована в `HealthCheckMixin`/`HealthCheckProviderMixin`; дополнительное «обобщение» здесь избыточно.
-1. **PubMed `__init__`** отличается по семантике (локальный state + extractor instances), поэтому не должен быть механически слит с остальными.
+**Impact**: низкий; экономия LOC, но текущая читаемость высокая.
 
-## 4. Матрица приоритизации
+**Recommendation**:
 
-| #   | Категория                                                     | Impact | Complexity                                  | LOC   | Приоритет |
-| --- | ------------------------------------------------------------- | ------ | ------------------------------------------- | ----- | --------- |
-| 1   | `__init__` passthrough в OpenAlex/CrossRef/S2                 | Низкий | Низкая/Средняя (влияние на signature tests) | 54-72 | P3        |
-| 2   | Selector hooks (`_get_primary_id_field`, `_get_entity_class`) | Низкий | Низкая                                      | 32-48 | P4        |
+```python
+# optional declarative variant in base
+PRIMARY_ID_FIELD: ClassVar[str]
+ENTITY_CLASS: ClassVar[type[BaseEntity]]
+```
 
-## 5. Чеклист валидации
+Сохранить hooks как fallback для backward compatibility в миграционный период.
 
-- [x] Инвентаризация transformer-файлов и base/mixin-иерархии.
-- [x] Проверка повторяющихся hook/skeleton-паттернов.
-- [x] Проверка зависимости через import/use/test search.
-- [ ] `pytest tests/ -v` (не запускался полностью в рамках этого анализа).
-- [ ] `mypy src/bioetl/ --strict` (не запускался полностью в рамках этого анализа).
-- [ ] Coverage >80% (не пересчитывался в рамках этого анализа).
+**Verification command**:  
+`rg "def _get_primary_id_field|def _get_entity_class" src/bioetl/application/pipelines -n`
 
-## 6. Verification Log (команды)
+## Positive Observations (verified)
+
+1. `BasePublicationTransformer` уже централизует общую оркестрацию трансформации (validation, fallback logging, hash, entity creation), то есть ключевой DRY-рефакторинг уже реализован.
+2. `BaseTransformer` и `PipelineRunner` имеют значимый объём, но не дают автоматически признаков god object по одному только LOC; требуется анализ делегирования.
+
+## Verification Log
 
 ```bash
+git branch --all --verbose --no-abbrev
 find src/bioetl/application -name '*transformer*.py' -exec wc -l {} + | sort -rn | head -30
-rg "^class Base" src/bioetl | wc -l
-rg "Mixin" src/bioetl --glob '*.py' | rg "class "
-rg "^\s*def _[a-zA-Z0-9_]+" src/bioetl/application/pipelines -g '*.py' -o -r '$0' | sed -E 's/.*def /def /' | sort | uniq -c | sort -rn | head -40
-rg "def _get_primary_id_field" src/bioetl/application/pipelines -n
+wc -l src/bioetl/application/core/base_transformer.py src/bioetl/application/core/runner.py
+grep -o "self\._[a-z_][a-z0-9_]*" src/bioetl/application/core/base_transformer.py | sort -u | wc -l
+grep -o "self\._[a-z_][a-z0-9_]*" src/bioetl/application/core/runner.py | sort -u | wc -l
+rg "def __init__\(" src/bioetl/application/pipelines/{openalex,crossref,semanticscholar,pubmed}/transformer.py -n
+rg "def _get_primary_id_field|def _get_entity_class" src/bioetl/application/pipelines -n
 rg "from bioetl\.application\.pipelines\.(openalex|crossref|semanticscholar|pubmed)\.transformer import|import bioetl\.application\.pipelines\.(openalex|crossref|semanticscholar|pubmed)\.transformer" src tests -n
 uv run python -m pytest tests/architecture/test_transformer_signatures.py -q
 ```
+
+## Requires Manual Review
+
+- Повторить консолидацию после предоставления/публикации refs трех запрошенных веток.


### PR DESCRIPTION
### Motivation
- Add a verifiable, project-format audit that documents identified code duplication and safe extraction candidates so teams can plan low-risk refactors and keep an audit trail of the analysis.

### Description
- Added `docs/99-archive/reports/code-duplication-analysis-2026-02-24.md` containing an executive summary, dependency maps, two verified low-priority duplication categories (passthrough `__init__` in publication transformers and selector-hook methods), recommended parent-object patterns, a prioritized migration plan, and a verification command log.

### Testing
- Ran the architecture signature test `uv run python -m pytest tests/architecture/test_transformer_signatures.py -q`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d37f1dbc483249d8c911683b685b1)