### PR TITLE
fix(scripts): restore compatibility wrapper for terminology linter

### DIFF
--- a/scripts/lint_terminology.py
+++ b/scripts/lint_terminology.py
@@ -6,78 +6,30 @@ Deprecated: use src/tools/scripts/lint_terminology.py instead.
 
 from __future__ import annotations
 
-import argparse
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Callable, cast
 
 
-def _load_impl():
+def _load_impl() -> ModuleType:
     repo_root = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(repo_root / "src"))
-    from tools.scripts import lint_terminology as impl
-
-    return impl
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Check BioETL code for terminology violations.",
-        epilog="See docs/glossary.md for canonical terminology.",
-    )
-    parser.add_argument(
-        "paths",
-        nargs="+",
-        type=Path,
-        help="Files or directories to check",
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Enable strict mode (adds docs/configs to checks)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Show files being checked (deprecated; ignored).",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Output violations as JSON",
-    )
-    parser.add_argument(
-        "--check",
-        action="store_true",
-        help="Deprecated flag (ignored).",
-    )
-    return parser.parse_args()
+    return importlib.import_module("tools.scripts.lint_terminology")
 
 
 def main() -> int:
     impl = _load_impl()
-    args = parse_args()
+    filtered_args = [arg for arg in sys.argv[1:] if arg != "--check"]
+    sys.argv = [sys.argv[0], *filtered_args]
 
-    patterns = list(impl.PYTHON_PATTERNS)
-    if args.strict:
-        patterns.extend(impl.MARKDOWN_PATTERNS)
-        patterns.extend(impl.YAML_PATTERNS)
+    impl_main_obj = getattr(impl, "main")
+    if not callable(impl_main_obj):
+        raise RuntimeError("tools.scripts.lint_terminology.main is not callable")
 
-    combined = impl.LintResult()
-    for path in args.paths:
-        resolved = path
-        if not resolved.is_absolute():
-            resolved = Path.cwd() / path
-        result = impl.lint_path(resolved, tuple(patterns))
-        combined.violations.extend(result.violations)
-        combined.files_checked += result.files_checked
-
-    if args.json:
-        impl.log_report_json(combined)
-    else:
-        impl.log_report_text(combined)
-
-    return 1 if combined.total_violations > 0 else 0
+    impl_main = cast(Callable[[], int], impl_main_obj)
+    return impl_main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Restore the deprecated `scripts/lint_terminology.py` wrapper after the upstream linter API changed so the wrapper remains usable and type-checks under `mypy --strict` while preserving the legacy `--check` flag behaviour.

### Description
- Simplified the wrapper to dynamically import `tools.scripts.lint_terminology`, forward CLI arguments (filtering out the deprecated `--check` flag), and call the target module's `main()` with a typed guard to satisfy static typing and runtime safety.

### Testing
- Ran `uv run python -m mypy --strict scripts/lint_terminology.py` (passed), `uv run python scripts/lint_terminology.py --check scripts/lint_terminology.py` (passed, wrapper self-check), and `uv run python scripts/lint_terminology.py src/bioetl/` (expected non-zero exit and reported existing terminology violations — 44 found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4f4c1e1883249def4acdeea91b9c)