### PR TITLE
refactor(domain): remove deprecated PubMed ArticleSchema alias

### DIFF
--- a/src/bioetl/domain/schemas/pubmed/publication.py
+++ b/src/bioetl/domain/schemas/pubmed/publication.py
@@ -4,7 +4,7 @@ Aligned with RULES.md v5.10 and MEDLINE DTD.
 Source: https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_230101.dtd
 
 Note: File renamed from article.py to publication.py per ADR-024 Entity Naming Unification.
-PubMedPublicationSchema replaces ArticleSchema for consistency with other providers.
+PubMedPublicationSchema is the canonical schema name for PubMed publications.
 """
 
 from __future__ import annotations
@@ -25,8 +25,8 @@ from bioetl.domain.validation import (
     DOI_REGEX_PATTERN,
 )
 
-# Re-export for backwards compatibility
-__all__ = ["LOOKUP_METHODS", "ArticleSchema", "PubMedPublicationSchema"]
+# Public exports
+__all__ = ["LOOKUP_METHODS", "PubMedPublicationSchema"]
 
 # === Fixed Value Constants ===
 PUBLICATION_STATUSES = ["ppublish", "epublish", "aheadofprint"]
@@ -37,9 +37,6 @@ class PubMedPublicationSchema(PublicationBaseSchema):
     """PubMed Publication validation schema for Silver layer.
 
     Represents a MEDLINE/PubMed citation record.
-
-    Note: Renamed from ArticleSchema per ADR-024 for consistency with
-    entity_type='publication' in pipeline configs and other providers.
 
     Fields excluded from PyArrow/Gold schemas (API deprecated 2026-01):
     - vernacular_title: Original non-English title (deprecated)
@@ -293,11 +290,3 @@ class PubMedPublicationSchema(PublicationBaseSchema):
         coerce = True
         name = "PubMedPublicationSchema"
         description = "PubMed Publication Silver layer validation"
-
-
-# Backward compatibility alias (deprecated)
-ArticleSchema = PubMedPublicationSchema
-"""Deprecated alias for PubMedPublicationSchema.
-
-Use PubMedPublicationSchema instead. This alias will be removed in v3.0.
-"""

--- a/tests/unit/domain/schemas/test_year_validation.py
+++ b/tests/unit/domain/schemas/test_year_validation.py
@@ -306,7 +306,7 @@ class TestPubMedYearValidation:
     """Year validation tests for PubMedPublicationSchema.
 
     Note: PubMed uses 'year' field (renamed from 'pub_year').
-    Schema renamed from ArticleSchema per ADR-024.
+    Canonical schema name follows ADR-024 publication naming.
     """
 
     @pytest.fixture


### PR DESCRIPTION
### Motivation

- Remove the deprecated `ArticleSchema` alias and legacy wording so the PubMed schema surface uses the canonical `PubMedPublicationSchema` per ADR-024.
- Keep tests and public exports aligned with the canonical naming to reduce backward-compatibility surface.

### Description

- Deleted the deprecated alias `ArticleSchema = PubMedPublicationSchema` and its docstring from `src/bioetl/domain/schemas/pubmed/publication.py`.
- Updated module exports to `__all__ = ["LOOKUP_METHODS", "PubMedPublicationSchema"]` in `src/bioetl/domain/schemas/pubmed/publication.py`.
- Adjusted the related unit test docstring in `tests/unit/domain/schemas/test_year_validation.py` to reference the canonical schema naming.

### Testing

- Ran `uv run python -m pytest tests/unit/domain/schemas/test_year_validation.py -q`, which passed.
- Ran `uv run python -m mypy --strict src/bioetl/domain/schemas/pubmed/publication.py`, which returned success for the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4f4c1e1883249def4acdeea91b9c)