### PR TITLE
Standardize defaults for bioetl-simple Grafana dashboard

### DIFF
--- a/grafana/dashboards/bioetl-simple.json
+++ b/grafana/dashboards/bioetl-simple.json
@@ -303,7 +303,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
@@ -395,7 +395,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -410,5 +410,5 @@
   "timezone": "",
   "title": "BioETL Simple Dashboard",
   "uid": "bioetl-simple",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
### Motivation
- Align the `bioetl-simple` dashboard with repository monitoring conventions by using a longer refresh interval and a 7-day default time window.

### Description
- Updated `grafana/dashboards/bioetl-simple.json` to set `refresh` to `"30s"`, set `time.from` to `"now-7d"` while keeping `time.to` as `"now"`, and incremented `version` by 1; `uid`, `title`, `panels`, and `templating` were left unchanged.

### Testing
- Verified the change with `jq '.refresh, .time.from' grafana/dashboards/bioetl-simple.json` which returned `"30s"` and `"now-7d"` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c4469e08324896a5ba8d06293ab)