### PR TITLE
observability: clarify MetricsPort extension policy and registry-based metric additions

### DIFF
--- a/docs/03-guides/metrics-monitoring.md
+++ b/docs/03-guides/metrics-monitoring.md
@@ -61,6 +61,25 @@ export BIOETL-METRICS-ENABLED=false
 
 ## Prometheus Metrics
 
+### Правила расширения MetricsPort (Implementation MUST)
+
+- **НЕ создавать** новый порт `domain/ports/metrics.py`.
+- Расширять существующий контракт `MetricsPort` только в
+  `src/bioetl/domain/ports/observability.py`.
+- В текущем проекте используется единый подход: **generic metrics API**.
+  Новые метрики добавляются через стандартные методы
+  `observe_histogram()` / `increment_counter()` / `set_gauge()` с
+  нормализованными строковыми именами.
+- Для каждой новой метрики обязательно:
+  1. определить объект метрики в
+     `src/bioetl/infrastructure/observability/metrics.py`,
+  2. зарегистрировать её в `HISTOGRAMS` / `COUNTERS` / `GAUGES` в
+     `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+
+> Если в будущем потребуется typed API, helper-методы добавляются в
+> `MetricsPort` в `observability.py` и синхронно реализуются в Prometheus и
+> NoOp реализациях без дублирования интерфейсов.
+
 ### Доступ к метрикам
 
 После запуска пайплайна метрики доступны на HTTP endpoint:

--- a/src/bioetl/domain/ports/observability.py
+++ b/src/bioetl/domain/ports/observability.py
@@ -85,6 +85,16 @@ class MetricsPort(Protocol):
     Note: MetricsPort uses synchronous methods for low-overhead operations.
     Unlike I/O ports, metric collection should be fast and non-blocking
     by design (using thread-safe counters, not I/O).
+
+    Implementation extension policy:
+        - DO NOT create a separate ``domain/ports/metrics.py`` contract.
+        - Extend this existing ``MetricsPort`` in ``observability.py``.
+        - Preferred approach is to keep the generic API
+          (``observe_histogram``, ``increment_counter``, ``set_gauge``)
+          and add standardized metric names plus infrastructure registries.
+        - If typed helper methods are introduced in the future, they MUST be
+          added to this protocol and implemented in both Prometheus and NoOp
+          adapters without interface duplication.
     """
 
     def observe_histogram(

--- a/src/bioetl/infrastructure/observability/prometheus_metrics.py
+++ b/src/bioetl/infrastructure/observability/prometheus_metrics.py
@@ -156,7 +156,12 @@ GAUGES = {
 class PrometheusMetrics(MetricsPort):
     """Prometheus implementation of MetricsPort.
 
-    Maps metric names to pre-defined Prometheus metrics and records observations.
+    Uses the generic MetricsPort API with standardized metric names that map
+    into ``HISTOGRAMS``, ``COUNTERS``, and ``GAUGES`` registries.
+
+    Extension rule: add new metric definitions in
+    ``infrastructure/observability/metrics.py`` and register them in this
+    module, rather than creating duplicate domain-level metrics interfaces.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
### Motivation
- Prevent proliferation of duplicate port interfaces by requiring extensions to the existing `MetricsPort` in `src/bioetl/domain/ports/observability.py` instead of creating `domain/ports/metrics.py`.
- Standardize how new metrics are introduced so application code continues to use the generic API (`observe_histogram`/`increment_counter`/`set_gauge`) with normalized metric names mapped into infrastructure registries.
- Ensure any future typed helper methods are added to the `MetricsPort` protocol and implemented in both Prometheus and NoOp adapters to avoid interface duplication.

### Description
- Added an "Implementation extension policy" block to the `MetricsPort` `Protocol` in `src/bioetl/domain/ports/observability.py` that mandates extending this contract and describes the preferred approaches and constraints.
- Documented the required workflow for adding new metrics in `docs/03-guides/metrics-monitoring.md`, including defining metric objects in `src/bioetl/infrastructure/observability/metrics.py` and registering them in the `HISTOGRAMS`/`COUNTERS`/`GAUGES` maps in `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
- Updated the `PrometheusMetrics` class docstring in `src/bioetl/infrastructure/observability/prometheus_metrics.py` to align with the registry-based extension policy and to discourage creating duplicate domain interfaces.
- Changes are confined to documentation and protocol docstrings and registry guidance; no behavioral changes to the metrics runtime were introduced.

### Testing
- Ran unit tests: `uv run python -m pytest tests/unit/infrastructure/observability/test_prometheus_metrics.py tests/unit/interfaces/test_observability.py -q`, and the test suite completed successfully (all tests passed).
- No automated tests were modified as part of this change and existing tests covering the Prometheus adapter and observability interface continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c83d12083248665f3762a72cdaa)