### PR TITLE
docs: align dashboard prompts with runtime observability module paths

### DIFF
--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_COMPLETE.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_COMPLETE.md
@@ -1,59 +1,65 @@
 # 📊 BioETL Dashboard — Полная подготовка завершена ✅
 
-**Дата:** 22 февраля 2026  
-**Время подготовки:** ~1 час  
-**Статус:** ✅ Готово к производству  
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
 
----
+**Дата:** 22 февраля 2026
+**Время подготовки:** ~1 час
+**Статус:** ✅ Готово к производству
+
+______________________________________________________________________
 
 ## 📋 Что было подготовлено
 
 ### 📚 Документация (1,800+ строк)
 
-| Документ | Размер | Аудитория | Содержание |
-|----------|--------|----------|-----------|
-| **BIOETL_DASHBOARD_README.md** | 264 строк | 🗺️ Все | Навигация и индекс |
-| **BIOETL_DASHBOARD_QUICKSTART.md** | 148 строк | 🚀 Разработчики | За 5 минут на вход |
-| **BIOETL_DASHBOARD_SETUP.md** | 572 строк | 📖 Полная инструкция | Все детали (60 минут) |
-| **BIOETL_DASHBOARD_VISUAL_GUIDE.md** | 278 строк | 👁️ Визуалы | Диаграммы и примеры |
-| **BIOETL_DASHBOARD_EXAMPLES.md** | 529 строк | 💡 Кастомизация | Примеры и расширение |
+| Документ                             | Размер    | Аудитория            | Содержание            |
+| ------------------------------------ | --------- | -------------------- | --------------------- |
+| **BIOETL_DASHBOARD_README.md**       | 264 строк | 🗺️ Все               | Навигация и индекс    |
+| **BIOETL_DASHBOARD_QUICKSTART.md**   | 148 строк | 🚀 Разработчики      | За 5 минут на вход    |
+| **BIOETL_DASHBOARD_SETUP.md**        | 572 строк | 📖 Полная инструкция | Все детали (60 минут) |
+| **BIOETL_DASHBOARD_VISUAL_GUIDE.md** | 278 строк | 👁️ Визуалы           | Диаграммы и примеры   |
+| **BIOETL_DASHBOARD_EXAMPLES.md**     | 529 строк | 💡 Кастомизация      | Примеры и расширение  |
 
 **Итого:** ~1,800 строк документации
 
 ### 🛠️ Рабочие файлы
 
-| Файл | Назначение | Статус |
-|------|-----------|--------|
-| **metrics_server.py** | Prometheus metrics endpoint | ✅ Работает |
-| **docker-compose.monitoring.yml** | Docker контейнеры (Prometheus, Grafana) | ✅ Готов |
-| **grafana/prometheus.yml** | Конфигурация Prometheus | ✅ Настроен |
-| **grafana/provisioning/** | Auto-provisioning дашбордов | ✅ 4 дашборда |
+| Файл                                                              | Назначение                              | Статус        |
+| ----------------------------------------------------------------- | --------------------------------------- | ------------- |
+| **src/bioetl/infrastructure/observability/prometheus_metrics.py** | Prometheus metrics endpoint             | ✅ Работает   |
+| **docker-compose.monitoring.yml**                                 | Docker контейнеры (Prometheus, Grafana) | ✅ Готов      |
+| **grafana/prometheus.yml**                                        | Конфигурация Prometheus                 | ✅ Настроен   |
+| **grafana/provisioning/**                                         | Auto-provisioning дашбордов             | ✅ 4 дашборда |
 
 ### 📊 Компоненты инфраструктуры
 
-| Компонент | Порт | Статус | URL |
-|-----------|------|--------|-----|
+| Компонент          | Порт | Статус     | URL                           |
+| ------------------ | ---- | ---------- | ----------------------------- |
 | **BioETL Metrics** | 8000 | ✅ Запущен | http://localhost:8000/metrics |
-| **Prometheus** | 9090 | ✅ Запущен | http://localhost:9090 |
-| **Grafana** | 3000 | ✅ Запущен | http://localhost:3000 |
-| **Neo4j** (опция) | 7687 | ✅ Запущен | http://localhost:7474 |
+| **Prometheus**     | 9090 | ✅ Запущен | http://localhost:9090         |
+| **Grafana**        | 3000 | ✅ Запущен | http://localhost:3000         |
+| **Neo4j** (опция)  | 7687 | ✅ Запущен | http://localhost:7474         |
 
 ### 📊 Дашборды (4 штуки)
 
-| № | Дашборд | UID | Панели | Назначение |
-|----|---------|-----|--------|-----------|
-| 1 | BioETL Simple | bioetl-simple | 5 | Основная статистика |
-| 2 | BioETL Data Quality v2 | bioetl-dq-v2 | 7 | Метрики качества данных |
-| 3 | BioETL Overview v2 | bioetl-overview-v2 | 7 | Общий обзор pipeline |
-| 4 | BioETL Provider Health v2 | bioetl-provider-health-v2 | 9 | Статус и latency provider'ов |
+| №   | Дашборд                   | UID                       | Панели | Назначение                   |
+| --- | ------------------------- | ------------------------- | ------ | ---------------------------- |
+| 1   | BioETL Simple             | bioetl-simple             | 5      | Основная статистика          |
+| 2   | BioETL Data Quality v2    | bioetl-dq-v2              | 7      | Метрики качества данных      |
+| 3   | BioETL Overview v2        | bioetl-overview-v2        | 7      | Общий обзор pipeline         |
+| 4   | BioETL Provider Health v2 | bioetl-provider-health-v2 | 9      | Статус и latency provider'ов |
 
 **Итого:** 4 полнофункциональных дашборда
 
----
+______________________________________________________________________
 
 ## 🚀 Состояние готовности
 
 ### ✅ Установка
+
 - [x] Docker Compose конфигурация
 - [x] Prometheus настроен
 - [x] Grafana подключена
@@ -61,6 +67,7 @@
 - [x] Дашборды загружены
 
 ### ✅ Конфигурация
+
 - [x] Prometheus scrape: 15 сек
 - [x] Retention: 15 дней
 - [x] Data source: http://host.docker.internal:9090
@@ -68,23 +75,26 @@
 - [x] Переменные фильтров: Pipeline, Run Type, Execution
 
 ### ✅ Мониторинг
+
 - [x] Метрики собираются ✅
 - [x] Дашборды отображают данные ✅
 - [x] Фильтры работают ✅
 - [x] Обновление: каждые 15 сек ✅
 
 ### ✅ Документация
+
 - [x] Быстрый старт (5 минут)
 - [x] Полная инструкция (60 минут)
 - [x] Визуальный гайд (диаграммы)
 - [x] Примеры кастомизации
 - [x] Troubleshooting guide
 
----
+______________________________________________________________________
 
 ## 🎯 Как использовать
 
 ### Шаг 1: Быстрый старт (5 минут)
+
 ```bash
 # Прочитать
 cat BIOETL_DASHBOARD_QUICKSTART.md
@@ -93,13 +103,14 @@ cat BIOETL_DASHBOARD_QUICKSTART.md
 docker compose -f docker-compose.monitoring.yml up -d
 
 # Запустить metrics сервер
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Открыть
 http://localhost:3000/d/bioetl-simple
 ```
 
 ### Шаг 2: Изучить документацию
+
 ```
 1. README (навигация) — 5 минут
 2. QUICKSTART (за 5 минут) — 10 минут
@@ -109,6 +120,7 @@ http://localhost:3000/d/bioetl-simple
 ```
 
 ### Шаг 3: Использовать дашборды
+
 ```
 1. Открыть http://localhost:3000
 2. Выбрать Dashboard → BioETL
@@ -118,14 +130,15 @@ http://localhost:3000/d/bioetl-simple
 ```
 
 ### Шаг 4: Кастомизировать (опционально)
+
 ```
-1. Добавить метрики в metrics_server.py
+1. Добавить метрики в src/bioetl/infrastructure/observability/prometheus_metrics.py
 2. Создать собственный дашборд
 3. Настроить alerts
 4. Интегрировать с Slack/Email
 ```
 
----
+______________________________________________________________________
 
 ## 📊 Текущие метрики
 
@@ -167,100 +180,110 @@ sum(bioetl_records_processed_total{stage="gold"}) / sum(bioetl_records_processed
 histogram_quantile(0.95, bioetl_health_check_latency_ms_bucket{provider="chembl"})
 ```
 
----
+______________________________________________________________________
 
 ## 🔧 Кастомизация
 
 ### Добавить метрику:
-1. Отредактировать `metrics_server.py`
-2. Добавить Counter/Gauge/Histogram
-3. Перезапустить сервер
-4. Использовать в Grafana
+
+1. Отредактировать `src/bioetl/infrastructure/observability/prometheus_metrics.py`
+1. Добавить Counter/Gauge/Histogram
+1. Перезапустить сервер
+1. Использовать в Grafana
 
 ### Создать дашборд:
+
 1. Открыть Grafana → Dashboards → New
-2. Добавить панели
-3. Настроить queries
-4. Сохранить
+1. Добавить панели
+1. Настроить queries
+1. Сохранить
 
 ### Настроить alert:
-1. Dashboard → Alert rules
-2. Create alert rule
-3. Set condition (например, error_rate > 10%)
-4. Выбрать notification channel
 
----
+1. Dashboard → Alert rules
+1. Create alert rule
+1. Set condition (например, error_rate > 10%)
+1. Выбрать notification channel
+
+______________________________________________________________________
 
 ## 🐛 Troubleshooting
 
 ### Если не работает:
 
 1. **Дашборд пуст (No data)**
+
    ```bash
    # Проверить metrics сервер
    curl http://localhost:8000/metrics
-   
+
    # Если ошибка, перезапустить
-   pkill -f metrics_server.py
-   python ./metrics_server.py &
+   pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+   python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
    ```
 
-2. **Prometheus target DOWN**
+1. **Prometheus target DOWN**
+
    ```bash
    # Проверить логи
    docker logs bioetl-prometheus | tail -20
-   
+
    # Перезапустить
    docker restart bioetl-prometheus
    ```
 
-3. **Grafana не подключается**
+1. **Grafana не подключается**
+
    ```bash
    # Проверить URL в Data Sources
    # http://host.docker.internal:9090
-   
+
    # Или для Linux:
    # http://prometheus:9090 (если в одной сети)
    ```
 
----
+______________________________________________________________________
 
 ## 📈 Производительность
 
-| Метрика | Значение |
-|---------|----------|
-| Scrape interval | 15 сек |
-| Query timeout | 10 сек |
-| Retention | 15 дней |
-| Prometheus RAM | ~500 MB |
-| Grafana RAM | ~300 MB |
+| Метрика          | Значение      |
+| ---------------- | ------------- |
+| Scrape interval  | 15 сек        |
+| Query timeout    | 10 сек        |
+| Retention        | 15 дней       |
+| Prometheus RAM   | ~500 MB       |
+| Grafana RAM      | ~300 MB       |
 | Metrics endpoint | ~50 KB/запрос |
 
----
+______________________________________________________________________
 
 ## 🎓 Обучение
 
 ### Для новичков (40 минут):
+
 1. Прочитать VISUAL_GUIDE.md — 20 минут
-2. Открыть BioETL Simple Dashboard — 10 минут
-3. Поменять фильтры — 10 минут
+1. Открыть BioETL Simple Dashboard — 10 минут
+1. Поменять фильтры — 10 минут
 
 ### Для intermediate (1.5 часа):
+
 1. Прочитать SETUP.md — 60 минут
-2. Написать PromQL query — 20 минут
-3. Добавить панель в дашборд — 10 минут
+1. Написать PromQL query — 20 минут
+1. Добавить панель в дашборд — 10 минут
 
 ### Для advanced (2+ часа):
-1. Прочитать EXAMPLES.md — 30 минут
-2. Добавить свою метрику — 30 минут
-3. Создать дашборд с JSON — 30 минут
-4. Настроить alerts — 30 минут
 
----
+1. Прочитать EXAMPLES.md — 30 минут
+1. Добавить свою метрику — 30 минут
+1. Создать дашборд с JSON — 30 минут
+1. Настроить alerts — 30 минут
+
+______________________________________________________________________
 
 ## 📞 Справка
 
 ### Основные файлы
+
 - `BIOETL_DASHBOARD_QUICKSTART.md` — Начните отсюда ⭐
 - `BIOETL_DASHBOARD_README.md` — Индекс всей документации
 - `BIOETL_DASHBOARD_SETUP.md` — Полная инструкция
@@ -268,47 +291,52 @@ histogram_quantile(0.95, bioetl_health_check_latency_ms_bucket{provider="chembl"
 - `BIOETL_DASHBOARD_EXAMPLES.md` — Кастомизация
 
 ### Основные URL
+
 - Grafana: http://localhost:3000
 - Prometheus: http://localhost:9090
 - Metrics: http://localhost:8000/metrics
 
 ### Основные команды
+
 ```bash
 # Запустить
 docker compose -f docker-compose.monitoring.yml up -d
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Остановить
 docker compose -f docker-compose.monitoring.yml down
-pkill -f metrics_server.py
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 # Диагностика
 curl http://localhost:9090/-/healthy
 curl http://localhost:8000/metrics
 ```
 
----
+______________________________________________________________________
 
 ## ✨ Что дальше?
 
 ### Базовое (0-2 часа):
+
 - [ ] Установить мониторинг (QUICKSTART.md)
 - [ ] Открыть http://localhost:3000
 - [ ] Исследовать дашборды
 
 ### Промежуточное (2-4 часа):
+
 - [ ] Прочитать SETUP.md
 - [ ] Понять архитектуру
 - [ ] Написать PromQL query
 - [ ] Добавить панель
 
 ### Продвинутое (4+ часа):
+
 - [ ] Добавить собственные метрики
 - [ ] Создать дашборд с JSON
 - [ ] Настроить alerts
 - [ ] Интегрировать с Slack
 
----
+______________________________________________________________________
 
 ## 🎉 Итог
 
@@ -326,19 +354,21 @@ curl http://localhost:8000/metrics
 
 ✅ **Troubleshooting гайд** — решение типичных проблем
 
----
+______________________________________________________________________
 
 ## 🚀 Начните сейчас!
 
 **Вариант 1: Быстрый старт (5 минут)**
+
 ```bash
 cat BIOETL_DASHBOARD_QUICKSTART.md
 docker compose -f docker-compose.monitoring.yml up -d
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 open http://localhost:3000
 ```
 
 **Вариант 2: Полная подготовка (2 часа)**
+
 ```bash
 cat BIOETL_DASHBOARD_SETUP.md          # 60 минут
 cat BIOETL_DASHBOARD_VISUAL_GUIDE.md   # 20 минут
@@ -346,21 +376,22 @@ cat BIOETL_DASHBOARD_VISUAL_GUIDE.md   # 20 минут
 open http://localhost:3000/d/bioetl-simple
 ```
 
----
+______________________________________________________________________
 
 ## 📞 Контакты для вопросов
 
 Все ответы в документации:
+
 - **Установка** → QUICKSTART.md
 - **Проблемы** → SETUP.md (Troubleshooting)
 - **Как использовать** → VISUAL_GUIDE.md
 - **Кастомизация** → EXAMPLES.md
 
----
+______________________________________________________________________
 
-**Статус:** ✅ Готово к использованию  
-**Версия документации:** 1.0  
-**Последнее обновление:** 22 февраля 2026  
+**Статус:** ✅ Готово к использованию
+**Версия документации:** 1.0
+**Последнее обновление:** 22 февраля 2026
 
 🎊 **Спасибо за использование BioETL Dashboard!** 🎊
 

--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_EXAMPLES.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_EXAMPLES.md
@@ -1,40 +1,41 @@
 # BioETL Dashboard — Примеры кастомизации
 
-## Содержание
-1. [Добавить новую метрику](#добавить-новую-метрику)
-2. [Создать пользовательский дашборд](#создать-пользовательский-дашборд)
-3. [Настроить Alert](#настроить-alert)
-4. [Использовать переменные фильтров](#использовать-переменные-фильтров)
-5. [Экспортировать/Импортировать дашборды](#экспортироватьимпортировать-дашборды)
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
 
----
+## Содержание
+
+1. [Добавить новую метрику](#%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%B8%D1%82%D1%8C-%D0%BD%D0%BE%D0%B2%D1%83%D1%8E-%D0%BC%D0%B5%D1%82%D1%80%D0%B8%D0%BA%D1%83)
+1. [Создать пользовательский дашборд](#%D1%81%D0%BE%D0%B7%D0%B4%D0%B0%D1%82%D1%8C-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D1%81%D0%BA%D0%B8%D0%B9-%D0%B4%D0%B0%D1%88%D0%B1%D0%BE%D1%80%D0%B4)
+1. [Настроить Alert](#%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B8%D1%82%D1%8C-alert)
+1. [Использовать переменные фильтров](#%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D1%8C-%D0%BF%D0%B5%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%BD%D1%8B%D0%B5-%D1%84%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D0%BE%D0%B2)
+1. [Экспортировать/Импортировать дашборды](#%D1%8D%D0%BA%D1%81%D0%BF%D0%BE%D1%80%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D1%82%D1%8C%D0%B8%D0%BC%D0%BF%D0%BE%D1%80%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D1%82%D1%8C-%D0%B4%D0%B0%D1%88%D0%B1%D0%BE%D1%80%D0%B4%D1%8B)
+
+______________________________________________________________________
 
 ## Добавить новую метрику
 
-### Шаг 1: Определить метрику в metrics_server.py
+### Шаг 1: Определить метрику в src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 ```python
 # Добавить в начало файла
 from prometheus_client import Counter, Gauge, Histogram
 
 # Новая метрика: количество активных run
-ACTIVE_RUNS = Gauge(
-    'bioetl_active_runs',
-    'Number of active pipeline runs'
-)
+ACTIVE_RUNS = Gauge("bioetl_active_runs", "Number of active pipeline runs")
 
 # Метрика: время ответа API
 API_RESPONSE_TIME = Histogram(
-    'bioetl_api_response_seconds',
-    'API response time in seconds',
-    ['endpoint', 'method']
+    "bioetl_api_response_seconds",
+    "API response time in seconds",
+    ["endpoint", "method"],
 )
 
 # Метрика: ошибки по типам
 ERRORS_BY_TYPE = Counter(
-    'bioetl_errors_total',
-    'Total errors by type',
-    ['error_type', 'pipeline']
+    "bioetl_errors_total", "Total errors by type", ["error_type", "pipeline"]
 )
 ```
 
@@ -44,32 +45,30 @@ ERRORS_BY_TYPE = Counter(
 def _generate_synthetic_metrics(self):
     """Generate synthetic BioETL metrics."""
     # ... существующий код ...
-    
+
     # Добавить новые метрики
     ACTIVE_RUNS.set(random.randint(3, 8))
-    
+
     # API response time
-    for endpoint in ['/fetch', '/process', '/validate']:
-        for method in ['GET', 'POST']:
-            API_RESPONSE_TIME.labels(
-                endpoint=endpoint,
-                method=method
-            ).observe(random.uniform(0.1, 2.0))
-    
+    for endpoint in ["/fetch", "/process", "/validate"]:
+        for method in ["GET", "POST"]:
+            API_RESPONSE_TIME.labels(endpoint=endpoint, method=method).observe(
+                random.uniform(0.1, 2.0)
+            )
+
     # Errors by type
-    for error_type in ['validation_error', 'network_error', 'timeout']:
-        for pipeline in ['uniprot', 'pubmed', 'pubchem']:
-            ERRORS_BY_TYPE.labels(
-                error_type=error_type,
-                pipeline=pipeline
-            ).inc(random.randint(0, 5))
+    for error_type in ["validation_error", "network_error", "timeout"]:
+        for pipeline in ["uniprot", "pubmed", "pubchem"]:
+            ERRORS_BY_TYPE.labels(error_type=error_type, pipeline=pipeline).inc(
+                random.randint(0, 5)
+            )
 ```
 
-### Шаг 3: Перезапустить metrics_server.py
+### Шаг 3: Перезапустить src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 ```bash
-pkill -f metrics_server.py
-python ./metrics_server.py &
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 ```
 
 ### Шаг 4: Дождаться scrape и использовать в Grafana
@@ -93,7 +92,7 @@ curl http://localhost:8000/metrics | grep bioetl_active_runs
 5. Save dashboard
 ```
 
----
+______________________________________________________________________
 
 ## Создать пользовательский дашборд
 
@@ -107,17 +106,17 @@ curl http://localhost:8000/metrics | grep bioetl_active_runs
    Name: "Records per Pipeline"
    Query: sum(rate(bioetl_records_processed_total[5m])) by (pipeline)
    Legend: {{pipeline}}
-   
+
 3. Add panel → Stat
    Name: "Error Rate"
    Query: avg(bioetl_error_rate)
    Thresholds: Green <5%, Orange <10%, Red >10%
-   
+
 4. Add panel → Gauge
    Name: "Quality Score"
    Query: sum(bioetl_records_processed_total{stage="gold"}) / sum(bioetl_records_processed_total{stage="bronze"})
    Min: 0, Max: 1
-   
+
 5. Dashboard settings → Save as "Pipeline Performance"
 ```
 
@@ -270,7 +269,7 @@ cp custom-dashboard.json ./grafana/dashboards/
 # Перезапустить: docker restart bioetl-grafana
 ```
 
----
+______________________________________________________________________
 
 ## Настроить Alert
 
@@ -346,7 +345,7 @@ groups:
           description: "P95 latency is {{ $value }}s"
 ```
 
----
+______________________________________________________________________
 
 ## Использовать переменные фильтров
 
@@ -415,7 +414,7 @@ Legend:
 {{stage}}
 ```
 
----
+______________________________________________________________________
 
 ## Экспортировать/Импортировать дашборды
 
@@ -475,7 +474,7 @@ docker restart bioetl-grafana
 # Дашборды автоматически загрузятся!
 ```
 
----
+______________________________________________________________________
 
 ## Продвинутые примеры
 
@@ -575,7 +574,7 @@ groups:
 4. Test → Save
 ```
 
----
+______________________________________________________________________
 
 ## Шпаргалка по PromQL
 
@@ -607,7 +606,7 @@ metric1 / metric2                                  # Деление
 metric1 > 100                                      # Сравнение
 ```
 
----
+______________________________________________________________________
 
-**Дата:** 22 февраля 2026  
+**Дата:** 22 февраля 2026
 **Версия:** 1.0

--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_QUICKSTART.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_QUICKSTART.md
@@ -1,5 +1,10 @@
 # BioETL Dashboard — Чек-лист быстрого старта
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 ## ✅ Pre-flight Checklist
 
 - [ ] Python 3.11+ установлен: `python --version`
@@ -10,12 +15,14 @@
 ## 🚀 Запуск (5 минут)
 
 ### 1️⃣ Клонировать/Обновить проект
+
 ```bash
 cd /path/to/BioactivityDataAcquisition2
 git pull origin main
 ```
 
 ### 2️⃣ Установить зависимости BioETL
+
 ```bash
 pip install -e .
 # Или через uv (быстрее)
@@ -23,6 +30,7 @@ uv sync
 ```
 
 ### 3️⃣ Запустить контейнеры мониторинга
+
 ```bash
 docker compose -f docker-compose.monitoring.yml up -d
 # Проверить статус
@@ -30,15 +38,17 @@ docker compose -f docker-compose.monitoring.yml ps
 ```
 
 ### 4️⃣ Запустить metrics сервер
+
 ```bash
 # Способ A: В фоне (разработка)
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Способ B: В отдельном терминале (удобно для debug)
-python ./metrics_server.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py
 ```
 
 ### 5️⃣ Проверить, что всё работает
+
 ```bash
 # Metrics endpoint
 curl http://localhost:8000/metrics | head -10
@@ -53,6 +63,7 @@ curl http://localhost:9090/api/v1/query?query=bioetl_records_processed_total
 ```
 
 ### 6️⃣ Открыть дашборд
+
 ```
 URL: http://localhost:3000/d/bioetl-simple
 Логин: admin
@@ -61,42 +72,45 @@ URL: http://localhost:3000/d/bioetl-simple
 
 ## 📊 Что смотреть в дашбордах
 
-| Дашборд | URL | Что показывает |
-|---------|-----|-----------------|
-| Simple | /d/bioetl-simple | Основные метрики (Records, Quality) |
-| Overview | /d/bioetl-overview | Общая статистика |
-| Data Quality | /d/bioetl-dq-v2 | Метрики качества данных |
-| Provider Health | /d/bioetl-provider-health | Статус каждого provider |
+| Дашборд         | URL                       | Что показывает                      |
+| --------------- | ------------------------- | ----------------------------------- |
+| Simple          | /d/bioetl-simple          | Основные метрики (Records, Quality) |
+| Overview        | /d/bioetl-overview        | Общая статистика                    |
+| Data Quality    | /d/bioetl-dq-v2           | Метрики качества данных             |
+| Provider Health | /d/bioetl-provider-health | Статус каждого provider             |
 
 ## 🔍 Отладка (если что-то не работает)
 
 ### Prometheus не собирает метрики (targets = DOWN)
+
 ```bash
 # Проверить metrics сервер
 curl http://localhost:8000/metrics
 
 # Если ошибка → перезапустить
-pkill -f metrics_server.py
-python ./metrics_server.py &
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Дождаться 15 сек, затем проверить Prometheus targets:
 # http://localhost:9090/targets
 ```
 
 ### Дашборд пуст (No data)
+
 ```bash
 # 1. Проверить Prometheus query
 # http://localhost:9090 → Explore
 # Query: bioetl_records_processed_total
 
 # 2. Если нет результатов → метрики не генерируются
-# Проверить metrics_server.py работает:
+# Проверить src/bioetl/infrastructure/observability/prometheus_metrics.py работает:
 ps aux | grep metrics_server
 
 # 3. Обновить дашборд (F5) после 15 сек scrape interval
 ```
 
 ### Grafana не подключается к Prometheus
+
 ```bash
 # Проверить статус Prometheus
 curl http://localhost:9090/-/healthy
@@ -113,12 +127,14 @@ curl http://localhost:9090/-/healthy
 ### BioETL Simple Dashboard
 
 **Верхняя строка (Stat панели):**
+
 - Bronze Records: 4000+ (исходные данные)
 - Silver Records: 3800+ (очищенные данные)
 - Gold Records: 3500+ (готовые данные)
 - Quality Ratio: 87% (процент данных, дошедших до gold)
 
 **Нижний график (Timeseries):**
+
 - Тренд обработки за последний час
 - Три линии: bronze (зелёная), silver (синяя), gold (красная)
 - Если линия плоская → данные не обновляются (проверить metrics)
@@ -130,7 +146,7 @@ curl http://localhost:9090/-/healthy
 docker compose -f docker-compose.monitoring.yml down
 
 # Остановить metrics сервер
-pkill -f metrics_server.py
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 # Удалить все данные (осторожно!)
 docker compose -f docker-compose.monitoring.yml down -v
@@ -138,38 +154,43 @@ docker compose -f docker-compose.monitoring.yml down -v
 
 ## 📝 Полезные файлы
 
-| Файл | Назначение |
-|------|-----------|
-| `docker-compose.monitoring.yml` | Конфигурация контейнеров |
-| `grafana/prometheus.yml` | Конфигурация Prometheus |
-| `grafana/provisioning/` | Автозагрузка дашбордов |
-| `metrics_server.py` | Metrics endpoint |
-| `BIOETL_DASHBOARD_SETUP.md` | Полная инструкция |
+| Файл                                                            | Назначение               |
+| --------------------------------------------------------------- | ------------------------ |
+| `docker-compose.monitoring.yml`                                 | Конфигурация контейнеров |
+| `grafana/prometheus.yml`                                        | Конфигурация Prometheus  |
+| `grafana/provisioning/`                                         | Автозагрузка дашбордов   |
+| `src/bioetl/infrastructure/observability/prometheus_metrics.py` | Metrics endpoint         |
+| `BIOETL_DASHBOARD_SETUP.md`                                     | Полная инструкция        |
 
 ## 🎯 Типичный workflow
 
 1. **Запустить**
+
    ```bash
    docker compose -f docker-compose.monitoring.yml up -d
-   python ./metrics_server.py &
+   python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
    ```
 
-2. **Открыть Grafana**
+1. **Открыть Grafana**
+
    ```
    http://localhost:3000/d/bioetl-simple
    ```
 
-3. **Мониторить метрики**
+1. **Мониторить метрики**
+
    - Обновляется каждые 5 сек (refresh rate в дашборде)
    - Данные собираются каждые 15 сек (scrape interval)
 
-4. **При нужде отредактировать**
+1. **При нужде отредактировать**
+
    - Dashboard → Edit panel → Update query → Save
 
-5. **Остановить**
+1. **Остановить**
+
    ```bash
    docker compose -f docker-compose.monitoring.yml down
-   pkill -f metrics_server.py
+   pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
    ```
 
 ## ❓ FAQ
@@ -178,7 +199,7 @@ docker compose -f docker-compose.monitoring.yml down -v
 A: `docker exec bioetl-grafana grafana-cli admin reset-admin-password newpassword`
 
 **Q: Как добавить свою метрику?**
-A: Отредактировать `metrics_server.py`, добавить Counter/Gauge, перезапустить
+A: Отредактировать `src/bioetl/infrastructure/observability/prometheus_metrics.py`, добавить Counter/Gauge, перезапустить
 
 **Q: Как сохранить дашборд?**
 A: Dashboard → Export → Save JSON → Поделиться с командой
@@ -189,8 +210,8 @@ A: В Docker volume `bioetl_prometheus_data` (retention: 15 дней)
 **Q: Как скачать метрики?**
 A: `http://localhost:9090/api/v1/query_range?query=...&start=...&end=...`
 
----
+______________________________________________________________________
 
-**Дата:** 22 февраля 2026  
-**Версия:** 1.0  
+**Дата:** 22 февраля 2026
+**Версия:** 1.0
 **Поддержка:** См. BIOETL_DASHBOARD_SETUP.md (раздел Troubleshooting)

--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_README.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_README.md
@@ -1,50 +1,64 @@
 # BioETL Dashboard Documentation — Полный индекс
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 ## 📚 Документация
 
-| Файл | Размер | Для кого | Читать |
-|------|--------|---------|--------|
-| **BIOETL_DASHBOARD_QUICKSTART.md** | 6.5 KB | 🚀 Разработчиков (за 5 минут) | [→](./BIOETL_DASHBOARD_QUICKSTART.md) |
-| **BIOETL_DASHBOARD_SETUP.md** | 23 KB | 📖 Полная инструкция (60 минут) | [→](./BIOETL_DASHBOARD_SETUP.md) |
-| **BIOETL_DASHBOARD_VISUAL_GUIDE.md** | 17 KB | 👁️ Визуальный гайд (20 минут) | [→](./BIOETL_DASHBOARD_VISUAL_GUIDE.md) |
-| **BIOETL_DASHBOARD_EXAMPLES.md** | 15 KB | 💡 Примеры кастомизации (30 минут) | [→](./BIOETL_DASHBOARD_EXAMPLES.md) |
-| **Этот файл** | 10 KB | 🗺️ Карта и навигация | - |
+| Файл                                 | Размер | Для кого                           | Читать                                  |
+| ------------------------------------ | ------ | ---------------------------------- | --------------------------------------- |
+| **BIOETL_DASHBOARD_QUICKSTART.md**   | 6.5 KB | 🚀 Разработчиков (за 5 минут)      | [→](./BIOETL_DASHBOARD_QUICKSTART.md)   |
+| **BIOETL_DASHBOARD_SETUP.md**        | 23 KB  | 📖 Полная инструкция (60 минут)    | [→](./BIOETL_DASHBOARD_SETUP.md)        |
+| **BIOETL_DASHBOARD_VISUAL_GUIDE.md** | 17 KB  | 👁️ Визуальный гайд (20 минут)      | [→](./BIOETL_DASHBOARD_VISUAL_GUIDE.md) |
+| **BIOETL_DASHBOARD_EXAMPLES.md**     | 15 KB  | 💡 Примеры кастомизации (30 минут) | [→](./BIOETL_DASHBOARD_EXAMPLES.md)     |
+| **Этот файл**                        | 10 KB  | 🗺️ Карта и навигация               | -                                       |
 
----
+______________________________________________________________________
 
 ## 🎯 С чего начать?
 
 ### Если у вас есть 5 минут ⏱️
+
 → Прочитайте [BIOETL_DASHBOARD_QUICKSTART.md](./BIOETL_DASHBOARD_QUICKSTART.md)
+
 - ✅ Чек-лист установки
 - ✅ 6 простых шагов
 - ✅ Быстрая диагностика
 
 ### Если у вас есть 1 час 📚
+
 → Прочитайте [BIOETL_DASHBOARD_SETUP.md](./BIOETL_DASHBOARD_SETUP.md)
+
 - ✅ Полная архитектура
 - ✅ Пошаговая установка
 - ✅ Конфигурация каждого компонента
 - ✅ Troubleshooting гайд
 
 ### Если вы визуал 👁️
+
 → Посмотрите [BIOETL_DASHBOARD_VISUAL_GUIDE.md](./BIOETL_DASHBOARD_VISUAL_GUIDE.md)
+
 - ✅ Диаграммы и схемы
 - ✅ Как читать дашборды
 - ✅ Примеры графиков
 
 ### Если вы хотите кастомизировать 💡
+
 → Изучите [BIOETL_DASHBOARD_EXAMPLES.md](./BIOETL_DASHBOARD_EXAMPLES.md)
+
 - ✅ Добавить метрики
 - ✅ Создать дашборды
 - ✅ Настроить алерты
 - ✅ PromQL примеры
 
----
+______________________________________________________________________
 
 ## 📊 Типичные сценарии
 
 ### Сценарий 1: "Я только что клонировал проект"
+
 ```
 1. Прочитать: QUICKSTART.md (5 минут)
 2. Выполнить: чек-лист установки (10 минут)
@@ -52,6 +66,7 @@
 ```
 
 ### Сценарий 2: "Дашборд пуст, нет данных"
+
 ```
 1. Перейти: SETUP.md → Troubleshooting
 2. Найти: раздел "Дашборд показывает No data"
@@ -59,14 +74,16 @@
 ```
 
 ### Сценарий 3: "Хочу добавить свою метрику"
+
 ```
 1. Перейти: EXAMPLES.md → Добавить новую метрику
-2. Отредактировать: metrics_server.py
+2. Отредактировать: src/bioetl/infrastructure/observability/prometheus_metrics.py
 3. Перезапустить: metrics сервер
 4. Использовать в Grafana: PromQL query
 ```
 
 ### Сценарий 4: "Нужно создать собственный дашборд"
+
 ```
 1. Перейти: EXAMPLES.md → Создать пользовательский дашборд
 2. Выбрать: Способ A (UI) или Способ B (JSON)
@@ -75,6 +92,7 @@
 ```
 
 ### Сценарий 5: "Нужно настроить алерты"
+
 ```
 1. Перейти: EXAMPLES.md → Настроить Alert
 2. Выбрать: простой способ (UI) или advanced (YAML)
@@ -82,7 +100,7 @@
 4. Протестировать: alert
 ```
 
----
+______________________________________________________________________
 
 ## 🏗️ Архитектура компонентов
 
@@ -107,18 +125,18 @@
 └─────────────────────────────────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ## 🔑 Ключевые метрики
 
-| Метрика | Как читать | Где используется |
-|---------|-----------|-----------------|
-| `bioetl_records_processed_total` | Кол-во обработанных записей по stage | Simple, DQ v2, Overview v2 |
-| `bioetl_records_processed_created` | Timestamp создания метрики | DQ v2, Overview v2 (Execution Timestamp) |
-| `bioetl_health_check_status` | Статус health check (1=healthy) | Provider Health v2 |
-| `bioetl_health_check_latency_ms` | P95 latency provider'а (histogram) | Provider Health v2 |
+| Метрика                            | Как читать                           | Где используется                         |
+| ---------------------------------- | ------------------------------------ | ---------------------------------------- |
+| `bioetl_records_processed_total`   | Кол-во обработанных записей по stage | Simple, DQ v2, Overview v2               |
+| `bioetl_records_processed_created` | Timestamp создания метрики           | DQ v2, Overview v2 (Execution Timestamp) |
+| `bioetl_health_check_status`       | Статус health check (1=healthy)      | Provider Health v2                       |
+| `bioetl_health_check_latency_ms`   | P95 latency provider'а (histogram)   | Provider Health v2                       |
 
----
+______________________________________________________________________
 
 ## 🎛️ Команды для справки
 
@@ -142,13 +160,13 @@ docker compose -f docker-compose.monitoring.yml down
 
 ```bash
 # Запустить
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Проверить
 curl http://localhost:8000/metrics
 
 # Остановить
-pkill -f metrics_server.py
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
 ```
 
 ### Grafana
@@ -178,73 +196,84 @@ start=1704067200&end=1704153600&step=300"
 curl "http://localhost:9090/api/v1/label/__name__/values"
 ```
 
----
+______________________________________________________________________
 
 ## 🔍 Где искать информацию
 
 ### Установка и первый запуск
+
 → **QUICKSTART.md** или **SETUP.md** раздел "Пошаговая установка"
 
 ### Диагностика проблем
+
 → **SETUP.md** раздел "Troubleshooting"
 
 ### Как использовать дашборды
+
 → **VISUAL_GUIDE.md** раздел "Как читать каждый дашборд"
 
 ### Кастомизация метрик
+
 → **EXAMPLES.md** раздел "Добавить новую метрику"
 
 ### Создание дашбордов
+
 → **EXAMPLES.md** раздел "Создать пользовательский дашборд"
 
 ### Настройка алертов
+
 → **EXAMPLES.md** раздел "Настроить Alert"
 
 ### PromQL примеры
+
 → **EXAMPLES.md** раздел "Шпаргалка по PromQL"
 
 ### Конфигурация компонентов
+
 → **SETUP.md** раздел "Конфигурация компонентов"
 
----
+______________________________________________________________________
 
 ## 📈 Быстрые ссылки
 
-| Компонент | URL | Назначение |
-|-----------|-----|-----------|
-| Grafana Home | http://localhost:3000 | Главная страница |
-| Simple Dashboard | http://localhost:3000/d/bioetl-simple | Основной дашборд |
-| Все дашборды | http://localhost:3000/dashboards | Список дашбордов |
-| Query Explorer | http://localhost:3000/explore | Тестирование PromQL |
-| Prometheus | http://localhost:9090 | Главная Prometheus |
-| Prometheus Targets | http://localhost:9090/targets | Статус target'ов |
-| Prometheus Graph | http://localhost:9090/graph | Ломаное UI (deprecated) |
-| Metrics endpoint | http://localhost:8000/metrics | Raw Prometheus metrics |
-| Health check | http://localhost:8000/health | Статус metrics сервера |
+| Компонент          | URL                                   | Назначение              |
+| ------------------ | ------------------------------------- | ----------------------- |
+| Grafana Home       | http://localhost:3000                 | Главная страница        |
+| Simple Dashboard   | http://localhost:3000/d/bioetl-simple | Основной дашборд        |
+| Все дашборды       | http://localhost:3000/dashboards      | Список дашбордов        |
+| Query Explorer     | http://localhost:3000/explore         | Тестирование PromQL     |
+| Prometheus         | http://localhost:9090                 | Главная Prometheus      |
+| Prometheus Targets | http://localhost:9090/targets         | Статус target'ов        |
+| Prometheus Graph   | http://localhost:9090/graph           | Ломаное UI (deprecated) |
+| Metrics endpoint   | http://localhost:8000/metrics         | Raw Prometheus metrics  |
+| Health check       | http://localhost:8000/health          | Статус metrics сервера  |
 
----
+______________________________________________________________________
 
 ## 🎓 Обучающие ресурсы
 
 ### Для новичков
+
 1. Посмотреть VISUAL_GUIDE.md
-2. Открыть BioETL Simple Dashboard
-3. Поменять фильтры (Pipeline, Run Type)
-4. Посмотреть как меняются графики
+1. Открыть BioETL Simple Dashboard
+1. Поменять фильтры (Pipeline, Run Type)
+1. Посмотреть как меняются графики
 
 ### Для intermediate
+
 1. Изучить PromQL в EXAMPLES.md
-2. Открыть http://localhost:9090/graph → Explore
-3. Написать собственный query
-4. Добавить панель в дашборд
+1. Открыть http://localhost:9090/graph → Explore
+1. Написать собственный query
+1. Добавить панель в дашборд
 
 ### Для advanced
-1. Отредактировать metrics_server.py
-2. Добавить собственную метрику
-3. Создать дашборд с JSON
-4. Настроить alerts с Prometheus
 
----
+1. Отредактировать src/bioetl/infrastructure/observability/prometheus_metrics.py
+1. Добавить собственную метрику
+1. Создать дашборд с JSON
+1. Настроить alerts с Prometheus
+
+______________________________________________________________________
 
 ## 🚨 Emergency Checklist
 
@@ -256,8 +285,8 @@ docker compose -f docker-compose.monitoring.yml down
 docker compose -f docker-compose.monitoring.yml up -d
 
 # 2. Перезапустить metrics сервер
-pkill -f metrics_server.py
-python ./metrics_server.py &
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # 3. Дождаться 15 секунд scrape interval
 sleep 15
@@ -274,16 +303,16 @@ curl http://localhost:3000/api/health
 curl http://localhost:8000/health
 ```
 
----
+______________________________________________________________________
 
 ## 📞 Получить помощь
 
 1. **Проверить Troubleshooting**: SETUP.md
-2. **Посмотреть логи**: `docker logs bioetl-prometheus`
-3. **Диагностировать**: [SETUP.md - Troubleshooting](./BIOETL_DASHBOARD_SETUP.md#troubleshooting)
-4. **Проверить архитектуру**: VISUAL_GUIDE.md
+1. **Посмотреть логи**: `docker logs bioetl-prometheus`
+1. **Диагностировать**: [SETUP.md - Troubleshooting](./BIOETL_DASHBOARD_SETUP.md#troubleshooting)
+1. **Проверить архитектуру**: VISUAL_GUIDE.md
 
----
+______________________________________________________________________
 
 ## 📦 Что включено в инструкцию
 
@@ -296,7 +325,7 @@ curl http://localhost:8000/health
 └── 📄 README.md (этот файл)
 
 📂 Конфигурация
-├── 📄 metrics_server.py                   (Metrics endpoint)
+├── 📄 src/bioetl/infrastructure/observability/prometheus_metrics.py                   (Metrics endpoint)
 ├── 📄 docker-compose.monitoring.yml       (Docker контейнеры)
 ├── 📄 grafana/prometheus.yml              (Prometheus конфиг)
 └── 📄 grafana/provisioning/               (Auto-provisioning)
@@ -308,7 +337,7 @@ curl http://localhost:8000/health
 └── 📊 bioetl-provider-health-v2.json
 ```
 
----
+______________________________________________________________________
 
 ## ✨ Что можно делать с BioETL Dashboard
 
@@ -323,11 +352,12 @@ curl http://localhost:8000/health
 - ✅ Интегрировать с другими системами (Slack, PagerDuty)
 - ✅ Использовать для внутренних презентаций
 
----
+______________________________________________________________________
 
 ## 🎯 Конечная цель
 
 Вы успешно:
+
 - ✅ Установили мониторинг (Prometheus + Grafana)
 - ✅ Запустили metrics сервер
 - ✅ Загрузили 4 дашборда
@@ -336,10 +366,10 @@ curl http://localhost:8000/health
 - ✅ Понимаете архитектуру мониторинга
 - ✅ Умеете диагностировать проблемы
 
----
+______________________________________________________________________
 
-**Последнее обновление:** 22 февраля 2026  
-**Версия:** 1.0  
+**Последнее обновление:** 22 февраля 2026
+**Версия:** 1.0
 **Статус:** ✅ Готово к использованию
 
 Начните с [BIOETL_DASHBOARD_QUICKSTART.md](./BIOETL_DASHBOARD_QUICKSTART.md) — займет 5 минут! ⏱️

--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_SETUP.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_SETUP.md
@@ -1,23 +1,30 @@
 # BioETL Dashboard — Подробная инструкция по настройке
 
-**Дата:** 22 февраля 2026  
-**Версия:** 1.0  
-**Автор:** Docker Assistant  
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
+**Дата:** 22 февраля 2026
+**Версия:** 1.0
+**Автор:** Docker Assistant
 
 ## Содержание
-1. [Быстрый старт (5 минут)](#быстрый-старт)
-2. [Архитектура мониторинга](#архитектура-мониторинга)
-3. [Пошаговая установка](#пошаговая-установка)
-4. [Конфигурация компонентов](#конфигурация-компонентов)
-5. [Использование дашбордов](#использование-дашбордов)
-6. [Кастомизация и расширение](#кастомизация-и-расширение)
-7. [Troubleshooting](#troubleshooting)
 
----
+1. [Быстрый старт (5 минут)](#%D0%B1%D1%8B%D1%81%D1%82%D1%80%D1%8B%D0%B9-%D1%81%D1%82%D0%B0%D1%80%D1%82)
+1. [Архитектура мониторинга](#%D0%B0%D1%80%D1%85%D0%B8%D1%82%D0%B5%D0%BA%D1%82%D1%83%D1%80%D0%B0-%D0%BC%D0%BE%D0%BD%D0%B8%D1%82%D0%BE%D1%80%D0%B8%D0%BD%D0%B3%D0%B0)
+1. [Пошаговая установка](#%D0%BF%D0%BE%D1%88%D0%B0%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F-%D1%83%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0)
+1. [Конфигурация компонентов](#%D0%BA%D0%BE%D0%BD%D1%84%D0%B8%D0%B3%D1%83%D1%80%D0%B0%D1%86%D0%B8%D1%8F-%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D0%BE%D0%B2)
+1. [Использование дашбордов](#%D0%B8%D1%81%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-%D0%B4%D0%B0%D1%88%D0%B1%D0%BE%D1%80%D0%B4%D0%BE%D0%B2)
+1. [Кастомизация и расширение](#%D0%BA%D0%B0%D1%81%D1%82%D0%BE%D0%BC%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F-%D0%B8-%D1%80%D0%B0%D1%81%D1%88%D0%B8%D1%80%D0%B5%D0%BD%D0%B8%D0%B5)
+1. [Troubleshooting](#troubleshooting)
+
+______________________________________________________________________
 
 ## Быстрый старт
 
 ### Требования
+
 - Docker & Docker Compose
 - Python 3.11+ (для BioETL metrics сервера)
 - 2GB свободной памяти
@@ -30,7 +37,7 @@
 docker compose -f docker-compose.monitoring.yml up -d
 
 # 2. Запустить Prometheus metrics сервер (в фоне)
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # 3. Открыть Grafana
 # Браузер: http://localhost:3000
@@ -40,7 +47,7 @@ python ./metrics_server.py &
 
 ✅ **Готово!** Дашборды доступны на http://localhost:3000/d/bioetl-simple
 
----
+______________________________________________________________________
 
 ## Архитектура мониторинга
 
@@ -77,14 +84,14 @@ python ./metrics_server.py &
 
 ### Компоненты
 
-| Компонент | Порт | Назначение | URL |
-|-----------|------|-----------|-----|
+| Компонент      | Порт | Назначение                             | URL                           |
+| -------------- | ---- | -------------------------------------- | ----------------------------- |
 | **BioETL App** | 8000 | Генерирует метрики (Prometheus format) | http://localhost:8000/metrics |
-| **Prometheus** | 9090 | Собирает и хранит метрики TSDB | http://localhost:9090 |
-| **Grafana** | 3000 | Визуализирует метрики в дашборды | http://localhost:3000 |
-| **Neo4j** | 7687 | База данных графов (опционально) | http://localhost:7474 |
+| **Prometheus** | 9090 | Собирает и хранит метрики TSDB         | http://localhost:9090         |
+| **Grafana**    | 3000 | Визуализирует метрики в дашборды       | http://localhost:3000         |
+| **Neo4j**      | 7687 | База данных графов (опционально)       | http://localhost:7474         |
 
----
+______________________________________________________________________
 
 ## Пошаговая установка
 
@@ -127,7 +134,7 @@ docker compose -f docker-compose.monitoring.yml ps
 
 ```bash
 # Запустить metrics сервер в фоне
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # Проверить, что работает
 curl http://localhost:8000/metrics | head -20
@@ -146,7 +153,7 @@ After=network.target
 Type=simple
 User=bioetl
 WorkingDirectory=/opt/bioetl
-ExecStart=/usr/bin/python3 /opt/bioetl/metrics_server.py
+ExecStart=/usr/bin/python3 /opt/bioetl/src/bioetl/infrastructure/observability/prometheus_metrics.py
 Restart=always
 RestartSec=10
 
@@ -168,9 +175,9 @@ cat > Dockerfile.metrics << 'EOF'
 FROM python:3.13-slim
 WORKDIR /app
 RUN pip install prometheus-client
-COPY metrics_server.py .
+COPY src/bioetl/infrastructure/observability/prometheus_metrics.py .
 EXPOSE 8000
-CMD ["python", "metrics_server.py"]
+CMD ["python", "src/bioetl/infrastructure/observability/prometheus_metrics.py"]
 EOF
 
 # Собрать и запустить
@@ -183,21 +190,22 @@ docker run -d --name bioetl-metrics \
 ### Шаг 4: Проверить подключение Prometheus
 
 1. Открыть http://localhost:9090/targets
-2. Проверить статус target `bioetl`:
+1. Проверить статус target `bioetl`:
    - ✅ **UP** — всё работает
    - ❌ **DOWN** — проверить Шаг 3
 
 ### Шаг 5: Подключить Grafana к Prometheus
 
 1. Открыть http://localhost:3000
-2. Войти (admin/admin)
-3. Перейти: **Configuration → Data Sources**
-4. Проверить, что Prometheus уже добавлен:
+1. Войти (admin/admin)
+1. Перейти: **Configuration → Data Sources**
+1. Проверить, что Prometheus уже добавлен:
    - **Name:** Prometheus
    - **URL:** http://host.docker.internal:9090
    - **Status:** ✅ Green (ready)
 
 Если не добавлен:
+
 - Кликнуть **Add data source**
 - Выбрать **Prometheus**
 - Заполнить URL: `http://host.docker.internal:9090`
@@ -206,13 +214,13 @@ docker run -d --name bioetl-metrics \
 ### Шаг 6: Проверить дашборды
 
 1. Перейти: http://localhost:3000/dashboards
-2. Нажать **Browse**
-3. Выбрать папку **BioETL**
-4. Открыть **BioETL Simple Dashboard**
+1. Нажать **Browse**
+1. Выбрать папку **BioETL**
+1. Открыть **BioETL Simple Dashboard**
 
 ✅ Дашборд должен показывать данные (графики, статистика)
 
----
+______________________________________________________________________
 
 ## Конфигурация компонентов
 
@@ -235,11 +243,13 @@ scrape_configs:
 ```
 
 **Параметры:**
+
 - `scrape_interval`: Интервал сбора метрик (15s = каждые 15 секунд)
 - `metrics_path`: Путь к метрикам (/metrics)
 - `targets`: Адреса приложений для мониторинга
 
 **Если изменить:**
+
 ```bash
 # Отредактировать
 nano ./grafana/prometheus.yml
@@ -269,10 +279,12 @@ grafana:
 ```
 
 **Важные переменные:**
+
 - `GF_SECURITY_ADMIN_PASSWORD` — пароль admin
 - `GF_USERS_ALLOW_SIGN_UP` — разрешить регистрацию пользователей
 
 **Изменить пароль в production:**
+
 ```bash
 # В docker-compose.monitoring.yml
 environment:
@@ -282,62 +294,64 @@ environment:
 docker compose -f docker-compose.monitoring.yml up -d
 ```
 
-### BioETL Metrics Server (metrics_server.py)
+### BioETL Metrics Server (src/bioetl/infrastructure/observability/prometheus_metrics.py)
 
 ```python
 # Порт и адрес
-HOST = '0.0.0.0'  # Слушать на всех интерфейсах
-PORT = 8000       # Порт для метрик
+HOST = "0.0.0.0"  # Слушать на всех интерфейсах
+PORT = 8000  # Порт для метрик
 
 # Метрики
 RECORDS_PROCESSED = Counter(
-    'bioetl_records_processed_total',
-    'Total records processed',
-    ['pipeline', 'run_id', 'stage', 'status']  # Labels
+    "bioetl_records_processed_total",
+    "Total records processed",
+    ["pipeline", "run_id", "stage", "status"],  # Labels
 )
 ```
 
 **Добавить собственную метрику:**
+
 ```python
 from prometheus_client import Gauge
 
-MY_METRIC = Gauge(
-    'bioetl_my_metric',
-    'My custom metric',
-    ['pipeline', 'stage']
-)
+MY_METRIC = Gauge("bioetl_my_metric", "My custom metric", ["pipeline", "stage"])
 
 # В коде приложения:
-MY_METRIC.labels(pipeline='uniprot', stage='bronze').set(value)
+MY_METRIC.labels(pipeline="uniprot", stage="bronze").set(value)
 ```
 
----
+______________________________________________________________________
 
 ## Использование дашбордов
 
 ### Доступные дашборды
 
 1. **BioETL Simple Dashboard** (`bioetl-simple`)
+
    - Bronze/Silver/Gold Records (текущие значения)
    - Quality Ratio (процент качества)
    - Live график по стадиям обработки
 
-2. **BioETL Overview** (`bioetl-overview`)
+1. **BioETL Overview** (`bioetl-overview`)
+
    - Общая статистика по всем pipeline
    - Тренды обработки данных
    - Error rate по компонентам
 
-3. **BioETL Data Quality v2** (`bioetl-dq-v2`)
+1. **BioETL Data Quality v2** (`bioetl-dq-v2`)
+
    - Метрики качества данных
    - Аномалии и отклонения
    - Исторические данные
 
-4. **BioETL Provider Health** (`bioetl-provider-health`)
+1. **BioETL Provider Health** (`bioetl-provider-health`)
+
    - Статус каждого provider (UniProt, PubMed, PubChem, ChemBL)
    - Response time
    - Error rate
 
-5. **BioETL Overview v2** (`bioetl-overview-v2`)
+1. **BioETL Overview v2** (`bioetl-overview-v2`)
+
    - Advanced обзор
    - Custom фильтры
    - Drill-down аналитика
@@ -347,16 +361,19 @@ MY_METRIC.labels(pipeline='uniprot', stage='bronze').set(value)
 Все дашборды имеют переменные для фильтрации:
 
 **Pipeline** — выбрать pipeline
+
 ```
 Доступные: uniprot, pubmed, pubchem, chembl, All
 ```
 
 **Run Type** — выбрать тип запуска
+
 ```
 Доступные: incremental, backfill, rebuild, All
 ```
 
 **Пример использования:**
+
 ```
 1. Открыть BioETL Simple Dashboard
 2. В левой панели: Pipeline = "uniprot"
@@ -367,12 +384,14 @@ MY_METRIC.labels(pipeline='uniprot', stage='bronze').set(value)
 ### Экспорт и обмен
 
 **Экспортировать дашборд как JSON:**
+
 ```
 Dashboard → Dashboard settings (⚙️) → JSON Model
 → Copy to clipboard → Сохранить в файл
 ```
 
 **Импортировать дашборд:**
+
 ```
 Home → Dashboards → New → Import
 → Paste JSON или загрузить файл
@@ -381,13 +400,14 @@ Home → Dashboards → New → Import
 ```
 
 **Поделиться ссылкой:**
+
 ```
 Dashboard → Share (🔗)
 → Copy dashboard URL
 → Отправить коллеге
 ```
 
----
+______________________________________________________________________
 
 ## Кастомизация и расширение
 
@@ -400,30 +420,23 @@ from prometheus_client import Counter, Gauge, Histogram
 
 # Определить метрику
 API_REQUESTS = Counter(
-    'bioetl_api_requests_total',
-    'Total API requests',
-    ['endpoint', 'method', 'status']
+    "bioetl_api_requests_total", "Total API requests", ["endpoint", "method", "status"]
 )
 
 RESPONSE_TIME = Histogram(
-    'bioetl_api_response_time_seconds',
-    'API response time',
-    ['endpoint']
+    "bioetl_api_response_time_seconds", "API response time", ["endpoint"]
 )
 
 # В коде API:
-API_REQUESTS.labels(
-    endpoint='/fetch',
-    method='GET',
-    status='200'
-).inc()
+API_REQUESTS.labels(endpoint="/fetch", method="GET", status="200").inc()
 
-RESPONSE_TIME.labels(endpoint='/fetch').observe(duration)
+RESPONSE_TIME.labels(endpoint="/fetch").observe(duration)
 ```
 
 **2. Prometheus автоматически подберёт новую метрику**
 
 **3. Использовать в Grafana:**
+
 ```
 Query: bioetl_api_requests_total
 Legend: {{endpoint}} - {{status}}
@@ -513,7 +526,7 @@ docker restart bioetl-grafana
 # 3. Дашборд автоматически загрузится и появится в папке BioETL
 ```
 
----
+______________________________________________________________________
 
 ## Troubleshooting
 
@@ -522,14 +535,15 @@ docker restart bioetl-grafana
 **Симптом:** Targets → bioetl = DOWN
 
 **Решение:**
+
 ```bash
 # 1. Проверить, работает ли metrics сервер
 curl http://localhost:8000/metrics
 
 # 2. Если curl не работает:
 # a) Перезапустить metrics сервер
-pkill -f metrics_server.py
-python ./metrics_server.py &
+pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # b) Проверить в логах контейнера Prometheus
 docker logs bioetl-prometheus | tail -20
@@ -545,6 +559,7 @@ docker logs bioetl-prometheus | tail -20
 **Симптом:** График пуст, нет данных
 
 **Решение:**
+
 ```bash
 # 1. Проверить Prometheus query
 # Home → Explore
@@ -555,7 +570,7 @@ docker logs bioetl-prometheus | tail -20
 curl http://localhost:8000/metrics | grep bioetl_records_processed
 
 # 3. Если метрик нет → перезапустить metrics сервер
-python ./metrics_server.py
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 # 4. Дождаться 15 сек (интервал scrape)
 # затем обновить дашборд (F5)
@@ -566,6 +581,7 @@ python ./metrics_server.py
 **Симптом:** Data source → Prometheus = Red (failed)
 
 **Решение:**
+
 ```bash
 # 1. Проверить, доступен ли Prometheus
 curl http://localhost:9090/-/healthy
@@ -606,6 +622,7 @@ docker logs bioetl-prometheus -f
 ### Проблема: Дашборд зависает при загрузке
 
 **Решение:**
+
 ```bash
 # 1. Открыть DevTools (F12 → Console)
 # Проверить ошибки в консоли браузера
@@ -656,7 +673,7 @@ du -sh /var/lib/docker/volumes/bioetl_prometheus_data/_data
 # docker restart bioetl-prometheus
 ```
 
----
+______________________________________________________________________
 
 ## Быстрая справка (шпаргалка)
 
@@ -704,44 +721,47 @@ avg(bioetl_processing_duration_seconds_bucket)
 
 ### Полезные URL
 
-| URL | Назначение |
-|-----|-----------|
-| http://localhost:3000 | Grafana Home |
-| http://localhost:3000/dashboards | Все дашборды |
-| http://localhost:3000/d/bioetl-simple | BioETL Simple Dashboard |
-| http://localhost:3000/explore | Prometheus Query Explorer |
-| http://localhost:9090 | Prometheus Web UI |
-| http://localhost:9090/targets | Targets статус |
-| http://localhost:9090/graph | Query граф (deprecated) |
-| http://localhost:8000/metrics | BioETL Metrics endpoint |
+| URL                                   | Назначение                |
+| ------------------------------------- | ------------------------- |
+| http://localhost:3000                 | Grafana Home              |
+| http://localhost:3000/dashboards      | Все дашборды              |
+| http://localhost:3000/d/bioetl-simple | BioETL Simple Dashboard   |
+| http://localhost:3000/explore         | Prometheus Query Explorer |
+| http://localhost:9090                 | Prometheus Web UI         |
+| http://localhost:9090/targets         | Targets статус            |
+| http://localhost:9090/graph           | Query граф (deprecated)   |
+| http://localhost:8000/metrics         | BioETL Metrics endpoint   |
 
----
+______________________________________________________________________
 
 ## Поддержка и вопросы
 
 Если возникают вопросы:
 
 1. **Проверить логи контейнеров**
+
    ```bash
    docker compose -f docker-compose.monitoring.yml logs
    ```
 
-2. **Перезагрузить все компоненты**
+1. **Перезагрузить все компоненты**
+
    ```bash
    docker compose -f docker-compose.monitoring.yml down
    docker compose -f docker-compose.monitoring.yml up -d
-   python ./metrics_server.py &
+   python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
    ```
 
-3. **Проверить здоровье компонентов**
+1. **Проверить здоровье компонентов**
+
    ```bash
    curl http://localhost:9090/-/healthy
    curl http://localhost:3000/api/health
    curl http://localhost:8000/health
    ```
 
----
+______________________________________________________________________
 
-**Версия документации:** 1.0  
-**Последнее обновление:** 22 февраля 2026  
+**Версия документации:** 1.0
+**Последнее обновление:** 22 февраля 2026
 **Совместимость:** BioETL v6.0.0, Prometheus 3.9.1, Grafana 10.2.0+

--- a/docs/03-guides/dashboards/BIOETL_DASHBOARD_VISUAL_GUIDE.md
+++ b/docs/03-guides/dashboards/BIOETL_DASHBOARD_VISUAL_GUIDE.md
@@ -1,5 +1,10 @@
 # BioETL Dashboard — Визуальный гайд
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 ## 🎯 Архитектура на одной странице
 
 ```
@@ -50,21 +55,21 @@
        ╚══════════╝  ╚═══════════╝  ╚════════════╝ ╚═════════════╝
 ```
 
----
+______________________________________________________________________
 
 ## 📊 Типы панелей в Grafana
 
-| Тип | Иконка | Пример | Когда использовать |
-|-----|--------|--------|-------------------|
-| **Stat** | 📊 | `Bronze Records: 4,523` | Текущее значение, KPI |
-| **Gauge** | 🎯 | Полукруг с % | Прогресс, процент, ratio |
-| **Graph/Timeseries** | 📈 | Линейный график | Тренды, изменения во времени |
-| **Table** | 📋 | Таблица с данными | Список метрик, детали |
-| **Heatmap** | 🔥 | Тепловая карта | Распределение, плотность |
-| **Piechart** | 🥧 | Круговая диаграмма | Доля компонентов |
-| **Alert list** | 🔔 | Список alert'ов | Активные алерты |
+| Тип                  | Иконка | Пример                  | Когда использовать           |
+| -------------------- | ------ | ----------------------- | ---------------------------- |
+| **Stat**             | 📊     | `Bronze Records: 4,523` | Текущее значение, KPI        |
+| **Gauge**            | 🎯     | Полукруг с %            | Прогресс, процент, ratio     |
+| **Graph/Timeseries** | 📈     | Линейный график         | Тренды, изменения во времени |
+| **Table**            | 📋     | Таблица с данными       | Список метрик, детали        |
+| **Heatmap**          | 🔥     | Тепловая карта          | Распределение, плотность     |
+| **Piechart**         | 🥧     | Круговая диаграмма      | Доля компонентов             |
+| **Alert list**       | 🔔     | Список alert'ов         | Активные алерты              |
 
----
+______________________________________________________________________
 
 ## 🔍 Как читать каждый дашборд
 
@@ -107,7 +112,7 @@ Records by Stage (Live)
 - Если золото не растёт → problem в Stage 3 ⚠️
 ```
 
----
+______________________________________________________________________
 
 ### 2️⃣ BioETL Overview Dashboard
 
@@ -132,7 +137,7 @@ Records by Stage (Live)
 └───────────────────────────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ### 3️⃣ BioETL Data Quality Dashboard
 
@@ -156,7 +161,7 @@ Quality Scores:
 └─────────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ### 4️⃣ BioETL Provider Health Dashboard
 
@@ -186,7 +191,7 @@ Provider Status:
 └───────────────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ## 🎛️ Фильтры и переменные
 
@@ -206,13 +211,14 @@ Run Type: [incremental ▼]  ← выбрать тип запуска
 5. Выбрать "All" чтобы увидеть все
 ```
 
----
+______________________________________________________________________
 
 ## ⚠️ Когда что-то не работает
 
 ### Признак: Дашборд пуст / "No data"
 
 **Диагностика:**
+
 ```
 1. Видны ли фильтры (Pipeline, Run Type)?
    ✅ Да   → перейти к шагу 2
@@ -227,10 +233,10 @@ Run Type: [incremental ▼]  ← выбрать тип запуска
 3. Работает ли metrics_server?
    curl http://localhost:8000/metrics
    ✅ Возвращает метрики → всё OK, подождать 15 сек
-   ❌ Connection refused  → запустить metrics_server.py
+   ❌ Connection refused  → запустить src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 Решение:
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 # Дождаться 15 сек scrape interval
 # Обновить дашборд (Ctrl+R)
 ```
@@ -249,8 +255,8 @@ python ./metrics_server.py &
 1. Проверить metrics_server
    curl http://localhost:8000/metrics
    ❌ Если ошибка:
-   pkill -f metrics_server.py
-   python ./metrics_server.py &
+   pkill -f src/bioetl/infrastructure/observability/prometheus_metrics.py
+   python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 2. Если URL неправильный (не host.docker.internal):
    docker logs bioetl-prometheus | grep -i error
@@ -258,33 +264,33 @@ python ./metrics_server.py &
    # Перезагрузить: docker restart bioetl-prometheus
 ```
 
----
+______________________________________________________________________
 
 ## 📈 Цели мониторинга
 
-| Метрика | Норма | Предупреждение | Критично |
-|---------|-------|----------------|----------|
-| Error Rate | <1% | 1-5% ⚠️ | >5% ❌ |
-| Quality Ratio | >90% | 80-90% ⚠️ | <80% ❌ |
-| Response Time (P95) | <500ms | 500-1000ms ⚠️ | >1000ms ❌ |
-| Records/min | >100 | 50-100 ⚠️ | <50 ❌ |
-| Provider Uptime | >99% | 95-99% ⚠️ | <95% ❌ |
+| Метрика             | Норма   | Предупреждение | Критично   |
+| ------------------- | ------- | -------------- | ---------- |
+| Error Rate          | \<1%    | 1-5% ⚠️        | >5% ❌     |
+| Quality Ratio       | >90%    | 80-90% ⚠️      | \<80% ❌   |
+| Response Time (P95) | \<500ms | 500-1000ms ⚠️  | >1000ms ❌ |
+| Records/min         | >100    | 50-100 ⚠️      | \<50 ❌    |
+| Provider Uptime     | >99%    | 95-99% ⚠️      | \<95% ❌   |
 
----
+______________________________________________________________________
 
 ## 🔧 Быстрые действия
 
-| Действие | Как сделать | Результат |
-|----------|------------|-----------|
-| **Обновить дашборд** | F5 или ⟲ кнопка | Свежие данные |
-| **Изменить время** | "Last 1 hour" ← клик | Другой временной диапазон |
-| **Зум на график** | Drag on graph | Увеличить участок |
-| **Export panel** | ⋮ → Export | Сохранить как PNG/CSV |
-| **Edit panel** | ⋮ → Edit | Изменить query |
-| **Save dashboard** | Ctrl+S или кнопка | Сохранить изменения |
-| **Поделиться** | ⋮ → Share | Link или embed |
+| Действие             | Как сделать          | Результат                 |
+| -------------------- | -------------------- | ------------------------- |
+| **Обновить дашборд** | F5 или ⟲ кнопка      | Свежие данные             |
+| **Изменить время**   | "Last 1 hour" ← клик | Другой временной диапазон |
+| **Зум на график**    | Drag on graph        | Увеличить участок         |
+| **Export panel**     | ⋮ → Export           | Сохранить как PNG/CSV     |
+| **Edit panel**       | ⋮ → Edit             | Изменить query            |
+| **Save dashboard**   | Ctrl+S или кнопка    | Сохранить изменения       |
+| **Поделиться**       | ⋮ → Share            | Link или embed            |
 
----
+______________________________________________________________________
 
 ## 🎓 Обучающие примеры
 
@@ -340,8 +346,8 @@ python ./metrics_server.py &
 - Или добавить параллельную обработку
 ```
 
----
+______________________________________________________________________
 
-**Дата:** 22 февраля 2026  
-**Версия:** 1.0  
+**Дата:** 22 февраля 2026
+**Версия:** 1.0
 **Для:** Визуальное понимание BioETL Dashboard

--- a/docs/03-guides/dashboards/DASHBOARD_V2_USAGE.md
+++ b/docs/03-guides/dashboards/DASHBOARD_V2_USAGE.md
@@ -1,65 +1,80 @@
 # BioETL Dashboards v2 — Руководство по использованию
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 ## 🎯 Обновленные дашборды
 
 Три дашборда версии 2.0 теперь включают информацию о последнем запуске:
 
-| Дашборд | URL | Переменные |
-|---------|-----|-----------|
-| **Data Quality v2** | http://localhost:3000/d/bioetl-dq-v2 | Pipeline, Run Type, Timestamp |
-| **Overview v2** | http://localhost:3000/d/bioetl-overview-v2 | Pipeline, Run Type, Timestamp |
-| **Provider Health v2** | http://localhost:3000/d/bioetl-provider-health-v2 | Provider, Timestamp |
+| Дашборд                | URL                                               | Переменные                    |
+| ---------------------- | ------------------------------------------------- | ----------------------------- |
+| **Data Quality v2**    | http://localhost:3000/d/bioetl-dq-v2              | Pipeline, Run Type, Timestamp |
+| **Overview v2**        | http://localhost:3000/d/bioetl-overview-v2        | Pipeline, Run Type, Timestamp |
+| **Provider Health v2** | http://localhost:3000/d/bioetl-provider-health-v2 | Provider, Timestamp           |
 
----
+______________________________________________________________________
 
 ## 📊 Что показывает каждый дашборд
 
 ### 1. BioETL Data Quality v2
+
 **Назначение:** Анализ качества данных
 
 **Верхняя строка (info-панели):**
+
 ```
 Pipeline: uniprot          Run Type: incremental     Execution Timestamp: 1645382400
 ```
 
 **Графики:**
+
 - Data Flow: Bronze → Silver → Gold (процесс обработки)
 - Data Quality Score (% качества - gauge)
 - Source Records (Bronze stage)
 - Clean Records (Gold stage)
 
 **Интерпретация:**
+
 - Если Quality Score > 95% ✅ — отлично
 - Если Quality Score 80-95% ⚠️ — норма
 - Если Quality Score < 80% ❌ — требует внимания
 
----
+______________________________________________________________________
 
 ### 2. BioETL Overview v2
+
 **Назначение:** Общий обзор обработки pipeline
 
 **Верхняя строка (info-панели):**
+
 ```
 Pipeline: pubmed           Run Type: backfill     Execution Timestamp: 1645386000
 ```
 
 **Графики:**
+
 - Processing Pipeline (тренд по стадиям)
 - Stage Distribution (pie chart)
 - Pipeline Distribution (pie chart)
 - Overall Quality (gauge)
 
 **Интерпретация:**
+
 - Bronze → Silver → Gold должны снижаться (нормальный процесс)
 - Overall Quality должен быть ≥95%
 - Если что-то застопорилось на стадии → ошибка
 
----
+______________________________________________________________________
 
 ### 3. BioETL Provider Health v2
+
 **Назначение:** Статус и latency каждого provider'а
 
 **Верхняя строка (info-панели):**
+
 ```
 Provider: chembl           Health Status: Provider Health     Execution Timestamp: 1645389600
 ```
@@ -67,33 +82,38 @@ Provider: chembl           Health Status: Provider Health     Execution Timestam
 **Переменная:** `$provider` (вместо $pipeline/$run_type в других дашбордах)
 
 **Графики:**
+
 - Provider Response Time (P95 latency, histogram_quantile)
 - Health Check Status (stat)
 - Individual Latency Gauges (UniProt, PubMed, PubChem, ChemBL)
 
 **Интерпретация (пороги в миллисекундах):**
+
 - Зелёный цвет ✅ — < 0.5ms
 - Жёлтый ⚠️ — 0.5-1ms
 - Оранжевый ⚠️ — 1-2ms
 - Красный ❌ — > 2ms
 
----
+______________________________________________________________________
 
 ## 🚀 Как использовать
 
 ### Первый раз
 
 1. **Откройте Grafana:**
+
    ```
    http://localhost:3000
    ```
 
-2. **Перейдите на дашборд:**
+1. **Перейдите на дашборд:**
+
    ```
    Home → Dashboards → BioETL → BioETL Data Quality v2
    ```
 
-3. **Дашборд покажет:**
+1. **Дашборд покажет:**
+
    - ✅ Pipeline название (info-панель)
    - ✅ Run Type (info-панель)
    - ✅ Execution Timestamp (info-панель)
@@ -102,47 +122,47 @@ Provider: chembl           Health Status: Provider Health     Execution Timestam
 ### Регулярно
 
 1. **Открывайте дашборд** — автоматически обновляется (каждые 30 сек)
-2. **Смотрите Pipeline и Run Type** — в info-панелях вверху
-3. **Проверяйте метрики** — сравнивайте с нормой
+1. **Смотрите Pipeline и Run Type** — в info-панелях вверху
+1. **Проверяйте метрики** — сравнивайте с нормой
 
----
+______________________________________________________________________
 
 ## 📈 Нормальные значения
 
 ### BioETL Data Quality v2
 
-| Метрика | Норма | Внимание | Критично |
-|---------|-------|----------|----------|
-| Data Quality Score | > 95% | 80-95% | < 80% |
-| Gold Records | > 90% Bronze | 70-90% | < 70% |
+| Метрика            | Норма        | Внимание | Критично |
+| ------------------ | ------------ | -------- | -------- |
+| Data Quality Score | > 95%        | 80-95%   | < 80%    |
+| Gold Records       | > 90% Bronze | 70-90%   | < 70%    |
 
 ### BioETL Overview v2
 
-| Метрика | Норма | Внимание | Критично |
-|---------|-------|----------|----------|
-| Overall Quality | > 95% | 80-95% | < 80% |
-| Bronze → Silver | > 80% | 50-80% | < 50% |
-| Silver → Gold | > 90% | 70-90% | < 70% |
+| Метрика         | Норма | Внимание | Критично |
+| --------------- | ----- | -------- | -------- |
+| Overall Quality | > 95% | 80-95%   | < 80%    |
+| Bronze → Silver | > 80% | 50-80%   | < 50%    |
+| Silver → Gold   | > 90% | 70-90%   | < 70%    |
 
 ### BioETL Provider Health v2
 
-| Provider | Норма | Внимание | Критично |
-|----------|-------|----------|----------|
-| UniProt | < 0.5ms | 0.5-1ms | > 1ms |
-| PubMed | < 1ms | 1-2ms | > 2ms |
-| PubChem | < 1ms | 1-2ms | > 2ms |
-| ChemBL | < 1ms | 1-2ms | > 2ms |
+| Provider | Норма   | Внимание | Критично |
+| -------- | ------- | -------- | -------- |
+| UniProt  | < 0.5ms | 0.5-1ms  | > 1ms    |
+| PubMed   | < 1ms   | 1-2ms    | > 2ms    |
+| PubChem  | < 1ms   | 1-2ms    | > 2ms    |
+| ChemBL   | < 1ms   | 1-2ms    | > 2ms    |
 
----
+______________________________________________________________________
 
 ## 🔍 Как ищете проблему
 
 ### Если качество упало
 
 1. **Откройте BioETL Data Quality v2**
-2. **Посмотрите Pipeline и Run Type**
-3. **Проверьте Data Quality Score**
-4. **Если < 80%:**
+1. **Посмотрите Pipeline и Run Type**
+1. **Проверьте Data Quality Score**
+1. **Если < 80%:**
    - Перейдите на **BioETL Provider Health v2**
    - Проверьте, какой provider медленный
    - Обновите данные или перезапустите
@@ -150,26 +170,27 @@ Provider: chembl           Health Status: Provider Health     Execution Timestam
 ### Если данные не обрабатываются
 
 1. **Откройте BioETL Overview v2**
-2. **Посмотрите Processing Pipeline график**
-3. **Если линии плоские:**
-   - Перезагрузите metrics server: `python ./metrics_server.py &`
+1. **Посмотрите Processing Pipeline график**
+1. **Если линии плоские:**
+   - Перезагрузите metrics server: `python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &`
    - Перезагрузите Prometheus: `docker restart bioetl-prometheus`
-4. **Дождитесь 15 сек scrape interval**
+1. **Дождитесь 15 сек scrape interval**
 
 ### Если provider недоступен
 
 1. **Откройте BioETL Provider Health v2**
-2. **Посмотрите Health Check Status**
-3. **Проверьте Individual Latency Gauges**
-4. **Проверьте Provider Response Time — высокая latency указывает на проблему**
+1. **Посмотрите Health Check Status**
+1. **Проверьте Individual Latency Gauges**
+1. **Проверьте Provider Response Time — высокая latency указывает на проблему**
 
----
+______________________________________________________________________
 
 ## 💡 Советы
 
 ### Совет 1: Сравнение разных запусков
 
 Хотите сравнить два разных запуска?
+
 ```
 1. Откройте BioETL Overview v2 в Tab 1
 2. Откройте BioETL Overview v2 в Tab 2
@@ -180,6 +201,7 @@ Provider: chembl           Health Status: Provider Health     Execution Timestam
 ### Совет 2: Мониторинг тренда
 
 Хотите видеть тренд последних запусков?
+
 ```
 1. Откройте BioETL Data Quality v2
 2. Скопируйте Query: bioetl_records_processed_total{pipeline=~"$pipeline", run_type=~"$run_type"}
@@ -190,25 +212,27 @@ Provider: chembl           Health Status: Provider Health     Execution Timestam
 ### Совет 3: Экспорт для отчётов
 
 Хотите экспортировать данные?
+
 ```
 1. Dashboard → 3 точки (⋮) → Export
 2. Выбрать Panel → Export as PNG
 3. Отправить в отчёт
 ```
 
----
+______________________________________________________________________
 
 ## 🐛 Проблемы и решения
 
 ### Проблема: "No data" в дашборде
 
 **Решение:**
+
 ```bash
 # 1. Проверить metrics сервер
 curl http://localhost:8000/metrics
 
 # 2. Если нет — перезапустить
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # 3. Дождаться 15 сек
 # 4. Обновить дашборд (F5)
@@ -217,6 +241,7 @@ python ./metrics_server.py &
 ### Проблема: Pipeline/Run Type не показывается
 
 **Решение:**
+
 ```bash
 # 1. Перезагрузить Grafana
 docker restart bioetl-grafana
@@ -231,13 +256,14 @@ docker restart bioetl-grafana
 ### Проблема: Timestamp показывает 0 или старый
 
 **Решение:**
+
 ```
 Это нормально — timestamp показывает время последней метрики.
 Если метрики старые, значит запуск был давно.
 Запустите новый run — обновится автоматически.
 ```
 
----
+______________________________________________________________________
 
 ## 📊 Примеры интерпретации
 
@@ -271,23 +297,24 @@ Quality Ratio: 0.62
 
 **Вывод:** Проблема — PubMed медленный, много ошибок ❌
 
----
+______________________________________________________________________
 
 ## 🎯 Когда открывать какой дашборд
 
-| Вопрос | Дашборд |
-|--------|---------|
-| Как качество данных? | Data Quality v2 |
-| Сколько данных обработано? | Overview v2 |
-| Какой provider медленный? | Provider Health v2 |
-| Почему упало качество? | Provider Health v2 |
+| Вопрос                      | Дашборд               |
+| --------------------------- | --------------------- |
+| Как качество данных?        | Data Quality v2       |
+| Сколько данных обработано?  | Overview v2           |
+| Какой provider медленный?   | Provider Health v2    |
+| Почему упало качество?      | Provider Health v2    |
 | Когда был последний запуск? | Любой (см. Timestamp) |
 
----
+______________________________________________________________________
 
 ## ✨ Итог
 
 **Три дашборда v2 теперь:**
+
 - ✅ Отображают Pipeline, Run Type и время запуска в info-панелях
 - ✅ Фильтрация по Pipeline и Run Type через dropdown
 - ✅ Автоматически обновляются (каждые 30 сек)
@@ -296,8 +323,8 @@ Quality Ratio: 0.62
 
 **Открывайте и мониторьте!** 🚀
 
----
+______________________________________________________________________
 
-**Последнее обновление:** 22 февраля 2026  
-**Версия:** 2.0  
+**Последнее обновление:** 22 февраля 2026
+**Версия:** 2.0
 **Статус:** ✅ Production Ready

--- a/docs/03-guides/dashboards/README.md
+++ b/docs/03-guides/dashboards/README.md
@@ -1,39 +1,50 @@
 # BioETL Dashboard Guides — Индекс документации
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 **Местоположение:** `/docs/03-guides/dashboards/`
 
 ## 📚 Документация
 
 ### 🌟 Главный файл (начните отсюда)
+
 - **BIOETL_DASHBOARD_COMPLETE.md** — Сводка всех компонентов и итоги
 
 ### 📖 Основные руководства
 
-1. **BIOETL_DASHBOARD_README.md** 
+1. **BIOETL_DASHBOARD_README.md**
+
    - Индекс и навигация по всей документации
    - Ответы на вопрос "Где искать?"
    - Быстрые ссылки на компоненты
 
-2. **BIOETL_DASHBOARD_QUICKSTART.md** (⏱️ 5 минут)
+1. **BIOETL_DASHBOARD_QUICKSTART.md** (⏱️ 5 минут)
+
    - Чек-лист установки
    - 6 простых команд для запуска
    - Диагностика проблем
    - FAQ
 
-3. **BIOETL_DASHBOARD_SETUP.md** (📖 60 минут)
+1. **BIOETL_DASHBOARD_SETUP.md** (📖 60 минут)
+
    - Полная архитектура мониторинга
    - Пошаговая установка (Шаг 1-6)
    - Конфигурация компонентов
    - Использование дашбордов
    - Troubleshooting гайд (10+ решений)
 
-4. **BIOETL_DASHBOARD_VISUAL_GUIDE.md** (👁️ 20 минут)
+1. **BIOETL_DASHBOARD_VISUAL_GUIDE.md** (👁️ 20 минут)
+
    - Диаграммы архитектуры
    - Типы панелей Grafana
    - Как читать каждый дашборд
    - Примеры интерпретации данных
 
-5. **BIOETL_DASHBOARD_EXAMPLES.md** (💡 30 минут)
+1. **BIOETL_DASHBOARD_EXAMPLES.md** (💡 30 минут)
+
    - Добавить новую метрику
    - Создать собственный дашборд
    - Настроить Alerts
@@ -42,29 +53,32 @@
 
 ### 🛠️ Рабочие файлы
 
-- **metrics_server.py** — Prometheus metrics endpoint (генерирует метрики)
+- **src/bioetl/infrastructure/observability/prometheus_metrics.py** — Prometheus metrics endpoint (генерирует метрики)
 
----
+______________________________________________________________________
 
 ## 🎯 Рекомендуемый порядок чтения
 
 ### Новичок (40 минут)
+
 1. BIOETL_DASHBOARD_COMPLETE.md ← Сводка (5 мин)
-2. BIOETL_DASHBOARD_VISUAL_GUIDE.md ← Диаграммы (20 мин)
-3. BIOETL_DASHBOARD_QUICKSTART.md ← Быстрый старт (15 мин)
+1. BIOETL_DASHBOARD_VISUAL_GUIDE.md ← Диаграммы (20 мин)
+1. BIOETL_DASHBOARD_QUICKSTART.md ← Быстрый старт (15 мин)
 
 ### Intermediate (2 часа)
+
 1. BIOETL_DASHBOARD_README.md ← Навигация (5 мин)
-2. BIOETL_DASHBOARD_SETUP.md ← Полная инструкция (60 мин)
-3. BIOETL_DASHBOARD_VISUAL_GUIDE.md ← Примеры (20 мин)
-4. BIOETL_DASHBOARD_QUICKSTART.md ← Настройка (35 мин)
+1. BIOETL_DASHBOARD_SETUP.md ← Полная инструкция (60 мин)
+1. BIOETL_DASHBOARD_VISUAL_GUIDE.md ← Примеры (20 мин)
+1. BIOETL_DASHBOARD_QUICKSTART.md ← Настройка (35 мин)
 
 ### Advanced (3+ часа)
-1. Все документы выше (2 часа)
-2. BIOETL_DASHBOARD_EXAMPLES.md ← Кастомизация (60 мин)
-3. Экспериментирование с Grafana
 
----
+1. Все документы выше (2 часа)
+1. BIOETL_DASHBOARD_EXAMPLES.md ← Кастомизация (60 мин)
+1. Экспериментирование с Grafana
+
+______________________________________________________________________
 
 ## 🚀 Быстрый старт
 
@@ -76,13 +90,13 @@ cat BIOETL_DASHBOARD_COMPLETE.md
 docker compose -f ../../docker-compose.monitoring.yml up -d
 
 # 3. Запустить metrics сервер
-python ./metrics_server.py &
+python ./src/bioetl/infrastructure/observability/prometheus_metrics.py &
 
 # 4. Открыть Grafana
 # http://localhost:3000
 ```
 
----
+______________________________________________________________________
 
 ## 📊 Структура документации
 
@@ -98,27 +112,27 @@ python ./metrics_server.py &
 ├── 👁️  BIOETL_DASHBOARD_VISUAL_GUIDE.md ← Диаграммы
 ├── 💡 BIOETL_DASHBOARD_EXAMPLES.md     ← Примеры
 │
-└── 🛠️  metrics_server.py                ← Рабочий код
+└── 🛠️  src/bioetl/infrastructure/observability/prometheus_metrics.py                ← Рабочий код
 ```
 
----
+______________________________________________________________________
 
 ## 🔍 Где найти ответ на вопрос?
 
-| Вопрос | Ответ в файле |
-|--------|--------------|
-| Что было сделано? | BIOETL_DASHBOARD_COMPLETE.md |
-| С чего начать? | BIOETL_DASHBOARD_README.md |
-| Дайте 5 минут на старт | BIOETL_DASHBOARD_QUICKSTART.md |
-| Дайте полную инструкцию | BIOETL_DASHBOARD_SETUP.md |
-| Покажите диаграммы | BIOETL_DASHBOARD_VISUAL_GUIDE.md |
-| Я хочу кастомизировать | BIOETL_DASHBOARD_EXAMPLES.md |
-| Что-то не работает | BIOETL_DASHBOARD_SETUP.md (Troubleshooting) |
-| Как читать графики? | BIOETL_DASHBOARD_VISUAL_GUIDE.md |
-| Как добавить метрику? | BIOETL_DASHBOARD_EXAMPLES.md |
-| PromQL примеры | BIOETL_DASHBOARD_EXAMPLES.md |
+| Вопрос                  | Ответ в файле                               |
+| ----------------------- | ------------------------------------------- |
+| Что было сделано?       | BIOETL_DASHBOARD_COMPLETE.md                |
+| С чего начать?          | BIOETL_DASHBOARD_README.md                  |
+| Дайте 5 минут на старт  | BIOETL_DASHBOARD_QUICKSTART.md              |
+| Дайте полную инструкцию | BIOETL_DASHBOARD_SETUP.md                   |
+| Покажите диаграммы      | BIOETL_DASHBOARD_VISUAL_GUIDE.md            |
+| Я хочу кастомизировать  | BIOETL_DASHBOARD_EXAMPLES.md                |
+| Что-то не работает      | BIOETL_DASHBOARD_SETUP.md (Troubleshooting) |
+| Как читать графики?     | BIOETL_DASHBOARD_VISUAL_GUIDE.md            |
+| Как добавить метрику?   | BIOETL_DASHBOARD_EXAMPLES.md                |
+| PromQL примеры          | BIOETL_DASHBOARD_EXAMPLES.md                |
 
----
+______________________________________________________________________
 
 ## 📈 Состояние готовности
 
@@ -128,39 +142,39 @@ python ./metrics_server.py &
 ✅ **Метрики** — Генерируются и собираются каждые 15 сек
 ✅ **Документация** — 1,900+ строк полной документации
 
----
+______________________________________________________________________
 
 ## 🎓 Уровни сложности
 
-| Уровень | Время | Что изучить | Результат |
-|---------|-------|-----------|-----------|
-| 🟢 **Новичок** | 40 мин | COMPLETE, VISUAL, QUICKSTART | Мониторинг работает |
-| 🟡 **Intermediate** | 2 часа | + SETUP + README | Понимаю архитектуру |
-| 🔴 **Advanced** | 3+ часа | + EXAMPLES | Кастомизирую дашборды |
+| Уровень             | Время   | Что изучить                  | Результат             |
+| ------------------- | ------- | ---------------------------- | --------------------- |
+| 🟢 **Новичок**      | 40 мин  | COMPLETE, VISUAL, QUICKSTART | Мониторинг работает   |
+| 🟡 **Intermediate** | 2 часа  | + SETUP + README             | Понимаю архитектуру   |
+| 🔴 **Advanced**     | 3+ часа | + EXAMPLES                   | Кастомизирую дашборды |
 
----
+______________________________________________________________________
 
 ## 📞 Поддержка
 
 Все вопросы и ответы находятся в этих документах:
 
 1. **Не знаю с чего начать?** → BIOETL_DASHBOARD_COMPLETE.md
-2. **Нужна полная инструкция?** → BIOETL_DASHBOARD_SETUP.md
-3. **Что-то не работает?** → BIOETL_DASHBOARD_SETUP.md (раздел Troubleshooting)
-4. **Хочу кастомизировать?** → BIOETL_DASHBOARD_EXAMPLES.md
+1. **Нужна полная инструкция?** → BIOETL_DASHBOARD_SETUP.md
+1. **Что-то не работает?** → BIOETL_DASHBOARD_SETUP.md (раздел Troubleshooting)
+1. **Хочу кастомизировать?** → BIOETL_DASHBOARD_EXAMPLES.md
 
----
+______________________________________________________________________
 
 ## 📂 Связанные файлы
 
 - Конфигурация Prometheus: `../../docker-compose.monitoring.yml`
-- Конфигурация метрик: `./metrics_server.py`
+- Конфигурация метрик: `./src/bioetl/infrastructure/observability/prometheus_metrics.py`
 - Дашборды JSON: `../../grafana/dashboards/`
 
----
+______________________________________________________________________
 
-**Версия:** 1.0  
-**Дата обновления:** 22 февраля 2026  
-**Статус:** ✅ Готово к использованию  
+**Версия:** 1.0
+**Дата обновления:** 22 февраля 2026
+**Статус:** ✅ Готово к использованию
 
 🚀 Начните с **BIOETL_DASHBOARD_COMPLETE.md**!

--- a/docs/03-guides/dashboards/TIMESTAMP_FIXED.md
+++ b/docs/03-guides/dashboards/TIMESTAMP_FIXED.md
@@ -1,19 +1,26 @@
 # Исправление: Время запуска теперь отображается!
 
+> **Path verification (required):** before applying this guide/prompt, locate the runtime observability modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl`.
+> Use these runtime paths:
+> Metric definitions/registries — `src/bioetl/infrastructure/observability/metrics.py`, `src/bioetl/infrastructure/observability/prometheus_metrics.py`.
+> Metrics server wiring/integration — `src/bioetl/infrastructure/observability/metrics_server_adapter.py`, `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`.
+
 ## ✅ Что было исправлено
 
-Добавлена новая метрика в `metrics_server.py` для отображения времени запуска:
+Добавлена новая метрика в `src/bioetl/infrastructure/observability/prometheus_metrics.py` для отображения времени запуска:
 
-### Обновление metrics_server.py
+### Обновление src/bioetl/infrastructure/observability/prometheus_metrics.py
 
 **Добавлены две новые метрики:**
 
 1. **bioetl_run_start_timestamp** (Gauge)
+
    - Unix timestamp времени запуска
    - Используется в дашбордах для отображения
    - Обновляется каждый запрос
 
-2. **bioetl_run** (Info)
+1. **bioetl_run** (Info)
+
    - Полная информация о запуске
    - Включает: run_id, pipeline, start_time, timestamp
 
@@ -22,16 +29,18 @@
 Все три дашборда обновлены:
 
 **Было:**
+
 ```promql
 timestamp(bioetl_records_processed_total) / 1000
 ```
 
 **Стало:**
+
 ```promql
 bioetl_run_start_timestamp
 ```
 
----
+______________________________________________________________________
 
 ## 📊 Теперь дашборды показывают:
 
@@ -43,25 +52,28 @@ bioetl_run_start_timestamp
 └──────────────────────┴────────────────┴──────────────────────────────┘
 ```
 
----
+______________________________________________________________________
 
 ## 🚀 Как использовать
 
 1. **Откройте дашборд:**
+
    ```
    http://localhost:3000/d/bioetl-dq-v2
    ```
 
-2. **В верхней части видны:**
+1. **В верхней части видны:**
+
    - ✅ Pipeline название
    - ✅ Run Type
    - ✅ Execution Timestamp (время запуска)
 
-3. **Timestamp конвертируется автоматически:**
+1. **Timestamp конвертируется автоматически:**
+
    - Unix timestamp: `1645382400`
    - Human readable: `26 Feb 2026, 10:00:00 UTC`
 
----
+______________________________________________________________________
 
 ## 🧪 Проверка
 
@@ -75,36 +87,37 @@ curl http://localhost:8000/metrics | grep bioetl_run_start_timestamp
 # bioetl_run_start_timestamp{pipeline="uniprot",run_id="run-492157"} 1645382400.0
 ```
 
----
+______________________________________________________________________
 
 ## 📄 Файлы, которые изменились
 
 ```
-✓ metrics_server.py
+✓ src/bioetl/infrastructure/observability/prometheus_metrics.py
   - Добавлены метрики bioetl_run_start_timestamp и bioetl_run
-  
+
 ✓ grafana/dashboards/bioetl-dq-v2.json
   - Обновлен запрос для Execution Timestamp
-  
+
 ✓ grafana/dashboards/bioetl-overview-v2.json
   - Обновлен запрос для Execution Timestamp
-  
+
 ✓ grafana/dashboards/bioetl-provider-health-v2.json
   - Обновлен запрос для Execution Timestamp
 ```
 
----
+______________________________________________________________________
 
 ## ✨ Итог
 
 Теперь все три дашборда v2 полностью функциональны и отображают:
+
 - ✅ Pipeline (название)
 - ✅ Run Type (тип запуска)
 - ✅ Execution Timestamp (время запуска) ← **НОВОЕ!**
 
 **Готовы к production!** 🚀
 
----
+______________________________________________________________________
 
-**Дата:** 22 февраля 2026  
+**Дата:** 22 февраля 2026
 **Статус:** ✅ Production Ready


### PR DESCRIPTION
### Motivation
- Replace legacy references to a root `metrics_server.py` in dashboard guides with the actual runtime observability modules so contributors edit and test live code instead of a stale top-level script. 
- Prevent accidental edits by prompt authors by requiring a quick runtime path verification step before making changes to metrics code or dashboards.

### Description
- Inserted a short "Path verification (required)" block at the top of the dashboard prompt docs that instructs authors to locate runtime modules with `rg -n "PrometheusMetrics|start_http_server|metrics_server_integration" src/bioetl` and to prefer runtime paths. 
- Updated references in nine dashboard guide files under `docs/03-guides/dashboards/` to use runtime modules: metric definitions/registries are referenced as `src/bioetl/infrastructure/observability/metrics.py` and `src/bioetl/infrastructure/observability/prometheus_metrics.py`, and metrics server wiring/integration as `src/bioetl/infrastructure/observability/metrics_server_adapter.py` and `src/bioetl/interfaces/cli/commands/metrics_server_integration.py`. 
- Replaced command examples and troubleshooting steps that previously referenced `metrics_server.py` with the runtime path `src/bioetl/infrastructure/observability/prometheus_metrics.py` and adjusted related markdown formatting for consistency. 
- Saved the updated markdown files in `docs/03-guides/dashboards/*.md`.

### Testing
- Confirmed no lingering legacy references by running `rg -n "metrics_server\.py" docs/03-guides/dashboards/*.md` which returned no matches (success). 
- Verified the path-verification block was inserted in all updated documents using `rg -n "Path verification \(required\)" docs/03-guides/dashboards/*.md | wc -l` and observed the expected count of files containing the block (success). 
- Project linters/formatters ran (pre-commit hooks auto-fixed trailing whitespace and markdown formatting issues) and those fixes were applied prior to persisting the final docs updates (auto-fixer actions succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c80bd108324a74ef3f22f1b674e)