### PR TITLE
Unify circuit breaker state mapping across metrics and Grafana

### DIFF
--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Provider health metrics from pipeline health checks",
+  "description": "Provider health metrics from pipeline health checks\n\nCircuit breaker gauge mapping: 0=closed, 1=half-open, 2=open (must match bioetl_circuit_breaker_state emitter constants).",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
@@ -141,8 +141,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 12,
-        "x": 12,
+        "w": 6,
+        "x": 18,
         "y": 0
       },
       "id": 101,
@@ -431,6 +431,88 @@
         }
       ],
       "title": "Total Health Check Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Closed",
+                  "color": "green",
+                  "index": 0
+                },
+                "1": {
+                  "text": "Half-Open",
+                  "color": "yellow",
+                  "index": 1
+                },
+                "2": {
+                  "text": "Open",
+                  "color": "red",
+                  "index": 2
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(bioetl_circuit_breaker_state)",
+          "legendFormat": "Circuit Breaker State",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker State",
+      "description": "Canonical mapping: 0=closed, 1=half-open, 2=open.",
       "type": "stat"
     }
   ],

--- a/src/bioetl/infrastructure/adapters/http/circuit_breaker.py
+++ b/src/bioetl/infrastructure/adapters/http/circuit_breaker.py
@@ -19,6 +19,9 @@ import httpx
 
 from bioetl.domain.exceptions import CircuitBreakerOpenError
 from bioetl.domain.types import CircuitBreakerState
+from bioetl.infrastructure.observability.circuit_breaker_mapping import (
+    CIRCUIT_BREAKER_STATE_VALUES,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -31,13 +34,6 @@ T = TypeVar("T")
 # Metric names as constants for consistency
 METRIC_CIRCUIT_BREAKER_STATE = "circuit_breaker_state"
 METRIC_CIRCUIT_BREAKER_TRIPS = "circuit_breaker_trips_total"
-
-# State values for gauge metric
-_STATE_VALUES: dict[CircuitBreakerState, float] = {
-    CircuitBreakerState.CLOSED: 0.0,
-    CircuitBreakerState.HALF_OPEN: 1.0,
-    CircuitBreakerState.OPEN: 2.0,
-}
 
 
 @dataclass
@@ -97,7 +93,7 @@ class CircuitBreaker:
         if self.metrics is not None:
             self.metrics.set_gauge(
                 METRIC_CIRCUIT_BREAKER_STATE,
-                _STATE_VALUES[self._state],
+                CIRCUIT_BREAKER_STATE_VALUES[self._state],
                 {"adapter": self.provider},
             )
 

--- a/src/bioetl/infrastructure/observability/circuit_breaker_mapping.py
+++ b/src/bioetl/infrastructure/observability/circuit_breaker_mapping.py
@@ -1,0 +1,19 @@
+"""Canonical mapping for circuit breaker state metrics.
+
+This module centralizes the numeric encoding used by `bioetl_circuit_breaker_state`
+so emitters, metric definitions, and dashboards stay consistent.
+"""
+
+from __future__ import annotations
+
+from bioetl.domain.types import CircuitBreakerState
+
+CIRCUIT_BREAKER_STATE_VALUES: dict[CircuitBreakerState, float] = {
+    CircuitBreakerState.CLOSED: 0.0,
+    CircuitBreakerState.HALF_OPEN: 1.0,
+    CircuitBreakerState.OPEN: 2.0,
+}
+
+CIRCUIT_BREAKER_STATE_DESCRIPTION = (
+    "Current state of the circuit breaker (0=closed, 1=half-open, 2=open)"
+)

--- a/src/bioetl/infrastructure/observability/metrics.py
+++ b/src/bioetl/infrastructure/observability/metrics.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from prometheus_client import Counter, Gauge, Histogram
 
+from bioetl.infrastructure.observability.circuit_breaker_mapping import (
+    CIRCUIT_BREAKER_STATE_DESCRIPTION,
+)
+
 # Generic pipeline metrics
 PIPELINE_DURATION_SECONDS = Histogram(
     "bioetl_pipeline_duration_seconds",
@@ -55,7 +59,7 @@ DQ_RECORDS_QUARANTINED_TOTAL = Counter(
 # Circuit Breaker metrics (per ADR-007)
 CIRCUIT_BREAKER_STATE = Gauge(
     "bioetl_circuit_breaker_state",
-    "Current state of the circuit breaker (0=closed, 1=half-open, 2=open)",
+    CIRCUIT_BREAKER_STATE_DESCRIPTION,
     ["adapter"],
 )
 

--- a/tests/unit/infrastructure/test_circuit_breaker.py
+++ b/tests/unit/infrastructure/test_circuit_breaker.py
@@ -15,6 +15,9 @@ from bioetl.infrastructure.adapters.http.circuit_breaker import (
     METRIC_CIRCUIT_BREAKER_TRIPS,
     CircuitBreaker,
 )
+from bioetl.infrastructure.observability.circuit_breaker_mapping import (
+    CIRCUIT_BREAKER_STATE_VALUES,
+)
 
 
 class TestCircuitBreaker:
@@ -295,6 +298,38 @@ class TestCircuitBreakerMetrics:
         assert calls[1][0] == (
             METRIC_CIRCUIT_BREAKER_STATE,
             0.0,  # CLOSED = 0
+            {"adapter": "test"},
+        )
+
+    @pytest.mark.unit
+    async def test_state_metric_uses_canonical_mapping(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        """Gauge emissions should follow canonical state-to-number mapping."""
+        cb = CircuitBreaker(
+            provider="test",
+            failure_threshold=1,
+            recovery_timeout=0,
+            metrics=mock_metrics,
+        )
+
+        async def fail() -> None:
+            raise RuntimeError("error")
+
+        # Initial emission in __post_init__
+        assert mock_metrics.set_gauge.call_args_list[0][0] == (
+            METRIC_CIRCUIT_BREAKER_STATE,
+            CIRCUIT_BREAKER_STATE_VALUES[CircuitBreakerState.CLOSED],
+            {"adapter": "test"},
+        )
+
+        with pytest.raises(RuntimeError):
+            await cb.call(fail)
+
+        # OPEN emission after threshold breach
+        assert mock_metrics.set_gauge.call_args_list[1][0] == (
+            METRIC_CIRCUIT_BREAKER_STATE,
+            CIRCUIT_BREAKER_STATE_VALUES[CircuitBreakerState.OPEN],
             {"adapter": "test"},
         )
 


### PR DESCRIPTION
### Motivation

- Prevent divergent encodings for circuit-breaker state by centralizing the numeric mapping and descriptive text so emitters, metric definitions, and dashboards remain consistent. 
- Reduce maintenance burden and accidental drift when mapping enum states to Prometheus gauge values and Grafana value mappings.

### Description

- Added a canonical observability mapping module `src/bioetl/infrastructure/observability/circuit_breaker_mapping.py` exposing `CIRCUIT_BREAKER_STATE_VALUES` and `CIRCUIT_BREAKER_STATE_DESCRIPTION` (maps `CLOSED=0.0`, `HALF_OPEN=1.0`, `OPEN=2.0`).
- Updated the Prometheus metric definition to use the shared description constant in `src/bioetl/infrastructure/observability/metrics.py` for `bioetl_circuit_breaker_state`.
- Updated circuit-breaker metric emissions to use `CIRCUIT_BREAKER_STATE_VALUES` in `src/bioetl/infrastructure/adapters/http/circuit_breaker.py` so the gauge values follow the canonical mapping.
- Added a unit test `tests/unit/infrastructure/test_circuit_breaker.py` that asserts gauge emissions use the canonical mapping for initial `CLOSED` emission and for `OPEN` after threshold breach, and updated the Provider Health Grafana dashboard `grafana/dashboards/bioetl-provider-health-v2.json` with a maintainer description and a `Circuit Breaker State` stat panel that contains explicit value mappings and a short canonical mapping note.

### Testing

- Ran unit tests: `uv run python -m pytest tests/unit/infrastructure/test_circuit_breaker.py -q` and they passed (all tests in that file succeeded). 
- Validated dashboard JSON syntax: `python -m json.tool grafana/dashboards/bioetl-provider-health-v2.json` which completed without error.
- Note: repository pre-commit hooks flagged unrelated baseline issues outside this change (mypy unused-ignore and other repo hygiene hooks); those did not affect the unit test or JSON validation for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c717e60832483ddbc9ad269d88b)