### PR TITLE
Add cross-dashboard links between Overview and Data Quality Grafana dashboards

### DIFF
--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -17,7 +17,20 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Back to Overview",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/bioetl-overview-v2"
+    }
+  ],
   "panels": [
     {
       "gridPos": {
@@ -956,5 +969,5 @@
   "timezone": "",
   "title": "BioETL Data Quality v2",
   "uid": "bioetl-dq-v2",
-  "version": 2
+  "version": 3
 }

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -106,7 +106,17 @@
         "tooltip": {
           "mode": "multi",
           "sort": "desc"
-        }
+        },
+        "dataLinks": [
+          {
+            "title": "Open DQ Dashboard",
+            "url": "/d/bioetl-dq-v2?var-pipeline=${__field.labels.pipeline}&var-run_type=${__field.labels.run_type}&var-stage=${__field.labels.stage}&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+          },
+          {
+            "title": "Open Provider Health Dashboard",
+            "url": "/d/bioetl-provider-health-v2?var-pipeline=${__field.labels.pipeline}&var-run_type=${__field.labels.run_type}&var-stage=${__field.labels.stage}&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+          }
+        ]
       },
       "targets": [
         {
@@ -469,5 +479,5 @@
   "timezone": "",
   "title": "BioETL Overview v2",
   "uid": "bioetl-overview-v2",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
### Motivation
- Improve navigation between the Overview and Data Quality/Provider Health Grafana dashboards by making the Processing Pipeline panel clickable. 
- Ensure links carry pipeline/run_type context using available field labels with fallbacks so that drill-through preserves relevant variables. 
- Keep dashboard JSON versions in sync so Grafana detects the updates.

### Description
- Added `options.dataLinks` to the "Processing Pipeline (Latest Run Only)" panel in `grafana/dashboards/bioetl-overview-v2.json` with two links: one to `/d/bioetl-dq-v2?...&${__url_time_range}` and one to `/d/bioetl-provider-health-v2?...&${__url_time_range}`. 
- Links prefer `${__field.labels.pipeline}`, `${__field.labels.run_type}`, and `${__field.labels.stage}` and include `$pipeline`/`$run_type` as fallbacks. 
- Added a dashboard-level link `Back to Overview` in `grafana/dashboards/bioetl-dq-v2.json` with `includeVars` and `keepTime` enabled. 
- Incremented the `version` field to `3` in both modified JSON files and avoided adding links to small stat panels as requested.

### Testing
- Validated both modified files parse as JSON using `python -m json.tool grafana/dashboards/bioetl-overview-v2.json` and `python -m json.tool grafana/dashboards/bioetl-dq-v2.json`, which succeeded. 
- Performed repository checks which surfaced unrelated environment/pre-commit issues (missing `pip-audit` and root-layout policy warnings), but those do not affect the dashboard JSON validity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c5a4c488324aa29c4ded0eda740)