### PR TITLE
Centralize adapter metrics initialization in BaseHttpAdapter

### DIFF
--- a/src/bioetl/infrastructure/adapters/base.py
+++ b/src/bioetl/infrastructure/adapters/base.py
@@ -24,6 +24,10 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Self
 
 from bioetl.domain.ports import DataSourcePort, LoggerPort, MetricsPort, NoOpMetrics
+from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
+from bioetl.infrastructure.adapters.common.api_request_collector import (
+    APIRequestCollector,
+)
 from bioetl.infrastructure.adapters.error_handling import ErrorService
 from bioetl.infrastructure.adapters.health_check_mixin import HealthCheckProviderMixin
 
@@ -62,6 +66,8 @@ class BaseHttpAdapter(HealthCheckProviderMixin, DataSourcePort):
     logger: LoggerPort
     metrics: MetricsPort | None  # Runtime-resolved to NoOpMetrics if None
     _error_handler: ErrorService
+    _adapter_metrics: AdapterMetrics
+    _request_collector: APIRequestCollector
 
     def __init__(
         self,
@@ -82,6 +88,21 @@ class BaseHttpAdapter(HealthCheckProviderMixin, DataSourcePort):
         self.logger = logger
         self.metrics = metrics if metrics is not None else NoOpMetrics()
         self._error_handler = ErrorService(logger)
+        self._init_adapter_metrics()
+
+    def _init_adapter_metrics(self) -> None:
+        """Initialize adapter metrics and request collector.
+
+        Creates standardized AdapterMetrics and APIRequestCollector instances.
+        Resolves None metrics to NoOpMetrics for the metrics port.
+
+        Called automatically from ``__init__``. For ``@dataclass`` subclasses
+        that bypass ``__init__``, call explicitly from ``__post_init__``.
+
+        """
+        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
+        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._request_collector = APIRequestCollector()
 
     @property
     def _circuit_breaker(self) -> CircuitBreakerPort:

--- a/src/bioetl/infrastructure/adapters/chembl/client.py
+++ b/src/bioetl/infrastructure/adapters/chembl/client.py
@@ -19,10 +19,8 @@ from bioetl.domain.exceptions import (
     RetryExhaustedError,
 )
 from bioetl.domain.models.filter import ExtractionParams
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.domain.resilience import AdapterConfig
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 from bioetl.infrastructure.adapters.chembl.constants import (
     _NO_PAGINATION_ENTITIES,
     _SILVER_TO_CHEMBL_API_FIELD,
@@ -38,9 +36,6 @@ from bioetl.infrastructure.adapters.chembl.entity_mapper import (
 )
 from bioetl.infrastructure.adapters.chembl.health import ChemblHealthMixin
 from bioetl.infrastructure.adapters.chembl.metadata import ChemblMetadataMixin
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.error_handling import ErrorService
 
 if TYPE_CHECKING:
@@ -73,9 +68,6 @@ class ChemblAdapter(ChemblHealthMixin, ChemblMetadataMixin, BaseHttpAdapter):
     _page_size: int = field(init=False, default=1000)
     _filter_batch_size: int = field(init=False, default=20)
     _mapper: ChemblEntityMapper = field(init=False, default_factory=ChemblEntityMapper)
-    _request_collector: APIRequestCollector = field(
-        init=False, default_factory=APIRequestCollector
-    )
     _extraction_params: ExtractionParams = field(
         init=False, default_factory=ExtractionParams.empty
     )
@@ -91,8 +83,7 @@ class ChemblAdapter(ChemblHealthMixin, ChemblMetadataMixin, BaseHttpAdapter):
         self._page_size = config.page_size
         self._filter_batch_size = config.batch_size
 
-        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._init_adapter_metrics()
 
         # Resolve extraction params
         self._extraction_params = self.extraction_params or ExtractionParams.empty()

--- a/src/bioetl/infrastructure/adapters/crossref/client.py
+++ b/src/bioetl/infrastructure/adapters/crossref/client.py
@@ -23,13 +23,8 @@ from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.models.metadata import SourceMetadata
 from bioetl.domain.normalization import normalize_doi
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.crossref.batch import (
     DoiBatchProcessor,
     SearchPaginator,
@@ -76,15 +71,9 @@ class CrossRefAdapter(BaseHttpAdapter):
     provider_name: str = field(init=False, default="crossref")
     """Provider identifier (required by DataSourcePort)."""
 
-    _request_collector: APIRequestCollector = field(
-        init=False, default_factory=APIRequestCollector
-    )
-    """Collects API request metadata for Bronze layer enrichment."""
-
     def __post_init__(self) -> None:
         """Initialize adapter metrics and helper components."""
-        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._init_adapter_metrics()
 
         # Initialize helper components for batch fetching and search
         self._batch_fetcher = DoiBatchProcessor(

--- a/src/bioetl/infrastructure/adapters/openalex/client.py
+++ b/src/bioetl/infrastructure/adapters/openalex/client.py
@@ -24,13 +24,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.models.metadata import SourceMetadata
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.openalex.fallback import TitleFallbackHandler
 
 if TYPE_CHECKING:
@@ -73,15 +68,9 @@ class OpenAlexAdapter(BaseHttpAdapter):
     provider_name: str = field(init=False, default="openalex")
     """Provider identifier (required by DataSourcePort)."""
 
-    _request_collector: APIRequestCollector = field(
-        init=False, default_factory=APIRequestCollector
-    )
-    """Collects API request metadata for Bronze layer enrichment."""
-
     def __post_init__(self) -> None:
         """Initialize adapter metrics and helper components."""
-        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._init_adapter_metrics()
 
         # Initialize helper components for fallback handling
         self._fallback_handler = TitleFallbackHandler(

--- a/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
+++ b/src/bioetl/infrastructure/adapters/pubmed/pubmed_client.py
@@ -13,12 +13,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from bioetl.domain.entities.pubmed import ArticleRecord
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.error_handling import ErrorService
 from bioetl.infrastructure.adapters.filterable_mixin import NotSupportedMultiFilterMixin
 from bioetl.infrastructure.adapters.pubmed._fetch import PubMedFetchMixin
@@ -75,15 +70,10 @@ class PubMedAdapter(
         default=None, init=False, repr=False
     )
 
-    _request_collector: APIRequestCollector = field(
-        init=False, default_factory=APIRequestCollector
-    )
-
     def __post_init__(self) -> None:
         """Initialize metrics, error handler and fallback handler."""
         self._error_handler = ErrorService(self.logger)
-        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._init_adapter_metrics()
 
         self._fallback_handler = TitleFallbackHandler(
             logger=self.logger,

--- a/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
+++ b/src/bioetl/infrastructure/adapters/semanticscholar/adapter.py
@@ -27,13 +27,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bioetl.domain.models.metadata import SourceMetadata
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.semanticscholar.constants import (
     SEMANTICSCHOLAR_BASE_URL,
 )
@@ -92,16 +87,9 @@ class SemanticScholarAdapter(BaseHttpAdapter):
     provider_name: str = field(init=False, default="semanticscholar")
     """Provider identifier (required by DataSourcePort)."""
 
-    _request_collector: APIRequestCollector = field(
-        init=False, default_factory=APIRequestCollector
-    )
-    """Collects API request metadata for Bronze layer enrichment."""
-
     def __post_init__(self) -> None:
         """Initialize adapter metrics and helper components."""
-
-        metrics_port = self.metrics if self.metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
+        self._init_adapter_metrics()
 
         # Initialize helper component for fallback handling
         self._fallback_handler = SemanticScholarTitleFallbackHandler(

--- a/src/bioetl/infrastructure/adapters/uniprot/client.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/client.py
@@ -20,13 +20,8 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
-from bioetl.domain.ports import NoOpMetrics
 from bioetl.domain.types import HealthStatus
 from bioetl.infrastructure.adapters.base import BaseHttpAdapter
-from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
-from bioetl.infrastructure.adapters.common.api_request_collector import (
-    APIRequestCollector,
-)
 from bioetl.infrastructure.adapters.http.pagination import PaginatedFetcherMixin
 from bioetl.infrastructure.adapters.uniprot.fasta_parser import FastaParser
 
@@ -125,13 +120,10 @@ class UniProtAdapter(BaseHttpAdapter, PaginatedFetcherMixin):
             metrics: MetricsPort instance for recording SLA metrics
 
         """
-        super().__init__(http_client, logger)
+        super().__init__(http_client, logger, metrics=metrics)
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.strict_error_handling = strict_error_handling
-        metrics_port = metrics if metrics is not None else NoOpMetrics()
-        self._adapter_metrics = AdapterMetrics(metrics_port, self.provider_name)
-        self._request_collector = APIRequestCollector()
         self._fetch_strategies = {
             "protein": self._fetch_proteins,
             "feature": self._fetch_features,


### PR DESCRIPTION
## Summary

Refactor metrics and request collector initialization to eliminate duplication across adapter implementations. Move the common initialization logic from individual adapter `__post_init__` methods into a centralized `_init_adapter_metrics()` method in `BaseHttpAdapter`.

## Changes

- Added `_init_adapter_metrics()` method to `BaseHttpAdapter` that initializes both `AdapterMetrics` and `APIRequestCollector` instances
- Moved `_adapter_metrics` and `_request_collector` field declarations from individual adapters to `BaseHttpAdapter`
- Updated all adapter implementations (SemanticScholar, CrossRef, OpenAlex, PubMed, ChemBL, UniProt) to call `_init_adapter_metrics()` from their `__post_init__` methods instead of duplicating initialization logic
- Removed redundant imports of `AdapterMetrics`, `APIRequestCollector`, and `NoOpMetrics` from adapter implementations
- Updated `UniProtAdapter.__init__` to pass metrics to parent class constructor instead of initializing separately

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] No hardcoded secrets or credentials
- [ ] Architecture tests pass (`pytest tests/architecture/ -v`)
- [ ] Documentation updated if behavior changed
- [ ] Follows Conventional Commits format

https://claude.ai/code/session_01DTwf4HAFFZdKRtMKq2LRj8