### PR TITLE
Add ADR-024 naming compliance report and update naming_exceptions registry

### DIFF
--- a/configs/naming_exceptions.yaml
+++ b/configs/naming_exceptions.yaml
@@ -1,7 +1,7 @@
 # Naming Convention Exceptions
 # This file documents allowed exceptions to the naming conventions in RULES.md §2.
 # Version: 2.1
-# Last Updated: 2026-01-21
+# Last Updated: 2026-02-24
 
 # Documentation files that are allowed to use UPPER_CASE names.
 # These are conventional files recognized by GitHub and standard tooling.
@@ -189,3 +189,50 @@ pipeline_id_format:
 # - The naming_audit.py tool uses this file's content as reference
 # - Violations against these exceptions should NOT be flagged
 # - Add new exceptions here with justification
+
+# Explicit exception registry for ADR-024 audit traceability
+exception_registry:
+  derived_entities:
+    - name: DocumentSimilarity
+      location: src/bioetl/domain/entities/chembl_structures.py
+      status: allowed
+      reason: ChEMBL-specific derived artifact kept by design.
+    - name: DocumentTerm
+      location: src/bioetl/domain/entities/chembl_structures.py
+      status: allowed
+      reason: ChEMBL-specific derived artifact kept by design.
+
+  pipeline_id_exceptions:
+    - name: pubchem_compound
+      location: configs/pipelines/pubchem/compound.yaml
+      status: allowed
+      reason: CLI/provider naming intentionally uses PubChem API term.
+    - name: uniprot_protein
+      location: configs/pipelines/uniprot/protein.yaml
+      status: allowed
+      reason: CLI/provider naming intentionally uses UniProt API term.
+
+  legacy_field_exceptions:
+    - field: document_id
+      status: allowed
+      reason: Foreign key alignment with ChEMBL API structure.
+    - field: document_chembl_id
+      status: allowed
+      reason: Foreign key alignment with ChEMBL API structure.
+
+  deprecated_aliases:
+    - alias: Document
+      canonical: ChemblPublication
+      status: not_implemented
+      removal_version: v3.0
+      reason: Direct migration to canonical names; no runtime alias exported.
+    - alias: Compound
+      canonical: PubchemMolecule
+      status: not_implemented
+      removal_version: v3.0
+      reason: Direct migration to canonical names; no runtime alias exported.
+    - alias: Protein
+      canonical: UniprotTarget
+      status: not_implemented
+      removal_version: v3.0
+      reason: Direct migration to canonical names; no runtime alias exported.

--- a/docs/99-archive/reports/adr-024-naming-audit/naming-compliance-report.md
+++ b/docs/99-archive/reports/adr-024-naming-audit/naming-compliance-report.md
@@ -1,0 +1,86 @@
+# Entity Naming Compliance Report
+
+Date: 2026-02-24
+Scope: `src/bioetl`, `configs`, architecture and terminology checks for ADR-024 + 5-layer boundaries
+
+## Executive Summary
+
+- Overall status: **Mostly compliant**.
+- ADR-024 canonical entities are present: `ChemblPublication`, `PubchemMolecule`, `UniprotTarget`.
+- No direct deprecated class aliases (`class Document`, `class Compound`, `class Protein`) were found.
+- 5-layer architecture boundary checks are effectively green in architecture suite; one unrelated formatting failure exists in tests.
+- Terminology lint script currently fails due to a runtime API mismatch and requires fix before it can be used as a gate.
+
+## Compliance Scorecard
+
+| Area                                                              | Status     | Evidence                                                                                   |
+| ----------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| ADR-024 canonical class names                                     | ✅ Pass    | Canonical classes defined in domain entities.                                              |
+| Deprecated class aliases                                          | ✅ Pass    | No deprecated class declarations found.                                                    |
+| Known ChEMBL derived exceptions                                   | ✅ Pass    | `DocumentTerm` and `DocumentSimilarity` intentionally present.                             |
+| Pipeline naming migration (`chembl_publication`)                  | ✅ Pass    | `configs/pipelines/chembl/publication.yaml` present; no `chembl_document` pipelines found. |
+| CLI/API naming exceptions (`pubchem_compound`, `uniprot_protein`) | ✅ Pass    | Present in pipeline configs as allowed exceptions.                                         |
+| Architecture boundaries                                           | ⚠️ Partial | Architecture suite: 1359 passed, 21 skipped, 1 failed (formatting-only).                   |
+| `import_linter` contract check                                    | ⚠️ Blocked | `import_linter` module unavailable in environment.                                         |
+| Terminology linter                                                | ❌ Fail    | `scripts/lint_terminology.py` crashes (`PYTHON_PATTERNS` attribute missing).               |
+
+## Detailed Findings
+
+## [P2 - Moderate] Terminology lint entrypoint is broken
+
+**Location**: `scripts/lint_terminology.py:61`
+**Rule**: Terminology audit command MUST be runnable for automated naming compliance.
+
+**Evidence**:
+
+```text
+AttributeError: module 'tools.scripts.lint_terminology' has no attribute 'PYTHON_PATTERNS'
+```
+
+**Impact**: Naming terminology checks cannot currently be used as a CI-quality gate; manual grep/rg checks are required.
+
+**Recommendation**:
+
+- Align `scripts/lint_terminology.py` with exported API from `tools.scripts.lint_terminology`.
+- Add a smoke test covering both normal and `--strict` execution.
+
+**Verification command**: `uv run python scripts/lint_terminology.py src/bioetl/ --strict`
+
+## [P3 - Informational] Backward-compatibility alias status differs from expected migration note
+
+**Location**: `src/bioetl/domain/entities/__init__.py`
+**Rule**: Migration notes should match real code behavior.
+
+**Evidence**:
+
+- Canonical exports are present (`ChemblPublication`, `PubchemMolecule`, `UniprotTarget`).
+- Deprecated aliases (`Document`, `Compound`, `Protein`) are not exported.
+
+**Impact**: Documentation/process notes may imply alias availability while codebase is already on direct canonical naming.
+
+**Recommendation**:
+
+- Keep docs/exception registry aligned with current codebase behavior.
+
+**Verification command**: `rg -n "Document|Compound|Protein" src/bioetl/domain/entities/__init__.py`
+
+## Positive Observations
+
+- `ChemblPublication` is implemented as canonical ChEMBL publication domain entity.
+- `PubchemMolecule` and `UniprotTarget` canonical entities are implemented in domain layer.
+- Derived ChEMBL technical entities (`DocumentTerm`, `DocumentSimilarity`) remain explicit and justified.
+- Config migration to `chembl_publication` pipeline naming is in place.
+
+## Migration Progress (ADR-024)
+
+- Canonical class migration: **100% complete** for targeted entities.
+- Deprecated alias class declarations: **0 remaining**.
+- No additional migration actions required for class names.
+
+## Verification Log
+
+1. Deprecated/canonical entity scans in source tree.
+1. Architecture suite execution (`tests/architecture`).
+1. Import boundary CLI check (`import_linter`) — environment package missing.
+1. Terminology linter execution (`normal` and `--strict`) — runtime failure.
+1. Config naming scans (`chembl_document`, `chembl_publication`, `pubchem_compound`).


### PR DESCRIPTION
### Motivation
- Provide an auditable compliance artifact for ADR-024 entity-name unification and make allowed exceptions explicit for traceability. 
- Reduce ambiguity during audits by recording ChEMBL-derived exceptions and CLI/provider naming exceptions in the canonical `naming_exceptions.yaml` registry. 

### Description
- Add a named audit report at `docs/99-archive/reports/adr-024-naming-audit/naming-compliance-report.md` containing executive summary, scorecard, findings, and verification log. 
- Update `configs/naming_exceptions.yaml` (bumped `Last Updated` to `2026-02-24`) and append an `exception_registry` section that records `derived_entities`, `pipeline_id_exceptions`, `legacy_field_exceptions`, and `deprecated_aliases` with locations, statuses, and reasons. 
- Validate the new YAML syntactically and relocate the generated report under `docs/99-archive/reports/` for repo cleanliness. 

### Testing
- Ran the full architecture test suite with `uv run python -m pytest tests/architecture/ -v`, which produced `1359 passed, 21 skipped, 1 failed` where the single failure is an existing tests formatting check (`ruff format`) unrelated to these changes. 
- Ran naming-specific checks with `uv run python -m pytest tests/architecture/test_naming_conventions.py -v`, which passed (`3 passed`). 
- Executed the terminology lint entrypoint with `uv run python scripts/lint_terminology.py src/bioetl/` and `--strict`, which currently fails due to an `AttributeError` in the linter integration and therefore is reported as a P2 finding. 
- Attempted `uv run python -m import_linter` which is unavailable in the environment and is reported as blocked; the new YAML was programmatically `yaml.safe_load`-validated (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c22df0483248adb5a0b8e9fd803)