### PR TITLE
Add ADR-024 naming compliance audit report and update naming_exceptions registry

### DIFF
--- a/configs/naming_exceptions.yaml
+++ b/configs/naming_exceptions.yaml
@@ -1,7 +1,7 @@
 # Naming Convention Exceptions
 # This file documents allowed exceptions to the naming conventions in RULES.md §2.
 # Version: 2.1
-# Last Updated: 2026-01-21
+# Last Updated: 2026-02-24
 
 # Documentation files that are allowed to use UPPER_CASE names.
 # These are conventional files recognized by GitHub and standard tooling.
@@ -189,3 +189,29 @@ pipeline_id_format:
 # - The naming_audit.py tool uses this file's content as reference
 # - Violations against these exceptions should NOT be flagged
 # - Add new exceptions here with justification
+
+
+# ADR-024 exception registry (audited 2026-02-24)
+adr_024_known_exceptions:
+  derived_entities:
+    - entity: DocumentSimilarity
+      location: src/bioetl/domain/entities/chembl_structures.py
+      reason: ChEMBL-specific derived entity kept per ADR-024
+    - entity: DocumentTerm
+      location: src/bioetl/domain/entities/chembl_structures.py
+      reason: ChEMBL-specific derived entity kept per ADR-024
+  pipeline_ids:
+    - pipeline: pubchem_compound
+      location: configs/pipelines/pubchem/compound.yaml
+      reason: CLI compatibility uses provider API term per glossary
+    - pipeline: uniprot_protein
+      location: configs/pipelines/uniprot/protein.yaml
+      reason: CLI compatibility uses provider API term per glossary
+  legacy_fields:
+    - field: document_id
+      reason: foreign-key compatibility with ChEMBL API source model
+    - field: document_chembl_id
+      reason: foreign-key compatibility with ChEMBL API source model
+  backward_compatibility:
+    - module: src/bioetl/domain/entities/__init__.py
+      note: compatibility export surface retained until alias removal window (v3.0).

--- a/docs/99-archive/reports/naming-compliance-report.md
+++ b/docs/99-archive/reports/naming-compliance-report.md
@@ -1,0 +1,139 @@
+# Architecture Audit Report
+
+Date: 2026-02-24
+Scope: Entity naming compliance (ADR-024 + glossary v2.0), deprecated-term drift, and 5-layer architecture boundary checks for `src/bioetl`, `configs`, and `tests/architecture`.
+
+## Executive Summary
+
+- Total findings: 3
+- Critical (MUST): 0
+- Moderate (SHOULD / tooling blockers): 3
+- Informational: 3
+- ADR-024 migration status: **100% complete** for canonical provider-prefixed domain entities.
+
+## Moderate Findings
+
+## [P2] Terminology linter entrypoint is broken
+
+**Location**: `scripts/lint_terminology.py:61`
+**Rule**: RULES.md §2 naming governance / mandatory terminology verification workflow.
+
+**Evidence**:
+
+```python
+patterns = list(impl.PYTHON_PATTERNS)
+```
+
+Runtime error observed:
+
+```text
+AttributeError: module 'tools.scripts.lint_terminology' has no attribute 'PYTHON_PATTERNS'
+```
+
+**Impact**:
+
+- Automated terminology validation cannot run in both normal and `--strict` modes.
+- Requires manual grep-based fallback; increases false-negative risk.
+
+**Recommendation**:
+
+- Align wrapper expectations with `tools.scripts.lint_terminology` public API.
+- Add a smoke test for the script entrypoint.
+
+**Verification command**: `uv run python scripts/lint_terminology.py src/bioetl/ --strict`
+
+______________________________________________________________________
+
+## [P2] `import_linter` check cannot execute in current environment
+
+**Location**: environment dependency (missing module)
+**Rule**: 5-layer architecture boundary verification phase.
+
+**Evidence**:
+
+```text
+/workspace/BioactivityDataAcquisition/.venv/bin/python3: No module named import_linter
+```
+
+**Impact**:
+
+- Import contract check from Phase 2 is skipped.
+- Confidence relies on architecture tests only.
+
+**Recommendation**:
+
+- Add `import-linter` to project dev dependencies and CI architecture target.
+
+**Verification command**: `uv run python -m import_linter`
+
+______________________________________________________________________
+
+## [P2] Architecture suite fails due test formatting drift
+
+**Location**: `tests/architecture/test_ci_test_strategy.py`
+**Rule**: formatting compliance gate in architecture suite.
+
+**Evidence**:
+
+```text
+Would reformat: tests/architecture/test_ci_test_strategy.py
+1 file would be reformatted
+```
+
+**Impact**:
+
+- `tests/architecture/` does not pass cleanly despite 1359 passing tests.
+- Architecture gate reported as failed in CI-like execution.
+
+**Recommendation**:
+
+- Run `ruff format tests/architecture/test_ci_test_strategy.py` and re-run architecture suite.
+
+**Verification command**: `uv run python -m pytest tests/architecture/ -v`
+
+## Informational Findings
+
+### [P3] ADR-024 canonical provider-prefixed entities are present
+
+- `ChemblPublication` declared in domain entity module.
+- `PubchemMolecule` declared in domain entity module.
+- `UniprotTarget` declared in domain entity module.
+
+### [P3] Deprecated alias classes are absent
+
+- No direct class declarations `class Document`, `class Compound`, or `class Protein` were found in `src/bioetl`.
+
+### [P3] Known exceptions remain explicitly intentional
+
+- `DocumentSimilarity` and `DocumentTerm` kept as ChEMBL derived entities.
+- CLI pipeline IDs `pubchem_compound` and `uniprot_protein` remain for compatibility.
+
+## Positive Observations
+
+- `scripts/naming_audit.py` reports **0 naming violations**.
+- Config names include canonical `chembl_publication` pipeline and related derivative pipelines.
+- Architecture tests show broad boundary compliance (high pass volume).
+
+## Migration Progress (ADR-024)
+
+- Canonical class migration (`ChemblPublication`, `PubchemMolecule`, `UniprotTarget`): **Complete**.
+- Deprecated class aliases (`Document`, `Compound`, `Protein`): **Not present as active class definitions**.
+- Exception handling: registered in `configs/naming_exceptions.yaml` (derived entities, CLI pipeline IDs, legacy fields).
+
+## Verification Log
+
+1. `grep -rn "class Document[^TS]" src/bioetl/ --include="*.py" | grep -v "Deprecated"`
+1. `grep -rn "class Compound[^R]" src/bioetl/ --include="*.py" | grep -v "Deprecated"`
+1. `grep -rn "class Protein[^C]" src/bioetl/ --include="*.py" | grep -v "Deprecated"`
+1. `rg -n "^class Document\\b|^class Compound\\b|^class Protein\\b" src/bioetl -g '*.py'`
+1. `grep -rn "class ChemblPublication" src/bioetl/ --include="*.py"`
+1. `grep -rn "class PubchemMolecule" src/bioetl/ --include="*.py"`
+1. `grep -rn "class UniprotTarget" src/bioetl/ --include="*.py"`
+1. `uv run python -m pytest tests/architecture/ -v`
+1. `uv run python -m import_linter`
+1. `uv run python scripts/lint_terminology.py src/bioetl/`
+1. `uv run python scripts/lint_terminology.py src/bioetl/ --strict`
+1. `grep -rn "chembl_document[^_]" configs/`
+1. `grep -rn "pubchem_compound" configs/`
+1. `grep -rn "chembl_publication" configs/`
+1. `uv run python scripts/naming_audit.py`


### PR DESCRIPTION
### Motivation
- Record and verify ADR-024 entity-name migration to canonical provider-prefixed names and capture any intentional exceptions for traceability. 
- Provide an auditable deliverable documenting the naming compliance status and any tooling/verification issues encountered during the audit.

### Description
- Updated `configs/naming_exceptions.yaml` to refresh the audit timestamp and add an `adr_024_known_exceptions` section that lists `DocumentSimilarity`/`DocumentTerm` (derived entities), CLI pipeline exceptions (`pubchem_compound`, `uniprot_protein`), legacy fields (`document_id`, `document_chembl_id`), and a compatibility note referencing `src/bioetl/domain/entities/__init__.py`.
- Added a detailed audit report at `docs/99-archive/reports/naming-compliance-report.md` containing executive summary, findings (P2/P3), migration progress, and the verification log of commands used.
- Placed the generated report under the project archive (`docs/99-archive/reports/`) to satisfy root-level cleanliness policy and avoid committing top-level artifacts.

### Testing
- Ran architecture suite with `uv run python -m pytest tests/architecture/ -v`, which collected 1381 tests with 1359 passed, 21 skipped and 1 failure due to a formatting check (`tests/architecture/test_ci_test_strategy.py` reported by `ruff format --check`).
- Executed the naming audit `uv run python scripts/naming_audit.py` which returned `Total violations: 0` (no naming violations found).
- Ran terminology and import tooling checks where issues were observed: `uv run python scripts/lint_terminology.py` failed with an `AttributeError` in the script wrapper, and `uv run python -m import_linter` could not run because `import_linter` is not installed in the environment. These are recorded as P2 findings in the report.
- Verified presence/absence of canonical/deprecated classes via repository searches (e.g. `grep`/`rg` for `ChemblPublication`, `PubchemMolecule`, `UniprotTarget` and absence of `Document`/`Compound`/`Protein`) and included the commands in the verification log.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5c22df0483248adb5a0b8e9fd803)