### PR TITLE
docs(adr): normalize ADR status policy, recalc baseline, add quality-gate and update prompts

### DIFF
--- a/.claude/prompts/02-Sync/04-schema-review.md
+++ b/.claude/prompts/02-Sync/04-schema-review.md
@@ -2,31 +2,31 @@
 
 *Priority: medium | Version: 1.0 | Aligned with RULES.md v5.19*
 
----
+______________________________________________________________________
 
 ## Goal
 
 Review schema coverage for a given `{{source}}`: verify that every DataFrame column produced by the transformer is covered by both a Pandera schema and a Pydantic/dataclass entity, with correct types and constraints.
 
----
+______________________________________________________________________
 
 ## Input
 
-| Parameter | Source | Example |
-|-----------|--------|---------|
-| `{{source}}` | User argument | `chembl`, `chembl/activity` |
-| schemas | `src/bioetl/domain/schemas/{{provider}}/` | Pandera DataFrameModel |
-| entities | `src/bioetl/domain/entities/{{provider}}.py` | Dataclass entities |
-| gold contracts | `src/bioetl/domain/contracts/gold/{{provider}}.py` | Gold Pandera schemas |
-| transformers | `src/bioetl/application/pipelines/{{provider}}/{{entity}}_transformer.py` | Field producers |
+| Parameter      | Source                                                                    | Example                     |
+| -------------- | ------------------------------------------------------------------------- | --------------------------- |
+| `{{source}}`   | User argument                                                             | `chembl`, `chembl/activity` |
+| schemas        | `src/bioetl/domain/schemas/{{provider}}/`                                 | Pandera DataFrameModel      |
+| entities       | `src/bioetl/domain/entities/{{provider}}.py`                              | Dataclass entities          |
+| gold contracts | `src/bioetl/domain/contracts/gold/{{provider}}.py`                        | Gold Pandera schemas        |
+| transformers   | `src/bioetl/application/pipelines/{{provider}}/{{entity}}_transformer.py` | Field producers             |
 
----
+______________________________________________________________________
 
 ## Output
 
 A checklist in Markdown format, suitable for a PR body or review comment.
 
----
+______________________________________________________________________
 
 ## Algorithm
 
@@ -35,12 +35,14 @@ A checklist in Markdown format, suitable for a PR body or review comment.
 Parse each transformer's `_transform_impl` method to extract the `business_data` dict keys. These are the columns that will appear in the Silver DataFrame.
 
 Also collect system columns added by `BaseTransformer`:
+
 - `entity_id`, `content_hash`
 - `_run_id`, `_run_type`, `_source_batch_id`, `_ingestion_ts`, `_index`
 
 ### 2. Collect schema fields
 
 From Pandera schema (Silver):
+
 ```python
 # src/bioetl/domain/schemas/{{provider}}/{{entity}}.py
 class EntitySchema(pa.DataFrameModel):
@@ -48,6 +50,7 @@ class EntitySchema(pa.DataFrameModel):
 ```
 
 From domain entity:
+
 ```python
 # src/bioetl/domain/entities/{{provider}}.py
 @dataclass
@@ -56,6 +59,7 @@ class Entity(BaseEntity):
 ```
 
 From Gold contract:
+
 ```python
 # src/bioetl/domain/contracts/gold/{{provider}}.py
 class EntityGoldSchema(pa.DataFrameModel):
@@ -66,9 +70,9 @@ class EntityGoldSchema(pa.DataFrameModel):
 
 For each column in transformer output:
 
-| Column | Transformer | Silver Schema | Entity | Gold Schema | Type Match | Nullable Match | Notes |
-|--------|-------------|---------------|--------|-------------|------------|----------------|-------|
-| `field` | `file:line` | `file:line` / MISSING | `file:line` / MISSING | `file:line` / MISSING | OK/MISMATCH | OK/MISMATCH | |
+| Column  | Transformer | Silver Schema         | Entity                | Gold Schema           | Type Match  | Nullable Match | Notes |
+| ------- | ----------- | --------------------- | --------------------- | --------------------- | ----------- | -------------- | ----- |
+| `field` | `file:line` | `file:line` / MISSING | `file:line` / MISSING | `file:line` / MISSING | OK/MISMATCH | OK/MISMATCH    |       |
 
 ### 4. Check architectural compliance
 
@@ -114,7 +118,7 @@ For each column in transformer output:
 - [ ] **ISSUE:** `FooSchema` in `infrastructure/` — move to `domain/schemas/`
 ```
 
----
+______________________________________________________________________
 
 ## Commit & PR Convention (`{{C}}`)
 
@@ -122,7 +126,7 @@ For each column in transformer output:
 - **PR title:** `refactor(schema): {{source}} coverage gaps`
 - **Labels:** `schema`
 
----
+______________________________________________________________________
 
 ## Example
 
@@ -137,7 +141,7 @@ Adding `tpsa` field to ChEMBL molecule:
   - Gold schema: chembl.py:ChemblMoleculeGoldSchema (MISSING)
 ```
 
----
+______________________________________________________________________
 
 ## Constraints
 
@@ -146,3 +150,10 @@ Adding `tpsa` field to ChEMBL molecule:
 - Respect EXC-015: Config classes with defaults are valid.
 - Fields starting with `_` are system/lineage fields — verify they follow `BaseTransformer` convention.
 - If schema files don't exist, flag as `[SCHEMA FILE NOT FOUND]`.
+
+## ADR Status Guardrail
+
+- Перед выводами по ADR пересчитать baseline как фактическое количество файлов `docs/02-architecture/decisions/ADR-*.md` (не фиксировать число вручную).
+- Разрешённые базовые статусы ADR: `Accepted`, `Superseded`, `Deprecated`, `Added`.
+- `Superseded` НЕ считать автоматическим дефектом: это нормальная эволюция архитектуры при наличии ADR-замены/контекста.
+- Дефектом считать только отсутствие статуса, невалидный статус или `Superseded` без связи с заменяющим ADR.

--- a/.claude/prompts/02-Sync/05-vcr-tests.md
+++ b/.claude/prompts/02-Sync/05-vcr-tests.md
@@ -2,37 +2,38 @@
 
 *Priority: medium | Version: 1.0 | Aligned with RULES.md v5.19*
 
----
+______________________________________________________________________
 
 ## Goal
 
 Analyze the crosswalk diff (output of `01-xwalk.md`) to determine which VCR cassettes need to be recorded or updated, and generate a task list with deterministic VCR recording instructions.
 
----
+______________________________________________________________________
 
 ## Input
 
-| Parameter | Source | Example |
-|-----------|--------|---------|
-| `{{source}}` | User argument | `chembl`, `chembl/activity` |
-| xwalk diff | Output of `01-xwalk.md` or git diff of xwalk CSV | Changed/added fields |
-| existing VCR | `tests/fixtures/vcr/{{provider}}/` | Current cassettes |
-| test files | `tests/integration/{{provider}}/` or `tests/integration/adapters/{{provider}}/` | Existing integration tests |
+| Parameter    | Source                                                                          | Example                     |
+| ------------ | ------------------------------------------------------------------------------- | --------------------------- |
+| `{{source}}` | User argument                                                                   | `chembl`, `chembl/activity` |
+| xwalk diff   | Output of `01-xwalk.md` or git diff of xwalk CSV                                | Changed/added fields        |
+| existing VCR | `tests/fixtures/vcr/{{provider}}/`                                              | Current cassettes           |
+| test files   | `tests/integration/{{provider}}/` or `tests/integration/adapters/{{provider}}/` | Existing integration tests  |
 
----
+______________________________________________________________________
 
 ## Output
 
 - **Task list** in Markdown: which cassettes to record/update
 - **VCR recording commands** ready to execute
 
----
+______________________________________________________________________
 
 ## Algorithm
 
 ### 1. Parse xwalk diff
 
 From the crosswalk output, identify:
+
 - **New fields** (present in code, absent from previous xwalk)
 - **Removed fields** (present in previous xwalk, absent from code)
 - **Type changes** (field type changed)
@@ -41,22 +42,23 @@ From the crosswalk output, identify:
 ### 2. Map fields to API responses
 
 For each changed field, determine:
+
 - Which API endpoint returns it
 - Which integration test covers that endpoint
 - Which VCR cassette records that response
 
 ### 3. Classify VCR actions
 
-| Action | Trigger | Command |
-|--------|---------|---------|
-| **RECORD** | New field not in any cassette | Record new cassette |
-| **UPDATE** | Field type/name changed | Delete + re-record cassette |
-| **VERIFY** | Field exists but cassette may be stale | Replay and check |
-| **NO-OP** | No change to API-facing fields | Skip |
+| Action     | Trigger                                | Command                     |
+| ---------- | -------------------------------------- | --------------------------- |
+| **RECORD** | New field not in any cassette          | Record new cassette         |
+| **UPDATE** | Field type/name changed                | Delete + re-record cassette |
+| **VERIFY** | Field exists but cassette may be stale | Replay and check            |
+| **NO-OP**  | No change to API-facing fields         | Skip                        |
 
 ### 4. Generate task list
 
-```markdown
+````markdown
 ## VCR Tasks: {{source}}
 
 ### Summary
@@ -83,9 +85,10 @@ For each changed field, determine:
 export VCR_RECORD_MODE=new_episodes
 pytest tests/integration/{{provider}}/test_{{entity}}.py -v -s
 export VCR_RECORD_MODE=none
-```
+````
 
 **Post-record:**
+
 - [ ] Verify cassette created: `ls tests/fixtures/vcr/{{provider}}/`
 - [ ] Check for secrets: `grep -i "api_key\|secret\|token" tests/fixtures/vcr/{{provider}}/test_*.yaml`
 - [ ] Replay test: `pytest tests/integration/{{provider}}/test_{{entity}}.py -v`
@@ -95,13 +98,15 @@ export VCR_RECORD_MODE=none
 **Reason:** Field `{{field}}` renamed from `{{old_name}}` to `{{new_name}}`.
 
 **Commands:**
+
 ```bash
 rm tests/fixtures/vcr/{{provider}}/TestAdapter.test_fetch_activities.yaml
 export VCR_RECORD_MODE=new_episodes
 pytest tests/integration/{{provider}}/test_adapter.py::TestAdapter::test_fetch_activities -v -s
 export VCR_RECORD_MODE=none
 ```
-```
+
+````
 
 ### 5. Detect missing integration tests
 
@@ -113,9 +118,9 @@ If a field change has no corresponding integration test:
 | Entity | Field | Reason | Suggested Test |
 |--------|-------|--------|---------------|
 | {{entity}} | {{field}} | No integration test covers this field | `test_fetch_{{entity}}_includes_{{field}}` |
-```
+````
 
----
+______________________________________________________________________
 
 ## Architecture Compliance
 
@@ -124,7 +129,7 @@ If a field change has no corresponding integration test:
 - Secrets MUST be sanitized via `before_record` callback (configured in `tests/conftest.py`)
 - CI MUST run with `VCR_RECORD_MODE=none`
 
----
+______________________________________________________________________
 
 ## Commit & PR Convention (`{{C}}`)
 
@@ -132,13 +137,13 @@ If a field change has no corresponding integration test:
 - **PR title:** `test({{source}}): update VCR cassettes`
 - **Labels:** `test`
 
----
+______________________________________________________________________
 
 ## Example
 
 For `chembl` after adding `tpsa` to molecule:
 
-```markdown
+````markdown
 ## VCR Tasks: chembl
 
 ### Tasks
@@ -153,7 +158,8 @@ rm tests/fixtures/vcr/chembl/TestChemblAdapter.test_fetch_molecules.yaml
 export VCR_RECORD_MODE=new_episodes
 pytest tests/integration/chembl/test_adapter.py::TestChemblAdapter::test_fetch_molecules -v -s
 export VCR_RECORD_MODE=none
-```
+````
+
 ```
 
 ---
@@ -164,3 +170,12 @@ export VCR_RECORD_MODE=none
 - VCR recording requires network access — document prerequisites clearly.
 - Cassette naming MUST follow pattern: `TestClassName.test_method_name.yaml`.
 - If no integration test directory exists for a provider, flag it as a gap.
+
+
+## ADR Status Guardrail
+
+- Перед выводами по ADR пересчитать baseline как фактическое количество файлов `docs/02-architecture/decisions/ADR-*.md` (не фиксировать число вручную).
+- Разрешённые базовые статусы ADR: `Accepted`, `Superseded`, `Deprecated`, `Added`.
+- `Superseded` НЕ считать автоматическим дефектом: это нормальная эволюция архитектуры при наличии ADR-замены/контекста.
+- Дефектом считать только отсутствие статуса, невалидный статус или `Superseded` без связи с заменяющим ADR.
+```

--- a/docs/00-project/RULES.md
+++ b/docs/00-project/RULES.md
@@ -248,10 +248,10 @@ Lock key включает тип запуска:
 
 ```python
 # В MedallionLifecycleService.clear()
-if self.runtime.run-type in (RunType.REBUILD, RunType.BACKFILL):
-    await self.services.storage.clear-silver(self.config.silver-table)
-    if self.config.gold-table:
-        await self.services.storage.clear-gold(self.config.gold-table)
+if self.runtime.run - type in (RunType.REBUILD, RunType.BACKFILL):
+    await self.services.storage.clear - silver(self.config.silver - table)
+    if self.config.gold - table:
+        await self.services.storage.clear - gold(self.config.gold - table)
 ```
 
 **Проверка:** Интеграционный тест `tests/integration/test-runner-lifecycle.py::test-incremental-skips-clear`.
@@ -385,12 +385,12 @@ if self.runtime.run-type in (RunType.REBUILD, RunType.BACKFILL):
 
 ### 2.7. Стратегия Загрузки (Load Strategy)
 
-| Критерий                                          | `loading_strategy: full_scan_only` |
-| ------------------------------------------------- | ---------------------------------- |
-| Источник с нестабильной offset-пагинацией         | ✅ Обязательно                     |
-| Checkpoint resume                                 | ❌ Запрещён                        |
-| Дедупликация                                      | ✅ Через content-hash в Silver     |
-| Типичные сущности                                 | Publication family, derived sets   |
+| Критерий                                  | `loading_strategy: full_scan_only` |
+| ----------------------------------------- | ---------------------------------- |
+| Источник с нестабильной offset-пагинацией | ✅ Обязательно                     |
+| Checkpoint resume                         | ❌ Запрещён                        |
+| Дедупликация                              | ✅ Через content-hash в Silver     |
+| Типичные сущности                         | Publication family, derived sets   |
 
 - **Watermark**: Механизм удалён согласно [ADR-011](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md).
 - **Конфигурация**: `loading_strategy: full_scan_only` задаётся в `configs/pipelines/*/*.yaml` (см. [ADR-031](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md)).
@@ -931,27 +931,27 @@ pip install -e ".[tests]"
 # RetryConfig (src/bioetl/domain/resilience.py)
 RetryConfig(
     deterministic=True,  # Hash-based jitter
-    jitter-seed=42,  # Reproducible seed
+    jitter - seed=42,  # Reproducible seed
 )
 ```
 
 При `deterministic=True` jitter вычисляется как:
 
 ```python
-hash-input = f"{attempt}:{url}:{seed}"
-jitter-factor = (hash(hash-input) % 1000) / 1000.0
+hash - input = f"{attempt}:{url}:{seed}"
+jitter - factor = (hash(hash - input) % 1000) / 1000.0
 ```
 
 #### Единый Источник Времени
 
 ```python
 # Application layer создаёт timestamp
-context = PipelineContext.create(run-id, run-type, logger)
+context = PipelineContext.create(run - id, run - type, logger)
 # context.started-at используется во всех компонентах
 
 # Infrastructure получает timestamp как параметр
-await bronze-writer.write-bronze(..., ingestion-ts=context.started-at)
-await quarantine.write(..., ingestion-ts=context.started-at)
+await bronze - writer.write - bronze(..., ingestion - ts=context.started - at)
+await quarantine.write(..., ingestion - ts=context.started - at)
 ```
 
 ### 4.4. Python Standards
@@ -1142,9 +1142,9 @@ async with services:  # --aenter-- инициализирует ресурсы
 
 ```python
 # domain/resilience.py — MD5-based jitter для кросс-процессной стабильности
-hash-input = f"{attempt}:{url}:{seed}"
-digest = hashlib.md5(hash-input.encode(), usedforsecurity=False).hexdigest()
-jitter-factor = int(digest[:8], 16) / 0xFFFFFFFF
+hash - input = f"{attempt}:{url}:{seed}"
+digest = hashlib.md5(hash - input.encode(), usedforsecurity=False).hexdigest()
+jitter - factor = int(digest[:8], 16) / 0xFFFFFFFF
 ```
 
 При `RetryConfig(deterministic=False)` выдаётся `DeprecationWarning` — рекомендуется переход на детерминистичный режим.
@@ -1325,7 +1325,7 @@ find tests -name "*.py" -exec grep -l "ClassName" {} \;
 grep -B2 -A2 "ComponentName" docs/archived/refactoring-plan.md
 ```
 
-----------------------------------------------------------------------
+______________________________________________________________________
 
 ## 8. Управление Изменениями
 
@@ -1411,7 +1411,7 @@ make run-local    # запуск сэмплового пайплайна на ф
 
 - **.env.example**: Шаблон переменных окружения (без секретов).
 
-----------------------------------------------------------------------
+______________________________________________________________________
 
 ## Приложение А: Источники и Библиотеки
 
@@ -1591,48 +1591,59 @@ fields:
 - Bump major version схемы
 - ADR с обоснованием изменения
 
+## 6.4 Политика статусов ADR
+
+Все ADR в `docs/02-architecture/decisions/ADR-*.md` MUST содержать явный статус в одном из разрешённых значений:
+
+- `Accepted` — действующее архитектурное решение, обязательное к применению.
+- `Superseded` — решение заменено более новым ADR; это ожидаемая эволюция архитектуры, а не дефект.
+- `Deprecated` — решение устарело и находится в фазе вывода без прямой замены.
+- `Added` — ADR добавлен в реестр и находится в стадии внедрения/ратификации до перехода в `Accepted`.
+
+Нормализация для quality gate: допускаются расширенные формулировки в заголовке (например, `Accepted (Revised)`), но базовый статус MUST быть одним из четырёх значений выше.
+
 ## Приложение F: Реестр Architecture Decision Records (ADR)
 
-| ADR                                                                               | Название                                 | Статус             | Дата       |
-| --------------------------------------------------------------------------------- | ---------------------------------------- | ------------------ | ---------- |
-| [ADR-001](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | 2025-05    |
-| [ADR-002](../02-architecture/decisions/ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | 2025-05    |
-| [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | 2025-12    |
-| [ADR-004](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | Accepted           | 2025-05    |
-| [ADR-005](../02-architecture/decisions/ADR-005-composition-layer-separation.md)      | Composition Layer Separation             | Accepted           | 2025-12    |
-| [ADR-006](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                 | Accepted           | 2025-12-18 |
-| [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation           | Accepted           | 2025-12-22 |
-| [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy               | Accepted           | 2025-12-22 |
-| [ADR-009](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design             | Accepted           | 2025-12-22 |
-| [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | Accepted           | 2025-12-23 |
-| [ADR-011](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism               | Accepted           | 2025-12-23 |
-| [ADR-012](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID        | Accepted           | 2025-12-23 |
-| [ADR-013](../02-architecture/decisions/ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | Accepted           | 2025-12-24 |
-| [ADR-014](../02-architecture/decisions/ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries         | Accepted           | 2025-12-24 |
-| [ADR-015](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | Accepted           | 2025-12-24 |
-| [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | 2025-12-26 |
-| [ADR-017](../02-architecture/decisions/ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | 2025-12-26 |
-| [ADR-018](../02-architecture/decisions/ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | 2025-12-28 |
-| [ADR-019](../02-architecture/decisions/ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | 2025-12-26 |
-| [ADR-020](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | 2025-12-16 |
-| [ADR-021](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | 2025-12-29 |
-| [ADR-022](../02-architecture/decisions/ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only              | Accepted           | 2025-12-30 |
-| [ADR-023](../02-architecture/decisions/ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | Accepted           | 2026-01-06 |
-| [ADR-024](../02-architecture/decisions/ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | Accepted           | 2026-01-06 |
-| [ADR-025](../02-architecture/decisions/ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | Accepted           | 2026-01-19 |
-| [ADR-026](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | Accepted           | 2026-01-15 |
-| [ADR-027](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | Accepted           | 2026-01-19 |
-| [ADR-028](../02-architecture/decisions/ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | Accepted           | 2026-01-20 |
-| [ADR-029](../02-architecture/decisions/ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | Accepted           | 2026-01-23 |
-| [ADR-030](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | Accepted           | 2026-01-26 |
-| [ADR-031](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | 2026-01-26 |
-| [ADR-032](../02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | 2026-01-28 |
-| [ADR-033](../02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | 2026-02-06 |
-| [ADR-034](../02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | 2026-02-15 |
-| [ADR-035](../02-architecture/decisions/ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)   | Accepted           | 2026-02-17 |
-| [ADR-036](../02-architecture/decisions/ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy           | Accepted           | 2026-02-18 |
-| [ADR-037](../02-architecture/decisions/ADR-037-canonical-schema-generation.md)       | Canonical Schema Source and Generation    | Accepted           | 2026-02-18 |
-| [ADR-038](../02-architecture/decisions/ADR-038-enum-externalization.md)              | ChEMBL Enum Values Externalization to YAML | Accepted          | 2026-02-16 |
+| ADR                                                                                  | Название                                   | Статус             | Дата       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------ | ------------------ | ---------- |
+| [ADR-001](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                      | Accepted           | 2025-05    |
+| [ADR-002](../02-architecture/decisions/ADR-002-medallion-architecture.md)            | Medallion Architecture                     | Accepted           | 2025-05    |
+| [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)             | Accepted (Revised) | 2025-12    |
+| [ADR-004](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                    | Accepted           | 2025-05    |
+| [ADR-005](../02-architecture/decisions/ADR-005-composition-layer-separation.md)      | Composition Layer Separation               | Accepted           | 2025-12    |
+| [ADR-006](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                   | Accepted           | 2025-12-18 |
+| [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation             | Accepted           | 2025-12-22 |
+| [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy                 | Accepted           | 2025-12-22 |
+| [ADR-009](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design               | Accepted           | 2025-12-22 |
+| [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)             | Local-Only Deployment                      | Accepted           | 2025-12-23 |
+| [ADR-011](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism                 | Accepted           | 2025-12-23 |
+| [ADR-012](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID          | Accepted           | 2025-12-23 |
+| [ADR-013](../02-architecture/decisions/ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                      | Accepted           | 2025-12-24 |
+| [ADR-014](../02-architecture/decisions/ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries           | Accepted           | 2025-12-24 |
+| [ADR-015](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle                | Accepted           | 2025-12-24 |
+| [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)           | Error Handling Strategy                    | Accepted           | 2025-12-26 |
+| [ADR-017](../02-architecture/decisions/ADR-017-observability-architecture.md)        | Observability Architecture                 | Accepted           | 2025-12-26 |
+| [ADR-018](../02-architecture/decisions/ADR-018-gold-strict-validation.md)            | Gold Strict Validation                     | Accepted           | 2025-12-28 |
+| [ADR-019](../02-architecture/decisions/ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement             | Accepted           | 2025-12-26 |
+| [ADR-020](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition                 | Accepted           | 2025-12-16 |
+| [ADR-021](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                    | Accepted           | 2025-12-29 |
+| [ADR-022](../02-architecture/decisions/ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only                | Accepted           | 2025-12-30 |
+| [ADR-023](../02-architecture/decisions/ADR-023-entity-type-patterns.md)              | Entity Type Patterns                       | Accepted           | 2026-01-06 |
+| [ADR-024](../02-architecture/decisions/ADR-024-entity-naming-unification.md)         | Entity Naming Unification                  | Accepted           | 2026-01-06 |
+| [ADR-025](../02-architecture/decisions/ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification                | Accepted           | 2026-01-19 |
+| [ADR-026](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern                 | Accepted           | 2026-01-15 |
+| [ADR-027](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                   | Accepted           | 2026-01-19 |
+| [ADR-028](../02-architecture/decisions/ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization               | Accepted           | 2026-01-20 |
+| [ADR-029](../02-architecture/decisions/ADR-029-output-metadata-unification.md)       | Output Metadata Unification                | Accepted           | 2026-01-23 |
+| [ADR-030](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy            | Accepted           | 2026-01-26 |
+| [ADR-031](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization             | Accepted           | 2026-01-26 |
+| [ADR-032](../02-architecture/decisions/ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern                | Accepted           | 2026-01-28 |
+| [ADR-033](../02-architecture/decisions/ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy   | Added              | 2026-02-06 |
+| [ADR-034](../02-architecture/decisions/ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs          | Accepted           | 2026-02-15 |
+| [ADR-035](../02-architecture/decisions/ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)     | Accepted           | 2026-02-17 |
+| [ADR-036](../02-architecture/decisions/ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy            | Accepted           | 2026-02-18 |
+| [ADR-037](../02-architecture/decisions/ADR-037-canonical-schema-generation.md)       | Canonical Schema Source and Generation     | Accepted           | 2026-02-18 |
+| [ADR-038](../02-architecture/decisions/ADR-038-enum-externalization.md)              | ChEMBL Enum Values Externalization to YAML | Accepted           | 2026-02-16 |
 
 ## История Изменений (Changelog)
 

--- a/docs/02-architecture/decisions/ADR-033-publication-validation-strategy.md
+++ b/docs/02-architecture/decisions/ADR-033-publication-validation-strategy.md
@@ -1,16 +1,16 @@
 # ADR-033: Publication Metadata Validation Strategy
 
-| Параметр | Значение |
-|----------|----------|
-| **Статус** | Proposed (per-provider schemas implemented; unified 5-level validation pipeline not yet realized) |
-| **Дата** | 2026-02-06 |
-| **Автор** | BioETL Team |
-| **Ревьюер** | — |
+| Параметр          | Значение                                                                                                                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Статус**        | Added (per-provider schemas implemented; unified 5-level validation pipeline not yet realized)                                                                                                                |
+| **Дата**          | 2026-02-06                                                                                                                                                                                                    |
+| **Автор**         | BioETL Team                                                                                                                                                                                                   |
+| **Ревьюер**       | —                                                                                                                                                                                                             |
 | **Связанные ADR** | [ADR-002](ADR-002-medallion-architecture.md) (Medallion Architecture), [ADR-014](ADR-014-deterministic-writes.md) (Deterministic Writes), [ADR-027](ADR-027-dq-rules-externalization.md) (DQ Externalization) |
-| **Заменяет** | — |
-| **Заменён** | — |
+| **Заменяет**      | —                                                                                                                                                                                                             |
+| **Заменён**       | —                                                                                                                                                                                                             |
 
----
+______________________________________________________________________
 
 ## Контекст
 
@@ -18,35 +18,39 @@
 
 Система BioETL интегрирует метаданные научных публикаций из **5 гетерогенных провайдеров**:
 
-| Провайдер | Полей | Primary Key | API Особенности |
-|-----------|-------|-------------|----------------|
-| **ChEMBL** | 28 | `document-chembl-id` | REST, стабильная схема |
-| **PubMed** | 52 | `pmid` | MEDLINE XML, богатые метаданные |
-| **CrossRef** | 37 | `doi` | REST, неполные данные |
-| **OpenAlex** | 39 | `openalex-id` | REST, академическая граф-база |
-| **Semantic Scholar** | 35 | `paper-id` | REST, AI-генерированные TLDR |
+| Провайдер            | Полей | Primary Key          | API Особенности                 |
+| -------------------- | ----- | -------------------- | ------------------------------- |
+| **ChEMBL**           | 28    | `document-chembl-id` | REST, стабильная схема          |
+| **PubMed**           | 52    | `pmid`               | MEDLINE XML, богатые метаданные |
+| **CrossRef**         | 37    | `doi`                | REST, неполные данные           |
+| **OpenAlex**         | 39    | `openalex-id`        | REST, академическая граф-база   |
+| **Semantic Scholar** | 35    | `paper-id`           | REST, AI-генерированные TLDR    |
 
 **Всего: 191 поле** (с учетом всех полей включая унаследованные от `PublicationBaseSchema`).
 
 #### Вызовы
 
 1. **Гетерогенность форматов:**
+
    - DOI regex различается (CrossRef: non-nullable PK vs PubMed: nullable enrichment field)
    - Типы данных: строки vs числа (page-first может быть "e1234" или "100")
    - Дублирование полей: 5 провайдеров × ~20 общих полей = ~100 вариаций
 
-2. **Качество данных:**
+1. **Качество данных:**
+
    - Неполные записи: ~15% CrossRef-записей без title
    - Противоречия: publication-year ≠ YEAR(publication-date) в ~2% PubMed
    - Семантическая несогласованность: title-abstract similarity < 0.1 в ~5% OpenAlex
 
-3. **Отсутствие унифицированной стратегии:**
+1. **Отсутствие унифицированной стратегии:**
+
    - Pandera валидирует только схему Silver (форматные проверки)
    - Нет кросс-полевой валидации (page-first ≤ page-last)
    - Нет верификации по внешним источникам (DOI существует в CrossRef API?)
    - Нет семантических проверок (язык аннотации совпадает с полем language?)
 
-4. **Отсутствие DQ-метрик:**
+1. **Отсутствие DQ-метрик:**
+
    - Нет отчётов о качестве данных на уровне провайдера/поля
    - Нет возможности отследить % записей с проблемами
    - Нет карантина для критически невалидных записей
@@ -54,6 +58,7 @@
 ### Требования
 
 **Функциональные:**
+
 - **REQ-VAL-001 (MUST):** Многоуровневая валидация: base → structural → external → logical → semantic.
 - **REQ-VAL-002 (MUST):** DQ-флаги: `-dq-error` (блокирующие ошибки), `-dq-warn` (предупреждения).
 - **REQ-VAL-003 (MUST):** Карантин: записи с `-dq-error=True` → Dead Letter Queue, не попадают в Gold.
@@ -61,6 +66,7 @@
 - **REQ-VAL-005 (SHOULD):** Graceful degradation: таймауты API не блокируют пайплайн (SKIP).
 
 **Нефункциональные:**
+
 - **REQ-VAL-006 (MUST):** Производительность: overhead валидации < 20% от времени трансформации.
 - **REQ-VAL-007 (MUST):** Детерминизм: валидация не зависит от порядка записей.
 - **REQ-VAL-008 (MUST):** Конфигурируемость: DQ-правила в YAML, не хардкод.
@@ -71,7 +77,7 @@
 - **ADR-014 (Deterministic Writes):** content-hash проверяется structural validation.
 - **ADR-027 (DQ Externalization):** DQ-правила в `configs/validation/{provider}.yaml`.
 
----
+______________________________________________________________________
 
 ## Решение
 
@@ -143,20 +149,23 @@
 **Назначение:** Форматная проверка на уровне поля.
 
 **Правила:**
+
 - Regex-паттерны: DOI (`^10\.\d{4,9}/.+$`), PMID (`^[1-9]\d*$`), ORCID (`^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$`)
 - Nullable constraints: PK поля — non-nullable, enrichment — nullable
 - Type coercion: `pd.Int64Dtype` для nullable integers
 
 **Результат:**
+
 - `PASS` → переход к structural
 - `FAIL` → `-dq-error=True`, запись отклонена
 
 **Пример (Pandera):**
+
 ```python
 class ChemblPublicationSchema(PublicationBaseSchema):
-    document-chembl-id: Series[str] = pa.Field(
+    document - chembl - id: Series[str] = pa.Field(
         nullable=False,
-        str-matches=r"^CHEMBL\d+$",
+        str - matches=r"^CHEMBL\d+$",
         description="ChEMBL Document ID (PK)",
     )
 ```
@@ -166,12 +175,14 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 **Назначение:** Проверка согласованности между полями одной записи.
 
 **Правила:**
+
 - `page-first ≤ page-last` (если оба числовые)
 - `content-hash == recomputed-hash(excl. -ingestion-ts, -run-id, -dq-*)`
 - `IF corpus-id NOT NULL THEN paper-id MUST NOT be NULL` (S2)
 - `publication-year == YEAR(publication-date)` (если оба заполнены)
 
 **Результат:**
+
 - `PASS` → external verification
 - `FAIL` → `-dq-error=True` (критические: content-hash)
 - `WARN` → `-dq-warn=True` (некритические: page ordering)
@@ -181,6 +192,7 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 **Назначение:** Сопоставление с авторитетными источниками.
 
 **Поддерживаемые API:**
+
 - CrossRef: `/works/{doi}` → HTTP 200
 - PubMed: `/efetch.fcgi?db=pubmed&id={pmid}`
 - OpenAlex: `/works/{openalex-id}`
@@ -190,11 +202,13 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 - ROR: `/organizations/{ror-id}`
 
 **Стратегия отказов:**
+
 - Timeout (> 5s) → `SKIP` (graceful degradation)
 - HTTP 404 → `FAIL` (для PK), `WARN` (для non-PK)
 - Rate limit (429) → Circuit Breaker → `SKIP`
 
 **Результат:**
+
 - `PASS` / `SKIP` → logical validation
 - `FAIL` (PK not found) → `-dq-error=True`
 - `WARN` (non-PK not found) → `-dq-warn=True`
@@ -204,6 +218,7 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 **Назначение:** Проверка числовых диапазонов и временных инвариантов.
 
 **Правила:**
+
 - `1800 ≤ publication-year ≤ CURRENT-YEAR + 1`
 - `citations-received ≥ 0`, `citations-made ≥ 0`
 - `fwci ≥ 0.0` (OpenAlex)
@@ -211,6 +226,7 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 - `date-completed ≤ date-revised` (PubMed)
 
 **Результат:**
+
 - `PASS` → semantic validation
 - `WARN` → `-dq-warn=True` (логически некорректно, но не блокирует)
 
@@ -219,23 +235,26 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 **Назначение:** Проверка смысловой согласованности текстовых полей.
 
 **Правила (примеры):**
+
 - `SemanticSimilarity(title, abstract) > 0.3` (Sentence-BERT)
 - `Language(abstract) == language` (langdetect)
 - `Keywords(abstract) ∩ subject-keywords ≠ ∅`
 - `MeSH` terms relevance (NLP topic modeling)
 
 **Результат:**
+
 - `PASS` / `WARN` → `-dq-warn=True`
 - **NEVER FAIL** (семантика не блокирует)
 
 ### DQ-флаги и карантин
 
-| Флаг | Устанавливается при | Действие |
-|------|---------------------|----------|
-| `-dq-error` | FAIL на уровнях 1-3 | Запись → Quarantine (Dead Letter), не попадает в Silver |
-| `-dq-warn` | WARN на уровнях 2-5 | Запись → Silver с флагом, может быть отфильтрована в Gold |
+| Флаг        | Устанавливается при | Действие                                                  |
+| ----------- | ------------------- | --------------------------------------------------------- |
+| `-dq-error` | FAIL на уровнях 1-3 | Запись → Quarantine (Dead Letter), не попадает в Silver   |
+| `-dq-warn`  | WARN на уровнях 2-5 | Запись → Silver с флагом, может быть отфильтрована в Gold |
 
 **Карантин:**
+
 - Путь: `data/output/quarantine/{provider}/publication/{date}/`
 - Формат: Delta Lake (для SCD Type 2)
 - Retention: 90 дней
@@ -244,6 +263,7 @@ class ChemblPublicationSchema(PublicationBaseSchema):
 ### Конфигурация DQ
 
 **Иерархия:**
+
 ```
 configs/validation/
 ├── -defaults.yaml                    # Глобальные пороги
@@ -255,6 +275,7 @@ configs/validation/
 ```
 
 **Пример конфигурации:**
+
 ```yaml
 # configs/validation/pubmed/publication.yaml
 validation:
@@ -289,21 +310,24 @@ dq-thresholds:
   hard-fail-threshold: 0.20  # 20% errors → pipeline fail
 ```
 
----
+______________________________________________________________________
 
 ## Альтернативы
 
 ### Альтернатива 1: Монолитная валидация в Pandera (отклонена)
 
 **Описание:**
+
 - Все правила (включая кросс-полевые и внешние) в Pandera `@pa.check()`.
 - Единая точка валидации на Silver-слое.
 
 **Преимущества:**
+
 - Простота: один инструмент
 - Декларативность: все правила в схеме
 
 **Недостатки:**
+
 - ❌ **Нет внешней верификации:** Pandera не поддерживает HTTP-вызовы в `@pa.check()`
 - ❌ **Плохая производительность:** синхронная валидация блокирует I/O
 - ❌ **Нет graceful degradation:** таймаут API = падение пайплайна
@@ -314,14 +338,17 @@ dq-thresholds:
 ### Альтернатива 2: Pandera + Great Expectations (отклонена)
 
 **Описание:**
+
 - Pandera для base validation
 - Great Expectations для structural/logical/external
 
 **Преимущества:**
+
 - Great Expectations имеет встроенные DQ-метрики
 - Rich HTML-отчёты
 
 **Недостатки:**
+
 - ❌ **Избыточная зависимость:** два фреймворка с перекрывающейся функциональностью
 - ❌ **Сложность интеграции:** GE работает с SQL, не с DataFrames напрямую
 - ❌ **Overhead:** GE checkpoint + validation = +30% времени
@@ -332,55 +359,65 @@ dq-thresholds:
 ### Альтернатива 3: Текущее решение — пятиуровневая валидация
 
 **Преимущества:**
+
 - ✅ Разделение ответственности: Pandera (schema), Service (logic), Integration (API)
 - ✅ Гибкость: каждый уровень можно отключить/настроить
 - ✅ Graceful degradation: external verification не блокирует пайплайн
 - ✅ Расширяемость: легко добавить новые уровни (e.g., ML-based anomaly detection)
 
 **Недостатки:**
+
 - ⚠️ Сложность: 5 уровней + конфигурация
 - ⚠️ Overhead: +15-20% времени выполнения (измерено на PubMed)
 
 **Вердикт:** Принято как оптимальное соотношение гибкость/сложность.
 
----
+______________________________________________________________________
 
 ## Последствия
 
 ### Позитивные
 
 1. **Качество данных:**
+
    - Снижение невалидных записей в Silver с ~8% до ~2% (измерено на ChEMBL pilot)
    - 100% покрытие PK-полей внешней верификацией
 
-2. **Наблюдаемость:**
+1. **Наблюдаемость:**
+
    - DQ-метрики на уровне провайдера/поля/уровня валидации
    - `-dq-report.json` для каждого run: error rate, warn rate, quarantine count
 
-3. **Гибкость:**
+1. **Гибкость:**
+
    - Можно отключить дорогие проверки (semantic, external) в production
    - Emergency overrides без деплоя кода
 
-4. **Compliance:**
+1. **Compliance:**
+
    - Аудитируемость: карантин хранит невалидные записи с причинами
    - Reproducibility: детерминистическая валидация (content-hash)
 
 ### Негативные
 
 1. **Сложность:**
+
    - 5 уровней валидации требуют понимания всей стратегии
    - Новым разработчикам нужно изучить иерархию конфигурации
 
-2. **Производительность:**
+1. **Производительность:**
+
    - External verification: +10% времени (с circuit breaker)
    - Semantic validation: +15-20% времени (если включена)
    - **Mitigation:** Batch API calls, async I/O, кеширование
 
-3. **Зависимости:**
+1. **Зависимости:**
+
    - Внешние API: CrossRef, PubMed, ORCID (риск downtime)
    - **Mitigation:** Circuit breaker, graceful degradation (SKIP)
 
-4. **Maintenance:**
+1. **Maintenance:**
+
    - Regex-паттерны и диапазоны нужно обновлять (e.g., MAX-YEAR)
    - API endpoints могут измениться
    - **Mitigation:** Версионирование конфигов, архитектурные тесты
@@ -388,14 +425,16 @@ dq-thresholds:
 ### Нейтральные
 
 1. **Размер кодовой базы:**
+
    - +~1500 LOC для validation services
    - +~735 тестов для покрытия всех уровней
 
-2. **Disk usage:**
+1. **Disk usage:**
+
    - Карантин: ~2% от Silver (оценка на ChEMBL)
    - DQ reports: ~10 MB/run
 
----
+______________________________________________________________________
 
 ## Связанные решения
 
@@ -405,37 +444,40 @@ dq-thresholds:
 - **ADR-024 (Entity Naming Unification):** `publication` entity для всех провайдеров.
 - **ADR-026 (Composite Publication Pipeline):** Валидация в seed + enricher pipelines.
 
----
+______________________________________________________________________
 
 ## Метрики успеха
 
-| Метрика | Baseline (до) | Target (после) | Measured |
-|---------|---------------|----------------|----------|
-| Невалидные записи в Silver | ~8% | < 2% | 1.8% (ChEMBL pilot) |
-| DQ coverage (полей с правилами) | 45% | 90% | 91% (191/191 полей) |
-| False positives (WARN → ручная проверка OK) | — | < 5% | 3.2% (PubMed) |
-| External verification coverage (PK) | 0% | 100% | 100% (5/5 провайдеров) |
-| Pipeline overhead | 0% | < 20% | 15-18% (зависит от external) |
+| Метрика                                     | Baseline (до) | Target (после) | Measured                     |
+| ------------------------------------------- | ------------- | -------------- | ---------------------------- |
+| Невалидные записи в Silver                  | ~8%           | < 2%           | 1.8% (ChEMBL pilot)          |
+| DQ coverage (полей с правилами)             | 45%           | 90%            | 91% (191/191 полей)          |
+| False positives (WARN → ручная проверка OK) | —             | < 5%           | 3.2% (PubMed)                |
+| External verification coverage (PK)         | 0%            | 100%           | 100% (5/5 провайдеров)       |
+| Pipeline overhead                           | 0%            | < 20%          | 15-18% (зависит от external) |
 
----
+______________________________________________________________________
 
 ## Ссылки
 
 **Документация:**
+
 - [Publication Fields Reference](../../04-reference/publication-fields-reference.md)
 - [Validation Guide](../../03-guides/publication-validation-guide.md)
 - [Operational Runbook](../../05-operations/runbooks/publication-validation-runbook.md)
 
 **Код:**
+
 - Schemas: `src/bioetl/domain/schemas/{provider}/publication.py`
 - Services: `src/bioetl/application/services/dq/`
 - Tests: `tests/unit/domain/schemas/`, `tests/integration/validation/`
 
 **Конфигурация:**
+
 - `docs/04-reference/schemas/publication-validation-schema-v3.xlsx` — источник правил
 - `configs/validation/{provider}.yaml` — runtime конфигурация
 
----
+______________________________________________________________________
 
 **Версия документа:** 1.0.0
 **Последнее обновление:** 2026-02-06

--- a/docs/02-architecture/decisions/README.md
+++ b/docs/02-architecture/decisions/README.md
@@ -4,46 +4,46 @@ This directory contains Architecture Decision Records documenting significant ar
 
 ## ADR Index
 
-| ADR                                                     | Title                                    | Status             | Category        | Date       |
-| ------------------------------------------------------- | ---------------------------------------- | ------------------ | --------------- | ---------- |
-| [ADR-001](ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                    | Accepted           | Storage         | 2025-05-20 |
-| [ADR-002](ADR-002-medallion-architecture.md)            | Medallion Architecture                   | Accepted           | Architecture    | 2025-05-20 |
-| [ADR-003](ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)           | Accepted (Revised) | Locking         | 2025-12-23 |
-| [ADR-004](ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                  | Accepted           | Data Modeling   | 2025-05-20 |
-| [ADR-005](ADR-005-composition-layer-separation.md)      | Composition Layer Separation             | Accepted           | Architecture    | 2025-12-15 |
-| [ADR-006](ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                 | Accepted           | Observability   | 2025-12-18 |
-| [ADR-007](ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation           | Accepted           | Resilience      | 2025-12-22 |
-| [ADR-008](ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy               | Accepted           | Lifecycle       | 2025-12-22 |
-| [ADR-009](ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design             | Accepted           | Data Fetching   | 2025-12-22 |
-| [ADR-010](ADR-010-local-only-deployment.md)             | Local-Only Deployment                    | Accepted           | Deployment      | 2025-12-23 |
-| [ADR-011](ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism               | Accepted           | Data Loading    | 2025-12-23 |
-| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID        | Accepted           | Storage         | 2025-12-23 |
-| [ADR-013](ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                    | Accepted           | Storage         | 2025-12-24 |
-| [ADR-014](ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries         | Accepted           | Reproducibility | 2025-12-24 |
-| [ADR-015](ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle              | Accepted           | Lifecycle       | 2025-12-24 |
-| [ADR-016](ADR-016-error-handling-strategy.md)           | Error Handling Strategy                  | Accepted           | Resilience      | 2025-12-26 |
-| [ADR-017](ADR-017-observability-architecture.md)        | Observability Architecture               | Accepted           | Observability   | 2025-12-26 |
-| [ADR-018](ADR-018-gold-strict-validation.md)            | Gold Strict Validation                   | Accepted           | Data Quality    | 2025-12-26 |
-| [ADR-019](ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement           | Accepted           | Observability   | 2025-12-26 |
-| [ADR-020](ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition               | Accepted           | Architecture    | 2025-12-16 |
-| [ADR-021](ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                  | Accepted           | Domain Model    | 2025-12-29 |
-| [ADR-022](ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only              | Accepted           | Observability   | 2025-12-30 |
-| [ADR-023](ADR-023-entity-type-patterns.md)              | Entity Type Patterns                     | Accepted           | Observability   | 2026-01-06 |
-| [ADR-024](ADR-024-entity-naming-unification.md)         | Entity Naming Unification                | Accepted           | Architecture    | 2026-01-07 |
-| [ADR-025](ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification              | Accepted           | Configuration   | 2026-01-14 |
-| [ADR-026](ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern               | Accepted           | Architecture    | 2026-01-15 |
-| [ADR-027](ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                 | Accepted           | Data Quality    | 2026-01-19 |
-| [ADR-028](ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization             | Accepted           | Configuration   | 2026-01-20 |
-| [ADR-029](ADR-029-output-metadata-unification.md)       | Output Metadata Unification              | Accepted           | Data Modeling   | 2026-01-23 |
-| [ADR-030](ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy          | Accepted           | Data Fetching   | 2026-01-25 |
-| [ADR-031](ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization           | Accepted           | Data Loading    | 2026-01-26 |
-| [ADR-032](ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern              | Accepted           | HTTP/Networking | 2026-01-28 |
-| [ADR-033](ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy | Proposed           | Data Quality    | 2026-02-06 |
-| [ADR-034](ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs        | Accepted           | Architecture    | 2026-02-15 |
-| [ADR-035](ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)   | Accepted           | Data Modeling   | 2026-02-17 |
-| [ADR-036](ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy          | Accepted           | Data Quality    | 2026-02-18 |
-| [ADR-037](ADR-037-canonical-schema-generation.md)       | Canonical Schema Source and Generation   | Accepted           | Data Contracts  | 2026-02-18 |
-| [ADR-038](ADR-038-enum-externalization.md)              | ChEMBL Enum Values Externalization to YAML | Accepted         | Configuration   | 2026-02-16 |
+| ADR                                                     | Title                                      | Status             | Category        | Date       |
+| ------------------------------------------------------- | ------------------------------------------ | ------------------ | --------------- | ---------- |
+| [ADR-001](ADR-001-delta-lake-vs-parquet.md)             | Delta Lake vs Parquet                      | Accepted           | Storage         | 2025-05-20 |
+| [ADR-002](ADR-002-medallion-architecture.md)            | Medallion Architecture                     | Accepted           | Architecture    | 2025-05-20 |
+| [ADR-003](ADR-003-in-memory-locking-strategy.md)        | In-Memory Locking (MemoryLock)             | Accepted (Revised) | Locking         | 2025-12-23 |
+| [ADR-004](ADR-004-pydantic-vs-dataclasses.md)           | Pydantic vs Dataclasses                    | Accepted           | Data Modeling   | 2025-05-20 |
+| [ADR-005](ADR-005-composition-layer-separation.md)      | Composition Layer Separation               | Accepted           | Architecture    | 2025-12-15 |
+| [ADR-006](ADR-006-logger-metrics-ports.md)              | Logger and Metrics Ports                   | Accepted           | Observability   | 2025-12-18 |
+| [ADR-007](ADR-007-circuit-breaker-implementation.md)    | Circuit Breaker Implementation             | Accepted           | Resilience      | 2025-12-22 |
+| [ADR-008](ADR-008-graceful-shutdown-strategy.md)        | Graceful Shutdown Strategy                 | Accepted           | Lifecycle       | 2025-12-22 |
+| [ADR-009](ADR-009-paginated-fetcher-mixin.md)           | PaginatedFetcherMixin Design               | Accepted           | Data Fetching   | 2025-12-22 |
+| [ADR-010](ADR-010-local-only-deployment.md)             | Local-Only Deployment                      | Accepted           | Deployment      | 2025-12-23 |
+| [ADR-011](ADR-011-remove-watermark-mechanism.md)        | Remove Watermark Mechanism                 | Accepted           | Data Loading    | 2025-12-23 |
+| [ADR-012](ADR-012-storage-clear-contract-and-run-id.md) | Storage Clear Contract and Run ID          | Accepted           | Storage         | 2025-12-23 |
+| [ADR-013](ADR-013-async-storage-cleanup.md)             | Async Storage Cleanup                      | Accepted           | Storage         | 2025-12-24 |
+| [ADR-014](ADR-014-deterministic-writes.md)              | Deterministic Writes and Retries           | Accepted           | Reproducibility | 2025-12-24 |
+| [ADR-015](ADR-015-pipeline-services-lifecycle.md)       | Pipeline Services Lifecycle                | Accepted           | Lifecycle       | 2025-12-24 |
+| [ADR-016](ADR-016-error-handling-strategy.md)           | Error Handling Strategy                    | Accepted           | Resilience      | 2025-12-26 |
+| [ADR-017](ADR-017-observability-architecture.md)        | Observability Architecture                 | Accepted           | Observability   | 2025-12-26 |
+| [ADR-018](ADR-018-gold-strict-validation.md)            | Gold Strict Validation                     | Accepted           | Data Quality    | 2025-12-26 |
+| [ADR-019](ADR-019-observability-port-enforcement.md)    | Observability Port Enforcement             | Accepted           | Observability   | 2025-12-26 |
+| [ADR-020](ADR-020-basepipeline-decomposition.md)        | BasePipeline Decomposition                 | Accepted           | Architecture    | 2025-12-16 |
+| [ADR-021](ADR-021-ddd-aggregates-adoption.md)           | DDD Aggregates Adoption                    | Accepted           | Domain Model    | 2025-12-29 |
+| [ADR-022](ADR-022-tracing-noop.md)                      | NoOp Tracing for Local-Only                | Accepted           | Observability   | 2025-12-30 |
+| [ADR-023](ADR-023-entity-type-patterns.md)              | Entity Type Patterns                       | Accepted           | Observability   | 2026-01-06 |
+| [ADR-024](ADR-024-entity-naming-unification.md)         | Entity Naming Unification                  | Accepted           | Architecture    | 2026-01-07 |
+| [ADR-025](ADR-025-pipeline-config-unification.md)       | Pipeline Config Unification                | Accepted           | Configuration   | 2026-01-14 |
+| [ADR-026](ADR-026-composite-pipeline-pattern.md)        | Composite Pipeline Pattern                 | Accepted           | Architecture    | 2026-01-15 |
+| [ADR-027](ADR-027-dq-rules-externalization.md)          | DQ Rules Externalization                   | Accepted           | Data Quality    | 2026-01-19 |
+| [ADR-028](ADR-028-filter-rules-externalization.md)      | Filter Rules Externalization               | Accepted           | Configuration   | 2026-01-20 |
+| [ADR-029](ADR-029-output-metadata-unification.md)       | Output Metadata Unification                | Accepted           | Data Modeling   | 2026-01-23 |
+| [ADR-030](ADR-030-publication-pagination-strategy.md)   | Publication Pagination Strategy            | Accepted           | Data Fetching   | 2026-01-25 |
+| [ADR-031](ADR-031-loading-strategy-formalization.md)    | Loading Strategy Formalization             | Accepted           | Data Loading    | 2026-01-26 |
+| [ADR-032](ADR-032-unified-http-client.md)               | Unified HTTP Client Pattern                | Accepted           | HTTP/Networking | 2026-01-28 |
+| [ADR-033](ADR-033-publication-validation-strategy.md)   | Publication Metadata Validation Strategy   | Added              | Data Quality    | 2026-02-06 |
+| [ADR-034](ADR-034-schema-domain-pairs.md)               | Schema↔Domain Configuration Pairs          | Accepted           | Architecture    | 2026-02-15 |
+| [ADR-035](ADR-035-json-field-typing-policy.md)          | JSON Field Typing Policy (Silver↔Gold)     | Accepted           | Data Modeling   | 2026-02-17 |
+| [ADR-036](ADR-036-gold-contract-versioning-policy.md)   | Gold Contract Versioning Policy            | Accepted           | Data Quality    | 2026-02-18 |
+| [ADR-037](ADR-037-canonical-schema-generation.md)       | Canonical Schema Source and Generation     | Accepted           | Data Contracts  | 2026-02-18 |
+| [ADR-038](ADR-038-enum-externalization.md)              | ChEMBL Enum Values Externalization to YAML | Accepted           | Configuration   | 2026-02-16 |
 
 ## ADRs by Category
 
@@ -196,7 +196,7 @@ This directory contains Architecture Decision Records documenting significant ar
 ```markdown
 # ADR-XXX: [Title]
 
-*   **Status**: Proposed | Accepted | Superseded | Deprecated
+*   **Status**: Added | Accepted | Superseded | Deprecated
 *   **Date**: YYYY-MM-DD
 *   **Supersedes**: ADR-NNN (if applicable)
 *   **Related**: ADR-NNN, ADR-NNN (brief context)

--- a/docs/02-architecture/diagrams/PROMPT-diagram-expansion.md
+++ b/docs/02-architecture/diagrams/PROMPT-diagram-expansion.md
@@ -2,7 +2,7 @@
 
 *Дата создания: 2026-02-17*
 
----
+______________________________________________________________________
 
 ## Контекст для AI-агента
 
@@ -11,7 +11,7 @@
 Hexagonal Architecture (Ports & Adapters) с 5 слоями и Medallion Architecture
 для хранения данных (Bronze → Silver → Gold).
 
----
+______________________________________________________________________
 
 ## Часть 0: Обязательное изучение проекта
 
@@ -39,7 +39,7 @@ docs/02-architecture/system-context.md       — System Context
 docs/02-architecture/observability-layers.md — Observability
 ```
 
-### 0.2 ADR (Architecture Decision Records) — все 34
+### 0.2 ADR (Architecture Decision Records) — все 38
 
 ```
 docs/02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md
@@ -76,6 +76,10 @@ docs/02-architecture/decisions/ADR-031-loading-strategy-formalization.md
 docs/02-architecture/decisions/ADR-032-unified-http-client.md
 docs/02-architecture/decisions/ADR-033-publication-validation-strategy.md
 docs/02-architecture/decisions/ADR-034-schema-domain-pairs.md
+docs/02-architecture/decisions/ADR-035-json-field-typing-policy.md
+docs/02-architecture/decisions/ADR-036-gold-contract-versioning-policy.md
+docs/02-architecture/decisions/ADR-037-canonical-schema-generation.md
+docs/02-architecture/decisions/ADR-038-enum-externalization.md
 ```
 
 ### 0.3 Существующие диаграммы (НЕ дублировать!)
@@ -335,7 +339,7 @@ src/bioetl/interfaces/http/health-server.py
 - **Цвета**: Bronze=#FFA500, Silver=#C0C0C0, Gold=#FFD700, Error=#FF6B6B, Success=#4CAF50, External=#2196F3
 - **Каждая диаграмма MUST** содержать: Title (как comment), Legend (если нужна), RULES.md reference
 
----
+______________________________________________________________________
 
 ## Часть 1: Генерация 500 НОВЫХ диаграмм
 
@@ -343,17 +347,18 @@ src/bioetl/interfaces/http/health-server.py
 **ещё нет** среди 34 существующих. Для каждой диаграммы укажи:
 
 1. **Порядковый номер** (1–500)
-2. **Название** (англ.)
-3. **Тип диаграммы** (одно из: `classDiagram`, `sequenceDiagram`, `flowchart`,
+1. **Название** (англ.)
+1. **Тип диаграммы** (одно из: `classDiagram`, `sequenceDiagram`, `flowchart`,
    `stateDiagram`, `erDiagram`, `C4Context`, `C4Container`, `C4Component`,
    `mindmap`, `timeline`, `gantt`, `pie`, `gitgraph`, `block-beta`,
    `architecture-beta`, `sankey-beta`, `xychart-beta`)
-4. **Категория** (одна из: Architecture, DataFlow, Pattern, Component,
+1. **Категория** (одна из: Architecture, DataFlow, Pattern, Component,
    Interaction, Lifecycle, Configuration, Provider, Testing, Security,
    Observability, Composite, DomainModel, ErrorHandling, Performance)
-5. **Краткое описание** (1 предложение)
+1. **Краткое описание** (1 предложение)
 
 Распредели диаграммы по категориям равномерно, но с акцентом на:
+
 - **Architecture** (~60): высокоуровневая архитектура, C4, deployment
 - **DataFlow** (~60): потоки данных через Bronze/Silver/Gold
 - **Pattern** (~50): паттерны проектирования, применённые в проекте
@@ -381,7 +386,7 @@ src/bioetl/interfaces/http/health-server.py
   методы и модули из кодовой базы (534 Python файла)
 - **Разнообразие типов**: используй минимум 10 разных типов Mermaid-диаграмм
 
----
+______________________________________________________________________
 
 ## Часть 2: Выбор 50 наиболее важных
 
@@ -389,13 +394,13 @@ src/bioetl/interfaces/http/health-server.py
 
 ### Критерии оценки (каждый 1–10 баллов)
 
-| Критерий | Вес | Описание |
-|----------|-----|----------|
-| **Arch** | ×2.0 | Архитектурная важность: насколько критична для понимания архитектуры |
-| **Doc** | ×1.5 | Документационная ценность: полезность для нового разработчика |
-| **Freq** | ×1.5 | Частота использования: как часто нужна при работе с проектом |
-| **Complex** | ×2.0 | Сложность без диаграммы: насколько сложно понять без визуализации |
-| **Coverage** | ×1.0 | Охват кодовой базы: сколько компонентов покрывает |
+| Критерий     | Вес  | Описание                                                             |
+| ------------ | ---- | -------------------------------------------------------------------- |
+| **Arch**     | ×2.0 | Архитектурная важность: насколько критична для понимания архитектуры |
+| **Doc**      | ×1.5 | Документационная ценность: полезность для нового разработчика        |
+| **Freq**     | ×1.5 | Частота использования: как часто нужна при работе с проектом         |
+| **Complex**  | ×2.0 | Сложность без диаграммы: насколько сложно понять без визуализации    |
+| **Coverage** | ×1.0 | Охват кодовой базы: сколько компонентов покрывает                    |
 
 **Формула**: `Priority = (Arch×2 + Doc×1.5 + Freq×1.5 + Complex×2 + Coverage×1) / 8`
 
@@ -409,7 +414,7 @@ src/bioetl/interfaces/http/health-server.py
 - Минимум 2 диаграммы observability
 - Не более 15 диаграмм одной категории
 
----
+______________________________________________________________________
 
 ## Часть 3: Таблица 50 диаграмм
 
@@ -430,7 +435,7 @@ src/bioetl/interfaces/http/health-server.py
 почему эта диаграмма попала в TOP-50, какую проблему понимания она решает,
 и кому из участников проекта она наиболее полезна.
 
----
+______________________________________________________________________
 
 ## Часть 4: Создание и рендер TOP-25 диаграмм
 
@@ -486,6 +491,7 @@ done
 
 **Критерий читаемости**: после рендера открой каждый PNG и проверь,
 что все надписи свободно читаются при 100% масштабе. Если текст мелкий:
+
 - Увеличь `--scale` до 4 или 5
 - Или увеличь `--width` до 3200+
 - Или упрости диаграмму, разбив на 2 отдельных
@@ -495,9 +501,9 @@ done
 После создания всех файлов обнови:
 
 1. `docs/02-architecture/diagrams/diagrams-index.md` — добавь новые диаграммы
-2. Создай директорию `docs/02-architecture/diagrams/png/` если не существует
+1. Создай директорию `docs/02-architecture/diagrams/png/` если не существует
 
----
+______________________________________________________________________
 
 ## Часть 5: Проверка качества (self-review)
 
@@ -531,7 +537,7 @@ grep -rn "class ИмяКласса" src/bioetl/ --include="*.py"
 - Каждый PNG весит > 50KB (не пустой/битый)
 - Текст на каждой диаграмме читаем при 100% масштабе
 
----
+______________________________________________________________________
 
 ## Справочная информация
 
@@ -547,25 +553,25 @@ Infrastructure → Adapters (7 providers), Storage (Bronze/Silver/Gold), HTTP, L
 
 ### Матрица импортов
 
-| From \ To | domain | application | infrastructure | composition | interfaces |
-|-----------|--------|-------------|----------------|-------------|------------|
-| domain | ✅ | ❌ | ❌ | ❌ | ❌ |
-| application | ✅ | ✅ | ❌ | ❌ | ❌ |
-| infrastructure | ✅ | ❌ | ✅ | ❌ | ❌ |
-| composition | ✅ | ✅ | ✅ | ✅ | ❌ |
-| interfaces | ✅ | ✅ | ✅ | ✅ | ✅ |
+| From \\ To     | domain | application | infrastructure | composition | interfaces |
+| -------------- | ------ | ----------- | -------------- | ----------- | ---------- |
+| domain         | ✅     | ❌          | ❌             | ❌          | ❌         |
+| application    | ✅     | ✅          | ❌             | ❌          | ❌         |
+| infrastructure | ✅     | ❌          | ✅             | ❌          | ❌         |
+| composition    | ✅     | ✅          | ✅             | ✅          | ❌         |
+| interfaces     | ✅     | ✅          | ✅             | ✅          | ✅         |
 
 ### 7 провайдеров
 
-| Provider | Entity Types | Adapter |
-|----------|-------------|---------|
-| ChEMBL | activity, molecule, target, assay, compound-record, cell-line, protein-class, tissue, publication, publication-term, publication-similarity, subcellular-fraction, assay-parameters, target-component | `ChemblClient` |
-| PubChem | compound | `PubChemClient` |
-| UniProt | protein, idmapping | `UniProtClient` |
-| CrossRef | publication | `CrossRefClient` |
-| PubMed | publication | `PubMedClient` |
-| OpenAlex | publication | `OpenAlexClient` |
-| SemanticScholar | publication | `SemanticScholarAdapter` |
+| Provider        | Entity Types                                                                                                                                                                                          | Adapter                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| ChEMBL          | activity, molecule, target, assay, compound-record, cell-line, protein-class, tissue, publication, publication-term, publication-similarity, subcellular-fraction, assay-parameters, target-component | `ChemblClient`           |
+| PubChem         | compound                                                                                                                                                                                              | `PubChemClient`          |
+| UniProt         | protein, idmapping                                                                                                                                                                                    | `UniProtClient`          |
+| CrossRef        | publication                                                                                                                                                                                           | `CrossRefClient`         |
+| PubMed          | publication                                                                                                                                                                                           | `PubMedClient`           |
+| OpenAlex        | publication                                                                                                                                                                                           | `OpenAlexClient`         |
+| SemanticScholar | publication                                                                                                                                                                                           | `SemanticScholarAdapter` |
 
 ### 24 доменных порта
 
@@ -580,34 +586,34 @@ ShutdownPort, SerializationPort, DQConfigLoaderPort, FilterConfigLoaderPort
 
 ### 3 DDD Aggregates
 
-| Aggregate | States | Key Methods |
-|-----------|--------|-------------|
-| PipelineRun | PENDING → RUNNING → COMPLETED/FAILED/CANCELLED | start(), complete-stage(), fail(), cancel() |
-| Batch | OPEN → SEALED → WRITING → COMMITTED/FAILED | add-record(), seal(), mark-writing(), commit(), mark-failed() |
-| QuarantineEntry | NEW → UNDER-REVIEW → RESOLVED/DISCARDED | start-review(), resolve(), discard() |
+| Aggregate       | States                                         | Key Methods                                                   |
+| --------------- | ---------------------------------------------- | ------------------------------------------------------------- |
+| PipelineRun     | PENDING → RUNNING → COMPLETED/FAILED/CANCELLED | start(), complete-stage(), fail(), cancel()                   |
+| Batch           | OPEN → SEALED → WRITING → COMMITTED/FAILED     | add-record(), seal(), mark-writing(), commit(), mark-failed() |
+| QuarantineEntry | NEW → UNDER-REVIEW → RESOLVED/DISCARDED        | start-review(), resolve(), discard()                          |
 
 ### Ключевые параметры
 
-| Parameter | Value |
-|-----------|-------|
-| Lock TTL | 90s |
-| Heartbeat Interval | 30s |
-| Circuit Breaker Threshold | 5 failures |
-| Circuit Breaker Recovery Timeout | 300s |
-| DQ Soft Threshold | 5% |
-| DQ Hard Threshold | 20% |
-| Bronze Retention | 90 days |
-| Quarantine Retention | 30 days |
-| Max Retry Attempts | 3 |
-| Batch Size (default) | 1000 records |
+| Parameter                        | Value        |
+| -------------------------------- | ------------ |
+| Lock TTL                         | 90s          |
+| Heartbeat Interval               | 30s          |
+| Circuit Breaker Threshold        | 5 failures   |
+| Circuit Breaker Recovery Timeout | 300s         |
+| DQ Soft Threshold                | 5%           |
+| DQ Hard Threshold                | 20%          |
+| Bronze Retention                 | 90 days      |
+| Quarantine Retention             | 30 days      |
+| Max Retry Attempts               | 3            |
+| Batch Size (default)             | 1000 records |
 
 ### Статистика кодовой базы
 
-| Слой | Python файлов |
-|------|--------------|
-| domain | ~170 |
-| application | ~100 |
-| infrastructure | ~85 |
-| composition | ~55 |
-| interfaces | ~25 |
-| **Всего** | **~534** |
+| Слой           | Python файлов |
+| -------------- | ------------- |
+| domain         | ~170          |
+| application    | ~100          |
+| infrastructure | ~85           |
+| composition    | ~55           |
+| interfaces     | ~25           |
+| **Всего**      | **~534**      |

--- a/tests/architecture/test_documentation_sync.py
+++ b/tests/architecture/test_documentation_sync.py
@@ -139,6 +139,48 @@ def test_adr_h1_number_matches_filename() -> None:
     assert not mismatches, "ADR heading/filename mismatch:\n" + "\n".join(mismatches)
 
 
+def test_adr_status_is_from_allowed_set() -> None:
+    """Each ADR file must declare a status from the allowed normalized set."""
+    decisions_dir = Path("docs/02-architecture/decisions")
+    allowed_statuses = {"accepted", "superseded", "deprecated", "added"}
+    violations: list[str] = []
+
+    status_patterns = (
+        re.compile(r"^\*\*Status:\*\*\s*(.+)$", flags=re.MULTILINE),
+        re.compile(r"^\*\s+\*\*Status\*\*:\s*(.+)$", flags=re.MULTILINE),
+        re.compile(
+            r"^\|\s*\*\*Статус\*\*\s*\|\s*(.+?)\s*\|$",
+            flags=re.MULTILINE,
+        ),
+        re.compile(
+            r"^\|\s*\*\*Status\*\*\s*\|\s*(.+?)\s*\|$",
+            flags=re.MULTILINE,
+        ),
+    )
+
+    for path in sorted(decisions_dir.glob("ADR-*.md")):
+        text = path.read_text(encoding="utf-8")
+        raw_status: str | None = None
+        for pattern in status_patterns:
+            match = pattern.search(text)
+            if match is not None:
+                raw_status = match.group(1).strip()
+                break
+
+        if raw_status is None:
+            violations.append(f"{path.name}: missing status field")
+            continue
+
+        normalized = re.split(r"[\s(]", raw_status, maxsplit=1)[0].strip().lower()
+        if normalized not in allowed_statuses:
+            violations.append(
+                f"{path.name}: invalid status '{raw_status}' "
+                f"(allowed: {sorted(allowed_statuses)})"
+            )
+
+    assert not violations, "ADR status validation failed:\n" + "\n".join(violations)
+
+
 def test_mkdocs_nav_references_existing_markdown_files() -> None:
     """All markdown paths referenced in mkdocs navigation MUST exist."""
     mkdocs_text = Path("mkdocs.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Recalculate the ADR baseline to reflect the current decision set and avoid stale hard-coded counts in prompts and checklists. 
- Standardize which ADR statuses are allowed so tooling and quality gates can validate ADR files reliably. 
- Prevent `Superseded` ADRs from being treated as automatic defects since supersession is an expected evolution. 
- Add an automated validation to ensure every ADR file declares an allowed status.

### Description
- Added an ADR status policy to `docs/00-project/RULES.md` defining the allowed normalized statuses: `Accepted`, `Superseded`, `Deprecated`, `Added`, and guidance that `Superseded` is not automatically a defect. (`docs/00-project/RULES.md`)
- Recalculated ADR baseline from the actual files and updated references/prompts to reflect 38 ADRs (updated diagram prompt and references). (`docs/02-architecture/diagrams/PROMPT-diagram-expansion.md`, prompt templates)
- Normalized `ADR-033` status from `Proposed` to `Added` and synchronized the ADR registry/README entries. (`docs/02-architecture/decisions/ADR-033-publication-validation-strategy.md`, `docs/02-architecture/decisions/README.md`)
- Updated prompt/checklist templates to include an "ADR Status Guardrail" and require computing the ADR baseline from the fileset rather than a hard-coded number. (`.claude/prompts/02-Sync/04-schema-review.md`, `.claude/prompts/02-Sync/05-vcr-tests.md`)
- Added an automated architecture QA test `test_adr_status_is_from_allowed_set` that validates every `docs/02-architecture/decisions/ADR-*.md` contains a status from the allowed set (accepts normalized forms like `Accepted (Revised)` and both RU/EN table formats). (`tests/architecture/test_documentation_sync.py`)

### Testing
- Ran the architecture documentation test file: `uv run python -m pytest tests/architecture/test_documentation_sync.py -q`, and it passed (all tests in that file succeeded).
- Verified ADR count with `find docs/02-architecture/decisions -maxdepth 1 -type f -name 'ADR-*.md' | wc -l` → `38` as reflected in updated documentation and prompts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d73fa33bc832497fe8ef5d215edd5)