### PR TITLE
docs: sync release version to 6.0.0 and add docs version consistency check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,11 +19,11 @@ make lint && make test && git commit
 
 Before contributing, read these documents:
 
-| Document                         | Purpose                           |
-| -------------------------------- | --------------------------------- |
-| [docs/00-project/RULES.md](../docs/00-project/RULES.md) | Project constitution (MUST read)  |
-| [AGENTS.md](../AGENTS.md)                                | Development workflow and patterns |
-| [docs/00-project/00-map.md](../docs/00-project/00-map.md) | Documentation navigator         |
+| Document                                                           | Purpose                           |
+| ------------------------------------------------------------------ | --------------------------------- |
+| [docs/00-project/RULES.md](../docs/00-project/RULES.md)            | Project constitution (MUST read)  |
+| [AGENTS.md](../AGENTS.md)                                          | Development workflow and patterns |
+| [docs/00-project/00-map.md](../docs/00-project/00-map.md)          | Documentation navigator           |
 | [GitHub Policy](../docs/00-project/governance/05-github-policy.md) | CI/CD, branch protection, reviews |
 
 ## Workflow
@@ -89,6 +89,14 @@ For PRs to `main`, configure GitHub branch protection/rulesets to require:
 - `detect-secrets` (from `.github/workflows/security.yml`)
 
 This ensures no PR can be merged with failing tests, lint errors, or secret leaks.
+
+## Release Documentation Sync (MUST)
+
+When preparing a release, contributors **MUST** keep release metadata synchronized:
+
+- Update `docs/00-project/index.md` section `Current Version` to match `pyproject.toml` version and release date from `CHANGELOG.md`.
+- Run `uv run python scripts/check_docs_version_sync.py` and ensure it passes.
+- Include documentation sync changes in the same release PR.
 
 ## Pull Request Checklist
 

--- a/docs/00-project/00-map.md
+++ b/docs/00-project/00-map.md
@@ -1,8 +1,9 @@
 # BioETL Project Navigator
 
-*Synced with RULES.md v5.21 | Last updated: 2026-02-21*
+*Synced with RULES.md v5.21 | BioETL release: v6.0.0 (2026-02-18) | Last updated: 2026-02-24*
 
 > **Documentation Update:** 2026-02-17
+>
 > - Codebase metrics updated: 1,120 Python files (534 src + 586 tests), ~116,120 src LOC
 > - ADR count: 34 ADRs (ADR-001 through ADR-034)
 > - Pipeline configs: 26 configurations (21 single-source + 5 composite)
@@ -13,29 +14,29 @@
 
 ## Quick Links
 
-| Need to...              | Go to                                                                  |
-|-------------------------|------------------------------------------------------------------------|
-| Understand the rules    | [RULES.md](RULES.md)                 |
-| Look up terminology     | [glossary.md](glossary.md)           |
-| Create a new pipeline   | [governance/04-extending-bioetl.md](governance/04-extending-bioetl.md)      |
+| Need to...              | Go to                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| Understand the rules    | [RULES.md](RULES.md)                                                                   |
+| Look up terminology     | [glossary.md](glossary.md)                                                             |
+| Create a new pipeline   | [governance/04-extending-bioetl.md](governance/04-extending-bioetl.md)                 |
 | Review a pipeline       | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md) |
-| Handle a prod error     | [runbooks/index.md](../05-operations/runbooks/index.md)                           |
-| Understand architecture | [00-overview.md](../02-architecture/00-overview.md)                  |
-| Check data contracts    | [chembl_activity_v1.0.json](../04-reference/contracts/gold/chembl_activity_v1.0.json)          |
+| Handle a prod error     | [runbooks/index.md](../05-operations/runbooks/index.md)                                |
+| Understand architecture | [00-overview.md](../02-architecture/00-overview.md)                                    |
+| Check data contracts    | [chembl_activity_v1.0.json](../04-reference/contracts/gold/chembl_activity_v1.0.json)  |
 
----
+______________________________________________________________________
 
 ## Language Policy
 
-| Category | Language | Examples |
-|----------|----------|----------|
-| **Public-facing** | English | README.md, CONTRIBUTING.md, CHANGELOG.md |
-| **User guides** | English | docs/03-guides/*, docs/04-reference/* |
-| **Internal governance** | Russian | RULES.md, AGENT.md, docs/00-project/governance/* |
-| **Architecture docs** | Russian | docs/02-architecture/* |
-| **Code comments** | Russian | Docstrings, inline comments |
+| Category                | Language | Examples                                          |
+| ----------------------- | -------- | ------------------------------------------------- |
+| **Public-facing**       | English  | README.md, CONTRIBUTING.md, CHANGELOG.md          |
+| **User guides**         | English  | docs/03-guides/*, docs/04-reference/*             |
+| **Internal governance** | Russian  | RULES.md, AGENT.md, docs/00-project/governance/\* |
+| **Architecture docs**   | Russian  | docs/02-architecture/\*                           |
+| **Code comments**       | Russian  | Docstrings, inline comments                       |
 
----
+______________________________________________________________________
 
 ## Documentation Structure
 
@@ -88,102 +89,102 @@ docs/
     └── ...
 ```
 
----
+______________________________________________________________________
 
 ## By Topic
 
 ### Getting Started
 
 1. [RULES.md](RULES.md) - Project rules (start here)
-2. [rules-summary.md](rules-summary.md) - Quick reference
-3. [04-extending-bioetl.md](governance/04-extending-bioetl.md) - Adding providers/pipelines
+1. [rules-summary.md](rules-summary.md) - Quick reference
+1. [04-extending-bioetl.md](governance/04-extending-bioetl.md) - Adding providers/pipelines
 
 ### Architecture
 
-| Document                                                                                     | Covers                                   | RULES.md |
-|----------------------------------------------------------------------------------------------|------------------------------------------|----------|
-| [system-context.md](../02-architecture/system-context.md)                                       | Entity models, IDs, relationships        | §2.8     |
-| [container-diagram.md](../02-architecture/container-diagram.md)                               | C4 Container, Docker services            | §5.6     |
-| [data-flow.md](../02-architecture/data-flow.md)                                                 | Ports & Adapters, layer responsibilities | §1.1     |
-| [05-composition-layer.md](../02-architecture/05-composition-layer.md)                           | Composition Root, DI, Factories          | §1.1     |
-| [ADR-001: Delta Lake](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)            | Storage engine choice                    | §2.1, §3 |
-| [ADR-002: Medallion](../02-architecture/decisions/ADR-002-medallion-architecture.md)            | Data layering pattern                    | §1       |
-| [ADR-003: In-Memory Locking](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md) | MemoryLock strategy                      | §6       |
-| [ADR-004: Pydantic](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)            | Validation approach                      | -        |
-| [ADR-005: Composition Layer](../02-architecture/decisions/ADR-005-composition-layer-separation.md) | DI and layer separation               | §1.1     |
-| [ADR-006: Logger/Metrics Ports](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)   | Port abstractions                        | §1.1     |
-| [ADR-007: Circuit Breaker](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) | Failure handling pattern               | §3.1.4   |
-| [ADR-008: Graceful Shutdown](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md) | SIGTERM/SIGINT handling                  | §5.3     |
-| [ADR-009: Paginated Fetcher](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)   | Pagination abstraction                   | App D    |
-| [ADR-010: Local-Only Deploy](../02-architecture/decisions/ADR-010-local-only-deployment.md)     | File-based deployment (no Docker)        | §5.6     |
-| [ADR-011: Watermark Removal](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md) | Simplified checkpoint model             | §2.4     |
-| [ADR-012: Storage Clear Contract](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md) | Storage clear API, run-id injection | §2.1     |
-| [ADR-013: Async Storage Cleanup](../02-architecture/decisions/ADR-013-async-storage-cleanup.md) | MedallionLifecycleService pattern        | §2.1     |
-| [ADR-014: Deterministic Writes](../02-architecture/decisions/ADR-014-deterministic-writes.md)   | SCD2 ingestion-ts, reproducible writes   | §2.1     |
-| [ADR-015: Pipeline Services Lifecycle](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md) | Port lifecycle contracts       | §1.1     |
-| [ADR-016: Error Handling Strategy](../02-architecture/decisions/ADR-016-error-handling-strategy.md) | Unified error classification          | §3.1     |
-| [ADR-017: Observability Architecture](../02-architecture/decisions/ADR-017-observability-architecture.md) | Metrics, tracing, logging ports    | §5.1     |
-| [ADR-018: Gold Strict Validation](../02-architecture/decisions/ADR-018-gold-strict-validation.md) | Pandera Gold validation                | §2.7     |
-| [ADR-019: Observability Port Enforcement](../02-architecture/decisions/ADR-019-observability-port-enforcement.md) | REQ-OBS-001 compliance       | §5.1     |
-| [ADR-020: BasePipeline Decomposition](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md) | God Object refactoring       | §1.1     |
-| [ADR-021: DDD Aggregates](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md) | DDD aggregates adoption       | -        |
-| [ADR-022: Tracing NoOp](../02-architecture/decisions/ADR-022-tracing-noop.md) | NoOp for tracing              | -        |
-| [ADR-023: Entity Type Patterns](../02-architecture/decisions/ADR-023-entity-type-patterns.md) | Entity type patterns          | -        |
-| [ADR-024: Entity Naming Unification](../02-architecture/decisions/ADR-024-entity-naming-unification.md) | Entity naming unification     | -        |
-| [ADR-025: Pipeline Config Unification](../02-architecture/decisions/ADR-025-pipeline-config-unification.md) | Pipeline config unification   | -        |
-| [ADR-026: Composite Pipeline Pattern](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) | Composite pipeline pattern    | -        |
-| [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md) | Hierarchical DQ configuration | §3.1.2   |
-| [ADR-028: Filter Rules Externalization](../02-architecture/decisions/ADR-028-filter-rules-externalization.md) | Hierarchical filter configuration | App D   |
-| [ADR-029: Output Metadata Unification](../02-architecture/decisions/ADR-029-output-metadata-unification.md) | Unified output metadata contracts | §2.4    |
-| [ADR-030: Publication Pagination Strategy](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication pagination strategy | -       |
-| [ADR-031: Loading Strategy Formalization](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md) | Loading strategy formalization | -       |
-| [ADR-032: Unified HTTP Client](../02-architecture/decisions/ADR-032-unified-http-client.md) | Unified HTTP client pattern | App A   |
+| Document                                                                                                            | Covers                                   | RULES.md |
+| ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | -------- |
+| [system-context.md](../02-architecture/system-context.md)                                                           | Entity models, IDs, relationships        | §2.8     |
+| [container-diagram.md](../02-architecture/container-diagram.md)                                                     | C4 Container, Docker services            | §5.6     |
+| [data-flow.md](../02-architecture/data-flow.md)                                                                     | Ports & Adapters, layer responsibilities | §1.1     |
+| [05-composition-layer.md](../02-architecture/05-composition-layer.md)                                               | Composition Root, DI, Factories          | §1.1     |
+| [ADR-001: Delta Lake](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)                                | Storage engine choice                    | §2.1, §3 |
+| [ADR-002: Medallion](../02-architecture/decisions/ADR-002-medallion-architecture.md)                                | Data layering pattern                    | §1       |
+| [ADR-003: In-Memory Locking](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)                    | MemoryLock strategy                      | §6       |
+| [ADR-004: Pydantic](../02-architecture/decisions/ADR-004-pydantic-vs-dataclasses.md)                                | Validation approach                      | -        |
+| [ADR-005: Composition Layer](../02-architecture/decisions/ADR-005-composition-layer-separation.md)                  | DI and layer separation                  | §1.1     |
+| [ADR-006: Logger/Metrics Ports](../02-architecture/decisions/ADR-006-logger-metrics-ports.md)                       | Port abstractions                        | §1.1     |
+| [ADR-007: Circuit Breaker](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)                  | Failure handling pattern                 | §3.1.4   |
+| [ADR-008: Graceful Shutdown](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)                    | SIGTERM/SIGINT handling                  | §5.3     |
+| [ADR-009: Paginated Fetcher](../02-architecture/decisions/ADR-009-paginated-fetcher-mixin.md)                       | Pagination abstraction                   | App D    |
+| [ADR-010: Local-Only Deploy](../02-architecture/decisions/ADR-010-local-only-deployment.md)                         | File-based deployment (no Docker)        | §5.6     |
+| [ADR-011: Watermark Removal](../02-architecture/decisions/ADR-011-remove-watermark-mechanism.md)                    | Simplified checkpoint model              | §2.4     |
+| [ADR-012: Storage Clear Contract](../02-architecture/decisions/ADR-012-storage-clear-contract-and-run-id.md)        | Storage clear API, run-id injection      | §2.1     |
+| [ADR-013: Async Storage Cleanup](../02-architecture/decisions/ADR-013-async-storage-cleanup.md)                     | MedallionLifecycleService pattern        | §2.1     |
+| [ADR-014: Deterministic Writes](../02-architecture/decisions/ADR-014-deterministic-writes.md)                       | SCD2 ingestion-ts, reproducible writes   | §2.1     |
+| [ADR-015: Pipeline Services Lifecycle](../02-architecture/decisions/ADR-015-pipeline-services-lifecycle.md)         | Port lifecycle contracts                 | §1.1     |
+| [ADR-016: Error Handling Strategy](../02-architecture/decisions/ADR-016-error-handling-strategy.md)                 | Unified error classification             | §3.1     |
+| [ADR-017: Observability Architecture](../02-architecture/decisions/ADR-017-observability-architecture.md)           | Metrics, tracing, logging ports          | §5.1     |
+| [ADR-018: Gold Strict Validation](../02-architecture/decisions/ADR-018-gold-strict-validation.md)                   | Pandera Gold validation                  | §2.7     |
+| [ADR-019: Observability Port Enforcement](../02-architecture/decisions/ADR-019-observability-port-enforcement.md)   | REQ-OBS-001 compliance                   | §5.1     |
+| [ADR-020: BasePipeline Decomposition](../02-architecture/decisions/ADR-020-basepipeline-decomposition.md)           | God Object refactoring                   | §1.1     |
+| [ADR-021: DDD Aggregates](../02-architecture/decisions/ADR-021-ddd-aggregates-adoption.md)                          | DDD aggregates adoption                  | -        |
+| [ADR-022: Tracing NoOp](../02-architecture/decisions/ADR-022-tracing-noop.md)                                       | NoOp for tracing                         | -        |
+| [ADR-023: Entity Type Patterns](../02-architecture/decisions/ADR-023-entity-type-patterns.md)                       | Entity type patterns                     | -        |
+| [ADR-024: Entity Naming Unification](../02-architecture/decisions/ADR-024-entity-naming-unification.md)             | Entity naming unification                | -        |
+| [ADR-025: Pipeline Config Unification](../02-architecture/decisions/ADR-025-pipeline-config-unification.md)         | Pipeline config unification              | -        |
+| [ADR-026: Composite Pipeline Pattern](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)           | Composite pipeline pattern               | -        |
+| [ADR-027: DQ Rules Externalization](../02-architecture/decisions/ADR-027-dq-rules-externalization.md)               | Hierarchical DQ configuration            | §3.1.2   |
+| [ADR-028: Filter Rules Externalization](../02-architecture/decisions/ADR-028-filter-rules-externalization.md)       | Hierarchical filter configuration        | App D    |
+| [ADR-029: Output Metadata Unification](../02-architecture/decisions/ADR-029-output-metadata-unification.md)         | Unified output metadata contracts        | §2.4     |
+| [ADR-030: Publication Pagination Strategy](../02-architecture/decisions/ADR-030-publication-pagination-strategy.md) | Publication pagination strategy          | -        |
+| [ADR-031: Loading Strategy Formalization](../02-architecture/decisions/ADR-031-loading-strategy-formalization.md)   | Loading strategy formalization           | -        |
+| [ADR-032: Unified HTTP Client](../02-architecture/decisions/ADR-032-unified-http-client.md)                         | Unified HTTP client pattern              | App A    |
 
 ### Data Management
 
-| Topic            | Document                                                                                            | RULES.md |
-|------------------|-----------------------------------------------------------------------------------------------------|----------|
-| Medallion Layers | [data-flow.md](../02-architecture/data-flow.md)                                                        | §2.1     |
-| Schema Drift     | [RULES.md](RULES.md#22-обработка-дрейфа-схемы)   | §2.2     |
-| Data Lineage     | [system-context.md](../02-architecture/system-context.md)                                              | §2.3     |
-| Backfill/Replay  | [RULES.md](RULES.md#24-стратегия-backfill-и-replay)            | §2.4     |
-| Quarantine       | [RULES.md](RULES.md#26-dead-letter-queue--quarantine) | §2.6     |
-| Content Hash     | [system-context.md](../02-architecture/system-context.md)                                              | §2.8     |
+| Topic            | Document                                                                                                                                           | RULES.md |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Medallion Layers | [data-flow.md](../02-architecture/data-flow.md)                                                                                                    | §2.1     |
+| Schema Drift     | [RULES.md](RULES.md#22-%D0%BE%D0%B1%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D0%B4%D1%80%D0%B5%D0%B9%D1%84%D0%B0-%D1%81%D1%85%D0%B5%D0%BC%D1%8B) | §2.2     |
+| Data Lineage     | [system-context.md](../02-architecture/system-context.md)                                                                                          | §2.3     |
+| Backfill/Replay  | [RULES.md](RULES.md#24-%D1%81%D1%82%D1%80%D0%B0%D1%82%D0%B5%D0%B3%D0%B8%D1%8F-backfill-%D0%B8-replay)                                              | §2.4     |
+| Quarantine       | [RULES.md](RULES.md#26-dead-letter-queue--quarantine)                                                                                              | §2.6     |
+| Content Hash     | [system-context.md](../02-architecture/system-context.md)                                                                                          | §2.8     |
 
 ### Schema Documentation
 
-| Provider | Entity | Schema Document | RULES.md |
-|----------|--------|-----------------|----------|
-| ChEMBL | Activity | [activity-schema.md](../04-reference/schemas/domain/chembl/activity-schema.md) | §2.8 |
-| ChEMBL | Molecule | [molecule-schema.md](../04-reference/schemas/domain/chembl/molecule-schema.md) | §2.8 |
-| ChEMBL | Target | [target-schema.md](../04-reference/schemas/domain/chembl/target-schema.md) | §2.8 |
-| ChEMBL | Assay | [assay-schema.md](../04-reference/schemas/domain/chembl/assay-schema.md) | §2.8 |
+| Provider | Entity   | Schema Document                                                                | RULES.md |
+| -------- | -------- | ------------------------------------------------------------------------------ | -------- |
+| ChEMBL   | Activity | [activity-schema.md](../04-reference/schemas/domain/chembl/activity-schema.md) | §2.8     |
+| ChEMBL   | Molecule | [molecule-schema.md](../04-reference/schemas/domain/chembl/molecule-schema.md) | §2.8     |
+| ChEMBL   | Target   | [target-schema.md](../04-reference/schemas/domain/chembl/target-schema.md)     | §2.8     |
+| ChEMBL   | Assay    | [assay-schema.md](../04-reference/schemas/domain/chembl/assay-schema.md)       | §2.8     |
 
 ### Operations
 
-| Topic             | Document                                                                                          | RULES.md |
-|-------------------|---------------------------------------------------------------------------------------------------|----------|
-| Error Handling    | [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)         | §3.1     |
-| Circuit Breaker   | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md)  | §3.1.4   |
-| Locking           | [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)      | §3.3     |
-| DQ Metrics        | [RULES.md](RULES.md#34-data-quality-метрики)                                    | §3.4     |
-| Graceful Shutdown | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)      | §5.3     |
-| DR Procedures     | [runbooks/index.md](../05-operations/runbooks/index.md)                            | §5.5     |
-| Cleanup           | [cleanup-policy.md](../03-guides/cleanup-policy.md)                                | §2.1.1   |
+| Topic             | Document                                                                          | RULES.md |
+| ----------------- | --------------------------------------------------------------------------------- | -------- |
+| Error Handling    | [ADR-016](../02-architecture/decisions/ADR-016-error-handling-strategy.md)        | §3.1     |
+| Circuit Breaker   | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) | §3.1.4   |
+| Locking           | [ADR-003](../02-architecture/decisions/ADR-003-in-memory-locking-strategy.md)     | §3.3     |
+| DQ Metrics        | [RULES.md](RULES.md#34-data-quality-%D0%BC%D0%B5%D1%82%D1%80%D0%B8%D0%BA%D0%B8)   | §3.4     |
+| Graceful Shutdown | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)     | §5.3     |
+| DR Procedures     | [runbooks/index.md](../05-operations/runbooks/index.md)                           | §5.5     |
+| Cleanup           | [cleanup-policy.md](../03-guides/cleanup-policy.md)                               | §2.1.1   |
 
 ### Development
 
-| Topic            | Document                                                                                        | RULES.md |
-|------------------|-------------------------------------------------------------------------------------------------|----------|
-| Adding Providers | [add-new-source.md](../03-guides/add-new-source.md)                                                | App D    |
-| Adding Pipelines | [add-pipeline-existing-source.md](../03-guides/add-pipeline-existing-source.md)                    | App D    |
-| Pipeline Review  | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md)                          | §4.2     |
-| Testing          | [testing.md](../03-guides/testing.md)                                                              | §4.2     |
-| E2E Testing      | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)                           | §4.2.3   |
-| Date Handling    | [date-handling.md](../03-guides/date-handling.md)                                                  | §2.4     |
-| Code Style       | [RULES.md §4](RULES.md#4-качество-кода-и-тестирование)                                          | §4       |
+| Topic            | Document                                                                                                                                                                            | RULES.md |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Adding Providers | [add-new-source.md](../03-guides/add-new-source.md)                                                                                                                                 | App D    |
+| Adding Pipelines | [add-pipeline-existing-source.md](../03-guides/add-pipeline-existing-source.md)                                                                                                     | App D    |
+| Pipeline Review  | [pipeline-review-checklist.md](../04-reference/templates/pipeline-review-checklist.md)                                                                                              | §4.2     |
+| Testing          | [testing.md](../03-guides/testing.md)                                                                                                                                               | §4.2     |
+| E2E Testing      | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)                                                                                                            | §4.2.3   |
+| Date Handling    | [date-handling.md](../03-guides/date-handling.md)                                                                                                                                   | §2.4     |
+| Code Style       | [RULES.md §4](RULES.md#4-%D0%BA%D0%B0%D1%87%D0%B5%D1%81%D1%82%D0%B2%D0%BE-%D0%BA%D0%BE%D0%B4%D0%B0-%D0%B8-%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5) | §4       |
 
----
+______________________________________________________________________
 
 ## Source Code Map
 
@@ -305,7 +306,7 @@ tests/
     └── vcr/                     # VCR cassettes for HTTP
 ```
 
----
+______________________________________________________________________
 
 ## Config Files Map
 
@@ -322,31 +323,31 @@ graph TD
     end
 ```
 
----
+______________________________________________________________________
 
 ## Key Files
 
-| File                                               | Purpose                   |
-|----------------------------------------------------|---------------------------|
-| `docs/00-project/RULES.md`                         | Master rules document     |
-| `docs/00-project/glossary.md`                      | Ubiquitous Language terminology |
-| `CHANGELOG.md`                                     | Version history           |
-| `configs/pipelines/{provider}/{entity}.yaml`       | Pipeline configuration    |
-| `src/bioetl/domain/ports/`                         | Protocol interfaces (package) |
-| `src/bioetl/composition/bootstrap-contexts.py`     | Composition root          |
-| `src/bioetl/infrastructure/config.py`              | Application settings      |
-| `docs/02-architecture/system-context.md`           | High-level system diagram |
-| `docs/04-reference/contracts/gold/{entity}.json`   | Gold data contracts       |
+| File                                             | Purpose                         |
+| ------------------------------------------------ | ------------------------------- |
+| `docs/00-project/RULES.md`                       | Master rules document           |
+| `docs/00-project/glossary.md`                    | Ubiquitous Language terminology |
+| `CHANGELOG.md`                                   | Version history                 |
+| `configs/pipelines/{provider}/{entity}.yaml`     | Pipeline configuration          |
+| `src/bioetl/domain/ports/`                       | Protocol interfaces (package)   |
+| `src/bioetl/composition/bootstrap-contexts.py`   | Composition root                |
+| `src/bioetl/infrastructure/config.py`            | Application settings            |
+| `docs/02-architecture/system-context.md`         | High-level system diagram       |
+| `docs/04-reference/contracts/gold/{entity}.json` | Gold data contracts             |
 
----
+______________________________________________________________________
 
 ### CI/CD & GitHub
 
-| Topic | Document | RULES.md |
-|-------|----------|----------|
-| GitHub Policy | [05-github-policy.md](governance/05-github-policy.md) | §4, §5 |
-| Contributing | [CONTRIBUTING.md](../../.github/CONTRIBUTING.md) | — |
-| Security | [SECURITY.md](../../.github/SECURITY.md) | §5.4 |
+| Topic         | Document                                              | RULES.md |
+| ------------- | ----------------------------------------------------- | -------- |
+| GitHub Policy | [05-github-policy.md](governance/05-github-policy.md) | §4, §5   |
+| Contributing  | [CONTRIBUTING.md](../../.github/CONTRIBUTING.md)      | —        |
+| Security      | [SECURITY.md](../../.github/SECURITY.md)              | §5.4     |
 
 ## Related Resources
 
@@ -354,26 +355,26 @@ graph TD
 - **Issues**: Report bugs and feature requests
 - **CI/CD**: GitHub Actions workflows ([GitHub Policy](governance/05-github-policy.md))
 
----
+______________________________________________________________________
 
 ## Document Status
 
-| Document                 | Last Updated | Status                       |
-|--------------------------|--------------|------------------------------|
-| RULES.md                 | 2026-02-21   | v5.21 (Latest)               |
-| REQUIREMENTS.md          | 2026-02-21   | v1.5 (Local-Only sync)       |
-| glossary.md              | 2026-02-06   | v2.5 (Ubiquitous Language)   |
-| 00-map.md                | 2026-02-21   | v7.3 Audit remediation       |
-| rules-summary.md         | 2026-02-21   | v5.21 Synced                 |
-| TOOLS.md                 | 2026-02-21   | v2.1 Synced with RULES v5.21 |
-| 03-guides/               | 2026-01-20   | Consolidated (16 guides)     |
-| 03-development/          | 2026-01-26   | Config schema guidelines     |
-| ADR-001..034             | 2026-02-17   | All 34 ADRs documented       |
-| 05-operations/runbooks/  | 2026-01-04   | 16 active runbooks           |
-| domain/schemas/          | 2025-12-28   | ChEMBL schemas (4 entities)  |
-| audits/                  | 2026-02-17   | Consolidated (audit/ merged) |
-| 02-architecture/diagrams/| 2025-12-31   | 50+ Mermaid diagrams         |
+| Document                  | Last Updated | Status                       |
+| ------------------------- | ------------ | ---------------------------- |
+| RULES.md                  | 2026-02-21   | v5.21 (Latest)               |
+| REQUIREMENTS.md           | 2026-02-21   | v1.5 (Local-Only sync)       |
+| glossary.md               | 2026-02-06   | v2.5 (Ubiquitous Language)   |
+| 00-map.md                 | 2026-02-21   | v7.3 Audit remediation       |
+| rules-summary.md          | 2026-02-21   | v5.21 Synced                 |
+| TOOLS.md                  | 2026-02-21   | v2.1 Synced with RULES v5.21 |
+| 03-guides/                | 2026-01-20   | Consolidated (16 guides)     |
+| 03-development/           | 2026-01-26   | Config schema guidelines     |
+| ADR-001..034              | 2026-02-17   | All 34 ADRs documented       |
+| 05-operations/runbooks/   | 2026-01-04   | 16 active runbooks           |
+| domain/schemas/           | 2025-12-28   | ChEMBL schemas (4 entities)  |
+| audits/                   | 2026-02-17   | Consolidated (audit/ merged) |
+| 02-architecture/diagrams/ | 2025-12-31   | 50+ Mermaid diagrams         |
 
----
+______________________________________________________________________
 
-*Last updated: 2026-02-21. Audit remediation (P0+P1) applied.*
+*Last updated: 2026-02-24. Audit remediation (P0+P1) applied.*

--- a/docs/00-project/index.md
+++ b/docs/00-project/index.md
@@ -8,38 +8,38 @@ To build a robust, scalable, and maintainable data pipeline for acquiring and pr
 
 ## Quick Links
 
-*   [**Documentation Index**](00-map.md): Structured navigation for all documentation.
-*   [**Quick Reference**](rules-summary.md): Key rules at a glance.
-*   [**Project Navigator**](00-map.md): Full documentation map with links to all resources.
-*   [**Project Rules**](RULES.md): The constitution of our project (SSOT). All contributions **MUST** adhere to these rules.
-*   [**Quick Start Guide**](../03-guides/quick-start.md): Get your local development environment up and running in minutes.
-*   [**Architecture Overview**](../02-architecture/system-context.md): Understand the high-level design and data flow.
-*   [**How-To Guides**](../03-guides/): Guides for common tasks (adding sources, pipelines, troubleshooting).
+- [**Documentation Index**](00-map.md): Structured navigation for all documentation.
+- [**Quick Reference**](rules-summary.md): Key rules at a glance.
+- [**Project Navigator**](00-map.md): Full documentation map with links to all resources.
+- [**Project Rules**](RULES.md): The constitution of our project (SSOT). All contributions **MUST** adhere to these rules.
+- [**Quick Start Guide**](../03-guides/quick-start.md): Get your local development environment up and running in minutes.
+- [**Architecture Overview**](../02-architecture/system-context.md): Understand the high-level design and data flow.
+- [**How-To Guides**](../03-guides/): Guides for common tasks (adding sources, pipelines, troubleshooting).
 
 ## Key Features
 
-| Feature | Description | ADR |
-|---------|-------------|-----|
-| **Medallion Architecture** | Bronze → Silver → Gold data flow | [ADR-002](../02-architecture/decisions/ADR-002-medallion-architecture.md) |
-| **Delta Lake Storage** | ACID transactions, time travel, schema evolution | [ADR-001](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md) |
-| **Local-Only Deployment** | File-based storage, no Docker/Redis required | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md) |
-| **Graceful Shutdown** | SIGTERM/SIGINT handling with checkpoint save | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md) |
-| **Circuit Breaker** | Fault tolerance for API failures | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) |
-| **Deterministic Writes** | Reproducible SCD2 with ingestion-ts | [ADR-014](../02-architecture/decisions/ADR-014-deterministic-writes.md) |
-| **Gold Validation** | Pandera strict schema validation | [ADR-018](../02-architecture/decisions/ADR-018-gold-strict-validation.md) |
-| **Composite Pipeline** | Multi-source data enrichment (seed → enrich → merge) | [ADR-026](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md) |
+| Feature                    | Description                                          | ADR                                                                               |
+| -------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Medallion Architecture** | Bronze → Silver → Gold data flow                     | [ADR-002](../02-architecture/decisions/ADR-002-medallion-architecture.md)         |
+| **Delta Lake Storage**     | ACID transactions, time travel, schema evolution     | [ADR-001](../02-architecture/decisions/ADR-001-delta-lake-vs-parquet.md)          |
+| **Local-Only Deployment**  | File-based storage, no Docker/Redis required         | [ADR-010](../02-architecture/decisions/ADR-010-local-only-deployment.md)          |
+| **Graceful Shutdown**      | SIGTERM/SIGINT handling with checkpoint save         | [ADR-008](../02-architecture/decisions/ADR-008-graceful-shutdown-strategy.md)     |
+| **Circuit Breaker**        | Fault tolerance for API failures                     | [ADR-007](../02-architecture/decisions/ADR-007-circuit-breaker-implementation.md) |
+| **Deterministic Writes**   | Reproducible SCD2 with ingestion-ts                  | [ADR-014](../02-architecture/decisions/ADR-014-deterministic-writes.md)           |
+| **Gold Validation**        | Pandera strict schema validation                     | [ADR-018](../02-architecture/decisions/ADR-018-gold-strict-validation.md)         |
+| **Composite Pipeline**     | Multi-source data enrichment (seed → enrich → merge) | [ADR-026](../02-architecture/decisions/ADR-026-composite-pipeline-pattern.md)     |
 
 ## Supported Providers (7)
 
-| Provider | Entities | Status | Rate Limit |
-|----------|----------|--------|------------|
-| **ChEMBL** | Activity, Assay, Molecule, Target, Target Component, Document (13 entities) | Production | None |
-| **PubChem** | Compound | Production | 5 req/sec |
-| **UniProt** | Protein | Production | 100 req/sec |
-| **PubMed** | Publication | Production | 3 req/sec |
-| **CrossRef** | Publication | Production | Polite pool |
-| **OpenAlex** | Publication | Production | 10 req/sec |
-| **SemanticScholar** | Publication | Production | 100 req/5min |
+| Provider            | Entities                                                                    | Status     | Rate Limit   |
+| ------------------- | --------------------------------------------------------------------------- | ---------- | ------------ |
+| **ChEMBL**          | Activity, Assay, Molecule, Target, Target Component, Document (13 entities) | Production | None         |
+| **PubChem**         | Compound                                                                    | Production | 5 req/sec    |
+| **UniProt**         | Protein                                                                     | Production | 100 req/sec  |
+| **PubMed**          | Publication                                                                 | Production | 3 req/sec    |
+| **CrossRef**        | Publication                                                                 | Production | Polite pool  |
+| **OpenAlex**        | Publication                                                                 | Production | 10 req/sec   |
+| **SemanticScholar** | Publication                                                                 | Production | 100 req/5min |
 
 ### Composite Pipeline (ADR-026)
 
@@ -54,7 +54,7 @@ See [Composite Pipeline Diagram](../02-architecture/diagrams/29-composite-pipeli
 
 ## Current Version
 
-**v5.9.0** (2026-01-06) — See [CHANGELOG](../../CHANGELOG.md) for details.
+**v6.0.0** (2026-02-18) — See [CHANGELOG](../../CHANGELOG.md) for details.
 
 ## Getting Started
 
@@ -71,6 +71,6 @@ bioetl run --pipeline chembl_activity --limit 100
 make test
 ```
 
----
+______________________________________________________________________
 
-*Last updated: 2026-01-26*
+*Last updated: 2026-02-24*

--- a/scripts/check_docs_version_sync.py
+++ b/scripts/check_docs_version_sync.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Validate that docs/00-project/index.md Current Version matches pyproject.toml."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+DOC_INDEX_PATH = REPO_ROOT / "docs" / "00-project" / "index.md"
+VERSION_PATTERN = re.compile(
+    r"\*\*v(?P<version>\d+\.\d+\.\d+)\*\*\s*\((?P<date>\d{4}-\d{2}-\d{2})\)"
+)
+
+
+def get_pyproject_version(pyproject_path: Path) -> str:
+    """Read project version from pyproject.toml."""
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    return str(data["project"]["version"])
+
+
+def get_docs_version(doc_index_path: Path) -> tuple[str, str]:
+    """Extract current version and release date from docs/00-project/index.md."""
+    content = doc_index_path.read_text(encoding="utf-8")
+    match = VERSION_PATTERN.search(content)
+    if match is None:
+        raise ValueError(
+            "Could not find Current Version entry in docs/00-project/index.md. "
+            "Expected format: **vX.Y.Z** (YYYY-MM-DD)."
+        )
+    return match.group("version"), match.group("date")
+
+
+def main() -> int:
+    """Run version consistency check."""
+    pyproject_version = get_pyproject_version(PYPROJECT_PATH)
+    docs_version, release_date = get_docs_version(DOC_INDEX_PATH)
+
+    if pyproject_version != docs_version:
+        sys.stderr.write(
+            "Version mismatch:\n"
+            f"  pyproject.toml: {pyproject_version}\n"
+            f"  docs/00-project/index.md: {docs_version} ({release_date})\n"
+        )
+        return 1
+
+    sys.stdout.write(
+        "Version sync OK: "
+        f"pyproject.toml and docs/00-project/index.md are both {pyproject_version} "
+        f"(release date: {release_date}).\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Ensure documentation `Current Version` is accurate for the v6.0.0 release and prevent future desynchronization between `pyproject.toml` and docs. 
- Make the version check part of contributor workflow so releases always include the docs metadata update.

### Description

- Updated `docs/00-project/index.md` `Current Version` to `v6.0.0` with release date `2026-02-18` and refreshed the `Last updated` date to `2026-02-24`.
- Updated `docs/00-project/00-map.md` header metadata to include the current release and updated last-updated date.
- Added `scripts/check_docs_version_sync.py`, a small validator that reads `project.version` from `pyproject.toml` and compares it to the `**vX.Y.Z** (YYYY-MM-DD)` entry in `docs/00-project/index.md`, exiting non‑zero on mismatch.
- Added a mandatory rule to `.github/CONTRIBUTING.md` requiring contributors to update `docs/00-project/index.md` for releases and to run the new check as part of release PRs.

### Testing

- Ran `uv run python scripts/check_docs_version_sync.py` and it returned success (prints "Version sync OK"), confirming parity with `pyproject.toml`.
- Ran `uv run ruff check scripts/check_docs_version_sync.py` which passed after fixing linter-reported `print` usage to `sys.stdout/sys.stderr` writes.
- Ran `uv run ruff format scripts/check_docs_version_sync.py` to apply formatting; formatting step completed successfully.
- Note: an initial pre-commit run flagged unrelated repo-wide hooks (missing `pip-audit` executable and an existing legacy config path warning); the script was adjusted for lint rules and verification commands above were re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d73efce34832489895eb14d0b77d8)