### PR TITLE
Add organism classification service (taxonomy-priority) with diagnostics and tests

### DIFF
--- a/src/bioetl/__init__.py
+++ b/src/bioetl/__init__.py
@@ -10,7 +10,7 @@ __version__ = "6.0.0"
 try:
     import typing
 
-    import typing_inspect  # type: ignore[import-untyped,import-not-found]
+    import typing_inspect  # type: ignore[import-untyped]
 
     # Fix typing_inspect.get_origin BEFORE importing pandera backends
     _orig_get_origin = typing_inspect.get_origin

--- a/src/bioetl/domain/services/__init__.py
+++ b/src/bioetl/domain/services/__init__.py
@@ -41,6 +41,11 @@ from bioetl.domain.services.dq_serializer import DQReportSerializer
 from bioetl.domain.services.identity_service import IdentityService
 from bioetl.domain.services.normalization_config import NormalizationConfig
 from bioetl.domain.services.normalization_service import NormalizationService
+from bioetl.domain.services.organism_classification_service import (
+    OrganismClass,
+    OrganismClassificationResult,
+    classify_organism,
+)
 from bioetl.domain.services.text_similarity import jaccard_similarity, normalize_text
 from bioetl.domain.services.unit_converter import UnitConverter
 from bioetl.domain.services.value_validator import ValueValidator
@@ -59,8 +64,11 @@ __all__ = [
     "IdentityService",
     "NormalizationConfig",
     "NormalizationService",
+    "OrganismClass",
+    "OrganismClassificationResult",
     "UnitConverter",
     "ValueValidator",
+    "classify_organism",
     "jaccard_similarity",
     "normalize_text",
 ]

--- a/src/bioetl/domain/services/organism_classification_service.py
+++ b/src/bioetl/domain/services/organism_classification_service.py
@@ -1,0 +1,205 @@
+"""Organism classification by taxonomy ID and organism name.
+
+Pure domain logic with deterministic lookup tables (no I/O).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from bioetl.domain.value_objects.taxonomy_id import validate_taxonomy_id
+
+
+class OrganismClass(str, Enum):
+    """High-level organism class."""
+
+    ACELLULAR = "acellular"
+    UNICELLULAR = "unicellular"
+    MULTICELLULAR = "multicellular"
+
+
+@dataclass(frozen=True)
+class OrganismClassificationResult:
+    """Classification result with source and diagnostics."""
+
+    organism_class: OrganismClass | None
+    normalized_organism: str | None
+    taxonomy_id: int | None
+    source: Literal["taxonomy_id", "organism_name", "unresolved"]
+    source_conflict: bool
+    reason: str | None
+
+
+_TAXONOMY_CLASS_MAP: dict[int, OrganismClass] = {
+    562: OrganismClass.UNICELLULAR,  # Escherichia coli
+    1280: OrganismClass.UNICELLULAR,  # Staphylococcus aureus
+    3847: OrganismClass.MULTICELLULAR,  # Glycine max
+    5476: OrganismClass.UNICELLULAR,  # Candida albicans
+    8005: OrganismClass.MULTICELLULAR,  # eel
+    9534: OrganismClass.MULTICELLULAR,  # monkey (Catarrhini)
+    9606: OrganismClass.MULTICELLULAR,  # Homo sapiens
+    10116: OrganismClass.MULTICELLULAR,  # Rattus norvegicus
+    10710: OrganismClass.ACELLULAR,  # Enterobacteria phage lambda
+    11676: OrganismClass.ACELLULAR,  # Human immunodeficiency virus 1
+    211044: OrganismClass.ACELLULAR,  # Influenza A virus
+}
+
+_ORGANISM_ALIAS_TO_CANONICAL: dict[str, str] = {
+    "hiv": "human immunodeficiency virus 1",
+    "eel": "anguilla anguilla",
+    "rice": "oryza sativa japonica group",
+    "monkey": "catarrhini",
+}
+
+_ORGANISM_NAME_CLASS_MAP: dict[str, OrganismClass] = {
+    "homo sapiens": OrganismClass.MULTICELLULAR,
+    "rattus norvegicus": OrganismClass.MULTICELLULAR,
+    "glycine max": OrganismClass.MULTICELLULAR,
+    "oryza sativa japonica group": OrganismClass.MULTICELLULAR,
+    "catarrhini": OrganismClass.MULTICELLULAR,
+    "anguilla anguilla": OrganismClass.MULTICELLULAR,
+    "escherichia coli": OrganismClass.UNICELLULAR,
+    "staphylococcus aureus": OrganismClass.UNICELLULAR,
+    "candida albicans": OrganismClass.UNICELLULAR,
+    "plasmodium falciparum": OrganismClass.UNICELLULAR,
+    "human immunodeficiency virus 1": OrganismClass.ACELLULAR,
+    "influenza a virus": OrganismClass.ACELLULAR,
+    "enterobacteria phage lambda": OrganismClass.ACELLULAR,
+}
+
+_ACELLULAR_HINTS: tuple[str, ...] = ("virus", "phage", "virion")
+_UNICELLULAR_HINTS: tuple[str, ...] = (
+    "bacter",
+    "archaea",
+    "archaeon",
+    "yeast",
+    "plasmodium",
+    "candida",
+)
+_MULTICELLULAR_HINTS: tuple[str, ...] = (
+    "homo sapiens",
+    "rattus",
+    "mus musculus",
+    "glycine",
+    "oryza",
+    "monkey",
+    "fish",
+    "eel",
+)
+
+_CLASS_HINTS: tuple[tuple[OrganismClass, tuple[str, ...]], ...] = (
+    (OrganismClass.ACELLULAR, _ACELLULAR_HINTS),
+    (OrganismClass.UNICELLULAR, _UNICELLULAR_HINTS),
+    (OrganismClass.MULTICELLULAR, _MULTICELLULAR_HINTS),
+)
+
+
+def _normalize_organism_name(assay_organism: str | None) -> str | None:
+    """Normalize organism name for deterministic lookup."""
+    if assay_organism is None:
+        return None
+
+    normalized = assay_organism.strip().lower()
+    if not normalized:
+        return None
+
+    normalized = re.sub(r"\([^)]*\)", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    normalized = _ORGANISM_ALIAS_TO_CANONICAL.get(normalized, normalized)
+
+    for canonical in _ORGANISM_NAME_CLASS_MAP:
+        if normalized.startswith(f"{canonical} "):
+            return canonical
+
+    return normalized
+
+
+def _classify_from_organism_name(
+    normalized_organism: str | None,
+) -> OrganismClass | None:
+    """Classify by normalized organism name and heuristic hints."""
+    if normalized_organism is None:
+        return None
+
+    direct_match = _ORGANISM_NAME_CLASS_MAP.get(normalized_organism)
+    if direct_match is not None:
+        return direct_match
+
+    return _classify_by_hints(normalized_organism)
+
+
+def _classify_by_hints(normalized_organism: str) -> OrganismClass | None:
+    """Classify name by ordered token hints."""
+    for organism_class, hints in _CLASS_HINTS:
+        if any(hint in normalized_organism for hint in hints):
+            return organism_class
+    return None
+
+
+def _build_result_from_taxonomy(
+    taxonomy_id: int,
+    normalized_organism: str | None,
+    name_class: OrganismClass | None,
+) -> OrganismClassificationResult:
+    """Build result for valid taxonomy ID input."""
+    taxonomy_class = _TAXONOMY_CLASS_MAP.get(taxonomy_id)
+    if taxonomy_class is None:
+        return OrganismClassificationResult(
+            organism_class=None,
+            normalized_organism=normalized_organism,
+            taxonomy_id=taxonomy_id,
+            source="unresolved",
+            source_conflict=False,
+            reason=f"taxonomy_id {taxonomy_id} is valid but not mapped",
+        )
+
+    source_conflict = name_class is not None and name_class != taxonomy_class
+    return OrganismClassificationResult(
+        organism_class=taxonomy_class,
+        normalized_organism=normalized_organism,
+        taxonomy_id=taxonomy_id,
+        source="taxonomy_id",
+        source_conflict=source_conflict,
+        reason="taxonomy_id took priority over conflicting organism name"
+        if source_conflict
+        else None,
+    )
+
+
+def classify_organism(
+    assay_organism: str | None,
+    assay_taxonomy_id: int | str | None,
+) -> OrganismClassificationResult:
+    """Classify organism as acellular/unicellular/multicellular.
+
+    Priority: taxonomy_id (if valid) > organism_name > unresolved.
+    """
+    taxonomy_id = validate_taxonomy_id(assay_taxonomy_id)
+    normalized_organism = _normalize_organism_name(assay_organism)
+
+    name_class = _classify_from_organism_name(normalized_organism)
+
+    if taxonomy_id is not None:
+        return _build_result_from_taxonomy(taxonomy_id, normalized_organism, name_class)
+
+    if name_class is not None:
+        return OrganismClassificationResult(
+            organism_class=name_class,
+            normalized_organism=normalized_organism,
+            taxonomy_id=None,
+            source="organism_name",
+            source_conflict=False,
+            reason=None,
+        )
+
+    return OrganismClassificationResult(
+        organism_class=None,
+        normalized_organism=normalized_organism,
+        taxonomy_id=None,
+        source="unresolved",
+        source_conflict=False,
+        reason="unable to classify organism from provided inputs",
+    )

--- a/src/bioetl/infrastructure/config/base_config_loader.py
+++ b/src/bioetl/infrastructure/config/base_config_loader.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 import yaml
+
 from bioetl.infrastructure.config_merge import config_merge
 
 T = TypeVar("T")

--- a/src/bioetl/infrastructure/config/contract_policy_loader.py
+++ b/src/bioetl/infrastructure/config/contract_policy_loader.py
@@ -41,8 +41,8 @@ def load_pipeline_contract_policy(provider: str, entity: str) -> PipelineContrac
         contracts_section = unified_raw.get("contracts")
         if isinstance(contracts_section, dict):
             raw = {**base_defaults, **contracts_section}
-            result: PipelineContractPolicy = PipelineContractPolicy.model_validate(raw)
-            return result
+            policy: PipelineContractPolicy = PipelineContractPolicy.model_validate(raw)
+            return policy
 
     legacy_path = (
         _CONFIGS_ROOT / "contracts" / "pipelines" / provider / f"{entity}.yaml"
@@ -58,5 +58,5 @@ def load_pipeline_contract_policy(provider: str, entity: str) -> PipelineContrac
 
     raw = legacy_raw
 
-    result: PipelineContractPolicy = PipelineContractPolicy.model_validate(raw)
-    return result
+    policy = PipelineContractPolicy.model_validate(raw)
+    return policy

--- a/src/bioetl/infrastructure/system/memory_monitor.py
+++ b/src/bioetl/infrastructure/system/memory_monitor.py
@@ -144,7 +144,7 @@ class MemoryMonitor:
         import resource
 
         # Get process memory usage (Unix-only attributes)
-        rusage = resource.getrusage(resource.RUSAGE_SELF)  # type: ignore[attr-defined]
+        rusage = resource.getrusage(resource.RUSAGE_SELF)
         process_mb = rusage.ru_maxrss / 1024  # Convert KB to MB on Linux
 
         # Try to read system memory from /proc/meminfo

--- a/tests/unit/domain/services/test_organism_classification_service.py
+++ b/tests/unit/domain/services/test_organism_classification_service.py
@@ -1,0 +1,120 @@
+"""Unit tests for organism classification service."""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.services.organism_classification_service import (
+    OrganismClass,
+    classify_organism,
+)
+
+
+@pytest.mark.parametrize(
+    ("organism", "taxonomy_id", "expected_class", "expected_source"),
+    [
+        (
+            "Human immunodeficiency virus 1",
+            11676,
+            OrganismClass.ACELLULAR,
+            "taxonomy_id",
+        ),
+        (
+            "Influenza A virus (A/duck/Alberta/35/76(H1N1))",
+            211044,
+            OrganismClass.ACELLULAR,
+            "taxonomy_id",
+        ),
+        ("Enterobacteria phage lambda", 10710, OrganismClass.ACELLULAR, "taxonomy_id"),
+        ("Escherichia coli", 562, OrganismClass.UNICELLULAR, "taxonomy_id"),
+        ("Staphylococcus aureus", 1280, OrganismClass.UNICELLULAR, "taxonomy_id"),
+        ("Candida albicans", 5476, OrganismClass.UNICELLULAR, "taxonomy_id"),
+        ("Homo sapiens", 9606, OrganismClass.MULTICELLULAR, "taxonomy_id"),
+        ("Rattus norvegicus", 10116, OrganismClass.MULTICELLULAR, "taxonomy_id"),
+        ("Glycine max", 3847, OrganismClass.MULTICELLULAR, "taxonomy_id"),
+    ],
+)
+def test_classification_by_taxonomy_id(
+    organism: str,
+    taxonomy_id: int,
+    expected_class: OrganismClass,
+    expected_source: str,
+) -> None:
+    """Known mapped taxonomy IDs should classify deterministically."""
+    result = classify_organism(organism, taxonomy_id)
+
+    assert result.organism_class == expected_class
+    assert result.source == expected_source
+    assert result.taxonomy_id == taxonomy_id
+
+
+@pytest.mark.parametrize(
+    ("organism", "taxonomy_id", "expected_normalized", "expected_class"),
+    [
+        ("hiv", None, "human immunodeficiency virus 1", OrganismClass.ACELLULAR),
+        (" eel ", None, "anguilla anguilla", OrganismClass.MULTICELLULAR),
+        ("rice", None, "oryza sativa japonica group", OrganismClass.MULTICELLULAR),
+        ("monkey", None, "catarrhini", OrganismClass.MULTICELLULAR),
+        (
+            "Plasmodium falciparum 3D7 (isolate)",
+            None,
+            "plasmodium falciparum",
+            OrganismClass.UNICELLULAR,
+        ),
+    ],
+)
+def test_alias_and_normalization_resolution(
+    organism: str,
+    taxonomy_id: int | None,
+    expected_normalized: str,
+    expected_class: OrganismClass,
+) -> None:
+    """Name-based path should normalize aliases and strain annotations."""
+    result = classify_organism(organism, taxonomy_id)
+
+    assert result.normalized_organism == expected_normalized
+    assert result.organism_class == expected_class
+    assert result.source == "organism_name"
+
+
+def test_taxonomy_id_priority_on_conflict_sets_diagnostics() -> None:
+    """taxonomy_id must win when organism_name disagrees."""
+    result = classify_organism("Escherichia coli", 9606)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+    assert result.source_conflict is True
+    assert result.reason is not None
+
+
+@pytest.mark.parametrize(
+    ("organism", "taxonomy_id", "reason_fragment"),
+    [
+        (None, None, "unable to classify"),
+        ("", "", "unable to classify"),
+        ("Unknown species", None, "unable to classify"),
+        ("Unknown species", "not-an-int", "unable to classify"),
+    ],
+)
+def test_unresolved_for_invalid_or_empty_input(
+    organism: str | None,
+    taxonomy_id: str | int | None,
+    reason_fragment: str,
+) -> None:
+    """Empty/invalid/unmapped inputs should be unresolved with explanation."""
+    result = classify_organism(organism, taxonomy_id)
+
+    assert result.organism_class is None
+    assert result.source == "unresolved"
+    assert result.reason is not None
+    assert reason_fragment in result.reason
+
+
+def test_valid_but_unmapped_taxonomy_id_is_unresolved() -> None:
+    """Valid taxonomy ID without a table entry should be unresolved."""
+    result = classify_organism("any", 123456)
+
+    assert result.taxonomy_id == 123456
+    assert result.organism_class is None
+    assert result.source == "unresolved"
+    assert result.reason == "taxonomy_id 123456 is valid but not mapped"

--- a/tests/unit/infrastructure/config/test_contract_policy_loader.py
+++ b/tests/unit/infrastructure/config/test_contract_policy_loader.py
@@ -67,9 +67,7 @@ def test_load_contracts_from_legacy_path_fallback(
     load_pipeline_contract_policy.cache_clear()
     monkeypatch.chdir(tmp_path)
 
-    contracts_dir = (
-        tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
-    )
+    contracts_dir = tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
     contracts_dir.mkdir(parents=True)
     (contracts_dir / "test_entity.yaml").write_text(
         yaml.safe_dump(


### PR DESCRIPTION
### Motivation
- Provide deterministic high-level organism classification (acellular / unicellular / multicellular) for assay records using the existing `assay_taxonomy_id` and `assay_organism` inputs. 
- Ensure taxonomy ID is the source-of-truth when available and record diagnostics when `assay_organism` and `assay_taxonomy_id` disagree. 
- Keep logic pure domain code (no I/O) and expose a typed, easily extensible API for downstream use in transformers/validation.

### Description
- Added a new pure-domain service `classify_organism(assay_organism, assay_taxonomy_id) -> OrganismClassificationResult` with the `OrganismClass` enum and `OrganismClassificationResult` dataclass to capture `organism_class`, `normalized_organism`, `taxonomy_id`, `source`, `source_conflict` and `reason` (file: `src/bioetl/domain/services/organism_classification_service.py`).
- Implemented deterministic normalization (trim, lower-case, remove parenthetical annotations), alias mapping (`hiv`, `eel`, `rice`, `monkey`) and lightweight heuristic hints plus lookup tables for known taxonomy IDs and canonical names.
- Taxonomy ID is given priority when valid; conflicts set `source_conflict=True` and populate `reason`; unmapped-but-valid taxonomy IDs return `source="unresolved"` with explanation.
- Exported the new API from the services package and added focused unit tests (file: `tests/unit/domain/services/test_organism_classification_service.py`).
- Small ancillary fixes for formatting/imports and a few type/comment adjustments in config/system modules to satisfy repo checks (files touched: `src/bioetl/domain/services/__init__.py`, `src/bioetl/infrastructure/config/*`, `src/bioetl/infrastructure/system/memory_monitor.py`, `src/bioetl/__init__.py`, and one test formatting change).

### Testing
- Ran unit tests for the new service with `uv run python -m pytest tests/unit/domain/services/test_organism_classification_service.py -q` and they passed. ✅
- Verified architecture/style gates with `uv run python -m pytest tests/architecture/test_code_formatting.py tests/architecture/test_code_metrics.py -q` and both passed after formatting fixes. ✅
- Type checking with `uv run python -m mypy --strict src/bioetl/` completed with no errors. ✅
- Ran the full test suite with `uv run python -m pytest tests/ -x -q`; the run failed on an unrelated live e2e test due to an upstream ChEMBL API `500 Internal Server Error` (`tests/e2e/test_full_pipeline.py::TestChEMBLPipelineE2E::test_chembl_activity_full_run`), which is external to the classification logic and not caused by this change. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc381d8888324be2b89b27b04dabb)