### PR TITLE
Add organism classification (acellular/unicellular/multicellular) for assay metadata

### DIFF
--- a/src/bioetl/domain/mapping/__init__.py
+++ b/src/bioetl/domain/mapping/__init__.py
@@ -2,6 +2,12 @@
 
 from bioetl.domain.mapping.activity_fields import ACTIVITY_FIELD_MAPPING
 from bioetl.domain.mapping.molecule_fields import MOLECULE_FIELD_MAPPING
+from bioetl.domain.mapping.organism_classification import (
+    OrganismClass,
+    OrganismClassificationResult,
+    classify_organism,
+    normalize_organism_name,
+)
 from bioetl.domain.mapping.publication_fields import (
     PUBLICATION_FIELD_MAPPING,
     UNIFIED_TO_PROVIDER,
@@ -24,10 +30,14 @@ __all__ = [
     "PUBLICATION_FIELD_MAPPING",
     "PUBLICATION_TYPE_MAPPING",
     "UNIFIED_TO_PROVIDER",
+    "OrganismClass",
+    "OrganismClassificationResult",
     "PublicationTypeEntry",
     "apply_field_mapping",
+    "classify_organism",
     "classify_publication_type",
     "get_provider_name",
     "get_unified_name",
+    "normalize_organism_name",
     "normalize_publication_type",
 ]

--- a/src/bioetl/domain/mapping/organism_classification.py
+++ b/src/bioetl/domain/mapping/organism_classification.py
@@ -1,0 +1,233 @@
+"""Organism class classification for assay organism metadata.
+
+Classifies assays into one of three organism classes:
+- acellular (viruses/phages)
+- unicellular (bacteria/archaea/single-celled eukaryotes)
+- multicellular (animals/plants/fungi multicellular forms)
+
+Classification priority:
+1. taxonomy_id (if valid and mapped)
+2. normalized organism name (including aliases)
+3. unresolved
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final, Literal
+
+__all__ = [
+    "OrganismClass",
+    "OrganismClassificationResult",
+    "classify_organism",
+    "normalize_organism_name",
+]
+
+
+class OrganismClass(StrEnum):
+    """Unified organism categories for assay metadata."""
+
+    ACELLULAR = "acellular"
+    UNICELLULAR = "unicellular"
+    MULTICELLULAR = "multicellular"
+
+
+@dataclass(frozen=True, slots=True)
+class OrganismClassificationResult:
+    """Classification result with diagnostics."""
+
+    organism_class: OrganismClass | None
+    normalized_organism: str | None
+    taxonomy_id: int | None
+    source: Literal["taxonomy_id", "organism_name", "unresolved"]
+    source_conflict: bool
+    reason: str | None
+
+
+_TAXONOMY_CLASS_MAP: Final[dict[int, OrganismClass]] = {
+    # Animals
+    9606: OrganismClass.MULTICELLULAR,  # Homo sapiens
+    10090: OrganismClass.MULTICELLULAR,  # Mus musculus
+    10116: OrganismClass.MULTICELLULAR,  # Rattus norvegicus
+    9534: OrganismClass.MULTICELLULAR,  # Macaca
+    8005: OrganismClass.MULTICELLULAR,  # Anguilla anguilla (eel)
+    # Plants
+    3847: OrganismClass.MULTICELLULAR,  # Glycine max
+    39947: OrganismClass.MULTICELLULAR,  # Oryza sativa Japonica Group
+    # Bacteria / unicellular microbes
+    562: OrganismClass.UNICELLULAR,  # Escherichia coli
+    1280: OrganismClass.UNICELLULAR,  # Staphylococcus aureus
+    1313: OrganismClass.UNICELLULAR,  # Streptococcus pneumoniae
+    5476: OrganismClass.UNICELLULAR,  # Candida albicans
+    5833: OrganismClass.UNICELLULAR,  # Plasmodium falciparum
+    # Acellular
+    11676: OrganismClass.ACELLULAR,  # Human immunodeficiency virus 1
+    10710: OrganismClass.ACELLULAR,  # Enterobacteria phage lambda
+    211044: OrganismClass.ACELLULAR,  # Influenza A virus
+}
+
+_ORGANISM_ALIAS_MAP: Final[dict[str, str]] = {
+    "hiv": "human immunodeficiency virus 1",
+    "rice": "oryza sativa japonica group",
+    "eel": "anguilla anguilla",
+    "monkey": "macaca",
+}
+
+_ORGANISM_NAME_CLASS_MAP: Final[dict[str, OrganismClass]] = {
+    "homo sapiens": OrganismClass.MULTICELLULAR,
+    "rattus norvegicus": OrganismClass.MULTICELLULAR,
+    "glycine max": OrganismClass.MULTICELLULAR,
+    "oryza sativa japonica group": OrganismClass.MULTICELLULAR,
+    "anguilla anguilla": OrganismClass.MULTICELLULAR,
+    "macaca": OrganismClass.MULTICELLULAR,
+    "escherichia coli": OrganismClass.UNICELLULAR,
+    "staphylococcus aureus": OrganismClass.UNICELLULAR,
+    "streptococcus pneumoniae": OrganismClass.UNICELLULAR,
+    "candida albicans": OrganismClass.UNICELLULAR,
+    "plasmodium falciparum": OrganismClass.UNICELLULAR,
+    "human immunodeficiency virus 1": OrganismClass.ACELLULAR,
+    "influenza a virus": OrganismClass.ACELLULAR,
+    "enterobacteria phage lambda": OrganismClass.ACELLULAR,
+}
+
+_ACELLULAR_KEYWORDS: Final[tuple[str, ...]] = (
+    "virus",
+    "viridae",
+    "phage",
+    "bacteriophage",
+)
+
+_UNICELLULAR_KEYWORDS: Final[tuple[str, ...]] = (
+    "bacter",
+    "archaea",
+    "archae",
+    "yeast",
+    "plasmodium",
+    "candida",
+)
+
+_MULTICELLULAR_KEYWORDS: Final[tuple[str, ...]] = (
+    "homo",
+    "mus ",
+    "rattus",
+    "glycine",
+    "oryza",
+    "macaca",
+    "anguilla",
+)
+
+_PARENTHESES_RE: Final[re.Pattern[str]] = re.compile(r"\s*\([^)]*\)")
+_SPACES_RE: Final[re.Pattern[str]] = re.compile(r"\s+")
+
+
+def normalize_organism_name(organism_name: str | None) -> str | None:
+    """Normalize organism name for deterministic lookup."""
+    if organism_name is None:
+        return None
+
+    normalized = _PARENTHESES_RE.sub("", organism_name.strip().lower())
+    normalized = _SPACES_RE.sub(" ", normalized).strip()
+    return normalized or None
+
+
+def _parse_taxonomy_id(assay_taxonomy_id: int | str | None) -> int | None:
+    if assay_taxonomy_id is None:
+        return None
+    if isinstance(assay_taxonomy_id, int):
+        return assay_taxonomy_id if assay_taxonomy_id > 0 else None
+
+    stripped = assay_taxonomy_id.strip()
+    if not stripped or not stripped.isdigit():
+        return None
+
+    parsed = int(stripped)
+    return parsed if parsed > 0 else None
+
+
+def _classify_from_taxonomy_id(taxonomy_id: int) -> OrganismClass | None:
+    return _TAXONOMY_CLASS_MAP.get(taxonomy_id)
+
+
+def _classify_from_organism_name(
+    normalized_organism: str | None,
+) -> OrganismClass | None:
+    if normalized_organism is None:
+        return None
+
+    canonical = _ORGANISM_ALIAS_MAP.get(normalized_organism, normalized_organism)
+
+    direct = _ORGANISM_NAME_CLASS_MAP.get(canonical)
+    if direct is not None:
+        return direct
+
+    # Handle strains / isolates by prefix matching canonical species names.
+    for species_name, organism_class in _ORGANISM_NAME_CLASS_MAP.items():
+        if canonical.startswith(f"{species_name} "):
+            return organism_class
+
+    if any(keyword in canonical for keyword in _ACELLULAR_KEYWORDS):
+        return OrganismClass.ACELLULAR
+    if any(keyword in canonical for keyword in _UNICELLULAR_KEYWORDS):
+        return OrganismClass.UNICELLULAR
+    if any(keyword in canonical for keyword in _MULTICELLULAR_KEYWORDS):
+        return OrganismClass.MULTICELLULAR
+
+    return None
+
+
+def classify_organism(
+    assay_organism: str | None,
+    assay_taxonomy_id: int | str | None,
+) -> OrganismClassificationResult:
+    """Classify organism by taxonomy id first, then by normalized organism name."""
+    normalized_organism = normalize_organism_name(assay_organism)
+    taxonomy_id = _parse_taxonomy_id(assay_taxonomy_id)
+
+    name_class = _classify_from_organism_name(normalized_organism)
+
+    if taxonomy_id is not None:
+        taxonomy_class = _classify_from_taxonomy_id(taxonomy_id)
+        if taxonomy_class is not None:
+            source_conflict = name_class is not None and name_class != taxonomy_class
+            reason = "taxonomy_id_priority"
+            if source_conflict:
+                reason = "taxonomy_id_priority_conflict_with_organism_name"
+
+            return OrganismClassificationResult(
+                organism_class=taxonomy_class,
+                normalized_organism=normalized_organism,
+                taxonomy_id=taxonomy_id,
+                source="taxonomy_id",
+                source_conflict=source_conflict,
+                reason=reason,
+            )
+
+        return OrganismClassificationResult(
+            organism_class=None,
+            normalized_organism=normalized_organism,
+            taxonomy_id=taxonomy_id,
+            source="unresolved",
+            source_conflict=False,
+            reason="taxonomy_id_not_mapped",
+        )
+
+    if name_class is not None:
+        return OrganismClassificationResult(
+            organism_class=name_class,
+            normalized_organism=normalized_organism,
+            taxonomy_id=None,
+            source="organism_name",
+            source_conflict=False,
+            reason="classified_by_organism_name",
+        )
+
+    return OrganismClassificationResult(
+        organism_class=None,
+        normalized_organism=normalized_organism,
+        taxonomy_id=None,
+        source="unresolved",
+        source_conflict=False,
+        reason="insufficient_or_unknown_input",
+    )

--- a/tests/unit/domain/mapping/test_organism_classification.py
+++ b/tests/unit/domain/mapping/test_organism_classification.py
@@ -1,0 +1,117 @@
+"""Tests for assay organism classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.domain.mapping.organism_classification import (
+    OrganismClass,
+    classify_organism,
+    normalize_organism_name,
+)
+
+
+class TestNormalizeOrganismName:
+    def test_none(self) -> None:
+        assert normalize_organism_name(None) is None
+
+    def test_trim_lower_and_parentheses_removal(self) -> None:
+        assert normalize_organism_name("  Homo sapiens (Human)  ") == "homo sapiens"
+
+    def test_empty_after_normalization(self) -> None:
+        assert normalize_organism_name("   ") is None
+
+
+class TestTaxonomyPriority:
+    @pytest.mark.parametrize(
+        ("taxonomy_id", "expected_class"),
+        [
+            (11676, OrganismClass.ACELLULAR),
+            (10710, OrganismClass.ACELLULAR),
+            (562, OrganismClass.UNICELLULAR),
+            (1280, OrganismClass.UNICELLULAR),
+            (9606, OrganismClass.MULTICELLULAR),
+            (10116, OrganismClass.MULTICELLULAR),
+            (3847, OrganismClass.MULTICELLULAR),
+        ],
+    )
+    def test_classification_by_taxonomy_id(
+        self, taxonomy_id: int, expected_class: OrganismClass
+    ) -> None:
+        result = classify_organism("random", taxonomy_id)
+        assert result.organism_class == expected_class
+        assert result.source == "taxonomy_id"
+
+    def test_taxonomy_id_wins_on_conflict(self) -> None:
+        result = classify_organism("Escherichia coli", 9606)
+        assert result.organism_class == OrganismClass.MULTICELLULAR
+        assert result.source == "taxonomy_id"
+        assert result.source_conflict is True
+
+    def test_unmapped_valid_taxonomy_id_is_unresolved(self) -> None:
+        result = classify_organism("Homo sapiens", 999999999)
+        assert result.organism_class is None
+        assert result.source == "unresolved"
+        assert result.reason == "taxonomy_id_not_mapped"
+
+
+class TestOrganismNameClassification:
+    @pytest.mark.parametrize(
+        ("organism_name", "expected_class"),
+        [
+            ("Human immunodeficiency virus 1", OrganismClass.ACELLULAR),
+            ("Influenza A virus (A/Puerto Rico/8/1934)", OrganismClass.ACELLULAR),
+            ("Enterobacteria phage lambda", OrganismClass.ACELLULAR),
+            ("Escherichia coli", OrganismClass.UNICELLULAR),
+            ("Staphylococcus aureus", OrganismClass.UNICELLULAR),
+            ("Candida albicans", OrganismClass.UNICELLULAR),
+            ("Plasmodium falciparum 3D7", OrganismClass.UNICELLULAR),
+            ("Homo sapiens", OrganismClass.MULTICELLULAR),
+            ("Rattus norvegicus", OrganismClass.MULTICELLULAR),
+            ("Glycine max", OrganismClass.MULTICELLULAR),
+            ("Streptococcus pneumoniae TIGR4", OrganismClass.UNICELLULAR),
+        ],
+    )
+    def test_classification_by_name(
+        self, organism_name: str, expected_class: OrganismClass
+    ) -> None:
+        result = classify_organism(organism_name, None)
+        assert result.organism_class == expected_class
+        assert result.source == "organism_name"
+
+
+class TestAliases:
+    @pytest.mark.parametrize(
+        ("organism_name", "taxonomy_id", "expected_class", "expected_source"),
+        [
+            ("hiv", None, OrganismClass.ACELLULAR, "organism_name"),
+            ("hiv", 11676, OrganismClass.ACELLULAR, "taxonomy_id"),
+            ("rice", None, OrganismClass.MULTICELLULAR, "organism_name"),
+            ("eel", 8005, OrganismClass.MULTICELLULAR, "taxonomy_id"),
+            ("monkey", 9534, OrganismClass.MULTICELLULAR, "taxonomy_id"),
+        ],
+    )
+    def test_aliases(
+        self,
+        organism_name: str,
+        taxonomy_id: int | None,
+        expected_class: OrganismClass,
+        expected_source: str,
+    ) -> None:
+        result = classify_organism(organism_name, taxonomy_id)
+        assert result.organism_class == expected_class
+        assert result.source == expected_source
+
+
+class TestInvalidInput:
+    @pytest.mark.parametrize("taxonomy_id", [None, "", "abc", "-1", -1, 0])
+    def test_invalid_taxonomy_inputs(self, taxonomy_id: int | str | None) -> None:
+        result = classify_organism("unknown organism", taxonomy_id)
+        assert result.organism_class is None
+        assert result.source == "unresolved"
+
+    def test_empty_inputs(self) -> None:
+        result = classify_organism(None, None)
+        assert result.organism_class is None
+        assert result.normalized_organism is None
+        assert result.source == "unresolved"


### PR DESCRIPTION
### Motivation

- Добавить детерминированную классификацию организмов по полям `assay_organism` и `assay_taxonomy_id` с приоритетом taxonomy_id и диагностикой конфликтов. 
- Обеспечить простую, расширяемую реализацию (нормализация имени, алиасы, базовая таблица соответствий taxonomy_id → класс) без внешних HTTP-вызовов и с полным типизированным публичным API.

### Description

- Добавлен новый доменный модуль `src/bioetl/domain/mapping/organism_classification.py`, экспортируемый через `bioetl.domain.mapping`, реализующий:
  - `OrganismClass` (Enum) с членами `ACELLULAR`, `UNICELLULAR`, `MULTICELLULAR`;
  - `OrganismClassificationResult` (frozen dataclass) с полями `organism_class`, `normalized_organism`, `taxonomy_id`, `source`, `source_conflict`, `reason`;
  - функцию `classify_organism(assay_organism, assay_taxonomy_id)` с приоритетом `taxonomy_id` и явным указанием причины/конфликта;
  - функцию `normalize_organism_name` (trim, lower, remove parenthetical fragments, collapse spaces);
  - встроенные маппинги `TAXONOMY_CLASS_MAP`, `ORGANISM_ALIAS_MAP` и `ORGANISM_NAME_CLASS_MAP` и правило ключевых слов для эвристики (штаммы/изолят, ключевые слова virus/bacter/etc.).
- Обновлён фасад `src/bioetl/domain/mapping/__init__.py`, добавлены экспорты `OrganismClass`, `OrganismClassificationResult`, `classify_organism`, `normalize_organism_name`.
- Добавлены unit-тесты `tests/unit/domain/mapping/test_organism_classification.py`, покрывающие: классификацию по taxonomy_id, классификацию по имени (включая штаммы), алиасы (`hiv`, `rice`, `eel`, `monkey`), поведение при конфликте и невалидный/пустой ввод.

### Testing

- Unit tests for the new module passed: `uv run python -m pytest tests/unit/domain/mapping/test_organism_classification.py -q` ✅.
- Ran repository-wide tests: `uv run python -m pytest tests/ -x -q` — failed due to pre-existing repository formatting checks (ruff) detecting an unrelated test file that needs formatting (`tests/unit/infrastructure/config/test_contract_policy_loader.py`) (failure is unrelated to the new mapping logic) ❌.
- Type check: `uv run python -m mypy --strict src/bioetl/` — reported pre-existing mypy issues in unrelated files (`src/bioetl/__init__.py`, `src/bioetl/infrastructure/config/contract_policy_loader.py`, `src/bioetl/infrastructure/system/memory_monitor.py`), so strict type-check for entire repo did not pass (these are existing errors) ❌.
- Lint/format: applied `ruff format` to the new files during the rollout; new module now adheres to ruff checks.

If desired, next steps: expand the taxonomy mapping table and aliases from a config file or reference CSV, and follow-up PRs can address the unrelated formatting/mypy issues that block full-suite gates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc381d8888324be2b89b27b04dabb)