### PR TITLE
Add organism classification by `assay_organism` / `assay_taxonomy_id`

### DIFF
--- a/src/bioetl/domain/mapping/__init__.py
+++ b/src/bioetl/domain/mapping/__init__.py
@@ -2,6 +2,12 @@
 
 from bioetl.domain.mapping.activity_fields import ACTIVITY_FIELD_MAPPING
 from bioetl.domain.mapping.molecule_fields import MOLECULE_FIELD_MAPPING
+from bioetl.domain.mapping.organism_classification import (
+    OrganismClass,
+    OrganismClassificationResult,
+    classify_organism,
+    normalize_organism_name,
+)
 from bioetl.domain.mapping.publication_fields import (
     PUBLICATION_FIELD_MAPPING,
     UNIFIED_TO_PROVIDER,
@@ -24,10 +30,14 @@ __all__ = [
     "PUBLICATION_FIELD_MAPPING",
     "PUBLICATION_TYPE_MAPPING",
     "UNIFIED_TO_PROVIDER",
+    "OrganismClass",
+    "OrganismClassificationResult",
     "PublicationTypeEntry",
     "apply_field_mapping",
+    "classify_organism",
     "classify_publication_type",
     "get_provider_name",
     "get_unified_name",
+    "normalize_organism_name",
     "normalize_publication_type",
 ]

--- a/src/bioetl/domain/mapping/organism_classification.py
+++ b/src/bioetl/domain/mapping/organism_classification.py
@@ -1,0 +1,268 @@
+"""Organism classification utilities for assay organism metadata.
+
+Classifies assay organisms into acellular / unicellular / multicellular
+using NCBI taxonomy ID (source of truth) with fallback to normalized organism
+name lookup.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final, Literal
+
+__all__ = [
+    "OrganismClass",
+    "OrganismClassificationResult",
+    "classify_organism",
+    "normalize_organism_name",
+]
+
+
+class OrganismClass(StrEnum):
+    """High-level organism class for assay context."""
+
+    ACELLULAR = "acellular"
+    UNICELLULAR = "unicellular"
+    MULTICELLULAR = "multicellular"
+
+
+@dataclass(frozen=True, slots=True)
+class OrganismClassificationResult:
+    """Classification result with source diagnostics."""
+
+    organism_class: OrganismClass | None
+    normalized_organism: str | None
+    taxonomy_id: int | None
+    source: Literal["taxonomy_id", "organism_name", "unresolved"]
+    source_conflict: bool
+    reason: str | None
+
+
+_PARENTHESES_RE: Final[re.Pattern[str]] = re.compile(r"\s*\([^)]*\)")
+_WHITESPACE_RE: Final[re.Pattern[str]] = re.compile(r"\s+")
+
+_ALIAS_TO_CANONICAL: Final[dict[str, str]] = {
+    "hiv": "human immunodeficiency virus 1",
+    "rice": "oryza sativa japonica group",
+    "eel": "anguilla japonica",
+    "monkey": "cercopithecidae",
+}
+
+_NAME_CLASS_MAP: Final[dict[str, OrganismClass]] = {
+    "homo sapiens": OrganismClass.MULTICELLULAR,
+    "rattus norvegicus": OrganismClass.MULTICELLULAR,
+    "glycine max": OrganismClass.MULTICELLULAR,
+    "oryza sativa japonica group": OrganismClass.MULTICELLULAR,
+    "anguilla japonica": OrganismClass.MULTICELLULAR,
+    "cercopithecidae": OrganismClass.MULTICELLULAR,
+    "escherichia coli": OrganismClass.UNICELLULAR,
+    "staphylococcus aureus": OrganismClass.UNICELLULAR,
+    "candida albicans": OrganismClass.UNICELLULAR,
+    "plasmodium falciparum": OrganismClass.UNICELLULAR,
+    "streptococcus pneumoniae": OrganismClass.UNICELLULAR,
+    "human immunodeficiency virus 1": OrganismClass.ACELLULAR,
+    "influenza a virus": OrganismClass.ACELLULAR,
+    "enterobacteria phage lambda": OrganismClass.ACELLULAR,
+}
+
+_TAXONOMY_CLASS_MAP: Final[dict[int, OrganismClass]] = {
+    562: OrganismClass.UNICELLULAR,
+    1280: OrganismClass.UNICELLULAR,
+    3847: OrganismClass.MULTICELLULAR,
+    5476: OrganismClass.UNICELLULAR,
+    8005: OrganismClass.MULTICELLULAR,
+    9534: OrganismClass.MULTICELLULAR,
+    9606: OrganismClass.MULTICELLULAR,
+    10116: OrganismClass.MULTICELLULAR,
+    10710: OrganismClass.ACELLULAR,
+    11676: OrganismClass.ACELLULAR,
+    211044: OrganismClass.ACELLULAR,
+}
+
+
+def normalize_organism_name(assay_organism: str | None) -> str | None:
+    """Normalize organism name for deterministic lookup."""
+    if assay_organism is None:
+        return None
+
+    stripped = assay_organism.strip()
+    if not stripped:
+        return None
+
+    no_parentheses = _PARENTHESES_RE.sub("", stripped)
+    normalized = _WHITESPACE_RE.sub(" ", no_parentheses).strip().lower()
+    if not normalized:
+        return None
+    return _ALIAS_TO_CANONICAL.get(normalized, normalized)
+
+
+def _parse_taxonomy_id(assay_taxonomy_id: int | str | None) -> int | None:
+    if assay_taxonomy_id is None:
+        return None
+
+    candidate = (
+        assay_taxonomy_id
+        if isinstance(assay_taxonomy_id, int)
+        else _parse_taxonomy_string(assay_taxonomy_id)
+    )
+    return candidate if candidate > 0 else None
+
+
+def _parse_taxonomy_string(raw_taxonomy_id: str) -> int:
+    candidate = raw_taxonomy_id.strip()
+    return int(candidate) if candidate.isdigit() else 0
+
+
+def _classify_by_name(normalized_organism: str | None) -> OrganismClass | None:
+    if normalized_organism is None:
+        return None
+
+    return (
+        _classify_direct_name(normalized_organism)
+        or _classify_prefixed_name(normalized_organism)
+        or _classify_keyword_name(normalized_organism)
+    )
+
+
+def _classify_direct_name(normalized_organism: str) -> OrganismClass | None:
+    return _NAME_CLASS_MAP.get(normalized_organism)
+
+
+def _classify_prefixed_name(normalized_organism: str) -> OrganismClass | None:
+    for base_name, organism_class in _NAME_CLASS_MAP.items():
+        if normalized_organism.startswith(f"{base_name} "):
+            return organism_class
+    return None
+
+
+def _classify_keyword_name(normalized_organism: str) -> OrganismClass | None:
+    if "virus" in normalized_organism or "phage" in normalized_organism:
+        return OrganismClass.ACELLULAR
+    return None
+
+
+def _build_result(
+    *,
+    organism_class: OrganismClass | None,
+    normalized_organism: str | None,
+    taxonomy_id: int | None,
+    source: Literal["taxonomy_id", "organism_name", "unresolved"],
+    source_conflict: bool,
+    reason: str | None,
+) -> OrganismClassificationResult:
+    return OrganismClassificationResult(
+        organism_class=organism_class,
+        normalized_organism=normalized_organism,
+        taxonomy_id=taxonomy_id,
+        source=source,
+        source_conflict=source_conflict,
+        reason=reason,
+    )
+
+
+def _classify_from_invalid_taxonomy(
+    normalized_organism: str | None,
+) -> OrganismClassificationResult:
+    name_class = _classify_by_name(normalized_organism)
+    if name_class is not None:
+        return _build_result(
+            organism_class=name_class,
+            normalized_organism=normalized_organism,
+            taxonomy_id=None,
+            source="organism_name",
+            source_conflict=False,
+            reason="taxonomy_id is invalid; used normalized organism name",
+        )
+
+    return _build_result(
+        organism_class=None,
+        normalized_organism=normalized_organism,
+        taxonomy_id=None,
+        source="unresolved",
+        source_conflict=False,
+        reason="taxonomy_id is invalid and organism name is not recognized",
+    )
+
+
+def _classify_from_taxonomy(
+    taxonomy_id: int,
+    normalized_organism: str | None,
+) -> OrganismClassificationResult:
+    taxonomy_class = _TAXONOMY_CLASS_MAP.get(taxonomy_id)
+    if taxonomy_class is None:
+        return _build_result(
+            organism_class=None,
+            normalized_organism=normalized_organism,
+            taxonomy_id=taxonomy_id,
+            source="unresolved",
+            source_conflict=False,
+            reason="taxonomy_id is valid but not mapped to organism class",
+        )
+
+    name_class = _classify_by_name(normalized_organism)
+    conflict = name_class is not None and taxonomy_class != name_class
+    return _build_result(
+        organism_class=taxonomy_class,
+        normalized_organism=normalized_organism,
+        taxonomy_id=taxonomy_id,
+        source="taxonomy_id",
+        source_conflict=conflict,
+        reason=(
+            "taxonomy_id and organism name classifications conflict"
+            if conflict
+            else None
+        ),
+    )
+
+
+def _classify_from_name(
+    normalized_organism: str | None,
+) -> OrganismClassificationResult:
+    name_class = _classify_by_name(normalized_organism)
+    if name_class is not None:
+        return _build_result(
+            organism_class=name_class,
+            normalized_organism=normalized_organism,
+            taxonomy_id=None,
+            source="organism_name",
+            source_conflict=False,
+            reason=None,
+        )
+
+    if normalized_organism is None:
+        return _build_result(
+            organism_class=None,
+            normalized_organism=None,
+            taxonomy_id=None,
+            source="unresolved",
+            source_conflict=False,
+            reason="assay_organism and taxonomy_id are empty",
+        )
+
+    return _build_result(
+        organism_class=None,
+        normalized_organism=normalized_organism,
+        taxonomy_id=None,
+        source="unresolved",
+        source_conflict=False,
+        reason="organism name is not recognized",
+    )
+
+
+def classify_organism(
+    assay_organism: str | None,
+    assay_taxonomy_id: int | str | None,
+) -> OrganismClassificationResult:
+    """Classify organism with taxonomy-first source precedence."""
+    normalized_organism = normalize_organism_name(assay_organism)
+    taxonomy_id = _parse_taxonomy_id(assay_taxonomy_id)
+
+    if assay_taxonomy_id is not None and taxonomy_id is None:
+        return _classify_from_invalid_taxonomy(normalized_organism)
+
+    if taxonomy_id is not None:
+        return _classify_from_taxonomy(taxonomy_id, normalized_organism)
+
+    return _classify_from_name(normalized_organism)

--- a/src/bioetl/infrastructure/config/base_config_loader.py
+++ b/src/bioetl/infrastructure/config/base_config_loader.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 import yaml
+
 from bioetl.infrastructure.config_merge import config_merge
 
 T = TypeVar("T")

--- a/tests/unit/domain/mapping/test_organism_classification.py
+++ b/tests/unit/domain/mapping/test_organism_classification.py
@@ -1,0 +1,80 @@
+"""Tests for assay organism classification."""
+
+from bioetl.domain.mapping.organism_classification import (
+    OrganismClass,
+    classify_organism,
+    normalize_organism_name,
+)
+
+
+def test_taxonomy_id_priority_for_multicellular() -> None:
+    result = classify_organism("Homo sapiens", 9606)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+    assert result.source_conflict is False
+
+
+def test_virus_and_phage_are_acellular() -> None:
+    hiv = classify_organism("hiv", 11676)
+    phage = classify_organism("Enterobacteria phage lambda", 10710)
+
+    assert hiv.organism_class == OrganismClass.ACELLULAR
+    assert phage.organism_class == OrganismClass.ACELLULAR
+
+
+def test_microorganisms_are_unicellular() -> None:
+    e_coli = classify_organism("Escherichia coli", 562)
+    candida = classify_organism("Candida albicans", 5476)
+
+    assert e_coli.organism_class == OrganismClass.UNICELLULAR
+    assert candida.organism_class == OrganismClass.UNICELLULAR
+
+
+def test_alias_resolution_by_name_when_taxonomy_id_missing() -> None:
+    rice = classify_organism("rice", None)
+    monkey = classify_organism("monkey", None)
+
+    assert rice.organism_class == OrganismClass.MULTICELLULAR
+    assert rice.source == "organism_name"
+    assert monkey.organism_class == OrganismClass.MULTICELLULAR
+
+
+def test_alias_eel_prefers_taxonomy_id() -> None:
+    result = classify_organism("eel", 8005)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+
+
+def test_conflict_marks_source_conflict_but_uses_taxonomy_id() -> None:
+    result = classify_organism("Escherichia coli", 9606)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+    assert result.source_conflict is True
+    assert result.reason is not None
+
+
+def test_normalization_removes_parentheses_and_supports_strain_prefix() -> None:
+    normalized = normalize_organism_name("  Streptococcus pneumoniae (TIGR4)  ")
+    result = classify_organism("Plasmodium falciparum 3D7", None)
+
+    assert normalized == "streptococcus pneumoniae"
+    assert result.organism_class == OrganismClass.UNICELLULAR
+
+
+def test_invalid_taxonomy_falls_back_to_name() -> None:
+    result = classify_organism("Influenza A virus (A/Puerto Rico/8/1934(H1N1))", "N/A")
+
+    assert result.organism_class == OrganismClass.ACELLULAR
+    assert result.source == "organism_name"
+    assert result.reason is not None
+
+
+def test_empty_input_is_unresolved() -> None:
+    result = classify_organism("   ", None)
+
+    assert result.organism_class is None
+    assert result.source == "unresolved"
+    assert result.reason is not None

--- a/tests/unit/infrastructure/config/test_contract_policy_loader.py
+++ b/tests/unit/infrastructure/config/test_contract_policy_loader.py
@@ -67,9 +67,7 @@ def test_load_contracts_from_legacy_path_fallback(
     load_pipeline_contract_policy.cache_clear()
     monkeypatch.chdir(tmp_path)
 
-    contracts_dir = (
-        tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
-    )
+    contracts_dir = tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
     contracts_dir.mkdir(parents=True)
     (contracts_dir / "test_entity.yaml").write_text(
         yaml.safe_dump(


### PR DESCRIPTION
### Motivation
- Need a deterministic, taxonomy-first classifier for assay organism metadata to tag records as `acellular` / `unicellular` / `multicellular` for downstream processing and DQ rules. 
- Classification must prefer `assay_taxonomy_id` when valid, fall back to normalized `assay_organism` with alias support, and surface diagnostics when sources conflict.

### Description
- Добавлен новый доменный модуль `src/bioetl/domain/mapping/organism_classification.py` с публичным API: `OrganismClass` (Enum), `OrganismClassificationResult` (dataclass), `classify_organism(...)` и `normalize_organism_name(...)`.
- Реализована логика: приоритет `taxonomy_id` → fallback по нормализованному `assay_organism`; при конфликте возвращается классификация по `taxonomy_id` и `source_conflict=True` с `reason` для диагностики.
- Нормализация имени удаляет внешние скобки, тримит/понижает регистр, сводит множественные пробелы и разрешает алиасы (`hiv`, `rice`, `eel`, `monkey`).
- Добавлены локальные маппинги примеров `taxonomy_id` и canonical names для ожидаемых случаев (например, `9606` → `multicellular`, `562` → `unicellular`, `11676` → `acellular`).
- Экспорт новых сущностей добавлен в `src/bioetl/domain/mapping/__init__.py` и добавлены unit-тесты `tests/unit/domain/mapping/test_organism_classification.py`.
- Минимальные форматные/импортные правки в существующих файлах для прохождения проектных проверок: `src/bioetl/infrastructure/config/base_config_loader.py` и `tests/unit/infrastructure/config/test_contract_policy_loader.py`.

### Testing
- Запуск юнит-тестов для новой функциональности: `uv run python -m pytest tests/unit/domain/mapping/test_organism_classification.py` — успешно (all tests passed).
- Локальный прогон полного тест-ранда: `uv run python -m pytest tests/ -x -q` — остановлен на e2e из-за внешней ошибки (ChEMBL returned HTTP 500) и не связан с внесёнными изменениями; см. лог ошибки `Exhausted 3 retry attempts ... 500 Internal Server Error`.
- Типизация: `uv run python -m mypy --strict src/bioetl/` — не проходит в текущом репозитории из-за pre-existing mypy-ошибок в других файлах (unrelated to this change).
- Форматирование/линтинг: `ruff` применялся автоматически для мелких исправлений (imports/format) в затронутых файлах; форматирование и import-order сейчас согласованы для добавленных файлов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc381d8888324be2b89b27b04dabb)