### PR TITLE
Add organism classification (taxonomy-first) with diagnostics

### DIFF
--- a/src/bioetl/__init__.py
+++ b/src/bioetl/__init__.py
@@ -10,7 +10,7 @@ __version__ = "6.0.0"
 try:
     import typing
 
-    import typing_inspect  # type: ignore[import-untyped,import-not-found]
+    import typing_inspect  # type: ignore[import-untyped]
 
     # Fix typing_inspect.get_origin BEFORE importing pandera backends
     _orig_get_origin = typing_inspect.get_origin

--- a/src/bioetl/domain/services/__init__.py
+++ b/src/bioetl/domain/services/__init__.py
@@ -41,6 +41,11 @@ from bioetl.domain.services.dq_serializer import DQReportSerializer
 from bioetl.domain.services.identity_service import IdentityService
 from bioetl.domain.services.normalization_config import NormalizationConfig
 from bioetl.domain.services.normalization_service import NormalizationService
+from bioetl.domain.services.organism_classification_service import (
+    OrganismClass,
+    OrganismClassificationResult,
+    classify_organism,
+)
 from bioetl.domain.services.text_similarity import jaccard_similarity, normalize_text
 from bioetl.domain.services.unit_converter import UnitConverter
 from bioetl.domain.services.value_validator import ValueValidator
@@ -59,8 +64,11 @@ __all__ = [
     "IdentityService",
     "NormalizationConfig",
     "NormalizationService",
+    "OrganismClass",
+    "OrganismClassificationResult",
     "UnitConverter",
     "ValueValidator",
+    "classify_organism",
     "jaccard_similarity",
     "normalize_text",
 ]

--- a/src/bioetl/domain/services/organism_classification_service.py
+++ b/src/bioetl/domain/services/organism_classification_service.py
@@ -1,0 +1,248 @@
+"""Organism classification service for assay biological context.
+
+Classifies organisms into acellular/unicellular/multicellular using
+NCBI taxonomy ID as primary source and normalized organism name as fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from re import sub
+from typing import Literal
+
+from bioetl.domain.value_objects import validate_taxonomy_id
+
+
+class OrganismClass(str, Enum):
+    """High-level organism classes used for assay context."""
+
+    ACELLULAR = "acellular"
+    UNICELLULAR = "unicellular"
+    MULTICELLULAR = "multicellular"
+
+
+@dataclass(frozen=True)
+class OrganismClassificationResult:
+    """Classification result with source and diagnostics."""
+
+    organism_class: OrganismClass | None
+    normalized_organism: str | None
+    taxonomy_id: int | None
+    source: Literal["taxonomy_id", "organism_name", "unresolved"]
+    source_conflict: bool
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class _AliasEntry:
+    canonical_name: str
+    organism_class: OrganismClass
+    taxonomy_id: int | None = None
+
+
+_TAXONOMY_CLASS_MAP: dict[int, OrganismClass] = {
+    562: OrganismClass.UNICELLULAR,
+    1280: OrganismClass.UNICELLULAR,
+    5476: OrganismClass.UNICELLULAR,
+    5833: OrganismClass.UNICELLULAR,
+    8005: OrganismClass.MULTICELLULAR,
+    3847: OrganismClass.MULTICELLULAR,
+    4530: OrganismClass.MULTICELLULAR,
+    9534: OrganismClass.MULTICELLULAR,
+    9606: OrganismClass.MULTICELLULAR,
+    10116: OrganismClass.MULTICELLULAR,
+    10710: OrganismClass.ACELLULAR,
+    11676: OrganismClass.ACELLULAR,
+    211044: OrganismClass.ACELLULAR,
+}
+
+_ALIAS_MAP: dict[str, _AliasEntry] = {
+    "hiv": _AliasEntry(
+        "human immunodeficiency virus 1", OrganismClass.ACELLULAR, 11676
+    ),
+    "rice": _AliasEntry(
+        "oryza sativa japonica group", OrganismClass.MULTICELLULAR, 4530
+    ),
+    "eel": _AliasEntry("anguilla japonica", OrganismClass.MULTICELLULAR, 8005),
+    "monkey": _AliasEntry("catarrhini", OrganismClass.MULTICELLULAR, 9534),
+}
+
+_NAME_CLASS_MAP: dict[str, OrganismClass] = {
+    "homo sapiens": OrganismClass.MULTICELLULAR,
+    "rattus norvegicus": OrganismClass.MULTICELLULAR,
+    "glycine max": OrganismClass.MULTICELLULAR,
+    "oryza sativa japonica group": OrganismClass.MULTICELLULAR,
+    "escherichia coli": OrganismClass.UNICELLULAR,
+    "staphylococcus aureus": OrganismClass.UNICELLULAR,
+    "candida albicans": OrganismClass.UNICELLULAR,
+    "plasmodium falciparum": OrganismClass.UNICELLULAR,
+    "streptococcus pneumoniae": OrganismClass.UNICELLULAR,
+    "human immunodeficiency virus 1": OrganismClass.ACELLULAR,
+    "influenza a virus": OrganismClass.ACELLULAR,
+    "enterobacteria phage lambda": OrganismClass.ACELLULAR,
+}
+
+
+def _normalize_organism_name(assay_organism: str | None) -> str | None:
+    if assay_organism is None:
+        return None
+
+    cleaned = sub(r"\([^)]*\)", " ", assay_organism).strip().lower()
+    normalized = " ".join(cleaned.split())
+    return normalized or None
+
+
+def _classify_by_taxonomy_id(taxonomy_id: int | None) -> OrganismClass | None:
+    if taxonomy_id is None:
+        return None
+    return _TAXONOMY_CLASS_MAP.get(taxonomy_id)
+
+
+def _lookup_alias_classification(
+    organism_name: str,
+) -> tuple[OrganismClass | None, str | None]:
+    alias = _ALIAS_MAP.get(organism_name)
+    if alias is None:
+        return None, None
+    return alias.organism_class, alias.canonical_name
+
+
+def _lookup_direct_name_classification(
+    organism_name: str,
+) -> tuple[OrganismClass | None, str]:
+    return _NAME_CLASS_MAP.get(organism_name), organism_name
+
+
+def _is_acellular_keyword_match(organism_name: str) -> bool:
+    return "virus" in organism_name or "phage" in organism_name
+
+
+def _lookup_binomial_class(organism_name: str) -> tuple[OrganismClass | None, str]:
+    tokens = organism_name.split()
+    if len(tokens) < 2:
+        return None, organism_name
+
+    binomial = f"{tokens[0]} {tokens[1]}"
+    return _NAME_CLASS_MAP.get(binomial), binomial
+
+
+def _lookup_name_based_classification(
+    organism_name: str,
+) -> tuple[OrganismClass | None, str | None]:
+    lookup_chain = (
+        _lookup_alias_classification,
+        _lookup_direct_name_classification,
+        _lookup_binomial_class,
+    )
+    for lookup in lookup_chain:
+        cls_result, normalized_name = lookup(organism_name)
+        if cls_result is not None:
+            return cls_result, normalized_name
+    return None, None
+
+
+def _classify_by_organism_name(
+    normalized_organism: str | None,
+) -> tuple[OrganismClass | None, str | None]:
+    if normalized_organism is None:
+        return None, None
+
+    resolved_class, resolved_name = _lookup_name_based_classification(
+        normalized_organism
+    )
+    if resolved_class is not None:
+        return resolved_class, resolved_name
+
+    if _is_acellular_keyword_match(normalized_organism):
+        return OrganismClass.ACELLULAR, normalized_organism
+
+    return None, normalized_organism
+
+
+def _build_taxonomy_result(
+    taxonomy_id: int,
+    taxonomy_class: OrganismClass | None,
+    normalized_organism: str | None,
+    source_conflict: bool,
+) -> OrganismClassificationResult:
+    if taxonomy_class is None:
+        return OrganismClassificationResult(
+            organism_class=None,
+            normalized_organism=normalized_organism,
+            taxonomy_id=taxonomy_id,
+            source="unresolved",
+            source_conflict=False,
+            reason="taxonomy_id_not_mapped",
+        )
+
+    return OrganismClassificationResult(
+        organism_class=taxonomy_class,
+        normalized_organism=normalized_organism,
+        taxonomy_id=taxonomy_id,
+        source="taxonomy_id",
+        source_conflict=source_conflict,
+        reason="taxonomy_id_classification",
+    )
+
+
+def _build_name_result(
+    name_class: OrganismClass | None,
+    normalized_organism: str | None,
+) -> OrganismClassificationResult:
+    if name_class is None:
+        return OrganismClassificationResult(
+            organism_class=None,
+            normalized_organism=normalized_organism,
+            taxonomy_id=None,
+            source="unresolved",
+            source_conflict=False,
+            reason="insufficient_or_unrecognized_input",
+        )
+
+    return OrganismClassificationResult(
+        organism_class=name_class,
+        normalized_organism=normalized_organism,
+        taxonomy_id=None,
+        source="organism_name",
+        source_conflict=False,
+        reason="organism_name_classification",
+    )
+
+
+def _has_source_conflict(
+    taxonomy_id: int | None,
+    taxonomy_class: OrganismClass | None,
+    name_class: OrganismClass | None,
+) -> bool:
+    return (
+        taxonomy_id is not None
+        and taxonomy_class is not None
+        and name_class is not None
+        and taxonomy_class != name_class
+    )
+
+
+def classify_organism(
+    assay_organism: str | None,
+    assay_taxonomy_id: int | str | None,
+) -> OrganismClassificationResult:
+    """Classify organism using taxonomy ID priority and name fallback."""
+    taxonomy_id = validate_taxonomy_id(assay_taxonomy_id)
+    normalized_organism = _normalize_organism_name(assay_organism)
+    taxonomy_class = _classify_by_taxonomy_id(taxonomy_id)
+    name_class, normalized_match = _classify_by_organism_name(normalized_organism)
+
+    if taxonomy_id is not None:
+        source_conflict = _has_source_conflict(taxonomy_id, taxonomy_class, name_class)
+        return _build_taxonomy_result(
+            taxonomy_id=taxonomy_id,
+            taxonomy_class=taxonomy_class,
+            normalized_organism=normalized_match,
+            source_conflict=source_conflict,
+        )
+
+    return _build_name_result(
+        name_class=name_class,
+        normalized_organism=normalized_match,
+    )

--- a/src/bioetl/infrastructure/config/base_config_loader.py
+++ b/src/bioetl/infrastructure/config/base_config_loader.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 import yaml
+
 from bioetl.infrastructure.config_merge import config_merge
 
 T = TypeVar("T")

--- a/src/bioetl/infrastructure/config/contract_policy_loader.py
+++ b/src/bioetl/infrastructure/config/contract_policy_loader.py
@@ -41,8 +41,7 @@ def load_pipeline_contract_policy(provider: str, entity: str) -> PipelineContrac
         contracts_section = unified_raw.get("contracts")
         if isinstance(contracts_section, dict):
             raw = {**base_defaults, **contracts_section}
-            result: PipelineContractPolicy = PipelineContractPolicy.model_validate(raw)
-            return result
+            return PipelineContractPolicy.model_validate(raw)
 
     legacy_path = (
         _CONFIGS_ROOT / "contracts" / "pipelines" / provider / f"{entity}.yaml"
@@ -58,5 +57,4 @@ def load_pipeline_contract_policy(provider: str, entity: str) -> PipelineContrac
 
     raw = legacy_raw
 
-    result: PipelineContractPolicy = PipelineContractPolicy.model_validate(raw)
-    return result
+    return PipelineContractPolicy.model_validate(raw)

--- a/src/bioetl/infrastructure/system/memory_monitor.py
+++ b/src/bioetl/infrastructure/system/memory_monitor.py
@@ -144,7 +144,7 @@ class MemoryMonitor:
         import resource
 
         # Get process memory usage (Unix-only attributes)
-        rusage = resource.getrusage(resource.RUSAGE_SELF)  # type: ignore[attr-defined]
+        rusage = resource.getrusage(resource.RUSAGE_SELF)
         process_mb = rusage.ru_maxrss / 1024  # Convert KB to MB on Linux
 
         # Try to read system memory from /proc/meminfo

--- a/tests/unit/domain/services/test_organism_classification_service.py
+++ b/tests/unit/domain/services/test_organism_classification_service.py
@@ -1,0 +1,65 @@
+"""Unit tests for organism classification service."""
+
+from bioetl.domain.services import (
+    OrganismClass,
+    classify_organism,
+)
+
+
+def test_classify_with_taxonomy_priority_multicellular() -> None:
+    result = classify_organism("Homo sapiens", 9606)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+    assert result.taxonomy_id == 9606
+    assert result.source_conflict is False
+
+
+def test_classify_acellular_virus_and_phage() -> None:
+    hiv = classify_organism("hiv", 11676)
+    phage = classify_organism("Enterobacteria phage lambda", 10710)
+
+    assert hiv.organism_class == OrganismClass.ACELLULAR
+    assert phage.organism_class == OrganismClass.ACELLULAR
+
+
+def test_classify_unicellular_microorganisms() -> None:
+    ecoli = classify_organism("Escherichia coli", 562)
+    candida = classify_organism("Candida albicans", 5476)
+
+    assert ecoli.organism_class == OrganismClass.UNICELLULAR
+    assert candida.organism_class == OrganismClass.UNICELLULAR
+
+
+def test_alias_lookup_without_taxonomy_id() -> None:
+    hiv = classify_organism("HiV", None)
+    rice = classify_organism("  rice  ", None)
+    monkey = classify_organism("monkey", None)
+
+    assert hiv.organism_class == OrganismClass.ACELLULAR
+    assert hiv.source == "organism_name"
+    assert rice.organism_class == OrganismClass.MULTICELLULAR
+    assert monkey.organism_class == OrganismClass.MULTICELLULAR
+
+
+def test_conflict_prefers_taxonomy_id_and_sets_flag() -> None:
+    result = classify_organism("Escherichia coli", 9606)
+
+    assert result.organism_class == OrganismClass.MULTICELLULAR
+    assert result.source == "taxonomy_id"
+    assert result.source_conflict is True
+
+
+def test_handles_strain_names_and_parentheses_normalization() -> None:
+    result = classify_organism("Plasmodium falciparum 3D7 (lab strain)", None)
+
+    assert result.organism_class == OrganismClass.UNICELLULAR
+    assert result.normalized_organism == "plasmodium falciparum"
+
+
+def test_invalid_input_unresolved() -> None:
+    result = classify_organism("", "invalid")
+
+    assert result.organism_class is None
+    assert result.source == "unresolved"
+    assert result.reason == "insufficient_or_unrecognized_input"

--- a/tests/unit/infrastructure/config/test_contract_policy_loader.py
+++ b/tests/unit/infrastructure/config/test_contract_policy_loader.py
@@ -67,9 +67,7 @@ def test_load_contracts_from_legacy_path_fallback(
     load_pipeline_contract_policy.cache_clear()
     monkeypatch.chdir(tmp_path)
 
-    contracts_dir = (
-        tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
-    )
+    contracts_dir = tmp_path / "configs" / "contracts" / "pipelines" / "test_provider"
     contracts_dir.mkdir(parents=True)
     (contracts_dir / "test_entity.yaml").write_text(
         yaml.safe_dump(


### PR DESCRIPTION
### Motivation
- Реализовать детерминированную классификацию организмов для полей `assay_organism` + `assay_taxonomy_id` в доменном слое (категории: `acellular` / `unicellular` / `multicellular`) с приоритетом `taxonomy_id` и диагностикой конфликтов источников. 
- Поддержать нормализацию имен, алиасы и простую расширяемую таблицу соответствий без внешних HTTP-вызовов и с полной типизацией публичного API. 

### Description
- Добавлен доменный сервис `classify_organism` в `src/bioetl/domain/services/organism_classification_service.py` с контрактом `OrganismClass` (Enum) и `OrganismClassificationResult` (frozen `dataclass`) и вспомогательными lookup/normalize-функциями. 
- Реализована логика: `assay_taxonomy_id` → map; при отсутствии валидного `taxonomy_id` — normalize `assay_organism` + alias/dictionary lookup + binomial fallback + keyword rule для вирусов/фагов; при конфликте помечается `source_conflict=True`. 
- Экспорт нового API через `bioetl.domain.services.__init__` для удобного импорта (`OrganismClass`, `OrganismClassificationResult`, `classify_organism`). 
- Добавлены unit-тесты `tests/unit/domain/services/test_organism_classification_service.py`, покрывающие требования (viruses/phage, bacteria/fungi, multicellular, aliases, conflicts, invalid input). 
- Небольшие вспомогательные правки для прохождения репозиторных проверок: упрощён возврат валидированных моделей в `contract_policy_loader`, мелкие формат/типографические правки в `base_config_loader` и `memory_monitor` (убраны/упрощены проблемные комменты), чтобы `mypy`/`ruff`/`isort` проходили. 

### Testing
- Выполнены unit-тесты для нового сервиса: `uv run python -m pytest tests/unit/domain/services/test_organism_classification_service.py` — успешно. 
- Архитектурный тест сложности функций: `uv run python -m pytest tests/architecture/test_code_metrics.py::TestFunctionComplexity::test_domain_complexity` — успешно (функции в домене в рамках CC limit). 
- Строгая типизация: `uv run python -m mypy --strict src/bioetl/` — успешно. 
- Форматирование/импорт-стиль: `uv run python -m ruff format --check src tests` и `uv run python -m ruff check --select I src tests` — успешно после авто-форматирования/фиксинга затронутых файлов. 
- Полный тестовый прогон: `uv run python -m pytest tests/ -x -q` — большинство тестов прошло; один E2E упал из-за внешнего `500 Internal Server Error` от ChEMBL API при запросе (вне области изменений классификатора) и отмечен как внешний/не относящийся к этой реализации.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc381d8888324be2b89b27b04dabb)