### PR TITLE
docs(diagrams): add Mermaid template and architecture metadata headers

### DIFF
--- a/docs/02-architecture/mmd-diagrams/_template.mmd
+++ b/docs/02-architecture/mmd-diagrams/_template.mmd
@@ -1,0 +1,30 @@
+%% <TITLE — one-line description>
+%% <COVERS — what architectural aspect>
+
+%% @version 1.0.0
+%% @date <YYYY-MM-DD>
+%% @type <flowchart|classDiagram|sequenceDiagram|stateDiagram|erDiagram|mindmap|legend>
+%% @level <System / Component|Class|Sequence|State>
+%% @status <active|superseded|draft>
+%% @view <overview|detail|full> (для декомпозированных файлов)
+%% @parent <original-file.mmd> (для декомпозированных файлов)
+%% @nodes <approximate count>
+%% @adr <related ADR numbers>
+%%
+%% NOTE: Styles applied via theme/mermaid-config.json + theme/custom.css
+%% Do NOT add %%{init:} blocks — use render.sh for consistent theming.
+%% Colour scheme: see README.md § Colour Scheme
+
+flowchart TD
+%% === NODES ===
+
+%% === LINKS ===
+
+%% === SUBGRAPH STYLES ===
+%% Use ONLY approved colours from theme/custom.css:
+%% style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+%% style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+%% style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+%% style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px
+%% style Interfaces fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+%% style External fill:#eceff1,stroke:#455a64,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/01-high-level-hexagonal.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/01-high-level-hexagonal.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~39
 
 graph TB
     subgraph External["External Systems"]

--- a/docs/02-architecture/mmd-diagrams/architecture/02-layer-dependency-matrix.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/02-layer-dependency-matrix.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~7
 
 graph LR
     subgraph Legend

--- a/docs/02-architecture/mmd-diagrams/architecture/03-medallion-data-flow.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/03-medallion-data-flow.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~36
 
 graph LR
     subgraph Sources["External Data Sources"]

--- a/docs/02-architecture/mmd-diagrams/architecture/04-pipeline-execution-flow.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/04-pipeline-execution-flow.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    sequenceDiagram
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~12
 
 sequenceDiagram
     participant CLI as CLI / Interfaces

--- a/docs/02-architecture/mmd-diagrams/architecture/05-provider-adapter-hierarchy.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/05-provider-adapter-hierarchy.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~27
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/06-storage-layer.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/06-storage-layer.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~21
 
 graph TB
     subgraph Port["Domain Port"]

--- a/docs/02-architecture/mmd-diagrams/architecture/07-dq-system.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/07-dq-system.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~22
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/08-composite-pipeline.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/08-composite-pipeline.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~35
 
 graph TB
     subgraph Config["Composite Configuration"]

--- a/docs/02-architecture/mmd-diagrams/architecture/09-observability-stack.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/09-observability-stack.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~24
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/10-resilience-patterns.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/10-resilience-patterns.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~21
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/11-configuration-system.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/11-configuration-system.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~29
 
 graph TB
     subgraph YAML["YAML Config Files"]

--- a/docs/02-architecture/mmd-diagrams/architecture/12-bootstrap-di-container.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/12-bootstrap-di-container.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~29
 
 graph TB
     subgraph Entry["Entry Points"]

--- a/docs/02-architecture/mmd-diagrams/architecture/13-port-protocol-contracts.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13-port-protocol-contracts.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~68
 
 graph LR
     subgraph Domain["Domain Ports (Protocols)"]

--- a/docs/02-architecture/mmd-diagrams/architecture/14-cli-interface-layer.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/14-cli-interface-layer.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~24
 
 graph TB
     subgraph User["User"]

--- a/docs/02-architecture/mmd-diagrams/architecture/15-batch-executor-internals.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/15-batch-executor-internals.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~15
 
 graph TB
     subgraph BatchExecutor["BatchExecutor"]

--- a/docs/02-architecture/mmd-diagrams/architecture/16-transformer-hierarchy.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/16-transformer-hierarchy.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~35
 
 graph TB
     subgraph TemplateMethod["Template Method Pattern"]

--- a/docs/02-architecture/mmd-diagrams/architecture/17-security-pii-audit.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/17-security-pii-audit.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~16
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/18-lock-checkpoint-shutdown.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/18-lock-checkpoint-shutdown.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   ~22
 
 graph TB
     subgraph Ports["Domain Ports"]


### PR DESCRIPTION
### Motivation
- Standardize Mermaid `.mmd` diagram metadata and guidance so subsequent decomposition, styling and CI linting operate from a single canonical template.
- Surface diagram status and approximate node counts in `architecture/` diagrams to drive the View-based decomposition and automated SIZE checks.
- Preserve existing theming workflow (external `theme/mermaid-config.json` + `theme/custom.css`) and avoid embedding `%%{init:}` blocks in new files.

### Description
- Added `docs/02-architecture/mmd-diagrams/_template.mmd` containing the canonical metadata block (`@version`, `@date`, `@type`, `@level`, `@status`, `@view`, `@parent`, `@nodes`, `@adr`) and subgraph/style guidance while explicitly advising against `%%{init:}` blocks.
- Updated all `docs/02-architecture/mmd-diagrams/architecture/*.mmd` (18 files) to insert `%% @status  active` and `%% @nodes   ~<count>` immediately after the existing `%% @level` header, preserving existing `@version`, `@date`, `@type`, and `@level` values.
- Did not modify `foundation/` or `class-diagrams/` content, and left any legacy `%%{init:}` blocks intact as per policy; no rendering pipeline changes were made in this PR.

### Testing
- Executed the node-count heuristic across the updated `architecture/` files using `for f in docs/02-architecture/mmd-diagrams/architecture/*.mmd; do count=$(grep -cP '^\s+\w+[\[\(\{>]' "$f" 2>/dev/null || echo 0); echo "$f: ~$count nodes"; done`, which produced the approximate counts used for `%% @nodes`.
- Ran a Python verification script that asserted each modified architecture file contains `%% @status` and `%% @nodes`, and the assertions passed for all 18 files.
- Ran repository pre-commit hooks as part of commit validation which failed on unrelated environment/repo checks (missing `pip-audit` executable and existing root-level VCR cassette guard failures for files: `test_chembl_activity_full_run`, `test_pipeline_idempotency`, `test_pipeline_resume_after_failure`, `test_pubchem_compound_pipeline`); these failures are unrelated to the documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2d1d85308324a4d5a085f1df15c2)