### PR TITLE
docs(diagrams): add template and decompose CRITICAL diagrams into Views [ADR-040]

### DIFF
--- a/docs/02-architecture/mmd-diagrams/README.md
+++ b/docs/02-architecture/mmd-diagrams/README.md
@@ -5,51 +5,51 @@
 All diagrams are in [Mermaid](https://mermaid.js.org/) format (`.mmd` files).
 Render them with any Mermaid-compatible viewer, IDE plugin, or the [Mermaid Live Editor](https://mermaid.live/).
 
----
+______________________________________________________________________
 
 ## Architecture Diagrams (18)
 
-| # | Diagram | File | Description |
-|---|---------|------|-------------|
-| 1 | High-Level Hexagonal Architecture | `architecture/01-high-level-hexagonal.mmd` | Full system overview: layers, external systems, dependency directions |
-| 2 | Layer Dependency Matrix | `architecture/02-layer-dependency-matrix.mmd` | ARCH-001 import boundary enforcement |
-| 3 | Medallion Data Flow | `architecture/03-medallion-data-flow.mmd` | Bronze → Silver → Gold pipeline with DQ and quarantine |
-| 4 | Pipeline Execution Flow | `architecture/04-pipeline-execution-flow.mmd` | Sequence diagram: preflight → lock → execute → postrun → cleanup |
-| 5 | Provider Adapter Hierarchy | `architecture/05-provider-adapter-hierarchy.mmd` | All 7 provider adapters, base classes, mixins, decorators |
-| 6 | Storage Layer | `architecture/06-storage-layer.mmd` | Bronze/Silver/Gold writers, Delta Lake, metadata, validation |
-| 7 | Data Quality System | `architecture/07-dq-system.mmd` | DQ monitoring, analysis, anomaly detection, reporting |
-| 8 | Composite Pipeline | `architecture/08-composite-pipeline.mmd` | Seed → dependencies → enrichers (parallel) → merge with FSM |
-| 9 | Observability Stack | `architecture/09-observability-stack.mmd` | Logging, metrics, tracing: ports and implementations |
-| 10 | Resilience Patterns | `architecture/10-resilience-patterns.mmd` | Circuit breaker, rate limiter, retry, health checks |
-| 11 | Configuration System | `architecture/11-configuration-system.mmd` | YAML configs → loaders → Pydantic schemas → domain config |
-| 12 | Bootstrap / DI Container | `architecture/12-bootstrap-di-container.mmd` | Composition root: factories, assembly, wiring |
-| 13 | Port/Protocol Contracts | `architecture/13-port-protocol-contracts.mmd` | All 29 domain ports mapped to their implementations |
-| 14 | CLI / Interface Layer | `architecture/14-cli-interface-layer.mmd` | CLI commands, routing to application services |
-| 15 | BatchExecutor Internals | `architecture/15-batch-executor-internals.mmd` | Executor composition: transformer, writer, memory, metrics |
-| 16 | Transformer Hierarchy | `architecture/16-transformer-hierarchy.mmd` | Template Method pattern, all provider transformers, extractors |
-| 17 | Security, PII & Audit | `architecture/17-security-pii-audit.mmd` | PII hashing, salt rotation, audit trail |
-| 18 | Lock, Checkpoint & Shutdown | `architecture/18-lock-checkpoint-shutdown.mmd` | Fencing tokens, safety guard, graceful shutdown |
+| #   | Diagram                           | File                                             | Description                                                           |
+| --- | --------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| 1   | High-Level Hexagonal Architecture | `architecture/01-high-level-hexagonal.mmd`       | Full system overview: layers, external systems, dependency directions |
+| 2   | Layer Dependency Matrix           | `architecture/02-layer-dependency-matrix.mmd`    | ARCH-001 import boundary enforcement                                  |
+| 3   | Medallion Data Flow               | `architecture/03-medallion-data-flow.mmd`        | Bronze → Silver → Gold pipeline with DQ and quarantine                |
+| 4   | Pipeline Execution Flow           | `architecture/04-pipeline-execution-flow.mmd`    | Sequence diagram: preflight → lock → execute → postrun → cleanup      |
+| 5   | Provider Adapter Hierarchy        | `architecture/05-provider-adapter-hierarchy.mmd` | All 7 provider adapters, base classes, mixins, decorators             |
+| 6   | Storage Layer                     | `architecture/06-storage-layer.mmd`              | Bronze/Silver/Gold writers, Delta Lake, metadata, validation          |
+| 7   | Data Quality System               | `architecture/07-dq-system.mmd`                  | DQ monitoring, analysis, anomaly detection, reporting                 |
+| 8   | Composite Pipeline                | `architecture/08-composite-pipeline.mmd`         | Seed → dependencies → enrichers (parallel) → merge with FSM           |
+| 9   | Observability Stack               | `architecture/09-observability-stack.mmd`        | Logging, metrics, tracing: ports and implementations                  |
+| 10  | Resilience Patterns               | `architecture/10-resilience-patterns.mmd`        | Circuit breaker, rate limiter, retry, health checks                   |
+| 11  | Configuration System              | `architecture/11-configuration-system.mmd`       | YAML configs → loaders → Pydantic schemas → domain config             |
+| 12  | Bootstrap / DI Container          | `architecture/12-bootstrap-di-container.mmd`     | Composition root: factories, assembly, wiring                         |
+| 13  | Port/Protocol Contracts           | `architecture/13-port-protocol-contracts.mmd`    | All 29 domain ports mapped to their implementations                   |
+| 14  | CLI / Interface Layer             | `architecture/14-cli-interface-layer.mmd`        | CLI commands, routing to application services                         |
+| 15  | BatchExecutor Internals           | `architecture/15-batch-executor-internals.mmd`   | Executor composition: transformer, writer, memory, metrics            |
+| 16  | Transformer Hierarchy             | `architecture/16-transformer-hierarchy.mmd`      | Template Method pattern, all provider transformers, extractors        |
+| 17  | Security, PII & Audit             | `architecture/17-security-pii-audit.mmd`         | PII hashing, salt rotation, audit trail                               |
+| 18  | Lock, Checkpoint & Shutdown       | `architecture/18-lock-checkpoint-shutdown.mmd`   | Fencing tokens, safety guard, graceful shutdown                       |
 
 ## Class Diagrams (16 families)
 
-| # | Family | File | Description |
-|---|--------|------|-------------|
-| 1 | Domain Ports | `class-diagrams/01-domain-ports.mmd` | All 29 Protocol interfaces with method signatures |
-| 2 | Entities & Aggregates | `class-diagrams/02-entities-aggregates.mmd` | BaseEntity, Batch, PipelineRun, BatchRecord |
-| 3 | Value Objects | `class-diagrams/03-value-objects.mmd` | BronzeWriteResult, SilverWriteResult, FencingToken, etc. |
-| 4 | Types & Enums | `class-diagrams/04-types-enums.mmd` | RunType, PublicationType, HealthStatus, NewTypes |
-| 5 | Exceptions | `class-diagrams/05-exceptions.mmd` | BioETLError hierarchy: Critical, Recoverable, DataQuality |
-| 6 | Configuration | `class-diagrams/06-config-classes.mmd` | PipelineConfig, RuntimeConfig, CompositeConfig |
-| 7 | Application Core | `class-diagrams/07-application-core-services.mmd` | PipelineRunner, BatchExecutor, LockManager |
-| 8 | Application Services | `class-diagrams/08-application-services.mmd` | DQ, Health, Export, Vacuum, Quarantine services |
-| 9 | Transformers | `class-diagrams/09-transformers.mmd` | BaseTransformer → ChEMBL/Publication/UniProt/PubChem |
-| 10 | Adapters | `class-diagrams/10-adapters.mmd` | BaseHttpAdapter, all provider adapters, resilience |
-| 11 | Storage | `class-diagrams/11-storage.mmd` | BronzeWriter, SilverWriter, GoldWriter, DeltaReader |
-| 12 | Composite Pipeline | `class-diagrams/12-composite-pipeline.mmd` | Runner, coordinators, merger, FSM |
-| 13 | Domain Services | `class-diagrams/13-domain-services.mmd` | IdentityService, Normalization, UnitConverter |
-| 14 | Observability | `class-diagrams/14-observability.mmd` | Logger, Metrics, Tracing implementations |
-| 15 | Extractors | `class-diagrams/15-extractors.mmd` | BaseFieldExtractor, PubMed & UniProt extractors |
-| 16 | Factories & Bootstrap | `class-diagrams/16-factories-bootstrap.mmd` | DataSourceRegistry, TransformerFactory, RunnerBuilder |
+| #   | Family                | File                                              | Description                                               |
+| --- | --------------------- | ------------------------------------------------- | --------------------------------------------------------- |
+| 1   | Domain Ports          | `class-diagrams/01-domain-ports.mmd`              | All 29 Protocol interfaces with method signatures         |
+| 2   | Entities & Aggregates | `class-diagrams/02-entities-aggregates.mmd`       | BaseEntity, Batch, PipelineRun, BatchRecord               |
+| 3   | Value Objects         | `class-diagrams/03-value-objects.mmd`             | BronzeWriteResult, SilverWriteResult, FencingToken, etc.  |
+| 4   | Types & Enums         | `class-diagrams/04-types-enums.mmd`               | RunType, PublicationType, HealthStatus, NewTypes          |
+| 5   | Exceptions            | `class-diagrams/05-exceptions.mmd`                | BioETLError hierarchy: Critical, Recoverable, DataQuality |
+| 6   | Configuration         | `class-diagrams/06-config-classes.mmd`            | PipelineConfig, RuntimeConfig, CompositeConfig            |
+| 7   | Application Core      | `class-diagrams/07-application-core-services.mmd` | PipelineRunner, BatchExecutor, LockManager                |
+| 8   | Application Services  | `class-diagrams/08-application-services.mmd`      | DQ, Health, Export, Vacuum, Quarantine services           |
+| 9   | Transformers          | `class-diagrams/09-transformers.mmd`              | BaseTransformer → ChEMBL/Publication/UniProt/PubChem      |
+| 10  | Adapters              | `class-diagrams/10-adapters.mmd`                  | BaseHttpAdapter, all provider adapters, resilience        |
+| 11  | Storage               | `class-diagrams/11-storage.mmd`                   | BronzeWriter, SilverWriter, GoldWriter, DeltaReader       |
+| 12  | Composite Pipeline    | `class-diagrams/12-composite-pipeline.mmd`        | Runner, coordinators, merger, FSM                         |
+| 13  | Domain Services       | `class-diagrams/13-domain-services.mmd`           | IdentityService, Normalization, UnitConverter             |
+| 14  | Observability         | `class-diagrams/14-observability.mmd`             | Logger, Metrics, Tracing implementations                  |
+| 15  | Extractors            | `class-diagrams/15-extractors.mmd`                | BaseFieldExtractor, PubMed & UniProt extractors           |
+| 16  | Factories & Bootstrap | `class-diagrams/16-factories-bootstrap.mmd`       | DataSourceRegistry, TransformerFactory, RunnerBuilder     |
 
 ## Foundation Diagrams (59)
 
@@ -57,79 +57,108 @@ Historical/foundational diagrams consolidated from `docs/02-architecture/diagram
 
 ### Foundation 01–25
 
-| # | File | Description |
-|---|------|-------------|
-| 01a | `foundation/01-full-system-component.mmd` | Full system component diagram (C4-style) |
-| 01b | `foundation/01-high-level.mmd` | High-level system overview |
-| 02a | `foundation/02-full-medallion-data-flow.mmd` | Medallion architecture data flow (detailed) |
-| 02b | `foundation/02-medallion.mmd` | Medallion architecture (simplified) |
-| 03a | `foundation/03-pipeline-execution-happy-path.mmd` | Pipeline execution sequence (happy path) |
-| 03b | `foundation/03-pipeline-sequence.mmd` | Pipeline sequence diagram |
-| 04a | `foundation/04-domain-layer-class-diagram.mmd` | Domain layer ports, entities, config |
-| 04b | `foundation/04-error-flow.mmd` | Error handling flow |
-| 05a | `foundation/05-layers-interaction.mmd` | Layer interaction diagram |
-| 05b | `foundation/05-locking.mmd` | Locking mechanism |
-| 05c | `foundation/05-pipeline-lifecycle-states.mmd` | Pipeline state machine |
-| 06a | `foundation/06-application-layer-class-diagram.mmd` | Application layer classes |
-| 06b | `foundation/06-pipeline-execution.mmd` | Pipeline execution flow |
-| 07a | `foundation/07-circuit-breaker-states.mmd` | Circuit breaker state machine |
-| 07b | `foundation/07-medallion-flow.mmd` | Medallion data flow |
-| 08a | `foundation/08-complete-etl-workflow.mmd` | Complete ETL workflow |
-| 08b | `foundation/08-domain-ddd.mmd` | Domain-driven design diagram |
-| 09 | `foundation/09-full-er-diagram.mmd` | Entity-relationship diagram |
-| 10 | `foundation/10-infrastructure-layer-class-diagram.mmd` | Infrastructure layer classes |
-| 11 | `foundation/11-lock-acquisition-sequence.mmd` | Lock acquisition sequence |
-| 12 | `foundation/12-local-deployment-architecture.mmd` | Local deployment architecture (ADR-010) |
-| 13 | `foundation/13-domain-models-relationship.mmd` | Domain model relationships |
-| 14 | `foundation/14-provider-health-states.mmd` | Provider health states |
-| 15 | `foundation/15-dq-check-workflow.mmd` | Data quality check workflow |
-| 16 | `foundation/16-memory-lock-class.mmd` | MemoryLock class diagram |
-| 17 | `foundation/17-pipeline-hierarchy.mmd` | Pipeline/Transformer hierarchy |
-| 18 | `foundation/18-bronze-write-sequence.mmd` | Bronze write sequence |
-| 19 | `foundation/19-delta-lake-write-sequence.mmd` | Delta Lake write sequence |
-| 20 | `foundation/20-quarantine-record-states.mmd` | Quarantine record states |
-| 21 | `foundation/21-activity-entity-data-flow.mmd` | Activity entity data flow |
-| 22 | `foundation/22-client-api-request-sequence.mmd` | Client API request sequence |
-| 23 | `foundation/23-silver-writer-class.mmd` | SilverWriter class diagram |
-| 24 | `foundation/24-hash-service-class.mmd` | Hash service class diagram |
-| 25 | `foundation/25-circuit-breaker-observer-class.mmd` | CircuitBreaker class diagram |
+| #   | File                                                   | Description                                 |
+| --- | ------------------------------------------------------ | ------------------------------------------- |
+| 01a | `foundation/01-full-system-component.mmd`              | Full system component diagram (C4-style)    |
+| 01b | `foundation/01-high-level.mmd`                         | High-level system overview                  |
+| 02a | `foundation/02-full-medallion-data-flow.mmd`           | Medallion architecture data flow (detailed) |
+| 02b | `foundation/02-medallion.mmd`                          | Medallion architecture (simplified)         |
+| 03a | `foundation/03-pipeline-execution-happy-path.mmd`      | Pipeline execution sequence (happy path)    |
+| 03b | `foundation/03-pipeline-sequence.mmd`                  | Pipeline sequence diagram                   |
+| 04a | `foundation/04-domain-layer-class-diagram.mmd`         | Domain layer ports, entities, config        |
+| 04b | `foundation/04-error-flow.mmd`                         | Error handling flow                         |
+| 05a | `foundation/05-layers-interaction.mmd`                 | Layer interaction diagram                   |
+| 05b | `foundation/05-locking.mmd`                            | Locking mechanism                           |
+| 05c | `foundation/05-pipeline-lifecycle-states.mmd`          | Pipeline state machine                      |
+| 06a | `foundation/06-application-layer-class-diagram.mmd`    | Application layer classes                   |
+| 06b | `foundation/06-pipeline-execution.mmd`                 | Pipeline execution flow                     |
+| 07a | `foundation/07-circuit-breaker-states.mmd`             | Circuit breaker state machine               |
+| 07b | `foundation/07-medallion-flow.mmd`                     | Medallion data flow                         |
+| 08a | `foundation/08-complete-etl-workflow.mmd`              | Complete ETL workflow                       |
+| 08b | `foundation/08-domain-ddd.mmd`                         | Domain-driven design diagram                |
+| 09  | `foundation/09-full-er-diagram.mmd`                    | Entity-relationship diagram                 |
+| 10  | `foundation/10-infrastructure-layer-class-diagram.mmd` | Infrastructure layer classes                |
+| 11  | `foundation/11-lock-acquisition-sequence.mmd`          | Lock acquisition sequence                   |
+| 12  | `foundation/12-local-deployment-architecture.mmd`      | Local deployment architecture (ADR-010)     |
+| 13  | `foundation/13-domain-models-relationship.mmd`         | Domain model relationships                  |
+| 14  | `foundation/14-provider-health-states.mmd`             | Provider health states                      |
+| 15  | `foundation/15-dq-check-workflow.mmd`                  | Data quality check workflow                 |
+| 16  | `foundation/16-memory-lock-class.mmd`                  | MemoryLock class diagram                    |
+| 17  | `foundation/17-pipeline-hierarchy.mmd`                 | Pipeline/Transformer hierarchy              |
+| 18  | `foundation/18-bronze-write-sequence.mmd`              | Bronze write sequence                       |
+| 19  | `foundation/19-delta-lake-write-sequence.mmd`          | Delta Lake write sequence                   |
+| 20  | `foundation/20-quarantine-record-states.mmd`           | Quarantine record states                    |
+| 21  | `foundation/21-activity-entity-data-flow.mmd`          | Activity entity data flow                   |
+| 22  | `foundation/22-client-api-request-sequence.mmd`        | Client API request sequence                 |
+| 23  | `foundation/23-silver-writer-class.mmd`                | SilverWriter class diagram                  |
+| 24  | `foundation/24-hash-service-class.mmd`                 | Hash service class diagram                  |
+| 25  | `foundation/25-circuit-breaker-observer-class.mmd`     | CircuitBreaker class diagram                |
 
 ### Foundation 26–50 (TOP-25 Architecture)
 
-| # | File | Type | Description |
-|---|------|------|-------------|
-| 26 | `foundation/26-hexagonal-ports-adapters.mmd` | flowchart | Hexagonal Architecture — all 24 ports mapped to adapters |
-| 27 | `foundation/27-import-matrix-enforcement.mmd` | flowchart | ARCH-001 Import Matrix — 5-layer dependency rules |
-| 28 | `foundation/28-composition-root-di-graph.mmd` | flowchart | Composition Root DI Graph — full DI assembly |
-| 29 | `foundation/29-composite-pipeline-workflow.mmd` | sequence | Composite Pipeline (ADR-026) — Seed→Deps→FanOut→Merge→Gold |
-| 30 | `foundation/30-port-adapter-mapping.mmd` | flowchart | Port → Adapter Reference — all 24 ports |
-| 31 | `foundation/31-pipeline-run-lifecycle.mmd` | state | PipelineRun Aggregate FSM |
-| 32 | `foundation/32-single-record-journey.mmd` | flowchart | Single Record Journey — API→Bronze→Transform→Silver→Gold |
-| 33 | `foundation/33-cli-run-interaction.mmd` | sequence | CLI → PipelineRunnerService interaction |
-| 34 | `foundation/34-batch-processing-flow.mmd` | sequence | Batch Processing — BatchExecutor cycle |
-| 35 | `foundation/35-bootstrap-sequence.mmd` | sequence | Bootstrap 9-step Sequence |
-| 36 | `foundation/36-architecture-principles-mindmap.mmd` | mindmap | Architecture Principles Mindmap |
-| 37 | `foundation/37-cli-entry-full-chain.mmd` | sequence | CLI Entry → Exit Code full chain |
-| 38 | `foundation/38-runtime-assembly-sequence.mmd` | sequence | Runtime Assembly — phases 1–8 |
-| 39 | `foundation/39-medallion-invariants.mmd` | flowchart | Medallion Invariants — ARCH-007 RunType clear policy |
-| 40 | `foundation/40-application-core-collaboration.mmd` | flowchart | Application Core — PipelineRunner orchestrating services |
-| 41 | `foundation/41-error-classification-tree.mmd` | flowchart | Error Classification — HTTP→Domain→Actions |
-| 42 | `foundation/42-pipeline-runner-class.mmd` | class | PipelineRunner Class — all 14 DI dependencies |
-| 43 | `foundation/43-fan-out-fan-in-pattern.mmd` | sequence | Fan-Out/Fan-In — asyncio.gather parallel enrichment |
-| 44 | `foundation/44-cross-provider-enrichment.mmd` | flowchart | Cross-Provider Enrichment — 5-provider publication flow |
-| 45 | `foundation/45-template-method-transformer.mmd` | class | Template Method Pattern — BaseTransformer hierarchy |
-| 46 | `foundation/46-yaml-config-resolution.mmd` | flowchart | YAML Config Resolution — hierarchical merge |
-| 47 | `foundation/47-publication-merge-sources.mmd` | sequence | Publication Composite — multi-source merge |
-| 48 | `foundation/48-composite-phase-lifecycle.mmd` | state | Composite Pipeline FSM — 10-state lifecycle |
-| 49 | `foundation/49-composite-runner-class.mmd` | class | CompositePipelineRunner — component diagram |
-| 50 | `foundation/50-exception-hierarchy.mmd` | flowchart | Exception Hierarchy — BioETLError full tree |
+| #   | File                                                | Type      | Description                                                |
+| --- | --------------------------------------------------- | --------- | ---------------------------------------------------------- |
+| 26  | `foundation/26-hexagonal-ports-adapters.mmd`        | flowchart | Hexagonal Architecture — all 24 ports mapped to adapters   |
+| 27  | `foundation/27-import-matrix-enforcement.mmd`       | flowchart | ARCH-001 Import Matrix — 5-layer dependency rules          |
+| 28  | `foundation/28-composition-root-di-graph.mmd`       | flowchart | Composition Root DI Graph — full DI assembly               |
+| 29  | `foundation/29-composite-pipeline-workflow.mmd`     | sequence  | Composite Pipeline (ADR-026) — Seed→Deps→FanOut→Merge→Gold |
+| 30  | ~~`foundation/30-port-adapter-mapping.mmd`~~        | flowchart | Superseded by `architecture/13a-13d-port-contracts-*.mmd`  |
+| 31  | `foundation/31-pipeline-run-lifecycle.mmd`          | state     | PipelineRun Aggregate FSM                                  |
+| 32  | `foundation/32-single-record-journey.mmd`           | flowchart | Single Record Journey — API→Bronze→Transform→Silver→Gold   |
+| 33  | `foundation/33-cli-run-interaction.mmd`             | sequence  | CLI → PipelineRunnerService interaction                    |
+| 34  | `foundation/34-batch-processing-flow.mmd`           | sequence  | Batch Processing — BatchExecutor cycle                     |
+| 35  | `foundation/35-bootstrap-sequence.mmd`              | sequence  | Bootstrap 9-step Sequence                                  |
+| 36  | `foundation/36-architecture-principles-mindmap.mmd` | mindmap   | Architecture Principles Mindmap                            |
+| 37  | `foundation/37-cli-entry-full-chain.mmd`            | sequence  | CLI Entry → Exit Code full chain                           |
+| 38  | `foundation/38-runtime-assembly-sequence.mmd`       | sequence  | Runtime Assembly — phases 1–8                              |
+| 39  | `foundation/39-medallion-invariants.mmd`            | flowchart | Medallion Invariants — ARCH-007 RunType clear policy       |
+| 40  | `foundation/40-application-core-collaboration.mmd`  | flowchart | Application Core — PipelineRunner orchestrating services   |
+| 41  | `foundation/41-error-classification-tree.mmd`       | flowchart | Error Classification — HTTP→Domain→Actions                 |
+| 42  | `foundation/42-pipeline-runner-class.mmd`           | class     | PipelineRunner Class — all 14 DI dependencies              |
+| 43  | `foundation/43-fan-out-fan-in-pattern.mmd`          | sequence  | Fan-Out/Fan-In — asyncio.gather parallel enrichment        |
+| 44  | `foundation/44-cross-provider-enrichment.mmd`       | flowchart | Cross-Provider Enrichment — 5-provider publication flow    |
+| 45  | `foundation/45-template-method-transformer.mmd`     | class     | Template Method Pattern — BaseTransformer hierarchy        |
+| 46  | `foundation/46-yaml-config-resolution.mmd`          | flowchart | YAML Config Resolution — hierarchical merge                |
+| 47  | `foundation/47-publication-merge-sources.mmd`       | sequence  | Publication Composite — multi-source merge                 |
+| 48  | `foundation/48-composite-phase-lifecycle.mmd`       | state     | Composite Pipeline FSM — 10-state lifecycle                |
+| 49  | `foundation/49-composite-runner-class.mmd`          | class     | CompositePipelineRunner — component diagram                |
+| 50  | `foundation/50-exception-hierarchy.mmd`             | flowchart | Exception Hierarchy — BioETLError full tree                |
 
----
+______________________________________________________________________
+
+## Decomposed Views
+
+The following diagrams were decomposed into view-based files to keep each view under the 20-node hard limit.
+
+### Recommended onboarding order
+
+1. `architecture/01a-hexagonal-overview.mmd`
+1. `architecture/01b-hexagonal-domain-application.mmd`
+1. `architecture/01c-hexagonal-infra-composition.mmd`
+1. `architecture/13a-port-contracts-data-sources.mmd`
+1. `architecture/13b-port-contracts-storage.mmd`
+1. `architecture/13c-port-contracts-observability.mmd`
+1. `architecture/13d-port-contracts-services.mmd`
+1. `foundation/01a-system-overview.mmd`
+1. `foundation/01b-system-data-pipeline.mmd`
+1. `foundation/01c-system-cross-cutting.mmd`
+1. `foundation/50a-exceptions-critical.mmd`
+1. `foundation/50b-exceptions-recoverable.mmd`
+1. `foundation/50c-exceptions-data-quality.mmd`
+
+### Superseded originals (kept for history)
+
+- `architecture/01-high-level-hexagonal.mmd`
+- `architecture/13-port-protocol-contracts.mmd`
+- `foundation/01-full-system-component.mmd`
+- `foundation/26-hexagonal-ports-adapters.mmd`
+- `foundation/30-port-adapter-mapping.mmd`
+- `foundation/50-exception-hierarchy.mmd`
 
 ## Colour Scheme
 
 | Layer          | Colour | Fill      | Border    |
-|----------------|--------|-----------|-----------|
+| -------------- | ------ | --------- | --------- |
 | Domain         | Purple | `#f3e5f5` | `#6a1b9a` |
 | Application    | Green  | `#e8f5e9` | `#2e7d32` |
 | Infrastructure | Red    | `#ffcdd2` | `#c62828` |
@@ -140,13 +169,13 @@ Historical/foundational diagrams consolidated from `docs/02-architecture/diagram
 ### Medallion Layers
 
 | Layer      | Fill      | Border    |
-|------------|-----------|-----------|
+| ---------- | --------- | --------- |
 | Bronze     | `#fff3e0` | `#e65100` |
 | Silver     | `#eceff1` | `#607d8b` |
 | Gold       | `#fff8e1` | `#f9a825` |
 | Quarantine | `#ffebee` | `#d32f2f` |
 
----
+______________________________________________________________________
 
 ## Rendering
 

--- a/docs/02-architecture/mmd-diagrams/_template.mmd
+++ b/docs/02-architecture/mmd-diagrams/_template.mmd
@@ -1,0 +1,30 @@
+%% <TITLE — one-line description>
+%% <COVERS — what architectural aspect>
+
+%% @version 1.0.0
+%% @date <YYYY-MM-DD>
+%% @type <flowchart|classDiagram|sequenceDiagram|stateDiagram|erDiagram|mindmap|legend>
+%% @level <System / Component|Class|Sequence|State>
+%% @status <active|superseded|draft>
+%% @view <overview|detail|full>
+%% @parent <original-file.mmd>
+%% @nodes   0
+%% @adr <related ADR numbers>
+%%
+%% NOTE: Styles applied via theme/mermaid-config.json + theme/custom.css
+%% Do NOT add %%{init:} blocks — use render.sh for consistent theming.
+%% Colour scheme: see README.md § Colour Scheme
+
+flowchart TD
+%% === NODES ===
+
+%% === LINKS ===
+
+%% === SUBGRAPH STYLES ===
+%% Use ONLY approved colours from theme/custom.css:
+%% style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+%% style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+%% style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+%% style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px
+%% style Interfaces fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+%% style External fill:#eceff1,stroke:#455a64,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/01-high-level-hexagonal.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/01-high-level-hexagonal.mmd
@@ -1,3 +1,11 @@
+%% ⚠️ SUPERSEDED — replaced by architecture/01a-hexagonal-overview.mmd, architecture/01b-hexagonal-domain-application.mmd, architecture/01c-hexagonal-infra-composition.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by architecture/01a-hexagonal-overview.mmd
+%% @superseded-by architecture/01b-hexagonal-domain-application.mmd
+%% @superseded-by architecture/01c-hexagonal-infra-composition.mmd
+
 %% BioETL — High-Level Hexagonal Architecture
 %% Shows the Ports & Adapters (Hexagonal) pattern across all layers.
 
@@ -5,6 +13,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  superseded
+%% @nodes   39
 
 graph TB
     subgraph External["External Systems"]

--- a/docs/02-architecture/mmd-diagrams/architecture/01a-hexagonal-overview.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/01a-hexagonal-overview.mmd
@@ -1,0 +1,49 @@
+%% Hexagonal Overview — Five Layers and External Systems
+%% Covers top-level layering and dependency direction.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    overview
+%% @parent  01-high-level-hexagonal.mmd
+%% @nodes   10
+
+flowchart TB
+    subgraph External
+        APIs[External APIs]
+        FS[File System]
+        OBS[Prometheus / OpenTelemetry]
+    end
+    subgraph Interfaces
+        CLI[CLI]
+    end
+    subgraph Composition
+        BOOT[Bootstrap + Factories]
+    end
+    subgraph Application
+        APP[Pipeline Services]
+    end
+    subgraph Domain
+        PORTS[Port Protocols]
+        ENT[Entities]
+    end
+    subgraph Infrastructure
+        ADAPT[Adapters]
+        STORE[Storage]
+    end
+
+    CLI --> BOOT --> APP --> PORTS
+    ADAPT --> PORTS
+    APP --> STORE
+    APIs --> ADAPT
+    FS --> STORE
+    OBS --> APP
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+    style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    style Interfaces fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    style External fill:#eceff1,stroke:#455a64,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/01b-hexagonal-domain-application.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/01b-hexagonal-domain-application.mmd
@@ -1,0 +1,40 @@
+%% Hexagonal Detail — Domain and Application Collaboration
+%% Covers application orchestration over domain contracts.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    detail
+%% @parent  01-high-level-hexagonal.mmd
+%% @nodes   9
+
+flowchart LR
+    subgraph Domain
+        PORTS[Domain Ports]
+        ENT[Entities & Aggregates]
+        VO[Value Objects]
+        ERR[Domain Exceptions]
+    end
+
+    subgraph Application
+        RUN[PipelineRunner]
+        BEX[BatchExecutor]
+        TRF[Transformers]
+        DQS[DQ Services]
+        OBS[PipelineObserver]
+    end
+
+    RUN --> BEX
+    BEX --> TRF
+    TRF --> VO
+    RUN --> DQS
+    DQS --> PORTS
+    RUN --> PORTS
+    RUN --> ENT
+    RUN --> ERR
+    OBS --> RUN
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/01c-hexagonal-infra-composition.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/01c-hexagonal-infra-composition.mmd
@@ -1,0 +1,54 @@
+%% Hexagonal Detail — Infrastructure and Composition Assembly
+%% Covers adapter wiring and runtime composition.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    detail
+%% @parent  01-high-level-hexagonal.mmd
+%% @nodes   12
+
+flowchart TB
+    subgraph Composition
+        BOOT[Bootstrap]
+        REG[ProviderRegistry]
+        FAC[Factories]
+        RT[RuntimeBuilders]
+    end
+
+    subgraph Infrastructure
+        ADP[Provider Adapters]
+        STR[Writers + DeltaReader]
+        OBS[Logger/Metrics/Tracing]
+        CTRL[Lock/Checkpoint/Quarantine]
+    end
+
+    subgraph Domain
+        PORTS[Port Protocols]
+    end
+
+    subgraph External
+        APIs[Provider APIs]
+        FS[Local data/]
+        MON[Prometheus + OTEL]
+    end
+
+    BOOT --> REG
+    BOOT --> FAC --> RT
+    RT --> ADP
+    RT --> STR
+    RT --> OBS
+    RT --> CTRL
+    ADP --> PORTS
+    STR --> PORTS
+    OBS --> PORTS
+    APIs --> ADP
+    FS --> STR
+    MON --> OBS
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+    style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    style External fill:#eceff1,stroke:#455a64,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/02-layer-dependency-matrix.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/02-layer-dependency-matrix.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   7
 
 graph LR
     subgraph Legend

--- a/docs/02-architecture/mmd-diagrams/architecture/03-medallion-data-flow.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/03-medallion-data-flow.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   36
 
 graph LR
     subgraph Sources["External Data Sources"]

--- a/docs/02-architecture/mmd-diagrams/architecture/04-pipeline-execution-flow.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/04-pipeline-execution-flow.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    sequenceDiagram
 %% @level   System / Component
+%% @status  active
+%% @nodes   0
 
 sequenceDiagram
     participant CLI as CLI / Interfaces

--- a/docs/02-architecture/mmd-diagrams/architecture/05-provider-adapter-hierarchy.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/05-provider-adapter-hierarchy.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   27
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/06-storage-layer.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/06-storage-layer.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   21
 
 graph TB
     subgraph Port["Domain Port"]

--- a/docs/02-architecture/mmd-diagrams/architecture/07-dq-system.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/07-dq-system.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   22
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/08-composite-pipeline.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/08-composite-pipeline.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   35
 
 graph TB
     subgraph Config["Composite Configuration"]

--- a/docs/02-architecture/mmd-diagrams/architecture/09-observability-stack.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/09-observability-stack.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   24
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/10-resilience-patterns.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/10-resilience-patterns.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   21
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/11-configuration-system.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/11-configuration-system.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   29
 
 graph TB
     subgraph YAML["YAML Config Files"]

--- a/docs/02-architecture/mmd-diagrams/architecture/12-bootstrap-di-container.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/12-bootstrap-di-container.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   29
 
 graph TB
     subgraph Entry["Entry Points"]

--- a/docs/02-architecture/mmd-diagrams/architecture/13-port-protocol-contracts.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13-port-protocol-contracts.mmd
@@ -1,3 +1,12 @@
+%% ⚠️ SUPERSEDED — replaced by architecture/13a-port-contracts-data-sources.mmd, architecture/13b-port-contracts-storage.mmd, architecture/13c-port-contracts-observability.mmd, architecture/13d-port-contracts-services.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by architecture/13a-port-contracts-data-sources.mmd
+%% @superseded-by architecture/13b-port-contracts-storage.mmd
+%% @superseded-by architecture/13c-port-contracts-observability.mmd
+%% @superseded-by architecture/13d-port-contracts-services.mmd
+
 %% BioETL — Port/Protocol Contracts (Full Map)
 %% All domain Ports and their infrastructure implementations.
 
@@ -5,6 +14,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  superseded
+%% @nodes   68
 
 graph LR
     subgraph Domain["Domain Ports (Protocols)"]

--- a/docs/02-architecture/mmd-diagrams/architecture/13a-port-contracts-data-sources.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13a-port-contracts-data-sources.mmd
@@ -1,0 +1,33 @@
+%% Port Contracts — Data Source Ports and Adapters
+%% Covers source-fetch interfaces and concrete provider adapters.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    data-sources
+%% @parent  13-port-protocol-contracts.mmd
+%% @nodes   9
+
+flowchart LR
+    subgraph Domain
+        DSP[DataSourcePort]
+        FDSP[FilterableDataSourcePort]
+    end
+
+    subgraph Infrastructure
+        CA[ChemblAdapter]
+        PA[PubMedAdapter]
+        UA[UniProtAdapter]
+        CRA[CrossRefAdapter]
+        OAA[OpenAlexAdapter]
+        SSA[SemanticScholarAdapter]
+        PCA[PubChemAdapter]
+    end
+
+    DSP --- CA & PA & UA & CRA & OAA & SSA & PCA
+    FDSP --- PCA
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/13b-port-contracts-storage.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13b-port-contracts-storage.mmd
@@ -1,0 +1,39 @@
+%% Port Contracts — Storage and Persistence Contracts
+%% Covers storage, checkpoint, lock and metadata writer contracts.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    storage
+%% @parent  13-port-protocol-contracts.mmd
+%% @nodes   12
+
+flowchart LR
+    subgraph Domain
+        STP[StoragePort]
+        DRP[DeltaReaderPort]
+        LKP[LockPort]
+        CKP[CheckpointPort]
+        MWP[MetadataWriterPort]
+    end
+
+    subgraph Infrastructure
+        BW[BronzeWriter]
+        SW[SilverWriter]
+        GW[GoldWriter]
+        DRI[DeltaReader]
+        ML[MemoryLock]
+        LC[LocalCheckpoint]
+        MWI[MetadataWriter]
+    end
+
+    STP --- BW & SW & GW
+    DRP --- DRI
+    LKP --- ML
+    CKP --- LC
+    MWP --- MWI
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/13c-port-contracts-observability.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13c-port-contracts-observability.mmd
@@ -1,0 +1,40 @@
+%% Port Contracts — Observability and Resilience
+%% Covers logging, metrics, tracing and runtime resilience contracts.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    observability
+%% @parent  13-port-protocol-contracts.mmd
+%% @nodes   13
+
+flowchart LR
+    subgraph Domain
+        LGP[LoggerPort]
+        MTP[MetricsPort]
+        TRP[TracingPort]
+        CBP[CircuitBreakerPort]
+        RLP[RateLimiterPort]
+    end
+
+    subgraph Infrastructure
+        UL[UnifiedLogger]
+        SLG[StructlogLogger]
+        NOL[NoOpLogger]
+        MCO[MetricsCollector]
+        PME[PrometheusMetrics]
+        OTT[OpenTelemetryTracer]
+        CB[CircuitBreaker]
+        TBI[TokenBucket]
+    end
+
+    LGP --- UL & SLG & NOL
+    MTP --- MCO & PME
+    TRP --- OTT
+    CBP --- CB
+    RLP --- TBI
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/13d-port-contracts-services.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/13d-port-contracts-services.mmd
@@ -1,0 +1,50 @@
+%% Port Contracts — Validation, DQ and Service Ports
+%% Covers quality/security service ports and adapters.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    services
+%% @parent  13-port-protocol-contracts.mmd
+%% @nodes   16
+
+flowchart LR
+    subgraph Domain
+        SVP[SilverValidatorPort]
+        GVP[GoldValidatorPort]
+        QRP[QuarantinePort]
+        ADP[AuditPort]
+        PIIP[PiiHasherPort]
+        BDQP[BronzeDQAnalyzerPort]
+        SDQP[SilverDQAnalyzerPort]
+        GDQP[GoldDQAnalyzerPort]
+    end
+
+    subgraph Application
+        BDA[BronzeDQAnalyzer]
+        SDA[SilverDQAnalyzer]
+        GDA[GoldDQAnalyzer]
+    end
+
+    subgraph Infrastructure
+        PSV[PanderaSilverValidator]
+        PGV[PanderaGoldValidator]
+        UQ[UnifiedQuarantine]
+        FA[FileAuditAdapter]
+        SPH[Sha256PiiHasher]
+    end
+
+    SVP --- PSV
+    GVP --- PGV
+    QRP --- UQ
+    ADP --- FA
+    PIIP --- SPH
+    BDQP --- BDA
+    SDQP --- SDA
+    GDQP --- GDA
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/architecture/14-cli-interface-layer.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/14-cli-interface-layer.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   24
 
 graph TB
     subgraph User["User"]

--- a/docs/02-architecture/mmd-diagrams/architecture/15-batch-executor-internals.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/15-batch-executor-internals.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   15
 
 graph TB
     subgraph BatchExecutor["BatchExecutor"]

--- a/docs/02-architecture/mmd-diagrams/architecture/16-transformer-hierarchy.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/16-transformer-hierarchy.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   35
 
 graph TB
     subgraph TemplateMethod["Template Method Pattern"]

--- a/docs/02-architecture/mmd-diagrams/architecture/17-security-pii-audit.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/17-security-pii-audit.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   16
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/architecture/18-lock-checkpoint-shutdown.mmd
+++ b/docs/02-architecture/mmd-diagrams/architecture/18-lock-checkpoint-shutdown.mmd
@@ -5,6 +5,8 @@
 %% @date    2026-02-24
 %% @type    flowchart
 %% @level   System / Component
+%% @status  active
+%% @nodes   22
 
 graph TB
     subgraph Ports["Domain Ports"]

--- a/docs/02-architecture/mmd-diagrams/foundation/01-full-system-component.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/01-full-system-component.mmd
@@ -1,3 +1,11 @@
+%% ⚠️ SUPERSEDED — replaced by foundation/01a-system-overview.mmd, foundation/01b-system-data-pipeline.mmd, foundation/01c-system-cross-cutting.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by foundation/01a-system-overview.mmd
+%% @superseded-by foundation/01b-system-data-pipeline.mmd
+%% @superseded-by foundation/01c-system-cross-cutting.mmd
+
 %% Title: Full System Component Diagram
 %% Covers: RULES.md §1.1 (Five-Layer Architecture), §1.2 (Ports & Adapters)
 %% Updated: 2026-02-17

--- a/docs/02-architecture/mmd-diagrams/foundation/01a-system-overview.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/01a-system-overview.mmd
@@ -1,0 +1,44 @@
+%% System Overview — Layers and External Boundaries
+%% Covers compact full-system component overview.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    overview
+%% @parent  01-full-system-component.mmd
+%% @nodes   8
+
+flowchart TB
+    subgraph External
+        APIs[External Provider APIs]
+        FS[Local Filesystem]
+    end
+    subgraph Interfaces
+        CLI[CLI Interface]
+    end
+    subgraph Composition
+        BOOT[Bootstrap + Registry]
+    end
+    subgraph Application
+        ORCH[Pipeline Orchestration]
+    end
+    subgraph Domain
+        PORTS[Domain Ports]
+    end
+    subgraph Infrastructure
+        ADP[Adapters]
+        WR[Bronze/Silver/Gold Writers]
+    end
+
+    CLI --> BOOT --> ORCH --> PORTS
+    APIs --> ADP --> PORTS
+    ORCH --> WR --> FS
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+    style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    style Interfaces fill:#e3f2fd,stroke:#1565c0,stroke-width:2px
+    style External fill:#eceff1,stroke:#455a64,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/foundation/01b-system-data-pipeline.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/01b-system-data-pipeline.mmd
@@ -1,0 +1,50 @@
+%% System Data Pipeline — ETL Record Flow
+%% Covers adapters, transformers and medallion storage path.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    data-pipeline
+%% @parent  01-full-system-component.mmd
+%% @nodes   11
+
+flowchart LR
+    subgraph Infrastructure
+        ADP[ProviderAdapter]
+        BW[BronzeWriter]
+        SW[SilverWriter]
+        GW[GoldWriter]
+    end
+    subgraph Application
+        BATCH[BatchTransformer]
+        REC[RecordProcessor]
+    end
+    subgraph Domain
+        DSP[DataSourcePort]
+        STP[StoragePort]
+    end
+    subgraph Bronze
+        BR[(Bronze JSONL)]
+    end
+    subgraph Silver
+        SI[(Silver Delta)]
+    end
+    subgraph Gold
+        GO[(Gold Delta/Parquet)]
+    end
+
+    ADP --> DSP
+    DSP --> REC --> BATCH
+    BATCH --> STP
+    STP --> BW --> BR
+    STP --> SW --> SI
+    STP --> GW --> GO
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+    style Bronze fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    style Silver fill:#eceff1,stroke:#607d8b,stroke-width:2px
+    style Gold fill:#fff8e1,stroke:#f9a825,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/foundation/01c-system-cross-cutting.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/01c-system-cross-cutting.mmd
@@ -1,0 +1,49 @@
+%% System Cross-Cutting Concerns — DI, Config, Observability
+%% Covers runtime controls and platform concerns.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    cross-cutting
+%% @parent  01-full-system-component.mmd
+%% @nodes   14
+
+flowchart TB
+    subgraph Composition
+        BOOT[Bootstrap]
+        CFG[RuntimeConfig]
+        DQC[DQConfig]
+    end
+    subgraph Application
+        RUN[PipelineRunner]
+    end
+    subgraph Domain
+        LKP[LockPort]
+        CKP[CheckpointPort]
+        MTP[MetricsPort]
+        TRP[TracingPort]
+        CBP[CircuitBreakerPort]
+    end
+    subgraph Infrastructure
+        ML[MemoryLock]
+        LC[LocalCheckpoint]
+        PM[PrometheusMetrics]
+        OT[OpenTelemetryTracer]
+        CB[CircuitBreaker]
+    end
+
+    BOOT --> RUN
+    CFG --> RUN
+    DQC --> RUN
+    RUN --> LKP --> ML
+    RUN --> CKP --> LC
+    RUN --> MTP --> PM
+    RUN --> TRP --> OT
+    RUN --> CBP --> CB
+
+    style Domain fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px
+    style Application fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style Infrastructure fill:#ffcdd2,stroke:#c62828,stroke-width:2px
+    style Composition fill:#fff3e0,stroke:#e65100,stroke-width:2px

--- a/docs/02-architecture/mmd-diagrams/foundation/26-hexagonal-ports-adapters.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/26-hexagonal-ports-adapters.mmd
@@ -1,3 +1,12 @@
+%% ⚠️ SUPERSEDED — replaced by architecture/13a-port-contracts-data-sources.mmd, architecture/13b-port-contracts-storage.mmd, architecture/13c-port-contracts-observability.mmd, architecture/13d-port-contracts-services.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by architecture/13a-port-contracts-data-sources.mmd
+%% @superseded-by architecture/13b-port-contracts-storage.mmd
+%% @superseded-by architecture/13c-port-contracts-observability.mmd
+%% @superseded-by architecture/13d-port-contracts-services.mmd
+
 %% Title: Hexagonal Architecture — Ports and Adapters Overview
 %% Covers: RULES.md §1.2 (Ports & Adapters), §1.1 (Five-Layer Architecture)
 %% Rank: 1 (Score 9.38) — All 24 domain ports mapped to infrastructure adapters

--- a/docs/02-architecture/mmd-diagrams/foundation/30-port-adapter-mapping.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/30-port-adapter-mapping.mmd
@@ -1,3 +1,12 @@
+%% ⚠️ SUPERSEDED — replaced by architecture/13a-port-contracts-data-sources.mmd, architecture/13b-port-contracts-storage.mmd, architecture/13c-port-contracts-observability.mmd, architecture/13d-port-contracts-services.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by architecture/13a-port-contracts-data-sources.mmd
+%% @superseded-by architecture/13b-port-contracts-storage.mmd
+%% @superseded-by architecture/13c-port-contracts-observability.mmd
+%% @superseded-by architecture/13d-port-contracts-services.mmd
+
 %% Title: Port-to-Adapter Mapping Table Diagram
 %% Covers: RULES.md §1.2 (Ports & Adapters), ARCH-008 (Single Source)
 %% Rank: 5 (Score 8.63) — Reference diagram: "where is X implemented?"

--- a/docs/02-architecture/mmd-diagrams/foundation/50-exception-hierarchy.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/50-exception-hierarchy.mmd
@@ -1,3 +1,11 @@
+%% ⚠️ SUPERSEDED — replaced by foundation/50a-exceptions-critical.mmd, foundation/50b-exceptions-recoverable.mmd, foundation/50c-exceptions-data-quality.mmd
+%% This file is retained as historical reference. Do not render in CI.
+%%
+%% @status superseded
+%% @superseded-by foundation/50a-exceptions-critical.mmd
+%% @superseded-by foundation/50b-exceptions-recoverable.mmd
+%% @superseded-by foundation/50c-exceptions-data-quality.mmd
+
 %% Title: Exception Hierarchy — Full Tree
 %% Covers: domain/exceptions/ (base, network, validation, internal, infrastructure, data_quality)
 %% Rank: 25 (Score 7.25) — Complete error taxonomy for retry/abort/quarantine decisions

--- a/docs/02-architecture/mmd-diagrams/foundation/50a-exceptions-critical.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/50a-exceptions-critical.mmd
@@ -1,0 +1,26 @@
+%% Exception Hierarchy — Critical Branch
+%% Covers critical errors that must abort pipeline execution.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    critical
+%% @parent  50-exception-hierarchy.mmd
+%% @nodes   7
+
+flowchart TD
+    ROOT[Exception]
+    BIO[BioETLError]
+    CRIT[CriticalError]
+    CFG[ConfigurationError]
+    AUTH[AuthenticationError]
+    PERM[PermissionError]
+    ABORT[Action: ABORT]
+
+    ROOT --> BIO --> CRIT
+    CRIT --> CFG
+    CRIT --> AUTH
+    CRIT --> PERM
+    CRIT --> ABORT

--- a/docs/02-architecture/mmd-diagrams/foundation/50b-exceptions-recoverable.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/50b-exceptions-recoverable.mmd
@@ -1,0 +1,26 @@
+%% Exception Hierarchy — Recoverable Branch
+%% Covers retryable failures and recovery actions.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    recoverable
+%% @parent  50-exception-hierarchy.mmd
+%% @nodes   7
+
+flowchart TD
+    ROOT[Exception]
+    BIO[BioETLError]
+    REC[RecoverableError]
+    NET[NetworkError]
+    RATE[RateLimitError]
+    TEMP[TemporaryServiceError]
+    RETRY[Action: RETRY]
+
+    ROOT --> BIO --> REC
+    REC --> NET
+    REC --> RATE
+    REC --> TEMP
+    REC --> RETRY

--- a/docs/02-architecture/mmd-diagrams/foundation/50c-exceptions-data-quality.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/50c-exceptions-data-quality.mmd
@@ -1,0 +1,27 @@
+%% Exception Hierarchy — Data Quality Branch
+%% Covers DQ failures and quarantine decision flow.
+
+%% @version 1.0.0
+%% @date    2026-02-25
+%% @type    flowchart
+%% @level   System / Component
+%% @status  active
+%% @view    dq
+%% @parent  50-exception-hierarchy.mmd
+%% @nodes   8
+
+flowchart TD
+    ROOT[Exception]
+    BIO[BioETLError]
+    DQ[DataQualityError]
+    SCHEMA[SchemaValidationError]
+    MISSING[MissingFieldError]
+    RANGE[OutOfRangeError]
+    QACTION[Action: QUARANTINE]
+    STORE[QuarantineEntry]
+
+    ROOT --> BIO --> DQ
+    DQ --> SCHEMA
+    DQ --> MISSING
+    DQ --> RANGE
+    DQ --> QACTION --> STORE

--- a/docs/02-architecture/mmd-diagrams/render.sh
+++ b/docs/02-architecture/mmd-diagrams/render.sh
@@ -166,13 +166,23 @@ for dir in "${DIRS[@]}"; do
   shopt -u nullglob
 done
 
+filtered_files=()
+for f in "${files[@]}"; do
+  if grep -q "@status.*superseded" "$f"; then
+    log_info "SKIP (superseded): $f"
+    continue
+  fi
+  filtered_files+=("$f")
+done
+files=("${filtered_files[@]}")
+
 TOTAL=${#files[@]}
 if [[ $TOTAL -eq 0 ]]; then
-  log_warn "No diagrams found matching filter '$FILTER'"
+  log_warn "No active diagrams found matching filter '$FILTER'"
   exit 0
 fi
 
-log_info "Found ${BOLD}$TOTAL${NC} diagrams across ${#DIRS[@]} directories"
+log_info "Found ${BOLD}$TOTAL${NC} active diagrams across ${#DIRS[@]} directories"
 echo ""
 
 # ── Build mmdc base args ───────────────────────────────────


### PR DESCRIPTION
### Motivation
- Standardize Mermaid sources with a canonical template and metadata to make diagram provenance and rendering deterministic across the repository. 
- Reduce oversized Mermaid files that trigger Dagre layout failures by decomposing CRITICAL diagrams into view-based files constrained to the 20-node hard limit. 
- Preserve original large diagrams as historical references while preventing them from being rendered in CI by marking them `superseded`. 
- Ensure the render pipeline and documentation reflect the new decomposition so CI/maintainers skip deprecated sources and follow a clear onboarding order.

### Description
- Added canonical template `docs/02-architecture/mmd-diagrams/_template.mmd` that defines required metadata fields and style guidance (e.g. `@status`, `@view`, `@parent`, `@nodes`).
- Added/updated metadata (`%% @status`, `%% @nodes`) to all `architecture/*.mmd` files and created decomposed view files (examples: `architecture/01a-hexagonal-overview.mmd`, `01b-hexagonal-domain-application.mmd`, `01c-hexagonal-infra-composition.mmd`, `architecture/13a-13d-port-contracts-*.mmd`, and `foundation/01a-01c`, `foundation/50a-50c`) with `@view`/`@parent` populated. 
- Inserted a standardized `SUPERSEDED` marker block into original overloaded files and added `%% @superseded-by` entries pointing at the new view files so originals remain as historical reference and are excluded from rendering. 
- Updated `docs/02-architecture/mmd-diagrams/render.sh` to filter out files with `@status superseded` before rendering and updated `README.md` to include a new "Decomposed Views" section with recommended onboarding order.

### Testing
- Executed a repository script to inject/verify that all `architecture/*.mmd` files contain `%% @status` and `%% @nodes` metadata and confirmed there are no missing entries. 
- Used the node-count heuristic `grep -cP '^\s+\w+[\[\(\{>]'` against each new decomposed file and confirmed all decomposed views report node counts ≤ 20. 
- Validated `render.sh` shell syntax with `bash -n` and updated the script to exclude superseded files; attempted a direct `mmdc` render for one new file but `mmdc` is not available in the execution environment so raster/vector render verification could not be completed here. 
- Exercised pre-commit hooks which surfaced unrelated repository issues (`pip-audit` executable missing, legacy root-level VCR cassettes, legacy config path references); these failures are external to the diagram changes and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2d1d85308324a4d5a085f1df15c2)