### PR TITLE
Add diagram audit script and pre-commit validation for docs diagrams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,6 +128,14 @@ repos:
         files: ^docs/02-architecture/(mmd-diagrams/.*\.mmd|diagrams/mermaid/.*\.mermaid)$
         pass_filenames: false
 
+
+      - id: validate-diagrams
+        name: Validate diagram metadata + source policy
+        entry: bash scripts/validate_diagrams.sh
+        language: system
+        pass_filenames: false
+        files: ^docs/
+
       - id: check-root-vcr-cassettes
         name: Block root-level VCR cassette files
         entry: python scripts/check_root_vcr_cassettes.py

--- a/docs/02-architecture/mmd-diagrams/README.md
+++ b/docs/02-architecture/mmd-diagrams/README.md
@@ -9,64 +9,64 @@ All diagrams are in [Mermaid](https://mermaid.js.org/) format.
 Canonical sources use `.mmd`; decomposed views use `.mermaid` in `views/`.
 Render them with any Mermaid-compatible viewer, IDE plugin, or the [Mermaid Live Editor](https://mermaid.live/).
 
----
+______________________________________________________________________
 
 ## Architecture Diagrams (18 core)
 
-| # | Diagram | File | Description |
-|---|---------|------|-------------|
-| 1 | High-Level Hexagonal Architecture | `architecture/01-high-level-hexagonal.mmd` | Full system overview: layers, external systems, dependency directions |
-| 2 | Layer Dependency Matrix | `architecture/02-layer-dependency-matrix.mmd` | ARCH-001 import boundary enforcement |
-| 3 | Medallion Data Flow | `architecture/03-medallion-data-flow.mmd` | Bronze → Silver → Gold pipeline with DQ and quarantine |
-| 4 | Pipeline Execution Flow | `architecture/04-pipeline-execution-flow.mmd` | Sequence diagram: preflight → lock → execute → postrun → cleanup |
-| 5 | Provider Adapter Hierarchy | `architecture/05-provider-adapter-hierarchy.mmd` | All 7 provider adapters, base classes, mixins, decorators |
-| 6 | Storage Layer | `architecture/06-storage-layer.mmd` | Bronze/Silver/Gold writers, Delta Lake, metadata, validation |
-| 7 | Data Quality System | `architecture/07-dq-system.mmd` | DQ monitoring, analysis, anomaly detection, reporting |
-| 8 | Composite Pipeline | `architecture/08-composite-pipeline.mmd` | Seed → dependencies → enrichers (parallel) → merge with FSM |
-| 9 | Observability Stack | `architecture/09-observability-stack.mmd` | Logging, metrics, tracing: ports and implementations |
-| 10 | Resilience Patterns | `architecture/10-resilience-patterns.mmd` | Circuit breaker, rate limiter, retry, health checks |
-| 11 | Configuration System | `architecture/11-configuration-system.mmd` | YAML configs → loaders → Pydantic schemas → domain config |
-| 12 | Bootstrap / DI Container | `architecture/12-bootstrap-di-container.mmd` | Composition root: factories, assembly, wiring |
-| 13 | Port/Protocol Contracts | `architecture/13-port-protocol-contracts.mmd` | All 29 domain ports mapped to their implementations |
-| 14 | CLI / Interface Layer | `architecture/14-cli-interface-layer.mmd` | CLI commands, routing to application services |
-| 15 | BatchExecutor Internals | `architecture/15-batch-executor-internals.mmd` | Executor composition: transformer, writer, memory, metrics |
-| 16 | Transformer Hierarchy | `architecture/16-transformer-hierarchy.mmd` | Template Method pattern, all provider transformers, extractors |
-| 17 | Security, PII & Audit | `architecture/17-security-pii-audit.mmd` | PII hashing, salt rotation, audit trail |
-| 18 | Lock, Checkpoint & Shutdown | `architecture/18-lock-checkpoint-shutdown.mmd` | Fencing tokens, safety guard, graceful shutdown |
+| #   | Diagram                           | File                                             | Description                                                           |
+| --- | --------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| 1   | High-Level Hexagonal Architecture | `architecture/01-high-level-hexagonal.mmd`       | Full system overview: layers, external systems, dependency directions |
+| 2   | Layer Dependency Matrix           | `architecture/02-layer-dependency-matrix.mmd`    | ARCH-001 import boundary enforcement                                  |
+| 3   | Medallion Data Flow               | `architecture/03-medallion-data-flow.mmd`        | Bronze → Silver → Gold pipeline with DQ and quarantine                |
+| 4   | Pipeline Execution Flow           | `architecture/04-pipeline-execution-flow.mmd`    | Sequence diagram: preflight → lock → execute → postrun → cleanup      |
+| 5   | Provider Adapter Hierarchy        | `architecture/05-provider-adapter-hierarchy.mmd` | All 7 provider adapters, base classes, mixins, decorators             |
+| 6   | Storage Layer                     | `architecture/06-storage-layer.mmd`              | Bronze/Silver/Gold writers, Delta Lake, metadata, validation          |
+| 7   | Data Quality System               | `architecture/07-dq-system.mmd`                  | DQ monitoring, analysis, anomaly detection, reporting                 |
+| 8   | Composite Pipeline                | `architecture/08-composite-pipeline.mmd`         | Seed → dependencies → enrichers (parallel) → merge with FSM           |
+| 9   | Observability Stack               | `architecture/09-observability-stack.mmd`        | Logging, metrics, tracing: ports and implementations                  |
+| 10  | Resilience Patterns               | `architecture/10-resilience-patterns.mmd`        | Circuit breaker, rate limiter, retry, health checks                   |
+| 11  | Configuration System              | `architecture/11-configuration-system.mmd`       | YAML configs → loaders → Pydantic schemas → domain config             |
+| 12  | Bootstrap / DI Container          | `architecture/12-bootstrap-di-container.mmd`     | Composition root: factories, assembly, wiring                         |
+| 13  | Port/Protocol Contracts           | `architecture/13-port-protocol-contracts.mmd`    | All 29 domain ports mapped to their implementations                   |
+| 14  | CLI / Interface Layer             | `architecture/14-cli-interface-layer.mmd`        | CLI commands, routing to application services                         |
+| 15  | BatchExecutor Internals           | `architecture/15-batch-executor-internals.mmd`   | Executor composition: transformer, writer, memory, metrics            |
+| 16  | Transformer Hierarchy             | `architecture/16-transformer-hierarchy.mmd`      | Template Method pattern, all provider transformers, extractors        |
+| 17  | Security, PII & Audit             | `architecture/17-security-pii-audit.mmd`         | PII hashing, salt rotation, audit trail                               |
+| 18  | Lock, Checkpoint & Shutdown       | `architecture/18-lock-checkpoint-shutdown.mmd`   | Fencing tokens, safety guard, graceful shutdown                       |
 
 ## Decomposed Architecture Diagrams
 
 Parent diagrams remain canonical references. Sub-files provide focused, low-density views for review and onboarding.
 
-| Parent (canonical) | Decomposed sub-files |
-|---|---|
-| `architecture/01-high-level-hexagonal.mmd` | `architecture/01a-hexagonal-overview.mmd`, `architecture/01b-hexagonal-domain-app.mmd`, `architecture/01c-hexagonal-infra-comp.mmd` |
-| `architecture/03-medallion-data-flow.mmd` | `architecture/03a-medallion-layers-overview.mmd` |
-| `architecture/05-provider-adapter-hierarchy.mmd` | `architecture/05a-adapter-hierarchy-base.mmd`, `architecture/05b-adapter-hierarchy-providers.mmd` |
-| `architecture/12-bootstrap-di-container.mmd` | `architecture/12a-bootstrap-factories.mmd`, `architecture/12b-bootstrap-wiring.mmd` |
-| `architecture/13-port-protocol-contracts.mmd` | `architecture/13a-port-contracts-data-sources.mmd`, `architecture/13b-port-contracts-storage.mmd`, `architecture/13c-port-contracts-observability.mmd`, `architecture/13d-port-contracts-services.mmd` |
-| `architecture/13-port-protocol-contracts.mmd` (alternate slices) | `architecture/13a-data-storage-ports.mmd`, `architecture/13b-operational-ports.mmd`, `architecture/13c-validation-dq-ports.mmd` |
+| Parent (canonical)                                               | Decomposed sub-files                                                                                                                                                                                   |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `architecture/01-high-level-hexagonal.mmd`                       | `architecture/01a-hexagonal-overview.mmd`, `architecture/01b-hexagonal-domain-app.mmd`, `architecture/01c-hexagonal-infra-comp.mmd`                                                                    |
+| `architecture/03-medallion-data-flow.mmd`                        | `architecture/03a-medallion-layers-overview.mmd`                                                                                                                                                       |
+| `architecture/05-provider-adapter-hierarchy.mmd`                 | `architecture/05a-adapter-hierarchy-base.mmd`, `architecture/05b-adapter-hierarchy-providers.mmd`                                                                                                      |
+| `architecture/12-bootstrap-di-container.mmd`                     | `architecture/12a-bootstrap-factories.mmd`, `architecture/12b-bootstrap-wiring.mmd`                                                                                                                    |
+| `architecture/13-port-protocol-contracts.mmd`                    | `architecture/13a-port-contracts-data-sources.mmd`, `architecture/13b-port-contracts-storage.mmd`, `architecture/13c-port-contracts-observability.mmd`, `architecture/13d-port-contracts-services.mmd` |
+| `architecture/13-port-protocol-contracts.mmd` (alternate slices) | `architecture/13a-data-storage-ports.mmd`, `architecture/13b-operational-ports.mmd`, `architecture/13c-validation-dq-ports.mmd`                                                                        |
 
 ## Class Diagrams (16 families)
 
-| # | Family | File | Description |
-|---|--------|------|-------------|
-| 1 | Domain Ports | `class-diagrams/01-domain-ports.mmd` | All 29 Protocol interfaces with method signatures |
-| 2 | Entities & Aggregates | `class-diagrams/02-entities-aggregates.mmd` | BaseEntity, Batch, PipelineRun, BatchRecord |
-| 3 | Value Objects | `class-diagrams/03-value-objects.mmd` | BronzeWriteResult, SilverWriteResult, FencingToken, etc. |
-| 4 | Types & Enums | `class-diagrams/04-types-enums.mmd` | RunType, PublicationType, HealthStatus, NewTypes |
-| 5 | Exceptions | `class-diagrams/05-exceptions.mmd` | BioETLError hierarchy: Critical, Recoverable, DataQuality |
-| 6 | Configuration | `class-diagrams/06-config-classes.mmd` | PipelineConfig, RuntimeConfig, CompositeConfig |
-| 7 | Application Core | `class-diagrams/07-application-core-services.mmd` | PipelineRunner, BatchExecutor, LockManager |
-| 8 | Application Services | `class-diagrams/08-application-services.mmd` | DQ, Health, Export, Vacuum, Quarantine services |
-| 9 | Transformers | `class-diagrams/09-transformers.mmd` | BaseTransformer → ChEMBL/Publication/UniProt/PubChem |
-| 10 | Adapters | `class-diagrams/10-adapters.mmd` | BaseHttpAdapter, all provider adapters, resilience |
-| 11 | Storage | `class-diagrams/11-storage.mmd` | BronzeWriter, SilverWriter, GoldWriter, DeltaReader |
-| 12 | Composite Pipeline | `class-diagrams/12-composite-pipeline.mmd` | Runner, coordinators, merger, FSM |
-| 13 | Domain Services | `class-diagrams/13-domain-services.mmd` | IdentityService, Normalization, UnitConverter |
-| 14 | Observability | `class-diagrams/14-observability.mmd` | Logger, Metrics, Tracing implementations |
-| 15 | Extractors | `class-diagrams/15-extractors.mmd` | BaseFieldExtractor, PubMed & UniProt extractors |
-| 16 | Factories & Bootstrap | `class-diagrams/16-factories-bootstrap.mmd` | DataSourceRegistry, TransformerFactory, RunnerBuilder |
+| #   | Family                | File                                              | Description                                               |
+| --- | --------------------- | ------------------------------------------------- | --------------------------------------------------------- |
+| 1   | Domain Ports          | `class-diagrams/01-domain-ports.mmd`              | All 29 Protocol interfaces with method signatures         |
+| 2   | Entities & Aggregates | `class-diagrams/02-entities-aggregates.mmd`       | BaseEntity, Batch, PipelineRun, BatchRecord               |
+| 3   | Value Objects         | `class-diagrams/03-value-objects.mmd`             | BronzeWriteResult, SilverWriteResult, FencingToken, etc.  |
+| 4   | Types & Enums         | `class-diagrams/04-types-enums.mmd`               | RunType, PublicationType, HealthStatus, NewTypes          |
+| 5   | Exceptions            | `class-diagrams/05-exceptions.mmd`                | BioETLError hierarchy: Critical, Recoverable, DataQuality |
+| 6   | Configuration         | `class-diagrams/06-config-classes.mmd`            | PipelineConfig, RuntimeConfig, CompositeConfig            |
+| 7   | Application Core      | `class-diagrams/07-application-core-services.mmd` | PipelineRunner, BatchExecutor, LockManager                |
+| 8   | Application Services  | `class-diagrams/08-application-services.mmd`      | DQ, Health, Export, Vacuum, Quarantine services           |
+| 9   | Transformers          | `class-diagrams/09-transformers.mmd`              | BaseTransformer → ChEMBL/Publication/UniProt/PubChem      |
+| 10  | Adapters              | `class-diagrams/10-adapters.mmd`                  | BaseHttpAdapter, all provider adapters, resilience        |
+| 11  | Storage               | `class-diagrams/11-storage.mmd`                   | BronzeWriter, SilverWriter, GoldWriter, DeltaReader       |
+| 12  | Composite Pipeline    | `class-diagrams/12-composite-pipeline.mmd`        | Runner, coordinators, merger, FSM                         |
+| 13  | Domain Services       | `class-diagrams/13-domain-services.mmd`           | IdentityService, Normalization, UnitConverter             |
+| 14  | Observability         | `class-diagrams/14-observability.mmd`             | Logger, Metrics, Tracing implementations                  |
+| 15  | Extractors            | `class-diagrams/15-extractors.mmd`                | BaseFieldExtractor, PubMed & UniProt extractors           |
+| 16  | Factories & Bootstrap | `class-diagrams/16-factories-bootstrap.mmd`       | DataSourceRegistry, TransformerFactory, RunnerBuilder     |
 
 ## Foundation Diagrams (54)
 
@@ -74,74 +74,74 @@ Historical/foundational diagrams consolidated from `docs/02-architecture/diagram
 
 ### Foundation 01–25
 
-| # | File | Description |
-|---|------|-------------|
-| 01a | `foundation/01-full-system-component.mmd` | Full system component diagram (C4-style) |
-| 01b | `foundation/01-high-level.mmd` | High-level system overview |
-| 02a | `foundation/02-full-medallion-data-flow.mmd` | Medallion architecture data flow (detailed) |
-| 03a | `foundation/03-pipeline-execution-happy-path.mmd` | Pipeline execution sequence (happy path) |
-| 04a | `foundation/04-domain-layer-class-diagram.mmd` | Domain layer ports, entities, config |
-| 04b | `foundation/04-error-flow.mmd` | Error handling flow |
-| 05a | `foundation/05-layers-interaction.mmd` | Layer interaction diagram |
-| 05c | `foundation/05-pipeline-lifecycle-states.mmd` | Pipeline state machine |
-| 06a | `foundation/06-application-layer-class-diagram.mmd` | Application layer classes |
-| 06b | `foundation/06-pipeline-execution.mmd` | Pipeline execution flow |
-| 07a | `foundation/07-circuit-breaker-states.mmd` | Circuit breaker state machine |
-| 07b | `foundation/07-medallion-flow.mmd` | Medallion data flow |
-| 08a | `foundation/08-complete-etl-workflow.mmd` | Complete ETL workflow |
-| 08b | `foundation/08-domain-ddd.mmd` | Domain-driven design diagram |
-| 09 | `foundation/09-full-er-diagram.mmd` | Entity-relationship diagram |
-| 10 | `foundation/10-infrastructure-layer-class-diagram.mmd` | Infrastructure layer classes |
-| 11 | `foundation/11-lock-acquisition-sequence.mmd` | Lock acquisition sequence |
-| 12 | `foundation/12-local-deployment-architecture.mmd` | Local deployment architecture (ADR-010) |
-| 13 | `foundation/13-domain-models-relationship.mmd` | Domain model relationships |
-| 14 | `foundation/14-provider-health-states.mmd` | Provider health states |
-| 15 | `foundation/15-dq-check-workflow.mmd` | Data quality check workflow |
-| 16 | `foundation/16-memory-lock-class.mmd` | MemoryLock class diagram |
-| 17 | `foundation/17-pipeline-hierarchy.mmd` | Pipeline/Transformer hierarchy |
-| 18 | `foundation/18-bronze-write-sequence.mmd` | Bronze write sequence |
-| 19 | `foundation/19-delta-lake-write-sequence.mmd` | Delta Lake write sequence |
-| 20 | `foundation/20-quarantine-record-states.mmd` | Quarantine record states |
-| 21 | `foundation/21-activity-entity-data-flow.mmd` | Activity entity data flow |
-| 22 | `foundation/22-client-api-request-sequence.mmd` | Client API request sequence |
-| 23 | `foundation/23-silver-writer-class.mmd` | SilverWriter class diagram |
-| 24 | `foundation/24-hash-service-class.mmd` | Hash service class diagram |
-| 25 | `foundation/25-circuit-breaker-observer-class.mmd` | CircuitBreaker class diagram |
+| #   | File                                                   | Description                                 |
+| --- | ------------------------------------------------------ | ------------------------------------------- |
+| 01a | `foundation/01-full-system-component.mmd`              | Full system component diagram (C4-style)    |
+| 01b | `foundation/01-high-level.mmd`                         | High-level system overview                  |
+| 02a | `foundation/02-full-medallion-data-flow.mmd`           | Medallion architecture data flow (detailed) |
+| 03a | `foundation/03-pipeline-execution-happy-path.mmd`      | Pipeline execution sequence (happy path)    |
+| 04a | `foundation/04-domain-layer-class-diagram.mmd`         | Domain layer ports, entities, config        |
+| 04b | `foundation/04-error-flow.mmd`                         | Error handling flow                         |
+| 05a | `foundation/05-layers-interaction.mmd`                 | Layer interaction diagram                   |
+| 05c | `foundation/05-pipeline-lifecycle-states.mmd`          | Pipeline state machine                      |
+| 06a | `foundation/06-application-layer-class-diagram.mmd`    | Application layer classes                   |
+| 06b | `foundation/06-pipeline-execution.mmd`                 | Pipeline execution flow                     |
+| 07a | `foundation/07-circuit-breaker-states.mmd`             | Circuit breaker state machine               |
+| 07b | `foundation/07-medallion-flow.mmd`                     | Medallion data flow                         |
+| 08a | `foundation/08-complete-etl-workflow.mmd`              | Complete ETL workflow                       |
+| 08b | `foundation/08-domain-ddd.mmd`                         | Domain-driven design diagram                |
+| 09  | `foundation/09-full-er-diagram.mmd`                    | Entity-relationship diagram                 |
+| 10  | `foundation/10-infrastructure-layer-class-diagram.mmd` | Infrastructure layer classes                |
+| 11  | `foundation/11-lock-acquisition-sequence.mmd`          | Lock acquisition sequence                   |
+| 12  | `foundation/12-local-deployment-architecture.mmd`      | Local deployment architecture (ADR-010)     |
+| 13  | `foundation/13-domain-models-relationship.mmd`         | Domain model relationships                  |
+| 14  | `foundation/14-provider-health-states.mmd`             | Provider health states                      |
+| 15  | `foundation/15-dq-check-workflow.mmd`                  | Data quality check workflow                 |
+| 16  | `foundation/16-memory-lock-class.mmd`                  | MemoryLock class diagram                    |
+| 17  | `foundation/17-pipeline-hierarchy.mmd`                 | Pipeline/Transformer hierarchy              |
+| 18  | `foundation/18-bronze-write-sequence.mmd`              | Bronze write sequence                       |
+| 19  | `foundation/19-delta-lake-write-sequence.mmd`          | Delta Lake write sequence                   |
+| 20  | `foundation/20-quarantine-record-states.mmd`           | Quarantine record states                    |
+| 21  | `foundation/21-activity-entity-data-flow.mmd`          | Activity entity data flow                   |
+| 22  | `foundation/22-client-api-request-sequence.mmd`        | Client API request sequence                 |
+| 23  | `foundation/23-silver-writer-class.mmd`                | SilverWriter class diagram                  |
+| 24  | `foundation/24-hash-service-class.mmd`                 | Hash service class diagram                  |
+| 25  | `foundation/25-circuit-breaker-observer-class.mmd`     | CircuitBreaker class diagram                |
 
 ### Foundation 26–50 (TOP-25 Architecture)
 
-| # | File | Type | Description |
-|---|------|------|-------------|
-| 26 | `foundation/26-hexagonal-ports-adapters.mmd` | flowchart | Hexagonal Architecture — all 24 ports mapped to adapters |
-| 27 | `foundation/27-import-matrix-enforcement.mmd` | flowchart | ARCH-001 Import Matrix — 5-layer dependency rules |
-| 28 | `foundation/28-composition-root-di-graph.mmd` | flowchart | Composition Root DI Graph — full DI assembly |
-| 29 | `foundation/29-composite-pipeline-workflow.mmd` | sequence | Composite Pipeline (ADR-026) — Seed→Deps→FanOut→Merge→Gold |
-| 30 | `foundation/30-port-adapter-mapping.mmd` | flowchart | Port → Adapter Reference — all 24 ports |
-| 31 | `foundation/31-pipeline-run-lifecycle.mmd` | state | PipelineRun Aggregate FSM |
-| 32 | `foundation/32-single-record-journey.mmd` | flowchart | Single Record Journey — API→Bronze→Transform→Silver→Gold |
-| 33 | `foundation/33-cli-run-interaction.mmd` | sequence | CLI → PipelineRunnerService interaction |
-| 34 | `foundation/34-batch-processing-flow.mmd` | sequence | Batch Processing — BatchExecutor cycle |
-| 36 | `foundation/36-architecture-principles-mindmap.mmd` | mindmap | Architecture Principles Mindmap |
-| 37 | `foundation/37-cli-entry-full-chain.mmd` | sequence | CLI Entry → Exit Code full chain |
-| 38 | `foundation/38-runtime-assembly-sequence.mmd` | sequence | Runtime Assembly — phases 1–8 |
-| 39 | `foundation/39-medallion-invariants.mmd` | flowchart | Medallion Invariants — ARCH-007 RunType clear policy |
-| 40 | `foundation/40-application-core-collaboration.mmd` | flowchart | Application Core — PipelineRunner orchestrating services |
-| 41 | `foundation/41-error-classification-tree.mmd` | flowchart | Error Classification — HTTP→Domain→Actions |
-| 42 | `foundation/42-pipeline-runner-class.mmd` | class | PipelineRunner Class — all 14 DI dependencies |
-| 43 | `foundation/43-fan-out-fan-in-pattern.mmd` | sequence | Fan-Out/Fan-In — asyncio.gather parallel enrichment |
-| 44 | `foundation/44-cross-provider-enrichment.mmd` | flowchart | Cross-Provider Enrichment — 5-provider publication flow |
-| 46 | `foundation/46-yaml-config-resolution.mmd` | flowchart | YAML Config Resolution — hierarchical merge |
-| 47 | `foundation/47-publication-merge-sources.mmd` | sequence | Publication Composite — multi-source merge |
-| 48 | `foundation/48-composite-phase-lifecycle.mmd` | state | Composite Pipeline FSM — 10-state lifecycle |
-| 49 | `foundation/49-composite-runner-class.mmd` | class | CompositePipelineRunner — component diagram |
-| 50 | `foundation/50-exception-hierarchy.mmd` | flowchart | Exception Hierarchy — BioETLError full tree |
+| #   | File                                                | Type      | Description                                                |
+| --- | --------------------------------------------------- | --------- | ---------------------------------------------------------- |
+| 26  | `foundation/26-hexagonal-ports-adapters.mmd`        | flowchart | Hexagonal Architecture — all 24 ports mapped to adapters   |
+| 27  | `foundation/27-import-matrix-enforcement.mmd`       | flowchart | ARCH-001 Import Matrix — 5-layer dependency rules          |
+| 28  | `foundation/28-composition-root-di-graph.mmd`       | flowchart | Composition Root DI Graph — full DI assembly               |
+| 29  | `foundation/29-composite-pipeline-workflow.mmd`     | sequence  | Composite Pipeline (ADR-026) — Seed→Deps→FanOut→Merge→Gold |
+| 30  | `foundation/30-port-adapter-mapping.mmd`            | flowchart | Port → Adapter Reference — all 24 ports                    |
+| 31  | `foundation/31-pipeline-run-lifecycle.mmd`          | state     | PipelineRun Aggregate FSM                                  |
+| 32  | `foundation/32-single-record-journey.mmd`           | flowchart | Single Record Journey — API→Bronze→Transform→Silver→Gold   |
+| 33  | `foundation/33-cli-run-interaction.mmd`             | sequence  | CLI → PipelineRunnerService interaction                    |
+| 34  | `foundation/34-batch-processing-flow.mmd`           | sequence  | Batch Processing — BatchExecutor cycle                     |
+| 36  | `foundation/36-architecture-principles-mindmap.mmd` | mindmap   | Architecture Principles Mindmap                            |
+| 37  | `foundation/37-cli-entry-full-chain.mmd`            | sequence  | CLI Entry → Exit Code full chain                           |
+| 38  | `foundation/38-runtime-assembly-sequence.mmd`       | sequence  | Runtime Assembly — phases 1–8                              |
+| 39  | `foundation/39-medallion-invariants.mmd`            | flowchart | Medallion Invariants — ARCH-007 RunType clear policy       |
+| 40  | `foundation/40-application-core-collaboration.mmd`  | flowchart | Application Core — PipelineRunner orchestrating services   |
+| 41  | `foundation/41-error-classification-tree.mmd`       | flowchart | Error Classification — HTTP→Domain→Actions                 |
+| 42  | `foundation/42-pipeline-runner-class.mmd`           | class     | PipelineRunner Class — all 14 DI dependencies              |
+| 43  | `foundation/43-fan-out-fan-in-pattern.mmd`          | sequence  | Fan-Out/Fan-In — asyncio.gather parallel enrichment        |
+| 44  | `foundation/44-cross-provider-enrichment.mmd`       | flowchart | Cross-Provider Enrichment — 5-provider publication flow    |
+| 46  | `foundation/46-yaml-config-resolution.mmd`          | flowchart | YAML Config Resolution — hierarchical merge                |
+| 47  | `foundation/47-publication-merge-sources.mmd`       | sequence  | Publication Composite — multi-source merge                 |
+| 48  | `foundation/48-composite-phase-lifecycle.mmd`       | state     | Composite Pipeline FSM — 10-state lifecycle                |
+| 49  | `foundation/49-composite-runner-class.mmd`          | class     | CompositePipelineRunner — component diagram                |
+| 50  | `foundation/50-exception-hierarchy.mmd`             | flowchart | Exception Hierarchy — BioETLError full tree                |
 
----
+______________________________________________________________________
 
 ## Colour Scheme
 
 | Layer          | Colour | Fill      | Border    |
-|----------------|--------|-----------|-----------|
+| -------------- | ------ | --------- | --------- |
 | Domain         | Purple | `#f5f3ff` | `#7c3aed` |
 | Application    | Green  | `#f0fdf4` | `#16a34a` |
 | Infrastructure | Red    | `#fff1f2` | `#dc2626` |
@@ -152,13 +152,13 @@ Historical/foundational diagrams consolidated from `docs/02-architecture/diagram
 ### Medallion Layers
 
 | Layer      | Fill      | Border    |
-|------------|-----------|-----------|
+| ---------- | --------- | --------- |
 | Bronze     | `#fff7ed` | `#f59e0b` |
 | Silver     | `#f8fafc` | `#475569` |
 | Gold       | `#fefce8` | `#ca8a04` |
 | Quarantine | `#ffe4e6` | `#e11d48` |
 
----
+______________________________________________________________________
 
 ## Rendering
 
@@ -264,7 +264,7 @@ Diagrams are validated and rendered automatically in GitHub Actions
 A drift check warns when `.mmd/.mermaid` sources change without re-rendering.
 The workflow also validates SVG text visibility for the smoke baseline set.
 
----
+______________________________________________________________________
 
 ## Size Normalization
 
@@ -283,29 +283,30 @@ Grouped diagrams support width strategy override:
 - `%% @uniform-width global` (default): one shared width across groups.
 - `%% @uniform-width group`: group-local widths to reduce excessive `&nbsp;` padding.
 
----
+______________________________________________________________________
 
 ## Validation Rules
 
 `scripts/lint_diagrams.py` enforces:
 
-| Rule | Description | Severity |
-|------|-------------|----------|
-| META-001 | Missing structured metadata (`@...` in `.mmd`, `%% View:` in `.mermaid`) | WARN |
-| META-002 | Invalid date format in `%% Updated:`/`%% @date` | ERROR |
-| COLOUR-001 | Deprecated pre-ADR palette in `style`/`classDef` | ERROR |
-| COLOUR-002 | Emoji in subgraph labels | ERROR |
-| SIZE-001 | `@nodes > 35` | ERROR |
-| SIZE-002 | `@nodes > 20` | WARN |
-| SIZE-003 | `@nodes > 35`, but decomposed sibling `.mmd` slices exist (`01a/01b/...`) | WARN |
-| LAYOUT-001 | `flowchart/graph` with `@nodes > 20` without ELK init | WARN |
-| LAYOUT-002 | `flowchart/graph` with `@nodes > 40` without ELK init | ERROR |
-| LINK-001 | Dense flowchart uses only one arrow semantic style | WARN |
-| LINK-002 | Fragile singleton-index `linkStyle` pattern (many one-by-one index lines) | WARN |
-| GRAPH-001 | Orphan nodes (defined but not in any edge) | WARN |
-| NBSP-001 | `&nbsp;` padding detected in source | ERROR |
+| Rule       | Description                                                               | Severity |
+| ---------- | ------------------------------------------------------------------------- | -------- |
+| META-001   | Missing structured metadata (`@...` in `.mmd`, `%% View:` in `.mermaid`)  | WARN     |
+| META-002   | Invalid date format in `%% Updated:`/`%% @date`                           | ERROR    |
+| COLOUR-001 | Deprecated pre-ADR palette in `style`/`classDef`                          | ERROR    |
+| COLOUR-002 | Emoji in subgraph labels                                                  | ERROR    |
+| SIZE-001   | `@nodes > 35`                                                             | ERROR    |
+| SIZE-002   | `@nodes > 20`                                                             | WARN     |
+| SIZE-003   | `@nodes > 35`, but decomposed sibling `.mmd` slices exist (`01a/01b/...`) | WARN     |
+| LAYOUT-001 | `flowchart/graph` with `@nodes > 20` without ELK init                     | WARN     |
+| LAYOUT-002 | `flowchart/graph` with `@nodes > 40` without ELK init                     | ERROR    |
+| LINK-001   | Dense flowchart uses only one arrow semantic style                        | WARN     |
+| LINK-002   | Fragile singleton-index `linkStyle` pattern (many one-by-one index lines) | WARN     |
+| GRAPH-001  | Orphan nodes (defined but not in any edge)                                | WARN     |
+| NBSP-001   | `&nbsp;` padding detected in source                                       | ERROR    |
 
 Node-size exceptions in current lint implementation:
+
 - `*-full.mermaid` reference views are exempt from `SIZE-001`/`SIZE-002`.
 - `00-legend*` files are exempt from `SIZE-001`/`SIZE-002`.
 
@@ -343,3 +344,46 @@ Insert anywhere in the file (commonly after the diagram-type declaration).
 **Lenient subgraph rule:** nodes inside a subgraph whose *name* appears in an
 edge (e.g. `Bronze --> Silver`) are **not** flagged — they are considered
 descriptive children of a connected subgraph container.
+
+## Diagram audit and validation
+
+### Inventory export (`diagram_audit.py`)
+
+```bash
+python scripts/diagram_audit.py
+```
+
+Скрипт обходит `docs/` и собирает инвентаризацию по расширениям:
+`.mmd`, `.mermaid`, `.puml`, `.d2`, `.svg`, `.png`.
+
+Выходные артефакты по умолчанию:
+
+- `docs/02-architecture/mmd-diagrams/diagram-audit.csv`
+- `docs/02-architecture/mmd-diagrams/diagram-audit.md`
+
+Колонки отчёта:
+`path,name,diag_type,format,nodes_count,edges_count,size_kb,last_modified,status,has_init,has_view_meta,parent`.
+
+### Policy validation (`validate_diagrams.sh`)
+
+```bash
+bash scripts/validate_diagrams.sh
+```
+
+Проверки:
+
+1. Для `.mmd/.mermaid` обязателен `%%{init ...}%%`.
+1. Для `.mmd/.mermaid` обязателен `%% View:`.
+1. Для `.png/.svg` обязателен source-партнёр: `.mmd/.mermaid/.puml/.d2/.meta`.
+
+Опциональный smoke-рендер (если `mmdc` установлен):
+
+```bash
+bash scripts/validate_diagrams.sh --smoke-render
+```
+
+### Exit codes
+
+- `0` — все проверки пройдены.
+- `1` — найдены нарушения policy/checks.
+- `2` — ошибка запуска (неверные аргументы, отсутствует docs root и т.п.).

--- a/scripts/diagram_audit.py
+++ b/scripts/diagram_audit.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Inventory diagram assets in docs/ and export CSV + Markdown reports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+SUPPORTED_EXTENSIONS = {".mmd", ".mermaid", ".puml", ".d2", ".svg", ".png"}
+TEXT_EXTENSIONS = {".mmd", ".mermaid", ".puml", ".d2"}
+SOURCE_EXTENSIONS = {".mmd", ".mermaid", ".puml", ".d2", ".meta"}
+
+MERMAID_EDGE_PATTERN = re.compile(r"-->|-\.->|==>|-.->|---")
+PLANTUML_EDGE_PATTERN = re.compile(r"-->|<--|<\.|\.>|\*--|o--|--")
+D2_EDGE_PATTERN = re.compile(r"\s->\s|\s<->\s|\s--\s")
+NODE_ID_PATTERN = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\b")
+
+
+@dataclass(frozen=True)
+class DiagramRow:
+    path: str
+    name: str
+    diag_type: str
+    format: str
+    nodes_count: int
+    edges_count: int
+    size_kb: float
+    last_modified: str
+    status: str
+    has_init: bool
+    has_view_meta: bool
+    parent: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit docs diagrams and export reports"
+    )
+    parser.add_argument("--docs-root", type=Path, default=Path("docs"))
+    parser.add_argument(
+        "--csv-out",
+        type=Path,
+        default=Path("docs/02-architecture/mmd-diagrams/diagram-audit.csv"),
+    )
+    parser.add_argument(
+        "--md-out",
+        type=Path,
+        default=Path("docs/02-architecture/mmd-diagrams/diagram-audit.md"),
+    )
+    return parser.parse_args()
+
+
+def iter_diagram_files(docs_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in docs_root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def detect_diag_type(path: Path, content: str) -> str:
+    ext = path.suffix.lower()
+    if ext in {".svg", ".png"}:
+        return "image"
+
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("%%") or line.startswith("'"):
+            continue
+        if line.startswith("graph") or line.startswith("flowchart"):
+            return "flowchart"
+        if line.startswith("sequenceDiagram"):
+            return "sequence"
+        if line.startswith("classDiagram"):
+            return "class"
+        if line.startswith("stateDiagram"):
+            return "state"
+        if line.startswith("erDiagram"):
+            return "er"
+        if line.startswith("mindmap"):
+            return "mindmap"
+        if line.startswith("@startuml"):
+            return "plantuml"
+        break
+
+    return ext.lstrip(".")
+
+
+def count_nodes_edges(path: Path, content: str) -> tuple[int, int]:
+    ext = path.suffix.lower()
+    if ext not in TEXT_EXTENSIONS:
+        return 0, 0
+
+    lines = [ln.strip() for ln in content.splitlines() if ln.strip()]
+
+    if ext in {".mmd", ".mermaid"}:
+        edges = sum(
+            1
+            for line in lines
+            if MERMAID_EDGE_PATTERN.search(line) and not line.startswith("%%")
+        )
+        nodes: set[str] = set()
+        for line in lines:
+            if line.startswith("%%"):
+                continue
+            if "[" in line or "(" in line or "{" in line:
+                for token in NODE_ID_PATTERN.findall(line.split("[")[0]):
+                    if token not in {
+                        "graph",
+                        "flowchart",
+                        "classDef",
+                        "style",
+                        "subgraph",
+                        "end",
+                    }:
+                        nodes.add(token)
+            if MERMAID_EDGE_PATTERN.search(line):
+                left = line.split("-")[0]
+                for token in NODE_ID_PATTERN.findall(left):
+                    if token not in {
+                        "graph",
+                        "flowchart",
+                        "classDef",
+                        "style",
+                        "subgraph",
+                        "end",
+                    }:
+                        nodes.add(token)
+        return len(nodes), edges
+
+    if ext == ".puml":
+        edges = sum(1 for line in lines if PLANTUML_EDGE_PATTERN.search(line))
+        nodes = {
+            token
+            for line in lines
+            if not line.startswith("'")
+            for token in NODE_ID_PATTERN.findall(line)
+            if token.lower() not in {"startuml", "enduml", "title", "skinparam"}
+        }
+        return len(nodes), edges
+
+    edges = sum(1 for line in lines if D2_EDGE_PATTERN.search(line))
+    nodes = {
+        line.split(":", maxsplit=1)[0].strip()
+        for line in lines
+        if ":" in line and not line.startswith("#")
+    }
+    return len({n for n in nodes if n}), edges
+
+
+def has_source_for_image(path: Path) -> bool:
+    stem = path.stem
+    candidates = [path.with_suffix(ext) for ext in SOURCE_EXTENSIONS]
+    candidates.extend((path.parent / f"{stem}{ext}") for ext in SOURCE_EXTENSIONS)
+    if path.parent.name in {"svg", "png"}:
+        parent = path.parent.parent
+        candidates.extend((parent / f"{stem}{ext}") for ext in SOURCE_EXTENSIONS)
+    return any(candidate.exists() for candidate in candidates)
+
+
+def build_row(root: Path, path: Path) -> DiagramRow:
+    content = ""
+    if path.suffix.lower() in TEXT_EXTENSIONS:
+        content = path.read_text(encoding="utf-8")
+
+    nodes_count, edges_count = count_nodes_edges(path, content)
+    has_init = "%%{init" in content if content else False
+    has_view_meta = "%% View:" in content if content else False
+
+    status = "ok"
+    if path.suffix.lower() in {".svg", ".png"} and not has_source_for_image(path):
+        status = "missing-source"
+
+    rel_path = path.relative_to(root)
+    size_kb = round(path.stat().st_size / 1024, 2)
+    last_modified = datetime.fromtimestamp(path.stat().st_mtime).isoformat(
+        timespec="seconds"
+    )
+
+    return DiagramRow(
+        path=str(rel_path),
+        name=path.name,
+        diag_type=detect_diag_type(path, content),
+        format=path.suffix.lower().lstrip("."),
+        nodes_count=nodes_count,
+        edges_count=edges_count,
+        size_kb=size_kb,
+        last_modified=last_modified,
+        status=status,
+        has_init=has_init,
+        has_view_meta=has_view_meta,
+        parent=str(rel_path.parent),
+    )
+
+
+def write_csv(rows: list[DiagramRow], target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(DiagramRow.__dataclass_fields__.keys())
+    with target.open("w", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row.__dict__)
+
+
+def write_markdown(rows: list[DiagramRow], target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    headers = list(DiagramRow.__dataclass_fields__.keys())
+    with target.open("w", encoding="utf-8") as fp:
+        fp.write("# Diagram audit\n\n")
+        fp.write(f"Total files: **{len(rows)}**\n\n")
+        fp.write("| " + " | ".join(headers) + " |\n")
+        fp.write("|" + "|".join(["---"] * len(headers)) + "|\n")
+        for row in rows:
+            values = [str(getattr(row, key)) for key in headers]
+            fp.write("| " + " | ".join(values) + " |\n")
+
+
+def main() -> int:
+    args = parse_args()
+    docs_root = args.docs_root
+    if not docs_root.exists():
+        raise FileNotFoundError(f"docs root not found: {docs_root}")
+
+    files = iter_diagram_files(docs_root)
+    rows = [build_row(docs_root, path) for path in files]
+
+    write_csv(rows, args.csv_out)
+    write_markdown(rows, args.md_out)
+    sys.stdout.write(f"Wrote {len(rows)} rows to {args.csv_out} and {args.md_out}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_diagrams.sh
+++ b/scripts/validate_diagrams.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCS_ROOT="$REPO_ROOT/docs"
+RUN_SMOKE=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Validate docs diagrams:
+  1) Mermaid headers: %%{init ...}%% and %% View:
+  2) Source policy for PNG/SVG: matching .mmd/.mermaid/.puml/.d2/.meta
+  3) Optional smoke-render for Mermaid sources if mmdc exists
+
+Options:
+  --docs-root DIR    Docs root (default: $DOCS_ROOT)
+  --smoke-render     Run mmdc smoke render if binary exists
+  -h, --help         Show this help
+
+Exit codes:
+  0 = all checks passed
+  1 = policy violations found
+  2 = usage or environment error
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --docs-root)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 2; }
+      DOCS_ROOT="$2"
+      shift 2
+      ;;
+    --smoke-render)
+      RUN_SMOKE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$DOCS_ROOT" != /* ]]; then
+  DOCS_ROOT="$REPO_ROOT/$DOCS_ROOT"
+fi
+
+if [[ ! -d "$DOCS_ROOT" ]]; then
+  echo "docs root does not exist: $DOCS_ROOT" >&2
+  exit 2
+fi
+
+violations=0
+checked_mermaid=0
+checked_images=0
+
+check_mermaid_metadata() {
+  local file="$1"
+  checked_mermaid=$((checked_mermaid + 1))
+
+  if ! grep -qE '^%%\{init.*\}%%' "$file"; then
+    echo "[META] missing init header: $file" >&2
+    violations=$((violations + 1))
+  fi
+
+  if ! grep -q '^%% View:' "$file"; then
+    echo "[META] missing View metadata: $file" >&2
+    violations=$((violations + 1))
+  fi
+}
+
+has_source_pair() {
+  local image="$1"
+  local dir stem parent
+  dir="$(dirname "$image")"
+  stem="$(basename "${image%.*}")"
+  parent="$(dirname "$dir")"
+
+  local exts=(".mmd" ".mermaid" ".puml" ".d2" ".meta")
+  local ext
+  for ext in "${exts[@]}"; do
+    [[ -f "$dir/$stem$ext" ]] && return 0
+    [[ -f "$parent/$stem$ext" ]] && return 0
+  done
+  return 1
+}
+
+while IFS= read -r -d '' src; do
+  base="$(basename "${src%.*}")"
+  [[ "$base" = _* ]] && continue
+  check_mermaid_metadata "$src"
+done < <(find "$DOCS_ROOT" -type f \( -name "*.mmd" -o -name "*.mermaid" \) -not -path "$DOCS_ROOT/99-archive/*" -print0)
+
+while IFS= read -r -d '' img; do
+  checked_images=$((checked_images + 1))
+  if ! has_source_pair "$img"; then
+    echo "[SOURCE] no source pair for image: $img" >&2
+    violations=$((violations + 1))
+  fi
+done < <(find "$DOCS_ROOT" -type f \( -name "*.svg" -o -name "*.png" \) -not -path "$DOCS_ROOT/99-archive/*" -print0)
+
+if [[ "$RUN_SMOKE" -eq 1 ]]; then
+  if command -v mmdc >/dev/null 2>&1; then
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    while IFS= read -r -d '' src; do
+      base="$(basename "${src%.*}")"
+      [[ "$base" = _* ]] && continue
+      out="$tmp_dir/$base.svg"
+      if ! mmdc -i "$src" -o "$out" >/dev/null 2>"$tmp_dir/mmdc.err"; then
+        echo "[SMOKE] mmdc failed: $src" >&2
+        sed -n '1,5p' "$tmp_dir/mmdc.err" >&2 || true
+        violations=$((violations + 1))
+      fi
+    done < <(find "$DOCS_ROOT" -type f \( -name "*.mmd" -o -name "*.mermaid" \) -not -path "$DOCS_ROOT/99-archive/*" -print0)
+  else
+    echo "[SMOKE] mmdc not found; smoke-render skipped" >&2
+  fi
+fi
+
+echo "Checked Mermaid sources: $checked_mermaid"
+echo "Checked image artifacts: $checked_images"
+
+if [[ "$violations" -gt 0 ]]; then
+  echo "Validation failed with $violations violation(s)." >&2
+  exit 1
+fi
+
+echo "Validation passed."
+exit 0


### PR DESCRIPTION
### Motivation

- Provide an automated inventory of architecture diagrams and enforce diagram metadata + source-policy so rendered artifacts remain reproducible and auditable.
- Add a lightweight, local validation step (including optional smoke render) that CI and developers can run to catch missing metadata and orphaned image sources early.

### Description

- Added `scripts/diagram_audit.py` which walks `docs/`, discovers files with extensions `.mmd/.mermaid/.puml/.d2/.svg/.png`, computes `nodes_count` and `edges_count`, detects `has_init` and `has_view_meta`, and exports reports to CSV and Markdown with columns `path,name,diag_type,format,nodes_count,edges_count,size_kb,last_modified,status,has_init,has_view_meta,parent`.
- Added `scripts/validate_diagrams.sh` which verifies Mermaid metadata (`%%{init ...}%%` and `%% View:`), enforces a source-policy for `.svg/.png` by checking for adjacent or parent source files (`.mmd/.mermaid/.puml/.d2/.meta`), and supports an optional smoke render using `mmdc` via `--smoke-render`.
- Integrated a local pre-commit hook `validate-diagrams` into `.pre-commit-config.yaml` with `pass_filenames: false` so the check runs repository-wide for docs changes.
- Updated `docs/02-architecture/mmd-diagrams/README.md` with usage instructions and documented exit codes (`0`=ok, `1`=policy violations, `2`=usage/env error).

### Testing

- Successfully byte-compiled the Python script with `python -m py_compile scripts/diagram_audit.py` and validated script syntax with `bash -n scripts/validate_diagrams.sh` (both passed).
- Ran `python scripts/diagram_audit.py --docs-root docs/02-architecture/mmd-diagrams --csv-out /tmp/diagram-audit.csv --md-out /tmp/diagram-audit.md` which produced an inventory (`Wrote 260 rows`) and exited successfully.
- Executed `bash scripts/validate_diagrams.sh --docs-root docs/02-architecture/mmd-diagrams` which ran policy checks and correctly reported existing repository violations (script exited non-zero because of current missing `%% View:` / `%%{init}` headers); this is expected on the present baseline.
- Attempting to run repository pre-commit in this environment failed to execute (`pre-commit` not found) and repository-level hooks flagged unrelated baseline issues (missing `pip-audit` binary and a few pre-existing root/layout and legacy config-path findings), so a full pre-commit pass could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fd39eef083248323ee1f9eb4560d)