### PR TITLE
Fix Mermaid Parent source integrity and add DIAG-T024 validation

### DIFF
--- a/docs/02-architecture/mmd-diagrams/foundation/35-bootstrap-sequence.mmd
+++ b/docs/02-architecture/mmd-diagrams/foundation/35-bootstrap-sequence.mmd
@@ -1,0 +1,103 @@
+%% Title: Composition Layer Bootstrap Sequence
+%% Covers: RULES.md §1.1 (Composition Root), composition/bootstrap/runtime/
+%% Rank: 10 (Score 8.44) — Step-by-step system assembly
+%% Updated: 2026-02-17
+
+%% @version 1.0.0
+%% @date    2026-02-24
+%% @type    flowchart
+%% @level   Mixed (System / Component / Class)
+
+%%{init: {'theme': 'neutral', 'themeVariables': {'fontFamily': 'Inter, system-ui', 'lineWidth': '2'},'layout':'elk','flowchart':{'curve':'linear'},'elk':{'nodePlacementStrategy':'BRANDES_KOEPF','mergeEdges':true,'edgeRouting':'ORTHOGONAL'}}}%%
+%% @uniform width=328 height=56 max_title_len=36 max_desc_lines=1
+flowchart TB
+    subgraph Step1["Step 1: Logger"]
+        S1A["BootstrapLogger.configure()<br/>"]
+        S1B["StructlogLogger<br/>(JSON, ISO timestamps, run_id binding)"]
+    end
+
+    subgraph Step2["Step 2: Configuration"]
+        S2A["ConfigLoader.load(pipeline_name)<br/>"]
+        S2B["PipelineYamlConfig<br/>(_base.yaml merged with entity.yaml)"]
+        S2C["DQConfigLoader.load()<br/>"]
+        S2D["FilterConfigLoader.load()<br/>"]
+    end
+
+    subgraph Step3["Step 3: Observability Bundle"]
+        S3A["ObservabilityBundle<br/>"]
+        S3B["PrometheusMetrics<br/>(MetricsPort)"]
+        S3C["NoOpTracing<br/>(TracingPort, ADR-022)"]
+    end
+
+    subgraph Step4["Step 4: Storage"]
+        S4A["StorageAdapter.create_bronze()<br/>"]
+        S4B["StorageAdapter.create_silver()<br/>"]
+        S4C["StorageAdapter.create_gold()<br/>"]
+        S4D["BronzeWriter<br/>(JSONL + zstd)"]
+        S4E["SilverWriter<br/>(Delta Lake)"]
+        S4F["GoldWriter<br/>(Delta / Parquet)"]
+    end
+
+    subgraph Step5["Step 5: HTTP Client"]
+        S5A["HttpClientFactory.create(provider)<br/>"]
+        S5B["UnifiedHTTPClient<br/>"]
+        S5C["TokenBucket<br/>(rate limiter)"]
+        S5D["CircuitBreaker<br/>(threshold=5, timeout=300s)"]
+    end
+
+    subgraph Step6["Step 6: Data Source"]
+        S6A["DataSourceFactory.create(provider)<br/>"]
+        S6B["ProviderRegistry.get(provider)<br/>"]
+        S6C["Provider Adapter<br/>(e.g., ChemblAdapter)"]
+    end
+
+    subgraph Step7["Step 7: Coordination"]
+        S7A["MemoryLock<br/>(LockPort, TTL=90s)"]
+        S7B["LocalCheckpoint<br/>(CheckpointPort)"]
+        S7C["UnifiedQuarantine<br/>(QuarantinePort)"]
+    end
+
+    subgraph Step8["Step 8: Services Bundle"]
+        S8A["ServicesBuilder<br/>"]
+        S8B[".with_storage(bronze, silver, gold)<br/>"]
+        S8C[".with_lock(memory_lock)<br/>"]
+        S8D[".with_checkpoint(local_checkpoint)<br/>"]
+        S8E[".with_quarantine(unified_quarantine)<br/>"]
+        S8F[".with_logger(structlog_logger)<br/>"]
+        S8G[".with_metrics(prometheus_metrics)<br/>"]
+        S8H[".build() → PipelineServices (frozen)<br/>"]
+    end
+
+    subgraph Step9["Step 9: Runner Assembly"]
+        S9A["RunnerFactory.create_runner()<br/>"]
+        S9B["PipelineRunner<br/>(fully assembled, ready to run)"]
+    end
+
+    %% Flow
+    S1A --> S1B
+    S1B --> S2A
+    S2A --> S2B
+    S2A --> S2C & S2D
+    S2B --> S3A
+    S3A --> S3B & S3C
+    S3B --> S4A
+    S4A --> S4D
+    S4B --> S4E
+    S4C --> S4F
+    S4D & S4E & S4F --> S5A
+    S5A --> S5B
+    S5B --> S5C & S5D
+    S5B --> S6A
+    S6A --> S6B --> S6C
+    S6C --> S7A & S7B & S7C
+    S7A & S7B & S7C --> S8A
+    S8A --> S8B --> S8C --> S8D --> S8E --> S8F --> S8G --> S8H
+    S8H --> S9A --> S9B
+
+    %% Styling
+    style Step1 fill:#f5f3ff,stroke:#7c3aed
+    style Step8 fill:#ffe4e6,stroke:#dc2626
+    style Step9 fill:#f0fdf4,stroke:#16a34a
+
+    linkStyle 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17 stroke:#475569,stroke-width:2px,stroke-dasharray:5
+    linkStyle 18 stroke:#475569,stroke-width:2px,stroke-dasharray:5,opacity:0.85

--- a/docs/02-architecture/mmd-diagrams/views/02-medallion-full.mermaid
+++ b/docs/02-architecture/mmd-diagrams/views/02-medallion-full.mermaid
@@ -1,5 +1,5 @@
 %% View: Full | Parent: (root)
-%% Parent source: docs/02-architecture/mmd-diagrams/foundation/02-medallion.mmd
+%% Parent source: docs/02-architecture/mmd-diagrams/foundation/02-full-medallion-data-flow.mmd
 %% Full reference diagram retained after decomposition.
 %% Title: Medallion Architecture Layers
 %% Covers: RULES.md §2.1 (Bronze/Silver/Gold), §2.3 (Quarantine)

--- a/scripts/check_diagram_quality_gates.py
+++ b/scripts/check_diagram_quality_gates.py
@@ -22,6 +22,7 @@ SUPPORTED_SUFFIXES = {".mmd", ".mermaid"}
 EXPECTED_CLASSDEFS = {"port", "adapter", "service", "process", "storage"}
 ALLOWED_EDGE_MARKERS = ("-->", "-.->", "==>")
 FORBIDDEN_EDGE_TOKENS = ("---", "--x", "x--", "<--", "<==>")
+PARENT_SOURCE_RE = re.compile(r"^%%\s*Parent source:\s*(.+?)\s*$")
 NODES_RE = re.compile(r"%%\s*@nodes\s+(\d+)")
 CLASSDEF_RE = re.compile(r"^\s*classDef\s+([A-Za-z0-9_-]+)")
 QUOTED_RE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"')
@@ -130,7 +131,13 @@ def is_flowchart(lines: list[str]) -> bool:
 def has_edge_syntax(line: str) -> bool:
     if "linkStyle" in line or line.strip().startswith("classDef"):
         return False
-    return "-->" in line or "-.->" in line or "==>" in line or "---" in line or "--x" in line
+    return (
+        "-->" in line
+        or "-.->" in line
+        or "==>" in line
+        or "---" in line
+        or "--x" in line
+    )
 
 
 def normalize_label(raw: str) -> str:
@@ -165,7 +172,9 @@ def check_line_style_guide(path: Path, lines: list[str]) -> list[Violation]:
             )
             continue
 
-        if "--" in stripped and not any(marker in stripped for marker in ALLOWED_EDGE_MARKERS):
+        if "--" in stripped and not any(
+            marker in stripped for marker in ALLOWED_EDGE_MARKERS
+        ):
             violations.append(
                 Violation(
                     file=str(path),
@@ -228,7 +237,9 @@ def sibling_views_for(path: Path) -> list[Path]:
     return sorted(views_dir.glob(f"{parent}-*.mermaid"))
 
 
-def check_large_diagram_decomposition(path: Path, lines: list[str], threshold: int) -> list[Violation]:
+def check_large_diagram_decomposition(
+    path: Path, lines: list[str], threshold: int
+) -> list[Violation]:
     violations: list[Violation] = []
     nodes = parse_node_count(lines)
     if nodes is None or nodes < threshold or path.suffix != ".mmd":
@@ -237,7 +248,10 @@ def check_large_diagram_decomposition(path: Path, lines: list[str], threshold: i
     views = sibling_views_for(path)
     has_full = any(view.name.endswith("-full.mermaid") for view in views)
     has_detail = any(
-        any(token in view.name for token in ("-overview", "-domain", "-infra", "-dataflow"))
+        any(
+            token in view.name
+            for token in ("-overview", "-domain", "-infra", "-dataflow")
+        )
         for view in views
     )
 
@@ -256,7 +270,9 @@ def check_large_diagram_decomposition(path: Path, lines: list[str], threshold: i
     return violations
 
 
-def check_large_diagram_legend(path: Path, lines: list[str], threshold: int) -> list[Violation]:
+def check_large_diagram_legend(
+    path: Path, lines: list[str], threshold: int
+) -> list[Violation]:
     violations: list[Violation] = []
     nodes = parse_node_count(lines)
     if nodes is None or nodes < threshold:
@@ -264,7 +280,9 @@ def check_large_diagram_legend(path: Path, lines: list[str], threshold: int) -> 
 
     content = "\n".join(lines)
     has_legend = (
-        re.search(r"^\s*subgraph\s+Legend\b", content, flags=re.IGNORECASE | re.MULTILINE)
+        re.search(
+            r"^\s*subgraph\s+Legend\b", content, flags=re.IGNORECASE | re.MULTILINE
+        )
         is not None
         or "%% Legend:" in content
         or "00-legend.mermaid" in content
@@ -281,7 +299,9 @@ def check_large_diagram_legend(path: Path, lines: list[str], threshold: int) -> 
     return violations
 
 
-def check_label_quality(path: Path, lines: list[str], max_label_length: int, max_br: int) -> list[Violation]:
+def check_label_quality(
+    path: Path, lines: list[str], max_label_length: int, max_br: int
+) -> list[Violation]:
     violations: list[Violation] = []
 
     for idx, line in enumerate(lines, start=1):
@@ -322,7 +342,49 @@ def check_label_quality(path: Path, lines: list[str], max_label_length: int, max
     return violations
 
 
-def evaluate_file(path: Path, *, large_threshold: int, max_label_length: int, max_br: int) -> list[Violation]:
+def check_parent_source_exists(path: Path, lines: list[str]) -> list[Violation]:
+    violations: list[Violation] = []
+
+    for idx, line in enumerate(lines, start=1):
+        match = PARENT_SOURCE_RE.match(line.strip())
+        if not match:
+            continue
+
+        parent_source = match.group(1).strip()
+        if not parent_source:
+            violations.append(
+                Violation(
+                    file=str(path),
+                    rule_id="DIAG-T024",
+                    severity="ERROR",
+                    message=f"line {idx}: Parent source metadata is empty",
+                )
+            )
+            continue
+
+        parent_path = (
+            Path(parent_source)
+            if Path(parent_source).is_absolute()
+            else (REPO_ROOT / parent_source)
+        )
+        if not parent_path.exists():
+            violations.append(
+                Violation(
+                    file=str(path),
+                    rule_id="DIAG-T024",
+                    severity="ERROR",
+                    message=(
+                        f"line {idx}: Parent source does not exist: {parent_source}"
+                    ),
+                )
+            )
+
+    return violations
+
+
+def evaluate_file(
+    path: Path, *, large_threshold: int, max_label_length: int, max_br: int
+) -> list[Violation]:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
@@ -338,15 +400,32 @@ def evaluate_file(path: Path, *, large_threshold: int, max_label_length: int, ma
     violations: list[Violation] = []
     violations.extend(check_line_style_guide(path, lines))
     violations.extend(check_classdef_coverage(path, lines))
-    violations.extend(check_large_diagram_decomposition(path, lines, threshold=large_threshold))
-    violations.extend(check_large_diagram_legend(path, lines, threshold=large_threshold))
-    violations.extend(check_label_quality(path, lines, max_label_length=max_label_length, max_br=max_br))
+    violations.extend(
+        check_large_diagram_decomposition(path, lines, threshold=large_threshold)
+    )
+    violations.extend(
+        check_large_diagram_legend(path, lines, threshold=large_threshold)
+    )
+    violations.extend(
+        check_label_quality(
+            path, lines, max_label_length=max_label_length, max_br=max_br
+        )
+    )
+    violations.extend(check_parent_source_exists(path, lines))
     return violations
 
 
 def summarize(violations: list[Violation]) -> list[RuleSummary]:
-    hard_rules = {"DIAG-T018", "DIAG-T020", "DIAG-T021"}
-    all_rules = ["DIAG-T018", "DIAG-T019", "DIAG-T020", "DIAG-T021", "DIAG-T022", "DIAG-T023"]
+    hard_rules = {"DIAG-T018", "DIAG-T020", "DIAG-T021", "DIAG-T024"}
+    all_rules = [
+        "DIAG-T018",
+        "DIAG-T019",
+        "DIAG-T020",
+        "DIAG-T021",
+        "DIAG-T022",
+        "DIAG-T023",
+        "DIAG-T024",
+    ]
     by_rule: dict[str, list[Violation]] = {rule: [] for rule in all_rules}
 
     for violation in violations:
@@ -456,10 +535,16 @@ def main() -> int:
 
     try:
         if not args.no_manifest:
-            manifest = args.manifest if args.manifest.is_absolute() else (REPO_ROOT / args.manifest)
+            manifest = (
+                args.manifest
+                if args.manifest.is_absolute()
+                else (REPO_ROOT / args.manifest)
+            )
             files = load_manifest(manifest)
         else:
-            targets = [Path(path) for path in args.paths] if args.paths else [DEFAULT_TARGET]
+            targets = (
+                [Path(path) for path in args.paths] if args.paths else [DEFAULT_TARGET]
+            )
             files = discover_files(targets)
     except (FileNotFoundError, ValueError) as exc:
         _err(f"[ERROR] {exc}")
@@ -484,7 +569,7 @@ def main() -> int:
     hard_failures = sum(
         1
         for violation in violations
-        if violation.rule_id in {"DIAG-T018", "DIAG-T020", "DIAG-T021"}
+        if violation.rule_id in {"DIAG-T018", "DIAG-T020", "DIAG-T021", "DIAG-T024"}
     )
     warning_failures = len(violations) - hard_failures
 
@@ -497,7 +582,11 @@ def main() -> int:
     )
 
     if args.json_out is not None:
-        out = args.json_out if args.json_out.is_absolute() else (REPO_ROOT / args.json_out)
+        out = (
+            args.json_out
+            if args.json_out.is_absolute()
+            else (REPO_ROOT / args.json_out)
+        )
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(
             json.dumps(
@@ -516,7 +605,11 @@ def main() -> int:
         )
 
     if args.markdown_out is not None:
-        out = args.markdown_out if args.markdown_out.is_absolute() else (REPO_ROOT / args.markdown_out)
+        out = (
+            args.markdown_out
+            if args.markdown_out.is_absolute()
+            else (REPO_ROOT / args.markdown_out)
+        )
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(render_markdown(report), encoding="utf-8")
 

--- a/tests/architecture/test_diagram_quality_gates.py
+++ b/tests/architecture/test_diagram_quality_gates.py
@@ -1,4 +1,4 @@
-"""Architecture tests for diagram regression quality gates (DIAG-T018..T023)."""
+"""Architecture tests for diagram regression quality gates (DIAG-T018..T024)."""
 
 from __future__ import annotations
 
@@ -86,3 +86,18 @@ def test_classdef_coverage_warns_when_missing() -> None:
     issues = module.check_classdef_coverage(Path("docs/sample.mmd"), lines)
 
     assert any(issue.rule_id == "DIAG-T019" for issue in issues)
+
+
+def test_parent_source_must_exist(tmp_path: Path) -> None:
+    module = _load_module()
+    missing_parent = "docs/02-architecture/mmd-diagrams/foundation/missing-source.mmd"
+    lines = [
+        "%% View: Full | Parent: (root)",
+        f"%% Parent source: {missing_parent}",
+        "flowchart TB",
+        "A --> B",
+    ]
+
+    issues = module.check_parent_source_exists(tmp_path / "sample.mermaid", lines)
+
+    assert any(issue.rule_id == "DIAG-T024" for issue in issues)


### PR DESCRIPTION
### Motivation
- Ensure `%% Parent source:` references in Mermaid view files point to a real SSOT so the diagram quality gates and render pipeline have a canonical source to reference.
- Prevent regressions by adding an automated lint/quality-gate that enforces the `Parent source` metadata points at an existing file.

### Description
- Restored the missing canonical foundation file for the bootstrap sequence at `docs/02-architecture/mmd-diagrams/foundation/35-bootstrap-sequence.mmd` so existing view headers resolve to a real SSOT.
- Fixed a stale parent pointer in `docs/02-architecture/mmd-diagrams/views/02-medallion-full.mermaid` to reference the existing foundation diagram `02-full-medallion-data-flow.mmd`.
- Added a new hard-gate rule `DIAG-T024` to `scripts/check_diagram_quality_gates.py` that parses `%% Parent source:` with `PARENT_SOURCE_RE` and validates the referenced path is non-empty and exists in the repository, and integrated it into `evaluate_file()` and the hard-gate summary.
- Added an architecture test `test_parent_source_must_exist` in `tests/architecture/test_diagram_quality_gates.py` and updated the test module docstring to include `DIAG-T024`.

### Testing
- Ran the architecture tests for the diagram quality gates with `uv run python -m pytest tests/architecture/test_diagram_quality_gates.py -q` and all tests passed.
- Executed the diagram linter for the changed foundation diagram with `uv run pre-commit run lint-diagrams --files docs/02-architecture/mmd-diagrams/foundation/35-bootstrap-sequence.mmd` and it passed for the file under the policy checks.
- Exercised the updated gate runner by invoking `uv run python scripts/check_diagram_quality_gates.py --no-manifest <files>` to confirm `DIAG-T024` is reported for missing parents and that the overall report composes hard/soft failures as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fdbb2d8c83248ab3dde25dfc7584)