### PR TITLE
Add diagram audit and validation tooling and enforce diagram policy in pre-commit + CI

### DIFF
--- a/.github/workflows/diagrams.yml
+++ b/.github/workflows/diagrams.yml
@@ -1,0 +1,35 @@
+name: diagram-validation
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**/*.mmd'
+      - 'docs/**/*.mermaid'
+      - 'docs/**/*.png'
+      - 'docs/**/*.svg'
+      - 'scripts/validate_diagrams.sh'
+      - 'scripts/diagram_audit.py'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/diagrams.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**/*.mmd'
+      - 'docs/**/*.mermaid'
+      - 'docs/**/*.png'
+      - 'docs/**/*.svg'
+      - 'scripts/validate_diagrams.sh'
+      - 'scripts/diagram_audit.py'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/diagrams.yml'
+
+jobs:
+  validate-diagrams:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate diagram policy (fail-fast)
+        run: |
+          bash scripts/validate_diagrams.sh --docs docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,14 @@ repos:
         language: python
         files: ^docs/02-architecture/(mmd-diagrams/.*\.mmd|diagrams/mermaid/.*\.mermaid)$
 
+
+      - id: validate-diagrams
+        name: Validate diagram metadata/source policy
+        entry: bash scripts/validate_diagrams.sh --docs docs
+        language: system
+        pass_filenames: false
+        files: \.(mermaid|mmd|png|svg)$
+
       - id: prune-orphan-diagram-nodes
         name: Check for orphan nodes in Mermaid diagrams (GRAPH-001)
         entry: python scripts/prune_orphan_nodes.py --check

--- a/docs/02-architecture/06-diagram-policy.md
+++ b/docs/02-architecture/06-diagram-policy.md
@@ -5,6 +5,7 @@
 ## 1. Назначение
 
 Этот документ задаёт обязательные правила для диаграмм как инженерных артефактов:
+
 - архитектурная корректность;
 - воспроизводимый рендер;
 - единый визуальный стандарт;
@@ -13,64 +14,65 @@
 ## 2. Источник истины и каталоги
 
 1. Канонический policy: `docs/02-architecture/06-diagram-policy.md`.
-2. Исторический policy (контекст): `docs/02-architecture/mmd-diagrams/docs/00-diagramming-policy.md`.
-3. Канонические исходники диаграмм: `docs/02-architecture/mmd-diagrams/**/*.mmd`.
-4. Decomposed views: `docs/02-architecture/mmd-diagrams/views/*.mermaid`.
-5. Рендеры: gitignored, регенерируются через `render.sh`.
+1. Исторический policy (контекст): `docs/02-architecture/mmd-diagrams/docs/00-diagramming-policy.md`.
+1. Канонические исходники диаграмм: `docs/02-architecture/mmd-diagrams/**/*.mmd`.
+1. Decomposed views: `docs/02-architecture/mmd-diagrams/views/*.mermaid`.
+1. Рендеры: gitignored, регенерируются через `render.sh`.
 
 ## 3. Форматы и именование
 
 1. Обязательный формат для новых диаграмм: Mermaid (`.mmd`).
-2. Расширение `.mermaid` допускается для decomposed views (`mmd-diagrams/views/`) и legacy-набора.
-3. Именование: `NN-topic-name.mmd` (порядковый номер + kebab-case).
-4. Одна диаграмма = один файл = одна основная архитектурная идея.
+1. Расширение `.mermaid` допускается для decomposed views (`mmd-diagrams/views/`) и legacy-набора.
+1. Именование: `NN-topic-name.mmd` (порядковый номер + kebab-case).
+1. Одна диаграмма = один файл = одна основная архитектурная идея.
 
 ## 4. Архитектурные ограничения
 
 1. Диаграммы обязаны отражать Hexagonal + DDD + Medallion архитектуру.
-2. Запрещено показывать зависимости `domain -> infrastructure`.
-3. Для application-вызовов infrastructure отображать контракт через port/protocol.
-4. В domain-диаграммах запрещён I/O контент.
-5. Наименования сущностей/интерфейсов должны соответствовать RULES.md.
+1. Запрещено показывать зависимости `domain -> infrastructure`.
+1. Для application-вызовов infrastructure отображать контракт через port/protocol.
+1. В domain-диаграммах запрещён I/O контент.
+1. Наименования сущностей/интерфейсов должны соответствовать RULES.md.
 
 ## 5. Типы диаграмм
 
 Разрешены:
+
 1. Architecture / C4 (context, container, component).
-2. Pipeline/Dataflow (DAG, Medallion flow).
-3. Class/Protocol maps.
-4. Sequence (retry, rate-limit, circuit breaker, lock/checkpoint).
-5. State/ER/Mindmap при обоснованной пользе.
+1. Pipeline/Dataflow (DAG, Medallion flow).
+1. Class/Protocol maps.
+1. Sequence (retry, rate-limit, circuit breaker, lock/checkpoint).
+1. State/ER/Mindmap при обоснованной пользе.
 
 ## 6. Визуальный стандарт
 
 ### 6.1 Палитра слоёв (muted)
 
-| Layer | Fill | Stroke |
-|---|---|---|
-| Domain | `#F5F3FF` | `#7C3AED` |
-| Application | `#F0FDF4` | `#16A34A` |
+| Layer          | Fill      | Stroke    |
+| -------------- | --------- | --------- |
+| Domain         | `#F5F3FF` | `#7C3AED` |
+| Application    | `#F0FDF4` | `#16A34A` |
 | Infrastructure | `#FFF1F2` | `#DC2626` |
-| Composition | `#FFF7ED` | `#F59E0B` |
-| Interfaces | `#EFF6FF` | `#2563EB` |
-| External | `#F1F5F9` | `#64748B` |
+| Composition    | `#FFF7ED` | `#F59E0B` |
+| Interfaces     | `#EFF6FF` | `#2563EB` |
+| External       | `#F1F5F9` | `#64748B` |
 
 ### 6.2 Medallion palette
 
-| Layer | Fill | Stroke |
-|---|---|---|
-| Bronze | `#FFF7ED` | `#F59E0B` |
-| Silver | `#F8FAFC` | `#475569` |
-| Gold | `#FEFCE8` | `#CA8A04` |
+| Layer      | Fill      | Stroke    |
+| ---------- | --------- | --------- |
+| Bronze     | `#FFF7ED` | `#F59E0B` |
+| Silver     | `#F8FAFC` | `#475569` |
+| Gold       | `#FEFCE8` | `#CA8A04` |
 | Quarantine | `#FFE4E6` | `#E11D48` |
 
 ### 6.3 Линии и семантика
 
 1. Data flow: сплошная линия.
-2. DI/implements: пунктир.
-3. Error/quarantine path: красный пунктир.
-4. Observability path: нейтральный серый.
-5. Непрозрачные/случайные цвета вне палитры запрещены.
+1. DI/implements: пунктир.
+1. Error/quarantine path: красный пунктир.
+1. Observability path: нейтральный серый.
+1. Непрозрачные/случайные цвета вне палитры запрещены.
 
 ### 6.4 Layout engine (ELK)
 
@@ -99,16 +101,19 @@
 ## 7. Definition of Done для диаграммы
 
 Диаграмма считается готовой, если одновременно выполнено:
+
 1. Есть исходник в каноническом каталоге (`.mmd`).
-2. Есть соответствующий рендер (`svg/png`) в ожидаемом каталоге.
-3. Есть запись в индексной странице/разделе документации.
-4. Ссылка на диаграмму не битая.
-5. `scripts/lint_diagrams.py` не даёт ошибок.
+1. Есть соответствующий рендер (`svg/png`) в ожидаемом каталоге.
+1. Есть запись в индексной странице/разделе документации.
+1. Ссылка на диаграмму не битая.
+1. `scripts/lint_diagrams.py` не даёт ошибок.
 
 ## 8. Обязательные проверки
 
 ```bash
 python3 scripts/lint_diagrams.py docs
+python3 scripts/diagram_audit.py --docs docs --out-csv reports/diagrams/inventory.csv --out-md reports/diagrams/inventory.md --use-git
+bash scripts/validate_diagrams.sh --docs docs
 python3 scripts/check_doc_links.py --links
 python3 scripts/check_diagram_visual_smoke.py
 bash scripts/validate_mermaid_syntax.sh
@@ -116,11 +121,15 @@ bash scripts/validate_mermaid_syntax.sh
 
 Если runtime для `validate_mermaid_syntax.sh` не готов, это фиксируется как открытый риск до устранения.
 
+Локальный pre-commit hook `validate-diagrams` обязан выполняться перед коммитом и
+проверяет `init`-директиву, view-метаданные, source-policy для `png/svg` и
+(опционально) `mmdc` smoke-check.
+
 `uniform_diagram_sizes.py` использовать только точечно и только после ручной проверки,
 так как режим с `&nbsp;` конфликтует с правилом `NBSP-001` в `lint_diagrams.py`.
 
 ## 9. Синхронизация с кодом
 
 1. Любое изменение архитектурных модулей или порт-контрактов требует обновления релевантных диаграмм.
-2. Изменение диаграммы без изменения кода допускается только для устранения рассинхрона или улучшения читаемости.
-3. Сначала документируем фактическую реализацию, затем желаемую (если есть расхождение).
+1. Изменение диаграммы без изменения кода допускается только для устранения рассинхрона или улучшения читаемости.
+1. Сначала документируем фактическую реализацию, затем желаемую (если есть расхождение).

--- a/docs/02-architecture/decisions/ADR-040-diagram-governance.md
+++ b/docs/02-architecture/decisions/ADR-040-diagram-governance.md
@@ -5,34 +5,36 @@
 **Decision makers:** @BioETL-Team
 **Related:** ADR-005 (Layered Architecture), ADR-020 (Composition Layer)
 
----
+______________________________________________________________________
 
 ## Context
 
 BioETL содержит два каталога диаграмм с разными форматами и назначением:
 
 **Canonical sources** (`docs/02-architecture/mmd-diagrams/`):
+
 - `architecture/` — 32 `.mmd` файла (18 core + decomposed subdomain files)
 - `class-diagrams/` — 16 `.mmd` файлов (class diagram families)
 - `foundation/` — 54 `.mmd` файла (historical + TOP-25)
 - Итого: **103 `.mmd` файлов** (включая `_template.mmd`)
 
 **Decomposed views** (`docs/02-architecture/mmd-diagrams/views/`):
+
 - 31 parent diagram × 5 views (`-full`, `-overview`, `-domain`, `-infra`, `-dataflow`)
-- + `00-legend.mermaid`
+- - `00-legend.mermaid`
 - Итого: **156 `.mermaid` файлов**
 
 ### Проблемы до ADR-040
 
 До принятия данного ADR в проекте сосуществовали **две несовместимые цветовые схемы**:
 
-| Слой | Старая (Tailwind-based) | Новая (canonical) |
-|------|------------------------|-------------------|
-| Domain | `#FFF7ED / #F59E0B` | `#f5f3ff / #7c3aed` |
-| Application | `#ECFDF5 / #10B981` | `#f0fdf4 / #16a34a` |
-| Infrastructure | `#EFF6FF / #2563EB` | `#fff1f2 / #dc2626` |
-| Composition | `#F5F3FF / #7C3AED` | `#fff7ed / #f59e0b` |
-| Interfaces | `#F1F5F9 / #64748B` | `#eff6ff / #2563eb` |
+| Слой           | Старая (Tailwind-based) | Новая (canonical)   |
+| -------------- | ----------------------- | ------------------- |
+| Domain         | `#FFF7ED / #F59E0B`     | `#f5f3ff / #7c3aed` |
+| Application    | `#ECFDF5 / #10B981`     | `#f0fdf4 / #16a34a` |
+| Infrastructure | `#EFF6FF / #2563EB`     | `#fff1f2 / #dc2626` |
+| Composition    | `#F5F3FF / #7C3AED`     | `#fff7ed / #f59e0b` |
+| Interfaces     | `#F1F5F9 / #64748B`     | `#eff6ff / #2563eb` |
 
 Дополнительно: 286 emoji-префиксов в subgraph labels (`🟡 Domain Layer`) мешали CLI-рендерингу.
 Все 156 `.mermaid` view-файлов использовали uniform `linkStyle` без семантического разделения типов связей.
@@ -45,7 +47,7 @@ BioETL содержит два каталога диаграмм с разным
 - Шаблон: `mmd-diagrams/_template.mmd`
 - Политика LLM: `docs/02-architecture/06-diagram-policy.md` (POL-LLM-DIAGRAMS-001)
 
----
+______________________________________________________________________
 
 ## Decision
 
@@ -54,18 +56,18 @@ BioETL содержит два каталога диаграмм с разным
 Единственным источником палитры является **`theme/custom.css` строки 140–151**.
 Все inline `style` директивы в `.mermaid` и `.mmd` файлах MUST соответствовать этой схеме.
 
-| Слой | Fill | Stroke |
-|------|------|--------|
-| Domain | `#f5f3ff` | `#7c3aed` |
-| Application | `#f0fdf4` | `#16a34a` |
+| Слой           | Fill      | Stroke    |
+| -------------- | --------- | --------- |
+| Domain         | `#f5f3ff` | `#7c3aed` |
+| Application    | `#f0fdf4` | `#16a34a` |
 | Infrastructure | `#fff1f2` | `#dc2626` |
-| Composition | `#fff7ed` | `#f59e0b` |
-| Interfaces | `#eff6ff` | `#2563eb` |
-| External | `#f1f5f9` | `#64748b` |
-| Bronze | `#fff7ed` | `#f59e0b` |
-| Silver | `#f8fafc` | `#475569` |
-| Gold | `#fefce8` | `#ca8a04` |
-| Quarantine | `#ffe4e6` | `#e11d48` |
+| Composition    | `#fff7ed` | `#f59e0b` |
+| Interfaces     | `#eff6ff` | `#2563eb` |
+| External       | `#f1f5f9` | `#64748b` |
+| Bronze         | `#fff7ed` | `#f59e0b` |
+| Silver         | `#f8fafc` | `#475569` |
+| Gold           | `#fefce8` | `#ca8a04` |
+| Quarantine     | `#ffe4e6` | `#e11d48` |
 
 Использование произвольных цветов MUST NOT. Emoji-префиксы в subgraph labels MUST NOT.
 
@@ -91,14 +93,15 @@ Foundation views создаются как `.mermaid` в `mmd-diagrams/views/`.
 
 ### D3: View-based Decomposition Rules
 
-| Threshold | Action |
-|-----------|--------|
-| ≤15 узлов | Рекомендуемый предел, без декомпозиции |
-| 16–20 узлов | Soft limit — рассмотреть декомпозицию |
-| 21–35 узлов | WARN — декомпозиция рекомендуется |
-| >35 узлов | CRITICAL — декомпозиция обязательна |
+| Threshold   | Action                                 |
+| ----------- | -------------------------------------- |
+| ≤15 узлов   | Рекомендуемый предел, без декомпозиции |
+| 16–20 узлов | Soft limit — рассмотреть декомпозицию  |
+| 21–35 узлов | WARN — декомпозиция рекомендуется      |
+| >35 узлов   | CRITICAL — декомпозиция обязательна    |
 
 Стандартные view-типы для **foundation/**:
+
 - `-full` — полный reference (сохраняется обязательно)
 - `-overview` — cross-layer (≤15 узлов)
 - `-domain` — domain-layer focus (≤15 узлов)
@@ -113,6 +116,7 @@ Foundation views создаются как `.mermaid` в `mmd-diagrams/views/`.
 ### D4: Metadata Formats
 
 **`.mmd` файлы** (canonical):
+
 ```
 %% BioETL — <Title>
 %% <Covers>
@@ -126,6 +130,7 @@ Foundation views создаются как `.mermaid` в `mmd-diagrams/views/`.
 ```
 
 **`.mermaid` view-файлы** (decomposed):
+
 ```
 %% View: <Overview|Domain|Infrastructure|Dataflow|Full> | Parent: <file.mermaid>
 flowchart TB
@@ -136,16 +141,17 @@ flowchart TB
 View-файлы с ≥3 типами связей и >5 соединениями SHOULD использовать дифференцированный `linkStyle`.
 Классификация выполняется по принадлежности узлов к subgraph-слою (Domain → DI, Infrastructure → data и т.д.).
 
-| Тип связи | Стиль |
-|-----------|-------|
-| data flow | `stroke:#1E293B,stroke-width:2px` |
-| orchestration | `stroke:#16a34a,stroke-width:2px` |
-| DI / implements | `stroke:#7c3aed,stroke-width:1.5px,stroke-dasharray:5` |
-| observability | `stroke:#94A3B8,stroke-width:1px` |
-| error / quarantine | `stroke:#dc2626,stroke-width:2px,stroke-dasharray:4` |
-| generic | `stroke:#475569,stroke-width:2px,stroke-dasharray:5` |
+| Тип связи          | Стиль                                                  |
+| ------------------ | ------------------------------------------------------ |
+| data flow          | `stroke:#1E293B,stroke-width:2px`                      |
+| orchestration      | `stroke:#16a34a,stroke-width:2px`                      |
+| DI / implements    | `stroke:#7c3aed,stroke-width:1.5px,stroke-dasharray:5` |
+| observability      | `stroke:#94A3B8,stroke-width:1px`                      |
+| error / quarantine | `stroke:#dc2626,stroke-width:2px,stroke-dasharray:4`   |
+| generic            | `stroke:#475569,stroke-width:2px,stroke-dasharray:5`   |
 
 Каждый differentiated блок MUST сопровождаться комментарием:
+
 ```
 %% linkStyle: data 0-3 | orchestration 4-8 | di 9-11
 ```
@@ -154,41 +160,60 @@ View-файлы с ≥3 типами связей и >5 соединениями
 
 `scripts/lint_diagrams.py` проверяет оба каталога:
 
-| Rule | Description |
-|------|-------------|
-| SIZE-001 | Node count > 35 → ERROR |
-| SIZE-002 | Node count > 20 → WARN |
-| META-001 | Отсутствие structured metadata (`@...` для `.mmd`, `%% View:` для `.mermaid`) → WARN |
-| META-002 | Некорректный формат даты в `%% Updated:`/`%% @date` → ERROR |
-| COLOUR-001 | Использование deprecated pre-ADR-040 палитры в `style`/`classDef` → ERROR |
-| COLOUR-002 | Emoji в subgraph labels → ERROR |
-| GRAPH-001 | Orphan nodes (defined but not in any edge) в `flowchart`/`sequenceDiagram` → WARN |
-| NBSP-001 | Использование `&nbsp;`-padding в исходнике → ERROR |
+| Rule       | Description                                                                          |
+| ---------- | ------------------------------------------------------------------------------------ |
+| SIZE-001   | Node count > 35 → ERROR                                                              |
+| SIZE-002   | Node count > 20 → WARN                                                               |
+| META-001   | Отсутствие structured metadata (`@...` для `.mmd`, `%% View:` для `.mermaid`) → WARN |
+| META-002   | Некорректный формат даты в `%% Updated:`/`%% @date` → ERROR                          |
+| COLOUR-001 | Использование deprecated pre-ADR-040 палитры в `style`/`classDef` → ERROR            |
+| COLOUR-002 | Emoji в subgraph labels → ERROR                                                      |
+| GRAPH-001  | Orphan nodes (defined but not in any edge) в `flowchart`/`sequenceDiagram` → WARN    |
+| NBSP-001   | Использование `&nbsp;`-padding в исходнике → ERROR                                   |
 
 Примечание по реализации `SIZE-*`:
+
 - `*-full.mermaid` reference views исключены из `SIZE-001`/`SIZE-002`.
 - `00-legend*` исключены из `SIZE-001`/`SIZE-002`.
 
 Примечание по size-normalization (`scripts/uniform_diagram_sizes.py`):
+
 - `@uniform-group` задаёт групповую нормализацию высоты.
 - `@uniform-width global` (по умолчанию) использует общую ширину для всех групп.
 - `@uniform-width group` разрешает width per group для снижения `&nbsp;`-padding в перегруженных class-diagram family.
 
-Pre-commit hooks: `lint-diagrams`, `prune-orphan-diagram-nodes`.
+Pre-commit hooks: `lint-diagrams`, `validate-diagrams`, `prune-orphan-diagram-nodes`.
+
+Инвентаризация и аудит метаданных выполняются утилитой:
+
+```bash
+python3 scripts/diagram_audit.py --docs docs --out-csv reports/diagrams/inventory.csv --out-md reports/diagrams/inventory.md --use-git
+```
+
+Базовая CI/pre-commit валидация policy выполняется:
+
+```bash
+bash scripts/validate_diagrams.sh --docs docs
+# optional smoke check
+bash scripts/validate_diagrams.sh --docs docs --smoke-mmdc
+```
 
 #### GRAPH-001 — Orphan Node Rule
 
 Реализован в `scripts/prune_orphan_nodes.py`. Нода считается orphan, если:
+
 - Определена (`NodeId["label"]` или bare `NodeId`) в diagram
 - Не участвует ни в одном edge / message в том же файле
 
 **Исключения (нода не флагируется):**
+
 - Аннотация `%% keep-orphan: NodeId` (inline в файле)
 - Нода внутри subgraph, чьё имя встречается в edge (lenient subgraph rule)
 - Файлы `00-legend*`
 - `classDiagram`, `stateDiagram`, `erDiagram`, `mindmap`
 
 **Инструмент:**
+
 ```bash
 python scripts/prune_orphan_nodes.py --check      # аудит
 python scripts/prune_orphan_nodes.py --fix         # удалить garbage orphans
@@ -197,11 +222,11 @@ python scripts/prune_orphan_nodes.py --grandfather # exemption для всех �
 
 ### D7: Tool Selection Criteria
 
-| Условие | Инструмент | Layout |
-|---------|------------|--------|
-| ≤20 узлов | Mermaid (Dagre) | TB или LR |
-| 21–40 узлов | Mermaid + ELK init | TB или LR |
-| >40 узлов | Mermaid + ELK init (preferred) или D2 (ELK engine) | TB или LR |
+| Условие     | Инструмент                                         | Layout    |
+| ----------- | -------------------------------------------------- | --------- |
+| ≤20 узлов   | Mermaid (Dagre)                                    | TB или LR |
+| 21–40 узлов | Mermaid + ELK init                                 | TB или LR |
+| >40 узлов   | Mermaid + ELK init (preferred) или D2 (ELK engine) | TB или LR |
 
 ### D8: Adaptive Layout Rules
 
@@ -215,35 +240,35 @@ ELK (Eclipse Layout Kernel) SHOULD использоваться для `flowchar
 
 **Direction selection:**
 
-| Паттерн | Direction | Примеры |
-|---------|-----------|---------|
-| Иерархия / DI граф / port map | `TB` | `01-high-level-hexagonal`, `12-bootstrap-di-container` |
-| Pipeline / data flow / config chain | `LR` | `03-medallion-data-flow`, `11-configuration-system` |
+| Паттерн                             | Direction | Примеры                                                |
+| ----------------------------------- | --------- | ------------------------------------------------------ |
+| Иерархия / DI граф / port map       | `TB`      | `01-high-level-hexagonal`, `12-bootstrap-di-container` |
+| Pipeline / data flow / config chain | `LR`      | `03-medallion-data-flow`, `11-configuration-system`    |
 
 **CI Rules (lint_diagrams.py):**
 
-| Rule | Условие | Severity |
-|------|---------|----------|
-| LAYOUT-001 | `flowchart/graph` с `@nodes > 20` без ELK init | WARNING |
-| LAYOUT-002 | `flowchart/graph` с `@nodes > 40` без ELK init | ERROR |
+| Rule       | Условие                                        | Severity |
+| ---------- | ---------------------------------------------- | -------- |
+| LAYOUT-001 | `flowchart/graph` с `@nodes > 20` без ELK init | WARNING  |
+| LAYOUT-002 | `flowchart/graph` с `@nodes > 40` без ELK init | ERROR    |
 
 **Инструмент:** `src/tools/apply_elk_layout.py --dry-run` для аудита, без `--dry-run` для применения.
 
----
+______________________________________________________________________
 
 ## Implementation
 
 Выполнено в рамках принятия ADR-040 (2026-02-25):
 
-| Действие | Scope | Результат |
-|----------|-------|-----------|
-| Гармонизация цветовой схемы | 106 `.mermaid` файлов | 300 замен, старая Tailwind-палитра удалена |
-| Удаление emoji из subgraph labels | 106 файлов | 286 emoji убрано |
-| linkStyle дифференциация | 16 flowchart файлов | 5 типов связей |
-| Создание `_template.mmd` | `mmd-diagrams/` | Единый шаблон для новых диаграмм |
-| `@nodes` в architecture/ | 29 файлов | Уже присутствовали |
+| Действие                          | Scope                 | Результат                                  |
+| --------------------------------- | --------------------- | ------------------------------------------ |
+| Гармонизация цветовой схемы       | 106 `.mermaid` файлов | 300 замен, старая Tailwind-палитра удалена |
+| Удаление emoji из subgraph labels | 106 файлов            | 286 emoji убрано                           |
+| linkStyle дифференциация          | 16 flowchart файлов   | 5 типов связей                             |
+| Создание `_template.mmd`          | `mmd-diagrams/`       | Единый шаблон для новых диаграмм           |
+| `@nodes` в architecture/          | 29 файлов             | Уже присутствовали                         |
 
----
+______________________________________________________________________
 
 ## Consequences
 
@@ -267,7 +292,7 @@ ELK (Eclipse Layout Kernel) SHOULD использоваться для `flowchar
 - **Эвристика `@nodes`**: подсчёт узлов ±20% от реального (subgraph границы). Митигация: lint проверяет только >35 threshold
 - **Расхождение `-full.mermaid` с источником**: `foundation/*.mmd` и `mmd-diagrams/views/*-full.mermaid` могут разойтись. Митигация: CI drift check (планируется)
 
----
+______________________________________________________________________
 
 ## Related ADRs
 

--- a/scripts/diagram_audit.py
+++ b/scripts/diagram_audit.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Diagram inventory audit with CSV/Markdown export."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess  # nosec B404
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DIAGRAM_SUFFIXES = {".mmd", ".mermaid", ".png", ".svg"}
+VIEW_MARKERS = ("%% View:", "%% Parent source:", "%% Title:")
+SOURCE_META_SUFFIXES = (".meta", ".source", ".md")
+
+
+@dataclass(slots=True)
+class DiagramRecord:
+    path: str
+    kind: str
+    has_init_directive: bool
+    has_view_metadata: bool
+    has_source_policy: bool
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build inventory for Mermaid/diagram assets and export CSV/Markdown."
+    )
+    parser.add_argument("--docs", default="docs", help="Root docs directory to scan.")
+    parser.add_argument("--out-csv", default="", help="Optional CSV output path.")
+    parser.add_argument("--out-md", default="", help="Optional Markdown output path.")
+    parser.add_argument(
+        "--use-git",
+        action="store_true",
+        help="Use git tracked files under --docs instead of filesystem walk.",
+    )
+    return parser.parse_args()
+
+
+def _tracked_files(docs_root: Path) -> list[Path]:
+    result = subprocess.run(  # nosec B603,B607
+        ["git", "ls-files", str(docs_root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    files: list[Path] = []
+    for line in result.stdout.splitlines():
+        candidate = Path(line.strip())
+        if candidate.suffix.lower() in DIAGRAM_SUFFIXES:
+            files.append(candidate)
+    return sorted(files)
+
+
+def _walk_files(docs_root: Path) -> list[Path]:
+    items: list[Path] = []
+    for suffix in DIAGRAM_SUFFIXES:
+        items.extend(docs_root.rglob(f"*{suffix}"))
+    return sorted(items)
+
+
+def _read_text_safe(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return ""
+
+
+def _has_source_policy(image_path: Path) -> bool:
+    siblings = {p.name: p for p in image_path.parent.iterdir() if p.is_file()}
+    stem = image_path.stem
+
+    if f"{stem}.mmd" in siblings or f"{stem}.mermaid" in siblings:
+        return True
+
+    for suffix in SOURCE_META_SUFFIXES:
+        file_name = f"{image_path.name}{suffix}"
+        if file_name in siblings:
+            return True
+
+    for suffix in SOURCE_META_SUFFIXES:
+        file_name = f"{stem}{suffix}"
+        sidecar = siblings.get(file_name)
+        if sidecar is None:
+            continue
+        content = _read_text_safe(sidecar).lower()
+        if "source:" in content or "parent source:" in content:
+            return True
+
+    return False
+
+
+def _record_for(path: Path) -> DiagramRecord:
+    suffix = path.suffix.lower()
+    text = _read_text_safe(path) if suffix in {".mmd", ".mermaid"} else ""
+
+    has_init = "%%{init:" in text if text else False
+    has_view_metadata = (
+        any(marker in text for marker in VIEW_MARKERS) if text else False
+    )
+    has_source_policy = _has_source_policy(path) if suffix in {".png", ".svg"} else True
+
+    return DiagramRecord(
+        path=str(path),
+        kind=suffix.lstrip("."),
+        has_init_directive=has_init,
+        has_view_metadata=has_view_metadata,
+        has_source_policy=has_source_policy,
+    )
+
+
+def _write_csv(records: list[DiagramRecord], out_csv: Path) -> None:
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "path",
+                "kind",
+                "has_init_directive",
+                "has_view_metadata",
+                "has_source_policy",
+            ],
+        )
+        writer.writeheader()
+        for item in records:
+            writer.writerow(asdict(item))
+
+
+def _write_markdown(records: list[DiagramRecord], out_md: Path) -> None:
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Diagram Audit Inventory",
+        "",
+        "| Path | Kind | Init directive | View metadata | Source policy |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for item in records:
+        lines.append(
+            "| {path} | {kind} | {init} | {view} | {source} |".format(
+                path=item.path,
+                kind=item.kind,
+                init="yes" if item.has_init_directive else "no",
+                view="yes" if item.has_view_metadata else "no",
+                source="yes" if item.has_source_policy else "no",
+            )
+        )
+
+    out_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = _parse_args()
+    docs_root = Path(args.docs)
+
+    if not docs_root.exists():
+        raise SystemExit(f"Docs directory not found: {docs_root}")
+
+    files = _tracked_files(docs_root) if args.use_git else _walk_files(docs_root)
+    records = [_record_for(path) for path in files]
+
+    if args.out_csv:
+        _write_csv(records, Path(args.out_csv))
+    if args.out_md:
+        _write_markdown(records, Path(args.out_md))
+
+    sys.stdout.write(f"Inventory size: {len(records)}\n")
+    sys.stdout.write(
+        f"Files with init directive: {sum(1 for r in records if r.has_init_directive)}\n"
+    )
+    sys.stdout.write(
+        f"Files with view metadata: {sum(1 for r in records if r.has_view_metadata)}\n"
+    )
+    sys.stdout.write(
+        f"Image files respecting source policy: {sum(1 for r in records if r.kind in {'png', 'svg'} and r.has_source_policy)}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_diagrams.sh
+++ b/scripts/validate_diagrams.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+DOCS_ROOT="$REPO_ROOT/docs"
+SMOKE_MMDC=0
+MMDC_BIN="mmdc"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validate_diagrams.sh [options]
+
+Options:
+  --docs <path>       Docs root to scan (default: docs)
+  --smoke-mmdc        Run optional Mermaid syntax smoke check via mmdc
+  --mmdc-bin <path>   mmdc executable name/path (default: mmdc)
+  -h, --help          Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --docs)
+      DOCS_ROOT="$2"
+      shift 2
+      ;;
+    --smoke-mmdc)
+      SMOKE_MMDC=1
+      shift
+      ;;
+    --mmdc-bin)
+      MMDC_BIN="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$DOCS_ROOT" != /* ]]; then
+  DOCS_ROOT="$REPO_ROOT/$DOCS_ROOT"
+fi
+
+if [[ ! -d "$DOCS_ROOT" ]]; then
+  echo "Error: docs root does not exist: $DOCS_ROOT" >&2
+  exit 2
+fi
+
+mapfile -d '' MERMAID_FILES < <(find "$DOCS_ROOT" -type f \( -name '*.mmd' -o -name '*.mermaid' \) -print0 | sort -z)
+mapfile -d '' IMAGE_FILES < <(find "$DOCS_ROOT" -type f \( -name '*.png' -o -name '*.svg' \) -print0 | sort -z)
+
+errors=0
+checked=0
+
+has_source_meta() {
+  local image="$1"
+  local dir stem base
+  dir="$(dirname "$image")"
+  base="$(basename "$image")"
+  stem="${base%.*}"
+
+  [[ -f "$dir/$stem.mmd" || -f "$dir/$stem.mermaid" ]] && return 0
+  [[ -f "$dir/$base.meta" || -f "$dir/$base.source" || -f "$dir/$base.md" ]] && return 0
+
+  for candidate in "$dir/$stem.meta" "$dir/$stem.source" "$dir/$stem.md"; do
+    if [[ -f "$candidate" ]] && grep -Eiq 'source:|parent source:' "$candidate"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+for file in "${MERMAID_FILES[@]}"; do
+  checked=$((checked + 1))
+
+  base_name="$(basename "$file")"
+  if [[ "$base_name" != _* && "$base_name" != 00-legend* ]]; then
+    if grep -Eiq '^(graph|flowchart)\b' "$file"; then
+      nodes=0
+      if grep -Eq '^%%[[:space:]]*@nodes[[:space:]]+[0-9]+' "$file"; then
+        nodes=$(grep -E '^%%[[:space:]]*@nodes[[:space:]]+[0-9]+' "$file" | head -n1 | sed -E 's/.*@nodes[[:space:]]+([0-9]+).*/\1/')
+      fi
+      if [[ "$nodes" -ge 21 ]] && ! grep -Eq '^%%\{init:' "$file"; then
+        echo "ERROR [INIT-001] Missing Mermaid init directive for flowchart with @nodes >= 21: $file" >&2
+        errors=$((errors + 1))
+      fi
+    fi
+  fi
+
+  if [[ "$file" == *.mermaid ]]; then
+    if ! grep -Eq '^%% View:' "$file"; then
+      echo "ERROR [META-001] Missing view metadata (%% View:) in: $file" >&2
+      errors=$((errors + 1))
+    fi
+  fi
+
+done
+
+for image in "${IMAGE_FILES[@]}"; do
+  checked=$((checked + 1))
+  if ! has_source_meta "$image"; then
+    echo "ERROR [SOURCE-001] Missing source policy metadata for image: $image" >&2
+    errors=$((errors + 1))
+  fi
+done
+
+if [[ "$SMOKE_MMDC" -eq 1 ]]; then
+  if ! command -v "$MMDC_BIN" >/dev/null 2>&1; then
+    echo "ERROR [SMOKE-001] mmdc is required for --smoke-mmdc but was not found: $MMDC_BIN" >&2
+    errors=$((errors + 1))
+  else
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    idx=0
+    for file in "${MERMAID_FILES[@]}"; do
+      idx=$((idx + 1))
+      out="$tmp_dir/$idx.svg"
+      if ! "$MMDC_BIN" -i "$file" -o "$out" >/dev/null 2>&1; then
+        echo "ERROR [SMOKE-002] Mermaid syntax/render smoke failed: $file" >&2
+        errors=$((errors + 1))
+      fi
+    done
+  fi
+fi
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "Diagram validation failed: $errors error(s), $checked file(s) checked." >&2
+  exit 1
+fi
+
+echo "Diagram validation passed: $checked file(s) checked."


### PR DESCRIPTION
### Motivation

- Provide an automated inventory and audit for Mermaid/diagram assets and enforce the project's diagram governance (init directives, view metadata, image source-policy). 
- Ensure diagram policy checks run as a developer pre-commit gate and in CI to catch regressions early. 
- Make documentation/ADR authoritative by surfacing the new commands and tooling in policy docs. 

### Description

- Added `scripts/diagram_audit.py` which scans `--docs` for `.mmd/.mermaid/.png/.svg`, supports `--use-git`, and exports inventory to `--out-csv`/`--out-md` while checking for `%%{init:}` directives, view metadata and image source-policy. 
- Added `scripts/validate_diagrams.sh` which enforces Mermaid init for large flowcharts (`@nodes >= 21`), requires `%% View:` metadata for `.mermaid` views, validates source-policy for `.png/.svg` (sibling source or metadata sidecar), and supports an optional `--smoke-mmdc` render/syntax smoke-check via `mmdc`. 
- Registered a local pre-commit hook `validate-diagrams` in `.pre-commit-config.yaml` with `pass_filenames: false` and files regex `\.(mermaid|mmd|png|svg)$`, and added a fail-fast GitHub Actions workflow `.github/workflows/diagrams.yml` that runs `bash scripts/validate_diagrams.sh --docs docs` on PR/push paths touching diagrams or related scripts. 
- Synchronized docs and governance by adding the audit/validation commands and references to `docs/02-architecture/06-diagram-policy.md` and updating `docs/02-architecture/decisions/ADR-040-diagram-governance.md` to reference the new utilities. 

### Testing

- Ran `python3 scripts/diagram_audit.py --docs docs --out-csv /tmp/diagram_inventory.csv --out-md /tmp/diagram_inventory.md --use-git` which completed successfully and reported `Inventory size: 272`, `Files with init directive: 139`, `Files with view metadata: 222`, and `Image files respecting source policy: 0`. 
- Ran `bash scripts/validate_diagrams.sh --docs docs` (without `--smoke-mmdc`) which completed successfully with output `Diagram validation passed: 272 file(s) checked.`. 
- Attempted a local `pre-commit run validate-diagrams --all-files` but the `pre-commit` binary was not available in the environment so the hook could not be executed there. 
- CI workflow added (`.github/workflows/diagrams.yml`) will run `validate_diagrams.sh` with fail-fast behavior on PR/push changes touching diagram sources.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a200571fec8324bc427d5b6d6bacf7)