### PR TITLE
Add documentation drift detection and docstring coverage checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # BioETL Makefile
 # Production-ready ETL system for bioactivity data
 
-.PHONY: help install install-uv install-pip setup-plugins setup-skills test test-ci lint run-local docker-up docker-down docker-reset seed-local clean clean-local-artifacts sanitize-local clean-preflight clean-all diagram-preflight lint-diagrams report-diagrams-policy validate-diagrams-syntax render-diagrams render-diagrams-all render-diagrams-svg render-diagrams-png render-diagrams-descriptions-docx render-diagrams-descriptions-pdf run-diagram-docs-agent check-diagrams-visibility check-diagrams-pdf-bounds diagrams-all report-diagram-padding docs-lint
+.PHONY: help install install-uv install-pip setup-plugins setup-skills test test-ci lint run-local docker-up docker-down docker-reset seed-local clean clean-local-artifacts sanitize-local clean-preflight clean-all diagram-preflight lint-diagrams report-diagrams-policy validate-diagrams-syntax render-diagrams render-diagrams-all render-diagrams-svg render-diagrams-png render-diagrams-descriptions-docx render-diagrams-descriptions-pdf run-diagram-docs-agent check-diagrams-visibility check-diagrams-pdf-bounds diagrams-all report-diagram-padding docs-lint docs-quality docs-docstrings docs-drift
 .DEFAULT_GOAL := help
 
 # Detect uv availability (preferred package manager)
@@ -485,6 +485,19 @@ docs-lint: ## Run documentation guardrails (links + config conventions + drift c
 	$(PY_RUN) scripts/check_doc_links.py --links
 	$(PY_RUN) scripts/check_doc_links.py --configs
 	$(PY_RUN) scripts/check_doc_links.py --legacy-paths
+
+docs-docstrings: ## Check docstring coverage (modules ≥100%, classes ≥95%, functions ≥90%)
+	@echo "$(BLUE)Checking docstring coverage...$(NC)"
+	$(PY_RUN) scripts/check_docstring_coverage.py
+	@echo "$(GREEN)Docstring coverage check complete!$(NC)"
+
+docs-drift: ## Detect documentation drift (code ↔ docs synchronization)
+	@echo "$(BLUE)Running documentation drift detection...$(NC)"
+	$(PY_RUN) scripts/check_doc_drift.py
+	@echo "$(GREEN)Drift detection complete!$(NC)"
+
+docs-quality: docs-lint docs-docstrings docs-drift ## Run all documentation quality checks
+	@echo "$(GREEN)All documentation quality checks passed!$(NC)"
 
 schema-artifacts: ## Generate canonical schema artifacts (registry + contracts)
 	@echo "$(BLUE)Generating schema artifacts...$(NC)"

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""check_doc_drift.py - Detect documentation drift between code and docs.
+
+Verifies that key entities referenced in architecture documentation still
+exist in the codebase.  Catches common drift scenarios:
+
+  1. Port protocols renamed/removed but docs still reference old names
+  2. Class names changed but architecture docs not updated
+  3. Module paths moved but docs still point to old locations
+  4. Provider/entity lists changed but reference docs are stale
+  5. Factory/registry changes not reflected in composition docs
+
+Usage:
+    python scripts/check_doc_drift.py              # Full drift check
+    python scripts/check_doc_drift.py --ports       # Only port drift
+    python scripts/check_doc_drift.py --classes     # Only class drift
+    python scripts/check_doc_drift.py --modules     # Only module path drift
+    python scripts/check_doc_drift.py --json        # Machine-readable JSON output
+
+Exit code: 0 = no drift, 1 = drift detected
+
+References:
+    - docs/02-architecture/ (layer documentation)
+    - docs/00-project/glossary.md (ubiquitous language)
+    - ADR-040 (diagram governance)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src" / "bioetl"
+DOCS_DIR = PROJECT_ROOT / "docs"
+
+
+@dataclass
+class DriftIssue:
+    """A single documentation drift finding."""
+
+    category: str
+    severity: str  # ERROR, WARNING
+    doc_file: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize to dictionary."""
+        return {
+            "category": self.category,
+            "severity": self.severity,
+            "doc_file": self.doc_file,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class DriftReport:
+    """Aggregated drift detection results."""
+
+    issues: list[DriftIssue] = field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        """Count of ERROR-severity issues."""
+        return sum(1 for i in self.issues if i.severity == "ERROR")
+
+    @property
+    def warning_count(self) -> int:
+        """Count of WARNING-severity issues."""
+        return sum(1 for i in self.issues if i.severity == "WARNING")
+
+    def add(
+        self,
+        category: str,
+        severity: str,
+        doc_file: str,
+        detail: str,
+    ) -> None:
+        """Append a drift issue to the report."""
+        self.issues.append(DriftIssue(category, severity, doc_file, detail))
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the full report."""
+        return {
+            "status": "FAIL" if self.error_count else "PASS",
+            "errors": self.error_count,
+            "warnings": self.warning_count,
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_classes(directory: Path) -> set[str]:
+    """Collect all class names defined under *directory*."""
+    classes: set[str] = set()
+    for py in directory.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                classes.add(node.name)
+    return classes
+
+
+def _collect_modules(directory: Path) -> set[str]:
+    """Collect dotted module paths under *directory* relative to src/."""
+    modules: set[str] = set()
+    src_root = directory
+    while src_root.name != "src" and src_root != src_root.parent:
+        src_root = src_root.parent
+    for py in directory.rglob("*.py"):
+        if "__pycache__" in py.parts:
+            continue
+        rel = py.relative_to(src_root).with_suffix("")
+        dotted = ".".join(rel.parts)
+        modules.add(dotted)
+    return modules
+
+
+def _extract_backtick_refs(text: str) -> list[str]:
+    """Extract all backtick-quoted references from markdown text."""
+    return re.findall(r"`([^`]+)`", text)
+
+
+def _read_doc(path: Path) -> str:
+    """Read a documentation file, return empty string if missing."""
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Check: Port protocols
+# ---------------------------------------------------------------------------
+
+def check_ports(report: DriftReport) -> None:
+    """Verify port classes referenced in domain-layer docs exist in code."""
+    ports_dir = SRC_DIR / "domain" / "ports"
+    if not ports_dir.exists():
+        report.add(
+            "ports", "ERROR", "src/bioetl/domain/ports/",
+            "Ports directory does not exist",
+        )
+        return
+
+    code_classes = _collect_classes(ports_dir)
+
+    # Check domain layer doc
+    doc_path = DOCS_DIR / "02-architecture" / "01-domain-layer.md"
+    doc_text = _read_doc(doc_path)
+    if not doc_text:
+        report.add(
+            "ports", "WARNING", str(doc_path.relative_to(PROJECT_ROOT)),
+            "Domain layer doc not found — cannot verify port references",
+        )
+        return
+
+    # Extract Port references
+    refs = _extract_backtick_refs(doc_text)
+    port_refs = {r for r in refs if r.endswith("Port") and r[0].isupper()}
+
+    for port_name in sorted(port_refs):
+        if port_name not in code_classes:
+            report.add(
+                "ports", "ERROR",
+                str(doc_path.relative_to(PROJECT_ROOT)),
+                f"Port `{port_name}` referenced in docs but not found in domain/ports/",
+            )
+
+    # Also check the ports __init__ facade (ARCH-008)
+    init_file = ports_dir / "__init__.py"
+    if init_file.exists():
+        init_text = init_file.read_text(encoding="utf-8")
+        for port_name in sorted(port_refs):
+            if port_name in code_classes and port_name not in init_text:
+                report.add(
+                    "ports", "WARNING",
+                    "src/bioetl/domain/ports/__init__.py",
+                    f"Port `{port_name}` exists but not re-exported in ports facade",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Check: Key architecture classes
+# ---------------------------------------------------------------------------
+
+def check_classes(report: DriftReport) -> None:
+    """Verify key classes referenced in architecture docs exist."""
+    all_classes = _collect_classes(SRC_DIR)
+
+    # Map doc files to expected class name patterns.
+    # Names here are the *canonical code names* — checked against actual AST.
+    doc_checks: list[tuple[Path, list[str]]] = [
+        (
+            DOCS_DIR / "02-architecture" / "02-application-layer.md",
+            [
+                "BasePipeline", "BaseTransformer", "RecordProcessor",
+                "BatchExecutor", "PipelineRunner", "PipelineService",
+                "LockManager", "PreflightService", "BatchMetricsRecorderService",
+                "FilteredDataSource", "CompositePipelineRunner",
+                "EnrichmentCoordinatorService",
+            ],
+        ),
+        (
+            DOCS_DIR / "02-architecture" / "03-infrastructure-layer.md",
+            [
+                "BronzeWriter", "SilverWriter", "GoldWriter",
+                "BaseHttpAdapter", "UnifiedHTTPClient",
+                "TokenBucket", "CircuitBreaker", "MemoryLock",
+            ],
+        ),
+        (
+            DOCS_DIR / "02-architecture" / "05-composition-layer.md",
+            [
+                "GenericPipelineFactory",
+            ],
+        ),
+    ]
+
+    for doc_path, expected_classes in doc_checks:
+        if not doc_path.exists():
+            report.add(
+                "classes", "WARNING",
+                str(doc_path.relative_to(PROJECT_ROOT)),
+                "Architecture doc not found — cannot verify class references",
+            )
+            continue
+
+        doc_text = _read_doc(doc_path)
+        doc_refs = set(_extract_backtick_refs(doc_text))
+
+        for cls_name in expected_classes:
+            if cls_name not in all_classes:
+                report.add(
+                    "classes", "ERROR",
+                    str(doc_path.relative_to(PROJECT_ROOT)),
+                    f"Class `{cls_name}` expected from docs but not found in codebase",
+                )
+            elif cls_name not in doc_refs:
+                # Class exists but not mentioned — possible doc gap
+                report.add(
+                    "classes", "WARNING",
+                    str(doc_path.relative_to(PROJECT_ROOT)),
+                    f"Class `{cls_name}` exists in code but not referenced in doc",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Check: Module paths referenced in docs
+# ---------------------------------------------------------------------------
+
+def check_modules(report: DriftReport) -> None:
+    """Verify module paths referenced in architecture docs resolve."""
+    all_modules = _collect_modules(SRC_DIR)
+
+    # Check all architecture docs for bioetl.* module path references
+    arch_dir = DOCS_DIR / "02-architecture"
+    if not arch_dir.exists():
+        return
+
+    module_pattern = re.compile(r"`(bioetl\.[a-z_.]+)`")
+
+    for md_file in sorted(arch_dir.glob("*.md")):
+        text = md_file.read_text(encoding="utf-8")
+        for match in module_pattern.finditer(text):
+            mod_path = match.group(1)
+            # Check if any module starts with this path (could be a package)
+            if not any(m == mod_path or m.startswith(mod_path + ".") for m in all_modules):
+                report.add(
+                    "modules", "ERROR",
+                    str(md_file.relative_to(PROJECT_ROOT)),
+                    f"Module path `{mod_path}` referenced but not found in src/",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Check: Provider registry
+# ---------------------------------------------------------------------------
+
+def check_providers(report: DriftReport) -> None:
+    """Verify documented providers match actual adapter directories."""
+    adapters_dir = SRC_DIR / "infrastructure" / "adapters"
+    if not adapters_dir.exists():
+        return
+
+    # Utility sub-packages that are NOT data providers
+    _NON_PROVIDER_DIRS = frozenset({
+        "common", "decorators", "http", "input", "__pycache__",
+    })
+
+    actual_providers = {
+        d.name
+        for d in adapters_dir.iterdir()
+        if d.is_dir()
+        and not d.name.startswith("_")
+        and d.name not in _NON_PROVIDER_DIRS
+    }
+
+    # Check provider reference docs
+    providers_doc = DOCS_DIR / "04-reference" / "providers"
+    if not providers_doc.exists():
+        return
+
+    readme = providers_doc / "README.md"
+    if not readme.exists():
+        return
+
+    doc_text = readme.read_text(encoding="utf-8")
+
+    for provider in sorted(actual_providers):
+        if provider not in doc_text and provider.replace("_", "-") not in doc_text:
+            report.add(
+                "providers", "WARNING",
+                "docs/04-reference/providers/README.md",
+                f"Provider `{provider}` has adapter but not referenced in provider docs",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Check: Glossary terms
+# ---------------------------------------------------------------------------
+
+def check_glossary(report: DriftReport) -> None:
+    """Verify glossary class/module references still exist."""
+    glossary_path = DOCS_DIR / "00-project" / "glossary.md"
+    if not glossary_path.exists():
+        return
+
+    all_classes = _collect_classes(SRC_DIR)
+    text = glossary_path.read_text(encoding="utf-8")
+
+    # Extract class-like references from glossary, but only from the
+    # "Canonical Term" / "Description" columns — skip the
+    # "Deprecated / Avoid" column (the last content column in glossary tables).
+    class_refs: list[str] = []
+    for line in text.splitlines():
+        if "|" in line:
+            cols = line.split("|")
+            # Table rows: ['', col1, col2, ..., colN, '']
+            # Strip the last content column (Avoid/Deprecated) and trailing empty
+            if len(cols) > 4:  # at least 3 content columns
+                canonical_part = "|".join(cols[:-2])
+            else:
+                canonical_part = line
+        else:
+            canonical_part = line
+        class_refs.extend(
+            re.findall(
+                r"`([A-Z][a-zA-Z]+(?:Port|Factory|Service|Writer|Reader|Adapter|Client))`",
+                canonical_part,
+            )
+        )
+
+    for cls_name in sorted(set(class_refs)):
+        if cls_name not in all_classes:
+            report.add(
+                "glossary", "WARNING",
+                "docs/00-project/glossary.md",
+                f"Glossary references `{cls_name}` which no longer exists in codebase",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def print_report(report: DriftReport) -> None:
+    """Print human-readable drift report."""
+    print("Documentation Drift Report")
+    print("=" * 60)
+
+    if not report.issues:
+        print("No drift detected. Documentation is in sync with code.")
+        return
+
+    by_category: dict[str, list[DriftIssue]] = {}
+    for issue in report.issues:
+        by_category.setdefault(issue.category, []).append(issue)
+
+    for category in sorted(by_category):
+        issues = by_category[category]
+        print(f"\n[{category.upper()}] ({len(issues)} issues)")
+        for issue in issues:
+            marker = "ERROR" if issue.severity == "ERROR" else "WARN "
+            print(f"  {marker}  {issue.doc_file}")
+            print(f"         {issue.detail}")
+
+    print()
+    print(
+        f"Summary: {report.error_count} errors, "
+        f"{report.warning_count} warnings"
+    )
+
+
+def main() -> int:
+    """Run documentation drift detection."""
+    parser = argparse.ArgumentParser(
+        description="Detect documentation drift in BioETL",
+    )
+    parser.add_argument("--ports", action="store_true", help="Check port drift only")
+    parser.add_argument("--classes", action="store_true", help="Check class drift only")
+    parser.add_argument("--modules", action="store_true", help="Check module path drift only")
+    parser.add_argument(
+        "--json", action="store_true", dest="json_output",
+        help="Output machine-readable JSON",
+    )
+    args = parser.parse_args()
+
+    report = DriftReport()
+
+    run_all = not (args.ports or args.classes or args.modules)
+
+    if run_all or args.ports:
+        check_ports(report)
+    if run_all or args.classes:
+        check_classes(report)
+    if run_all or args.modules:
+        check_modules(report)
+    if run_all:
+        check_providers(report)
+        check_glossary(report)
+
+    if args.json_output:
+        json.dump(report.to_dict(), sys.stdout, indent=2)
+        print()
+    else:
+        print_report(report)
+
+    return 1 if report.error_count else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docstring_coverage.py
+++ b/scripts/check_docstring_coverage.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""check_docstring_coverage.py - Verify docstring coverage meets project thresholds.
+
+Checks that all public modules, classes, and functions in src/bioetl/ have
+docstrings.  Exits with code 1 if coverage drops below the configured
+thresholds (see ``THRESHOLDS``).
+
+Usage:
+    python scripts/check_docstring_coverage.py            # Full report
+    python scripts/check_docstring_coverage.py --summary   # One-line summary only
+    python scripts/check_docstring_coverage.py --json      # Machine-readable JSON
+    python scripts/check_docstring_coverage.py --fail-under 95  # Custom threshold (%)
+
+Exit code: 0 = pass, 1 = threshold violation found
+
+References:
+    - RULES.md TYPE-001 (public function annotations)
+    - ai-selfreview-rules.md §5 (Type Annotations)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src" / "bioetl"
+
+# Default thresholds (percent)
+THRESHOLDS = {
+    "modules": 100,
+    "classes": 95,
+    "functions": 90,
+}
+
+
+@dataclass
+class CoverageStats:
+    """Accumulated docstring coverage statistics."""
+
+    modules_total: int = 0
+    modules_with_doc: int = 0
+    classes_total: int = 0
+    classes_with_doc: int = 0
+    functions_total: int = 0
+    functions_with_doc: int = 0
+    missing: list[dict[str, str]] = field(default_factory=list)
+
+    def _pct(self, with_doc: int, total: int) -> float:
+        return round(100.0 * with_doc / total, 1) if total else 100.0
+
+    @property
+    def modules_pct(self) -> float:
+        return self._pct(self.modules_with_doc, self.modules_total)
+
+    @property
+    def classes_pct(self) -> float:
+        return self._pct(self.classes_with_doc, self.classes_total)
+
+    @property
+    def functions_pct(self) -> float:
+        return self._pct(self.functions_with_doc, self.functions_total)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize statistics to a plain dictionary."""
+        return {
+            "modules": {
+                "total": self.modules_total,
+                "documented": self.modules_with_doc,
+                "percent": self.modules_pct,
+            },
+            "classes": {
+                "total": self.classes_total,
+                "documented": self.classes_with_doc,
+                "percent": self.classes_pct,
+            },
+            "functions": {
+                "total": self.functions_total,
+                "documented": self.functions_with_doc,
+                "percent": self.functions_pct,
+            },
+            "missing_count": len(self.missing),
+            "missing": self.missing,
+        }
+
+
+def collect_stats(src_dir: Path) -> CoverageStats:
+    """Walk *src_dir* and gather docstring coverage data."""
+    stats = CoverageStats()
+
+    for py_file in sorted(src_dir.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+
+        rel = py_file.relative_to(src_dir)
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        # Module-level docstring
+        stats.modules_total += 1
+        if ast.get_docstring(tree):
+            stats.modules_with_doc += 1
+        else:
+            stats.missing.append(
+                {"file": str(rel), "kind": "module", "name": str(rel)}
+            )
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                stats.classes_total += 1
+                if ast.get_docstring(node):
+                    stats.classes_with_doc += 1
+                elif not node.name.startswith("_"):
+                    stats.missing.append(
+                        {
+                            "file": str(rel),
+                            "line": str(node.lineno),
+                            "kind": "class",
+                            "name": node.name,
+                        }
+                    )
+
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                stats.functions_total += 1
+                if ast.get_docstring(node):
+                    stats.functions_with_doc += 1
+                elif not node.name.startswith("_"):
+                    stats.missing.append(
+                        {
+                            "file": str(rel),
+                            "line": str(node.lineno),
+                            "kind": "function",
+                            "name": node.name,
+                        }
+                    )
+
+    return stats
+
+
+def print_report(stats: CoverageStats, *, verbose: bool = True) -> None:
+    """Print a human-readable coverage report to *stdout*."""
+    print("Docstring Coverage Report")
+    print("=" * 50)
+    print(
+        f"  Modules:   {stats.modules_with_doc}/{stats.modules_total}"
+        f"  ({stats.modules_pct}%)"
+    )
+    print(
+        f"  Classes:   {stats.classes_with_doc}/{stats.classes_total}"
+        f"  ({stats.classes_pct}%)"
+    )
+    print(
+        f"  Functions: {stats.functions_with_doc}/{stats.functions_total}"
+        f"  ({stats.functions_pct}%)"
+    )
+    print()
+
+    if verbose and stats.missing:
+        public_missing = [
+            m for m in stats.missing if not m["name"].startswith("_")
+        ]
+        if public_missing:
+            print(f"Public items missing docstrings ({len(public_missing)}):")
+            for m in public_missing:
+                loc = f"{m['file']}:{m.get('line', '1')}"
+                print(f"  {m['kind']:>8}  {loc}  {m['name']}")
+            print()
+
+
+def check_thresholds(
+    stats: CoverageStats,
+    fail_under: float | None = None,
+) -> list[str]:
+    """Return list of threshold violations (empty = pass)."""
+    violations: list[str] = []
+
+    thresholds = dict(THRESHOLDS)
+    if fail_under is not None:
+        thresholds = {k: fail_under for k in thresholds}
+
+    for kind, threshold in thresholds.items():
+        actual = getattr(stats, f"{kind}_pct")
+        if actual < threshold:
+            violations.append(
+                f"{kind}: {actual}% < {threshold}% threshold"
+            )
+
+    return violations
+
+
+def main() -> int:
+    """Run the docstring coverage checker."""
+    parser = argparse.ArgumentParser(
+        description="Check docstring coverage for src/bioetl/",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print one-line summary only",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output machine-readable JSON",
+    )
+    parser.add_argument(
+        "--fail-under",
+        type=float,
+        default=None,
+        help="Override all thresholds with a single percentage (e.g. 95)",
+    )
+    parser.add_argument(
+        "--src",
+        type=Path,
+        default=SRC_DIR,
+        help="Source directory to scan (default: src/bioetl)",
+    )
+    args = parser.parse_args()
+
+    stats = collect_stats(args.src)
+
+    if args.json_output:
+        violations = check_thresholds(stats, args.fail_under)
+        output = stats.to_dict()
+        output["violations"] = violations
+        output["status"] = "FAIL" if violations else "PASS"
+        json.dump(output, sys.stdout, indent=2)
+        print()
+        return 1 if violations else 0
+
+    if args.summary:
+        print(
+            f"Docstrings: modules={stats.modules_pct}%"
+            f" classes={stats.classes_pct}%"
+            f" functions={stats.functions_pct}%"
+            f" (missing={len(stats.missing)})"
+        )
+    else:
+        print_report(stats)
+
+    violations = check_thresholds(stats, args.fail_under)
+    if violations:
+        print("THRESHOLD VIOLATIONS:")
+        for v in violations:
+            print(f"  FAIL: {v}")
+        return 1
+
+    print("All thresholds passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bioetl/application/composite/coalesce_policy.py
+++ b/src/bioetl/application/composite/coalesce_policy.py
@@ -178,6 +178,7 @@ class CoalescePolicyService:
         """Sort columns with either seed-first or enricher-first strategy."""
 
         def sort_key(col: str) -> int:
+            """Return 0 for preferred-origin columns and 1 for others."""
             is_seed = bool(seed_prefix and col.startswith(seed_prefix))
             if prefer_seed:
                 return 0 if is_seed else 1

--- a/src/bioetl/application/composite/dependency_key_resolvers.py
+++ b/src/bioetl/application/composite/dependency_key_resolvers.py
@@ -43,6 +43,7 @@ class SeedKeyResolver:
         dep_config_lookup: dict[str, DependencyConfig],
         delta_reader: DeltaReaderPort | None,
     ) -> pl.DataFrame:
+        """Resolve keys by passing through the seed keys unchanged."""
         del dep_config_lookup, delta_reader
         self._logger.debug(
             "Using seed keys for dependency",
@@ -65,6 +66,7 @@ class ChainedKeyResolver:
         dep_config_lookup: dict[str, DependencyConfig],
         delta_reader: DeltaReaderPort | None,
     ) -> pl.DataFrame:
+        """Resolve keys by reading them from the source dependency's Silver table."""
         reader = self._require_delta_reader(dependency, delta_reader)
         source_config = self._resolve_source_config(dependency, dep_config_lookup)
         source_table = source_config.silver_table

--- a/src/bioetl/composition/bootstrap/runtime/runner_factory_builder_service.py
+++ b/src/bioetl/composition/bootstrap/runtime/runner_factory_builder_service.py
@@ -73,6 +73,7 @@ class RunnerFactoryBuilderService(Generic[_RunOptionsT]):
         """Build seed phase runner factory."""
 
         def seed_runner_factory() -> PipelineRunner:
+            """Create a PipelineRunner configured for the seed phase."""
             options = self._run_options_cls(
                 run_type="incremental",
                 limit=seed_limit,
@@ -97,6 +98,7 @@ class RunnerFactoryBuilderService(Generic[_RunOptionsT]):
             pipeline_name: str,
             keys: pl.DataFrame,
         ) -> PipelineRunner:
+            """Create a PipelineRunner configured for the given enricher."""
             enricher_cfg = enricher_configs.get(pipeline_name)
             filter_ids: tuple[str, ...] | None = None
             filter_field: str | None = None
@@ -156,6 +158,7 @@ class RunnerFactoryBuilderService(Generic[_RunOptionsT]):
             pipeline_name: str,
             keys: pl.DataFrame,
         ) -> PipelineRunner:
+            """Create a PipelineRunner configured for the given dependency."""
             dep_cfg = dependency_configs.get(pipeline_name)
             filter_ids, filter_field, multi_filter_ids = (
                 self._filter_extraction_service.resolve_dependency_filter_inputs(

--- a/src/bioetl/domain/composite/config.py
+++ b/src/bioetl/domain/composite/config.py
@@ -99,22 +99,26 @@ class CompositeConfig:
 
     @property
     def required_enrichers(self) -> tuple[str, ...]:
+        """Return pipeline names of required enrichers."""
         return tuple(
             enricher.pipeline for enricher in self.enrichers if enricher.required
         )
 
     @property
     def optional_enrichers(self) -> tuple[str, ...]:
+        """Return pipeline names of optional enrichers."""
         return tuple(
             enricher.pipeline for enricher in self.enrichers if not enricher.required
         )
 
     @property
     def all_enricher_names(self) -> tuple[str, ...]:
+        """Return all enricher pipeline names (required and optional)."""
         return tuple(enricher.pipeline for enricher in self.enrichers)
 
     @property
     def required_dependencies(self) -> tuple[str, ...]:
+        """Return pipeline names of required dependencies."""
         return tuple(
             dependency.pipeline
             for dependency in self.dependencies
@@ -123,6 +127,7 @@ class CompositeConfig:
 
     @property
     def optional_dependencies(self) -> tuple[str, ...]:
+        """Return pipeline names of optional dependencies."""
         return tuple(
             dependency.pipeline
             for dependency in self.dependencies
@@ -131,15 +136,18 @@ class CompositeConfig:
 
     @property
     def all_dependency_names(self) -> tuple[str, ...]:
+        """Return all dependency pipeline names."""
         return tuple(dependency.pipeline for dependency in self.dependencies)
 
     def get_dependency(self, pipeline_name: str) -> DependencyConfig | None:
+        """Look up a dependency config by pipeline name."""
         for dependency in self.dependencies:
             if dependency.pipeline == pipeline_name:
                 return dependency
         return None
 
     def get_enricher(self, pipeline_name: str) -> EnricherConfig | None:
+        """Look up an enricher config by pipeline name."""
         for enricher in self.enrichers:
             if enricher.pipeline == pipeline_name:
                 return enricher
@@ -147,13 +155,16 @@ class CompositeConfig:
 
     @property
     def lock_key(self) -> str:
+        """Return the distributed lock key for this composite pipeline."""
         return f"composite:{self.name}"
 
     def to_dict(self) -> dict[str, object]:
+        """Serialize this config to a plain dictionary."""
         return _composite_to_dict(self)
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> CompositeConfig:
+        """Deserialize a CompositeConfig from a plain dictionary."""
         return _composite_from_dict(data)
 
 

--- a/src/bioetl/domain/composite/config_models.py
+++ b/src/bioetl/domain/composite/config_models.py
@@ -29,6 +29,8 @@ __all__ = [
 
 @dataclass(frozen=True, slots=True)
 class SeedConfig:
+    """Configuration for the seed phase of a composite pipeline."""
+
     pipeline: str
     output_keys: tuple[str, ...]
     silver_table: str
@@ -48,6 +50,8 @@ class SeedConfig:
 
 @dataclass(frozen=True, slots=True)
 class DependencyConfig:
+    """Configuration for a dependency pipeline in a composite run."""
+
     pipeline: str
     join_keys: tuple[str, ...]
     required: bool = False
@@ -79,14 +83,17 @@ class DependencyConfig:
 
     @property
     def primary_join_key(self) -> str:
+        """Return the first join key used for primary matching."""
         return self.join_keys[0]
 
     @property
     def uses_seed_keys(self) -> bool:
+        """Check whether this dependency resolves keys from the seed phase."""
         return self.key_source is None or self.key_source == "seed"
 
     @property
     def effective_filter_fields(self) -> tuple[str, ...]:
+        """Return the resolved filter fields, falling back to the primary join key."""
         if self.filter_fields:
             return self.filter_fields
         if self.filter_field:
@@ -95,11 +102,14 @@ class DependencyConfig:
 
     @property
     def is_multi_field_filter(self) -> bool:
+        """Check whether filtering uses more than one field."""
         return len(self.effective_filter_fields) > 1
 
 
 @dataclass(frozen=True, slots=True)
 class EnricherConfig:
+    """Configuration for an enricher pipeline in a composite run."""
+
     pipeline: str
     join_keys: tuple[str, ...]
     required: bool = False
@@ -151,14 +161,17 @@ class EnricherConfig:
 
     @property
     def primary_join_key(self) -> str:
+        """Return the first join key used for primary matching."""
         return self.join_keys[0]
 
     @property
     def has_fallback_keys(self) -> bool:
+        """Check whether this enricher defines fallback join keys."""
         return len(self.join_keys) > 1
 
     @property
     def is_many_to_one(self) -> bool:
+        """Check whether this enricher uses many-to-one cardinality."""
         return self.cardinality == EnricherCardinality.MANY_TO_ONE
 
 
@@ -183,6 +196,8 @@ def _coerce_column_groups(obj: object, attr: str) -> None:
 
 @dataclass(frozen=True, slots=True)
 class LayerColumnConfig:
+    """Column selection and renaming configuration for a medallion layer."""
+
     columns: tuple[str, ...] | None = None
     column_groups: tuple[ColumnGroupConfig, ...] | None = None
     include_groups: tuple[str, ...] | None = None
@@ -214,6 +229,8 @@ class LayerColumnConfig:
 
 @dataclass(frozen=True, slots=True)
 class DataSchemaConfig:
+    """Schema configuration with column groups for silver and gold layers."""
+
     column_groups: tuple[ColumnGroupConfig, ...] = ()
     silver: LayerColumnConfig | None = None
     gold: LayerColumnConfig | None = None
@@ -226,12 +243,14 @@ class DataSchemaConfig:
             object.__setattr__(self, "gold", LayerColumnConfig(**self.gold))
 
     def get_layer_groups(self, layer: str) -> tuple[ColumnGroupConfig, ...]:
+        """Return column groups for the given layer, falling back to top-level groups."""
         layer_config: LayerColumnConfig | None = getattr(self, layer, None)
         if layer_config and layer_config.column_groups:
             return layer_config.column_groups
         return self.column_groups
 
     def should_include_group(self, layer: str, group_name: str) -> bool:
+        """Check whether the named column group is included for the given layer."""
         layer_config = getattr(self, layer, None)
         if not layer_config or not layer_config.include_groups:
             return True
@@ -240,6 +259,8 @@ class DataSchemaConfig:
 
 @dataclass(frozen=True, slots=True)
 class CrossValidationConfig:
+    """Configuration for cross-enricher data validation."""
+
     enabled: bool = True
     warning_threshold: int = 1
     error_threshold: int = 2
@@ -284,6 +305,7 @@ class CrossValidationConfig:
             )
 
     def get_pairing(self, enricher_pipeline: str) -> EnricherFieldPairing | None:
+        """Look up field pairing config for the given enricher pipeline."""
         for pairing in self.enricher_pairings:
             if pairing.enricher_pipeline == enricher_pipeline:
                 return pairing

--- a/src/bioetl/domain/services/organism_classification_service.py
+++ b/src/bioetl/domain/services/organism_classification_service.py
@@ -279,6 +279,7 @@ class OrganismClassificationService:
         """Return include-only filter strategy."""
 
         def strategy(cellularity: CellularityType | None) -> bool:
+            """Accept cellularity if it is in the include set."""
             if cellularity is None:
                 return keep_unresolved
             return cellularity in include
@@ -293,6 +294,7 @@ class OrganismClassificationService:
         """Return exclusion filter strategy."""
 
         def strategy(cellularity: CellularityType | None) -> bool:
+            """Reject cellularity if it is in the exclude set."""
             if cellularity is None:
                 return keep_unresolved
             return cellularity not in exclude
@@ -304,6 +306,7 @@ class OrganismClassificationService:
         """Return strategy when neither include nor exclude is provided."""
 
         def strategy(cellularity: CellularityType | None) -> bool:
+            """Accept all resolved cellularity values."""
             if cellularity is None:
                 return keep_unresolved
             return True

--- a/src/bioetl/infrastructure/adapters/common/fetch_retry_policy.py
+++ b/src/bioetl/infrastructure/adapters/common/fetch_retry_policy.py
@@ -36,6 +36,7 @@ class _FetchState:
     limit: int | None = None
 
     def limit_reached(self) -> bool:
+        """Check whether the fetch count has reached the configured limit."""
         return self.limit is not None and self.fetched >= self.limit
 
 

--- a/src/bioetl/infrastructure/storage/silver_writer_validation_mixin.py
+++ b/src/bioetl/infrastructure/storage/silver_writer_validation_mixin.py
@@ -136,6 +136,7 @@ class SilverWriterValidationMixin:
         def collect_violations(
             field: str, key_type: Literal["merge", "partition"]
         ) -> int:
+            """Count null values for a non-nullable key field."""
             rule = rules.get((field, key_type))
             if rule is None or rule.nullable:
                 return 0

--- a/src/bioetl/interfaces/cli/commands/execution_policy.py
+++ b/src/bioetl/interfaces/cli/commands/execution_policy.py
@@ -54,14 +54,22 @@ _FAILED_STATUS_EXIT_OVERRIDES: Mapping[str, ExitCode] = {
 
 
 class BatchRunResultProtocol(Protocol):
-    @property
-    def failed(self) -> int: ...
+    """Protocol for batch run result objects used in exit-code mapping."""
 
     @property
-    def total(self) -> int: ...
+    def failed(self) -> int:
+        """Return the number of failed runs."""
+        ...
 
     @property
-    def results(self) -> Sequence[object]: ...
+    def total(self) -> int:
+        """Return the total number of runs."""
+        ...
+
+    @property
+    def results(self) -> Sequence[object]:
+        """Return the individual run results."""
+        ...
 
 
 def map_run_status_to_exit_code(

--- a/src/bioetl/interfaces/cli/commands/export.py
+++ b/src/bioetl/interfaces/cli/commands/export.py
@@ -44,16 +44,24 @@ ExportFormat = Literal["csv", "xlsx", "tsv"]
 
 
 class _ExportCommandService(Protocol):
-    async def preview(self, table_name: str, layer: str = "silver") -> TablePreview: ...
+    """Service protocol for export CLI commands."""
+
+    async def preview(self, table_name: str, layer: str = "silver") -> TablePreview:
+        """Return a preview of the given table."""
+        ...
 
     async def export(
         self,
         table_name: str,
         layer: str = "silver",
         options: ExportOptions | None = None,
-    ) -> ExportResult: ...
+    ) -> ExportResult:
+        """Export the given table to the specified format."""
+        ...
 
-    def list_tables(self, layer: str = "all") -> list[TableInfo]: ...
+    def list_tables(self, layer: str = "all") -> list[TableInfo]:
+        """List available tables for export."""
+        ...
 
 
 def _handle_export_failure(


### PR DESCRIPTION
## Summary

Adds two new quality assurance scripts to detect documentation drift and verify docstring coverage across the codebase. These tools help maintain alignment between code and documentation, and ensure consistent API documentation standards.

## Changes

- **`scripts/check_doc_drift.py`**: New script that detects documentation drift by verifying that:
  - Port protocols referenced in domain-layer docs exist in code
  - Key architecture classes (pipelines, services, writers, etc.) are documented
  - Module paths referenced in architecture docs resolve correctly
  - Provider adapters are documented in reference docs
  - Glossary terms reference existing classes
  
  Supports selective checks via `--ports`, `--classes`, `--modules` flags and JSON output via `--json`.

- **`scripts/check_docstring_coverage.py`**: New script that verifies docstring coverage meets project thresholds:
  - Modules: 100% coverage required
  - Classes: 95% coverage required
  - Functions: 90% coverage required
  
  Supports custom thresholds via `--fail-under`, summary output, and JSON reporting.

- **Docstring additions**: Added missing docstrings to 10+ public methods and protocol definitions across:
  - `src/bioetl/domain/composite/config_models.py` (dataclass and property docstrings)
  - `src/bioetl/domain/composite/config.py` (property docstrings)
  - `src/bioetl/interfaces/cli/commands/execution_policy.py` (protocol docstrings)
  - `src/bioetl/interfaces/cli/commands/export.py` (protocol docstrings)
  - Nested function docstrings in service and utility modules

- **Makefile**: Updated to include new check targets for drift and coverage validation.

## Type

- [x] New feature
- [x] Documentation

## Affected layers

- [x] Domain
- [x] Application
- [x] Infrastructure
- [x] Interfaces

## Test plan

- Existing tests pass (no functional changes to core logic)
- New scripts are self-contained quality checks with no external dependencies beyond stdlib
- Manual verification: Run `python scripts/check_doc_drift.py` and `python scripts/check_docstring_coverage.py` to verify output format and detection logic

## Checklist

- [x] No new import boundary violations (ARCH-001)
- [x] No hardcoded secrets (AP-005)
- [x] Type annotations on all public functions (TYPE-001)
- [x] Docstrings added to previously undocumented public APIs

https://claude.ai/code/session_01M2vZmeJefuUREDbpoDQEYJ