### PR TITLE
Reorganize imports to follow PEP 8 conventions

### DIFF
--- a/src/bioetl/infrastructure/adapters/uniprot/filtering_adapter_mixin.py
+++ b/src/bioetl/infrastructure/adapters/uniprot/filtering_adapter_mixin.py
@@ -5,7 +5,7 @@ Contains FilterableDataSourcePort-compatible filtering methods.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING
 
 from bioetl.domain.types import BronzeRecord
@@ -17,9 +17,6 @@ from bioetl.infrastructure.adapters.uniprot.fallback_resolver import (
     iter_uniprot_fallback_records,
     resolve_uniprot_missing_ids,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
 
 _FetchStrategy = Callable[..., AsyncIterator[BronzeRecord]]
 

--- a/src/bioetl/infrastructure/quality/_quarterly_targets_validation.py
+++ b/src/bioetl/infrastructure/quality/_quarterly_targets_validation.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from itertools import pairwise
 from typing import Any
 
-from bioetl.domain.types import JsonDict, cast
+from typing import cast
+
+from bioetl.domain.types import JsonDict
 
 from bioetl.infrastructure.quality._primitives import (
     QuarterTarget,

--- a/src/bioetl/infrastructure/schemas/pipeline_config.py
+++ b/src/bioetl/infrastructure/schemas/pipeline_config.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
+from bioetl.domain.types import JsonDict
+
 from pydantic import (
     BaseModel,
     ConfigDict,


### PR DESCRIPTION
## Summary

This PR reorganizes imports across three files to follow PEP 8 conventions. Specifically, it moves `AsyncIterator` from a `TYPE_CHECKING` block to the main import statement, moves `cast` to the standard library imports section, and adds a missing import statement in the correct location.

## Changes

- **filtering_adapter_mixin.py**: Moved `AsyncIterator` from `TYPE_CHECKING` conditional import to the main `collections.abc` import statement, eliminating the unnecessary conditional block
- **_quarterly_targets_validation.py**: Separated `cast` from `bioetl.domain.types` import and placed it in the standard library `typing` imports section where it belongs
- **pipeline_config.py**: Added `JsonDict` import from `bioetl.domain.types` in the correct location after standard library imports

## Type

- [x] Refactoring (no functional changes)

## Affected layers

- [x] Infrastructure

## Test plan

- [x] Type check passes (`mypy --strict src/bioetl/`)

## Checklist

- [x] No new import boundary violations (ARCH-001)
- [x] No hardcoded secrets (AP-005)
- [x] Type annotations on all public functions (TYPE-001)
- [x] Tests added/updated for new code (TEST-002) - N/A, refactoring only

https://claude.ai/code/session_01EyviqKbJ93ukdtkXbLhJwC