### PR TITLE
Use errno.EBUSY constant instead of hardcoded error code 16

### DIFF
--- a/tests/unit/infrastructure/storage/test_atomic.py
+++ b/tests/unit/infrastructure/storage/test_atomic.py
@@ -123,7 +123,7 @@ class TestAtomicWrite:
         assert target.read_text() == "original content"
 
     def test_atomic_write_retries_transient_replace_error(self, tmp_path: Path) -> None:
-        """Transient EACCES during replace should be retried and eventually succeed."""
+        """Transient EBUSY during replace should be retried and eventually succeed."""
         target = tmp_path / "retry_target.txt"
         original_replace = Path.replace
         call_count = {"count": 0}
@@ -131,7 +131,7 @@ class TestAtomicWrite:
         def flaky_replace(self: Path, target_path: Path) -> Path:
             call_count["count"] += 1
             if call_count["count"] < 3:
-                raise OSError(16, "Device or resource busy")
+                raise OSError(errno.EBUSY, "Device or resource busy")
             return original_replace(self, target_path)
 
         with patch.object(Path, "replace", flaky_replace):
@@ -170,7 +170,7 @@ class TestAtomicWrite:
         def flaky_replace(self: Path, target_path: Path) -> Path:
             call_count["count"] += 1
             if call_count["count"] == 1:
-                raise OSError(16, "Device or resource busy")
+                raise OSError(errno.EBUSY, "Device or resource busy")
             return original_replace(self, target_path)
 
         policy = AdaptiveRetryPolicy(

--- a/tests/unit/infrastructure/storage/test_metadata_writer.py
+++ b/tests/unit/infrastructure/storage/test_metadata_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -392,7 +393,7 @@ class TestMetadataWriter:
         def flaky_replace(self: Path, target_path: Path) -> Path:
             call_count["count"] += 1
             if call_count["count"] == 1:
-                raise OSError(16, "Device or resource busy")
+                raise OSError(errno.EBUSY, "Device or resource busy")
             return original_replace(self, target_path)
 
         with (


### PR DESCRIPTION
## Summary

Replace hardcoded OS error code `16` with the `errno.EBUSY` constant for improved code clarity and maintainability. Update test docstring to accurately reflect the error being tested.

## Changes

- Import `errno` module in test files
- Replace `OSError(16, ...)` with `OSError(errno.EBUSY, ...)` in atomic write and metadata writer tests
- Update docstring in `test_atomic_write_retries_transient_replace_error` to correctly reference EBUSY instead of EACCES

## Type

- [x] Refactoring (no functional changes)

## Affected layers

- [x] Infrastructure

## Test plan

- [x] Existing unit tests pass (no functional changes, only constant substitution)

## Checklist

- [x] No new import boundary violations (ARCH-001)
- [x] No hardcoded secrets (AP-005)
- [x] Type annotations on all public functions (TYPE-001)
- [x] Tests added/updated for new code (TEST-002)

https://claude.ai/code/session_01SHvXW4srkHAbbTAhFaQdTZ