### PR TITLE
Introduce ClockPort and inject SystemClock into runner/coordinator/checkpoint

### DIFF
--- a/src/bioetl/application/composite/checkpoint.py
+++ b/src/bioetl/application/composite/checkpoint.py
@@ -25,7 +25,15 @@ from bioetl.domain.composite.state import CompositePipelineState
 from bioetl.domain.exceptions import BioETLError, CheckpointConflictError, StorageError
 
 if TYPE_CHECKING:
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import ClockPort, LoggerPort
+
+
+class _UtcClock:
+    """Fallback UTC clock for gradual migration."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC)
+
 
 __all__ = [
     "CompositeCheckpointManager",
@@ -101,7 +109,9 @@ class CompositeCheckpointState:
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
-    def with_seed_completed(self, result: SeedResult) -> CompositeCheckpointState:
+    def with_seed_completed(
+        self, result: SeedResult, updated_at: datetime | None = None
+    ) -> CompositeCheckpointState:
         """Create new state with seed marked as completed.
 
         Sets state to SEED_COMPLETED to indicate seed phase is done.
@@ -123,11 +133,14 @@ class CompositeCheckpointState:
             completed_enrichers=self.completed_enrichers,
             enrichment_results=self.enrichment_results,
             created_at=self.created_at,
-            updated_at=datetime.now(tz=UTC),
+            updated_at=updated_at or self.updated_at or self.created_at,
         )
 
     def with_dependency_completed(
-        self, dependency_name: str, result: DependencyResult
+        self,
+        dependency_name: str,
+        result: DependencyResult,
+        updated_at: datetime | None = None,
     ) -> CompositeCheckpointState:
         """Create new state with dependency marked as completed.
 
@@ -155,11 +168,14 @@ class CompositeCheckpointState:
             completed_enrichers=self.completed_enrichers,
             enrichment_results=self.enrichment_results,
             created_at=self.created_at,
-            updated_at=datetime.now(tz=UTC),
+            updated_at=updated_at or self.updated_at or self.created_at,
         )
 
     def with_enricher_completed(
-        self, enricher_name: str, result: EnrichmentResult
+        self,
+        enricher_name: str,
+        result: EnrichmentResult,
+        updated_at: datetime | None = None,
     ) -> CompositeCheckpointState:
         """Create new state with enricher marked as completed.
 
@@ -187,10 +203,12 @@ class CompositeCheckpointState:
             completed_enrichers=frozenset(new_completed),
             enrichment_results=new_results,
             created_at=self.created_at,
-            updated_at=datetime.now(tz=UTC),
+            updated_at=updated_at or self.updated_at or self.created_at,
         )
 
-    def with_state(self, new_state: CompositePipelineState) -> CompositeCheckpointState:
+    def with_state(
+        self, new_state: CompositePipelineState, updated_at: datetime | None = None
+    ) -> CompositeCheckpointState:
         """Create new state with updated FSM state.
 
         Allows Runner to explicitly set state transitions (e.g., to MERGING,
@@ -214,7 +232,7 @@ class CompositeCheckpointState:
             completed_enrichers=self.completed_enrichers,
             enrichment_results=self.enrichment_results,
             created_at=self.created_at,
-            updated_at=datetime.now(tz=UTC),
+            updated_at=updated_at or self.updated_at or self.created_at,
         )
 
     @property
@@ -420,6 +438,7 @@ class CompositeCheckpointService:
         checkpoint_dir: Path,
         logger: LoggerPort,
         resume: bool = False,
+        clock: ClockPort | None = None,
     ) -> None:
         """Initialize checkpoint manager.
 
@@ -436,6 +455,7 @@ class CompositeCheckpointService:
         self._logger = logger
         self._resume = resume
         self._checkpoint_path = self._get_checkpoint_path()
+        self._clock = clock or _UtcClock()
 
     def _get_checkpoint_path(self) -> Path:
         """Get path to checkpoint file."""
@@ -563,7 +583,7 @@ class CompositeCheckpointService:
         return CompositeCheckpointState(
             composite_name=self._composite_name,
             run_id=self._run_id,
-            created_at=datetime.now(tz=UTC),
+            created_at=self._clock.now(),
         )
 
     async def save(self, state: CompositeCheckpointState) -> None:

--- a/src/bioetl/application/composite/coordinator.py
+++ b/src/bioetl/application/composite/coordinator.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
     from bioetl.application.core.runner import PipelineRunner
     from bioetl.domain.composite.config import CompositeDQConfig, EnricherConfig
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import ClockPort, LoggerPort
 
 
 _FILTER_CONDITION_ERRORS = (
@@ -48,6 +48,13 @@ _ENRICHER_EXECUTION_ERRORS = (
 
 
 __all__ = ["EnrichmentCoordinator", "EnrichmentCoordinatorService"]
+
+
+class _UtcClock:
+    """Fallback UTC clock for gradual migration."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC)
 
 
 class EnrichmentCoordinatorService:
@@ -85,6 +92,7 @@ class EnrichmentCoordinatorService:
         logger: LoggerPort,
         dq_config: CompositeDQConfig,
         max_concurrency: int = 4,
+        clock: ClockPort | None = None,
     ) -> None:
         """Initialize enrichment coordinator.
 
@@ -97,6 +105,7 @@ class EnrichmentCoordinatorService:
         self._dq_config = dq_config
         self._max_concurrency = max_concurrency
         self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._clock = clock or _UtcClock()
 
     async def run_enrichers(
         self,
@@ -286,7 +295,7 @@ class EnrichmentCoordinatorService:
             EnrichmentResult with execution outcome.
         """
         async with self._semaphore:
-            started_at = datetime.now(tz=UTC)
+            started_at = self._clock.now()
             records_input = len(keys)
 
             self._logger.info(
@@ -302,7 +311,7 @@ class EnrichmentCoordinatorService:
                     runner = runner_factory(enricher.pipeline, keys)
                     await runner.run()
 
-                completed_at = datetime.now(tz=UTC)
+                completed_at = self._clock.now()
                 duration = (completed_at - started_at).total_seconds()
 
                 # Extract stats from runner
@@ -373,7 +382,7 @@ class EnrichmentCoordinatorService:
                 )
 
             except TimeoutError:
-                duration = (datetime.now(tz=UTC) - started_at).total_seconds()
+                duration = (self._clock.now() - started_at).total_seconds()
                 self._logger.warning(
                     "Enricher timed out",
                     enricher=enricher.pipeline,
@@ -386,7 +395,7 @@ class EnrichmentCoordinatorService:
                 )
 
             except _ENRICHER_EXECUTION_ERRORS as e:
-                duration = (datetime.now(tz=UTC) - started_at).total_seconds()
+                duration = (self._clock.now() - started_at).total_seconds()
 
                 # Re-raise for required enrichers (logged as error)
                 if enricher.required:
@@ -415,7 +424,7 @@ class EnrichmentCoordinatorService:
                     duration_seconds=duration,
                 )
             except BioETLError as e:
-                duration = (datetime.now(tz=UTC) - started_at).total_seconds()
+                duration = (self._clock.now() - started_at).total_seconds()
 
                 # Re-raise for required enrichers (logged as error)
                 if enricher.required:

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -48,7 +48,21 @@ if TYPE_CHECKING:
     from bioetl.application.core.runner import PipelineRunner
     from bioetl.application.services.dq_report_service import DQReportService
     from bioetl.domain.composite.config import CompositeConfig
-    from bioetl.domain.ports import LockPort, LoggerPort, MetricsPort, QuarantinePort
+    from bioetl.domain.ports import (
+        ClockPort,
+        LockPort,
+        LoggerPort,
+        MetricsPort,
+        QuarantinePort,
+    )
+
+
+class _UtcClock:
+    """Fallback UTC clock for gradual migration."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC)
+
 
 __all__ = [
     "CompositePipelineRunner",
@@ -125,6 +139,7 @@ class CompositePipelineRunnerService(
         dependency_coordinator: DependencyCoordinatorService | None = None,
         quarantine_port: QuarantinePort | None = None,
         metrics: MetricsPort | None = None,
+        clock: ClockPort | None = None,
     ) -> None:
         """Initialize runner and all stage dependencies."""
         self._config = config
@@ -148,6 +163,7 @@ class CompositePipelineRunnerService(
         self._preflight_validator = preflight_validator
         self._quarantine_port = quarantine_port
         self._metrics = metrics
+        self._clock = clock or _UtcClock()
 
         from bioetl.application.composite.fsm_helper import FSMStateHelperService
 
@@ -179,7 +195,7 @@ class CompositePipelineRunnerService(
         self._validate_config_consistency()
         self._run_preflight_validation()
 
-        self._started_at = datetime.now(tz=UTC)
+        self._started_at = self._clock.now()
         self._logger.info(
             PipelineEvent.START,
             composite=self._config.name,

--- a/src/bioetl/application/composite/runner_stage_mixin.py
+++ b/src/bioetl/application/composite/runner_stage_mixin.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from bioetl.application.composite.runner import CompositeRuntimeConfig
     from bioetl.application.core.runner import PipelineRunner
     from bioetl.domain.composite.config import CompositeConfig, EnricherConfig
-    from bioetl.domain.ports import LoggerPort
+    from bioetl.domain.ports import ClockPort, LoggerPort
 
 __all__ = ["CompositeRunnerStageHelper"]
 
@@ -56,6 +56,8 @@ class _CompositeRunnerStageSupportMixin:
     _dependencies_runner_factory: Callable[[str, pl.DataFrame], PipelineRunner] | None
     _coordinator: EnrichmentCoordinatorService
     _enricher_runner_factory: Callable[[str, pl.DataFrame], PipelineRunner]
+    _clock: ClockPort
+
 
     async def _call_save_checkpoint_safe(
         self,
@@ -65,7 +67,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer checkpoint save helper."""
         save_checkpoint = cast(
             "Callable[[CompositeCheckpointState, str], Awaitable[bool]]",
-            getattr(self, "_save_checkpoint_safe"),
+            self._save_checkpoint_safe,
         )
         return await save_checkpoint(state, operation)
 
@@ -73,7 +75,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer seed runner helper."""
         run_seed = cast(
             "Callable[[], Awaitable[SeedResult]]",
-            getattr(self, "_run_seed"),
+            self._run_seed,
         )
         return await run_seed()
 
@@ -84,7 +86,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer enricher selection helper."""
         get_enrichers = cast(
             "Callable[[CompositeCheckpointState], list[EnricherConfig]]",
-            getattr(self, "_get_enrichers_to_run"),
+            self._get_enrichers_to_run,
         )
         return get_enrichers(state)
 
@@ -95,7 +97,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer required-enricher validation helper."""
         check_required = cast(
             "Callable[[dict[str, EnrichmentResult]], None]",
-            getattr(self, "_check_required_enrichers"),
+            self._check_required_enrichers,
         )
         check_required(enrichment_results)
 
@@ -140,7 +142,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
         )
         if state.state != CompositePipelineState.SEED_COMPLETED:
             previous_state = state.state
-            state = state.with_state(CompositePipelineState.SEED_COMPLETED)
+            state = state.with_state(
+                CompositePipelineState.SEED_COMPLETED, updated_at=self._clock.now()
+            )
             self._fsm.log_fsm_transition(
                 from_state=previous_state,
                 to_state=CompositePipelineState.SEED_COMPLETED,
@@ -158,7 +162,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
             previous_state,
             CompositePipelineState.SEED_RUNNING,
         )
-        state = state.with_state(CompositePipelineState.SEED_RUNNING)
+        state = state.with_state(
+            CompositePipelineState.SEED_RUNNING, updated_at=self._clock.now()
+        )
         self._fsm.log_fsm_transition(
             from_state=previous_state,
             to_state=CompositePipelineState.SEED_RUNNING,
@@ -188,7 +194,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
                 stage="seed_failed",
                 error=str(error),
             )
-            failed_state = state.with_state(CompositePipelineState.FAILED)
+            failed_state = state.with_state(
+                CompositePipelineState.FAILED, updated_at=self._clock.now()
+            )
             await self._call_save_checkpoint_safe(failed_state, "seed_failed")
             raise
         except BioETLError as error:
@@ -207,11 +215,13 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
                 stage="seed_failed",
                 error=str(error),
             )
-            failed_state = state.with_state(CompositePipelineState.FAILED)
+            failed_state = state.with_state(
+                CompositePipelineState.FAILED, updated_at=self._clock.now()
+            )
             await self._call_save_checkpoint_safe(failed_state, "seed_failed")
             raise
 
-        state = state.with_seed_completed(seed_result)
+        state = state.with_seed_completed(seed_result, updated_at=self._clock.now())
         self._fsm.log_fsm_transition(
             from_state=CompositePipelineState.SEED_RUNNING,
             to_state=CompositePipelineState.SEED_COMPLETED,
@@ -247,7 +257,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
             previous_state,
             CompositePipelineState.DEPENDENCIES_RUNNING,
         )
-        state = state.with_state(CompositePipelineState.DEPENDENCIES_RUNNING)
+        state = state.with_state(
+            CompositePipelineState.DEPENDENCIES_RUNNING, updated_at=self._clock.now()
+        )
         await self._checkpoint_manager.save(state)
 
         dep_pipelines = [
@@ -281,16 +293,22 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
 
         for dep_name, dep_result in dependency_results.items():
             if dep_result.is_success:
-                state = state.with_dependency_completed(dep_name, dep_result)
+                state = state.with_dependency_completed(
+                    dep_name, dep_result, updated_at=self._clock.now()
+                )
 
         required_failed = self._find_required_failures(dependency_results)
         if required_failed:
-            state = state.with_state(CompositePipelineState.FAILED)
+            state = state.with_state(
+                CompositePipelineState.FAILED, updated_at=self._clock.now()
+            )
             await self._checkpoint_manager.save(state)
             raise RuntimeError(f"Required dependencies failed: {required_failed}")
 
         previous_state = state.state
-        state = state.with_state(CompositePipelineState.DEPENDENCIES_COMPLETED)
+        state = state.with_state(
+            CompositePipelineState.DEPENDENCIES_COMPLETED, updated_at=self._clock.now()
+        )
         succeeded = sum(
             1 for result in dependency_results.values() if result.is_success
         )
@@ -328,7 +346,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
                 previous_state,
                 CompositePipelineState.ENRICHING,
             )
-            state = state.with_state(CompositePipelineState.ENRICHING)
+            state = state.with_state(
+                CompositePipelineState.ENRICHING, updated_at=self._clock.now()
+            )
             await self._checkpoint_manager.save(state)
 
             self._fsm.log_fsm_transition(
@@ -355,7 +375,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
 
             for name, result in enrichment_results.items():
                 if result.is_success or result.status == EnrichmentStatus.SKIPPED:
-                    state = state.with_enricher_completed(name, result)
+                    state = state.with_enricher_completed(
+                        name, result, updated_at=self._clock.now()
+                    )
             await self._checkpoint_manager.save(state)
 
             log_enrichment_summary(enrichment_results, self._config.name, self._logger)
@@ -382,7 +404,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
             self._call_check_required_enrichers(enrichment_results)
         except RuntimeError as error:
             previous_state = state.state
-            state = state.with_state(CompositePipelineState.FAILED)
+            state = state.with_state(
+                CompositePipelineState.FAILED, updated_at=self._clock.now()
+            )
             self._fsm.log_fsm_transition(
                 from_state=previous_state,
                 to_state=CompositePipelineState.FAILED,
@@ -432,7 +456,9 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
                 previous_state,
                 CompositePipelineState.ENRICHING,
             )
-            state = state.with_state(CompositePipelineState.ENRICHING)
+            state = state.with_state(
+                CompositePipelineState.ENRICHING, updated_at=self._clock.now()
+            )
             self._fsm.log_fsm_transition(
                 from_state=previous_state,
                 to_state=CompositePipelineState.ENRICHING,
@@ -446,7 +472,10 @@ class CompositeRunnerStageHelper(_CompositeRunnerStageSupportMixin):
                 enriching_state,
                 CompositePipelineState.ENRICHMENT_COMPLETED,
             )
-            state = state.with_state(CompositePipelineState.ENRICHMENT_COMPLETED)
+            state = state.with_state(
+                CompositePipelineState.ENRICHMENT_COMPLETED,
+                updated_at=self._clock.now(),
+            )
             await self._call_save_checkpoint_safe(state, "enrichment_completed")
 
             self._fsm.log_fsm_transition(

--- a/src/bioetl/application/composite/runner_support_mixin.py
+++ b/src/bioetl/application/composite/runner_support_mixin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 from bioetl.application.composite.runner_constants import (
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from bioetl.application.services.dq_report_service import DQReportService
     from bioetl.domain.composite.config import CompositeConfig, EnricherConfig
     from bioetl.domain.composite.result import DependencyResult, MergeResult
-    from bioetl.domain.ports import LoggerPort, MetricsPort, QuarantinePort
+    from bioetl.domain.ports import ClockPort, LoggerPort, MetricsPort, QuarantinePort
     from bioetl.domain.types import RunID
 
 __all__ = ["CompositeRunnerSupportHelper"]
@@ -51,6 +51,7 @@ class CompositeRunnerSupportHelper:
     _preflight_validator: CompositePreflightValidationService | None
     _quarantine_port: QuarantinePort | None
     _metrics: MetricsPort | None
+    _clock: ClockPort
     _fsm: FSMStateHelperService
 
     def _build_composite_result(
@@ -61,7 +62,7 @@ class CompositeRunnerSupportHelper:
         merge_result: MergeResult | None,
     ) -> CompositeResult:
         """Build the final CompositeResult."""
-        completed_at = datetime.now(tz=UTC)
+        completed_at = self._clock.now()
         started = self._started_at or completed_at
         total_duration = (completed_at - started).total_seconds()
 
@@ -210,10 +211,10 @@ class CompositeRunnerSupportHelper:
             seed_pipeline=self._config.seed.pipeline,
         )
 
-        started_at = datetime.now(tz=UTC)
+        started_at = self._clock.now()
         runner = self._seed_runner_factory()
         await runner.run()
-        completed_at = datetime.now(tz=UTC)
+        completed_at = self._clock.now()
 
         records_extracted = getattr(runner, "_executor", None)
         records_silver = 0
@@ -289,7 +290,7 @@ class CompositeRunnerSupportHelper:
             context = DQReportContext(
                 run_id=self._run_id_str,
                 pipeline_name=f"composite_{self._config.name}",
-                timestamp=datetime.now(tz=UTC),
+                timestamp=self._clock.now(),
                 provider="composite",
                 entity=self._config.name,
                 silver_target_table=self._config.merge.output_silver_path,
@@ -329,7 +330,7 @@ class CompositeRunnerSupportHelper:
 
         from bioetl.domain.types import BatchID
 
-        now = datetime.now(tz=UTC)
+        now = self._clock.now()
         pipeline_name = f"composite:{self._config.name}"
         written = 0
 

--- a/src/bioetl/application/services/pipeline_runner_service.py
+++ b/src/bioetl/application/services/pipeline_runner_service.py
@@ -25,11 +25,19 @@ from bioetl.domain.types import RunID, RunType
 
 if TYPE_CHECKING:
     from bioetl.domain.ports import (
+        ClockPort,
         LoggerPort,
         MetricsExtractorPort,
         RunnablePort,
         RunnerFactoryPort,
     )
+
+
+class _UtcClock:
+    """Fallback UTC clock for gradual migration to injected clocks."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=UTC)
 
 
 _PIPELINE_RUN_ERRORS = (
@@ -214,6 +222,7 @@ class PipelineRunnerService:
     runner_factory: RunnerFactoryPort
     metrics_extractor: MetricsExtractorPort
     logger: LoggerPort
+    clock: ClockPort = field(default_factory=_UtcClock)
 
     async def run(
         self,
@@ -249,7 +258,7 @@ class PipelineRunnerService:
             >>> if result.status == PipelineRunResult.DRY_RUN:
             ...     logger.info("dry_run_complete", pipeline="chembl_activity")
         """
-        started_at = datetime.now(tz=UTC)
+        started_at = self.clock.now()
 
         # Merge options with individual parameters
         effective_options = self._merge_options(options, dry_run)
@@ -284,7 +293,7 @@ class PipelineRunnerService:
                 run_id=str(effective_run_id),
                 run_type=effective_options.run_type,
                 started_at=started_at,
-                completed_at=datetime.now(tz=UTC),
+                completed_at=self.clock.now(),
             )
 
         # Build context and create runner
@@ -450,7 +459,7 @@ class PipelineRunnerService:
                 error_type=error_type,
             )
 
-        completed_at = datetime.now(tz=UTC)
+        completed_at = self.clock.now()
 
         # Extract metrics from runner
         metrics = self.metrics_extractor.extract_metrics(runner)

--- a/src/bioetl/composition/bootstrap/runtime/clock.py
+++ b/src/bioetl/composition/bootstrap/runtime/clock.py
@@ -1,0 +1,11 @@
+"""Clock bootstrap helpers."""
+
+from __future__ import annotations
+
+from bioetl.domain.ports import ClockPort
+from bioetl.infrastructure.system import SystemClock
+
+
+def bootstrap_clock_port() -> ClockPort:
+    """Create default system clock adapter."""
+    return SystemClock()

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -24,6 +24,7 @@ from bioetl.application.composite.runner import (
     CompositeRuntimeConfig,
 )
 from bioetl.composition.bootstrap.assembly.storage import bootstrap_storage_adapter
+from bioetl.composition.bootstrap.runtime.clock import bootstrap_clock_port
 from bioetl.composition.bootstrap.runtime.observability import bootstrap_logger_port
 from bioetl.composition.bootstrap.runtime.pipeline import bootstrap_pipeline_runner
 from bioetl.domain.composite.config import (
@@ -525,6 +526,8 @@ def bootstrap_composite_runner(
         logger=logger,
     )
 
+    clock = bootstrap_clock_port()
+
     key_extractor = KeyExtractorService(
         delta_reader=delta_reader,
         logger=logger,
@@ -536,6 +539,7 @@ def bootstrap_composite_runner(
     )
 
     coordinator = EnrichmentCoordinator(
+        clock=clock,
         logger=logger,
         dq_config=config.dq,
         max_concurrency=config.execution.max_concurrency,
@@ -569,6 +573,7 @@ def bootstrap_composite_runner(
         checkpoint_dir=checkpoint_dir,
         logger=logger,
         resume=runtime.resume,
+        clock=clock,
     )
 
     # Create DQ report service for composite
@@ -599,6 +604,7 @@ def bootstrap_composite_runner(
         run_id=effective_run_id,
         dq_report_service=dq_report_service,
         quarantine_port=quarantine_port,
+        clock=clock,
     )
 
 

--- a/src/bioetl/composition/bootstrap/runtime/runner.py
+++ b/src/bioetl/composition/bootstrap/runtime/runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from uuid import uuid4
 
 from bioetl.application.services import PipelineRunnerService
+from bioetl.composition.bootstrap.runtime.clock import bootstrap_clock_port
 from bioetl.composition.bootstrap.runtime.observability import bootstrap_logger_port
 from bioetl.composition.factories.runner_factory import (
     create_metrics_extractor,
@@ -55,4 +56,5 @@ def bootstrap_pipeline_runner_service(
         runner_factory=runner_factory,
         metrics_extractor=metrics_extractor,
         logger=logger,
+        clock=bootstrap_clock_port(),
     )

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -34,6 +34,7 @@ from bioetl.domain.ports.audit import (
     AuditPort,
 )
 from bioetl.domain.ports.checkpoint import CheckpointPort
+from bioetl.domain.ports.clock import ClockPort
 from bioetl.domain.ports.data_normalization import DataNormalizationPort
 from bioetl.domain.ports.data_source import (
     DataSourcePort,
@@ -112,6 +113,7 @@ __all__ = [
     "BronzeMetadataInput",
     "CheckpointPort",
     "CircuitBreakerPort",
+    "ClockPort",
     "DQMonitorPort",
     "DQReportWriterPort",
     "DataNormalizationPort",

--- a/src/bioetl/domain/ports/clock.py
+++ b/src/bioetl/domain/ports/clock.py
@@ -1,0 +1,17 @@
+"""Clock port for deterministic time access."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ClockPort(Protocol):
+    """Port for retrieving current time.
+
+    Enables deterministic tests by injecting fake/fixed clock implementations.
+    """
+
+    def now(self) -> datetime:
+        """Return current timestamp."""

--- a/src/bioetl/infrastructure/system/__init__.py
+++ b/src/bioetl/infrastructure/system/__init__.py
@@ -7,6 +7,7 @@ This package contains infrastructure adapters for system-level operations:
 
 from __future__ import annotations
 
+from bioetl.infrastructure.system.clock import SystemClock
 from bioetl.infrastructure.system.memory_monitor import MemoryMonitor
 
-__all__ = ["MemoryMonitor"]
+__all__ = ["MemoryMonitor", "SystemClock"]

--- a/src/bioetl/infrastructure/system/clock.py
+++ b/src/bioetl/infrastructure/system/clock.py
@@ -1,0 +1,15 @@
+"""System clock adapter implementation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bioetl.domain.ports import ClockPort
+
+
+class SystemClock(ClockPort):
+    """Clock adapter backed by system UTC time."""
+
+    def now(self) -> datetime:
+        """Return current UTC timestamp."""
+        return datetime.now(tz=UTC)

--- a/tests/unit/application/composite/test_checkpoint.py
+++ b/tests/unit/application/composite/test_checkpoint.py
@@ -117,8 +117,9 @@ class TestWithSeedCompleted:
             keys_generated=90,
             duration_seconds=10.5,
         )
-        updated = initial.with_seed_completed(seed_result)
-        assert updated.updated_at is not None
+        now = datetime(2024, 1, 1, tzinfo=UTC)
+        updated = initial.with_seed_completed(seed_result, updated_at=now)
+        assert updated.updated_at == now
 
 
 class TestWithEnricherCompleted:
@@ -277,8 +278,11 @@ class TestWithState:
             composite_name="test_composite",
             run_id="run-123",
         )
-        updated = initial.with_state(CompositePipelineState.SEED_RUNNING)
-        assert updated.updated_at is not None
+        now = datetime(2024, 1, 2, tzinfo=UTC)
+        updated = initial.with_state(
+            CompositePipelineState.SEED_RUNNING, updated_at=now
+        )
+        assert updated.updated_at == now
 
 
 class TestIsResumable:

--- a/tests/unit/application/services/test_pipeline_runner_service.py
+++ b/tests/unit/application/services/test_pipeline_runner_service.py
@@ -21,6 +21,18 @@ from bioetl.application.services.pipeline_runner_service import (
 )
 
 
+class FixedClock:
+    """Deterministic clock for timestamp assertions."""
+
+    def __init__(self, *timestamps: datetime) -> None:
+        self._timestamps = list(timestamps)
+
+    def now(self) -> datetime:
+        if len(self._timestamps) > 1:
+            return self._timestamps.pop(0)
+        return self._timestamps[0]
+
+
 @pytest.fixture
 def mock_logger():
     """Create a mock logger."""
@@ -69,12 +81,22 @@ def mock_metrics_extractor():
 
 
 @pytest.fixture
-def service(mock_runner_factory, mock_metrics_extractor, mock_logger):
+def fixed_clock():
+    """Create a deterministic clock fixture."""
+    return FixedClock(
+        datetime(2024, 1, 1, 12, 0, tzinfo=UTC),
+        datetime(2024, 1, 1, 12, 5, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def service(mock_runner_factory, mock_metrics_extractor, mock_logger, fixed_clock):
     """Create a PipelineRunnerService instance."""
     return PipelineRunnerService(
         runner_factory=mock_runner_factory,
         metrics_extractor=mock_metrics_extractor,
         logger=mock_logger,
+        clock=fixed_clock,
     )
 
 
@@ -267,6 +289,8 @@ class TestPipelineRunnerServiceRun:
         assert result.pipeline_name == "test_pipeline"
         assert result.records_fetched == 100
         assert result.records_silver == 90
+        assert result.started_at == datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        assert result.completed_at == datetime(2024, 1, 1, 12, 5, tzinfo=UTC)
         mock_runner_factory.contains.assert_called_with("test_pipeline")
         mock_runner_factory.create.assert_called_once()
         mock_runner.run.assert_called_once()


### PR DESCRIPTION
### Motivation
- Add a pluggable clock abstraction so application services can obtain time via a port rather than calling `datetime.now(tz=UTC)`, enabling deterministic timestamps and easier testing.  
- Gradually migrate key runner/composite checkpointing code to use injected clock to avoid wide regressions while enabling testable timestamp assertions.  

### Description
- Added new port `ClockPort` at `src/bioetl/domain/ports/clock.py` and exported it from the ports facade.  
- Implemented `SystemClock` adapter in `src/bioetl/infrastructure/system/clock.py` and a composition helper `bootstrap_clock_port()` under `src/bioetl/composition/bootstrap/runtime/clock.py`.  
- Wired a `clock` into composition bootstraps so production wiring supplies a `SystemClock` to services (`bootstrap_pipeline_runner_service` and composite bootstrap).  
- Injected `ClockPort` into application services: `PipelineRunnerService`, `CompositePipelineRunnerService`, `EnrichmentCoordinatorService`, and `CompositeCheckpointService`, with a lightweight fallback `_UtcClock` used during incremental migration.  
- Replaced direct `datetime.now(tz=UTC)` calls in the targeted runner/coordinator/checkpoint/support code with `self.clock.now()` / `self._clock.now()`.  
- Extended `CompositeCheckpointState` mutation methods to accept an optional `updated_at: datetime | None` so orchestration layers can supply clock-driven timestamps when transitioning FSM/checkpoint state.  
- Updated unit tests to use a `FixedClock` (fake clock) for deterministic `started_at`/`completed_at` and checkpoint `updated_at` assertions.  

### Testing
- Ran targeted compilation of modified modules with `python -m compileall` and succeeded.  
- Ran unit tests for the modified areas with `uv run python -m pytest tests/unit/application/services/test_pipeline_runner_service.py tests/unit/application/composite/test_checkpoint.py tests/unit/application/composite/test_coordinator_logging.py tests/unit/composition/bootstrap/test_runner_bootstrap.py -q` and all targeted tests passed.  
- Ran type checks for the edited clock-related modules with `uv run python -m mypy --strict` (targeted files) and the checked files passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3e1fd688324924cf1a88b43c610)