### PR TITLE
Refactor SilverDQAnalyzer into delegated subservices (evaluator, statistics, report assembler)

### DIFF
--- a/src/bioetl/application/services/dq/__init__.py
+++ b/src/bioetl/application/services/dq/__init__.py
@@ -13,11 +13,27 @@ Components:
 from bioetl.application.services.dq.bronze_analyzer import BronzeDQAnalyzer
 from bioetl.application.services.dq.gold_analyzer import GoldDQAnalyzer
 from bioetl.application.services.dq.silver_analyzer import SilverDQAnalyzer
+from bioetl.application.services.dq.silver_dq_checks_service import (
+    SilverDQChecksService,
+)
+from bioetl.application.services.dq.silver_dq_report_assembler_service import (
+    SilverDQReportAssemblerService,
+)
+from bioetl.application.services.dq.silver_dq_rule_evaluator_service import (
+    DQRuleEvaluatorService,
+)
+from bioetl.application.services.dq.silver_dq_statistics_service import (
+    SilverDQStatisticsService,
+)
 from bioetl.domain.services.dq_serializer import DQReportSerializer
 
 __all__ = [
     "BronzeDQAnalyzer",
     "DQReportSerializer",
+    "DQRuleEvaluatorService",
     "GoldDQAnalyzer",
     "SilverDQAnalyzer",
+    "SilverDQChecksService",
+    "SilverDQReportAssemblerService",
+    "SilverDQStatisticsService",
 ]

--- a/src/bioetl/application/services/dq/silver_analyzer.py
+++ b/src/bioetl/application/services/dq/silver_analyzer.py
@@ -1,42 +1,27 @@
-"""Silver layer DQ analyzer.
-
-Implements data quality monitoring for normalized Silver data:
-- Record count with input/output comparison
-- Null rate analysis per column
-- Uniqueness and cardinality checks
-- Type conformance validation
-- Value distribution statistics
-- Schema drift detection
-- Deduplication statistics
-- Content hash integrity
-
-Follows RULES.md §3.1 DQ strategy for Silver layer.
-"""
+"""Silver layer DQ analyzer orchestration facade."""
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 import polars as pl
 import pyarrow as pa
 
-from bioetl.application.services.dq.dq_report_builders import (
-    build_summary,
-    update_counts,
+from bioetl.application.services.dq.silver_dq_report_assembler_service import (
+    SilverDQReportAssemblerService,
+)
+from bioetl.application.services.dq.silver_dq_rule_evaluator_service import (
+    DQRuleEvaluatorService,
+)
+from bioetl.application.services.dq.silver_dq_statistics_service import (
+    SilverDQStatisticsService,
 )
 from bioetl.domain.ports import SilverDQConfigPort
-from bioetl.domain.services.dq_serializer import to_dict
 from bioetl.domain.value_objects.dq_report import (
-    CategoricalDistribution,
     ContentHashIntegrityResult,
     DeduplicationStatsResult,
-    DQCheckStatus,
     DQThresholds,
-    DriftLevel,
-    MedallionLayer,
     NullRateResult,
-    NumericDistribution,
     RecordCountResult,
     SchemaDriftResult,
     SilverDQCheckType,
@@ -46,20 +31,23 @@ from bioetl.domain.value_objects.dq_report import (
     ValueDistributionResult,
 )
 
-_SILVER_PROFILE_ERRORS = (
-    pl.exceptions.PolarsError,
-    ValueError,
-    TypeError,
-    RuntimeError,
-)
-
 
 class SilverDQAnalyzer:
-    """Analyzer for Silver layer DQ checks.
+    """Facade for Silver DQ analysis preserving existing public contract."""
 
-    Performs comprehensive data quality monitoring on normalized data.
-    Implements SilverDQAnalyzerPort.
-    """
+    def __init__(
+        self,
+        evaluator_service: DQRuleEvaluatorService | None = None,
+        statistics_service: SilverDQStatisticsService | None = None,
+        report_assembler_service: SilverDQReportAssemblerService | None = None,
+    ) -> None:
+        self._statistics_service = statistics_service or SilverDQStatisticsService()
+        self._evaluator_service = evaluator_service or DQRuleEvaluatorService(
+            statistics_service=self._statistics_service
+        )
+        self._report_assembler_service = (
+            report_assembler_service or SilverDQReportAssemblerService()
+        )
 
     def _execute_checks(
         self,
@@ -69,105 +57,18 @@ class SilverDQAnalyzer:
         input_record_count: int | None,
         quarantined_count: int,
         previous_schema: dict[str, str] | None,
-        key_nullability_rules: list[
-            dict[str, Any]  # Any: DQ check values vary by check type
-        ]  # Any: DQ rule definitions have heterogeneous values
-        | None,  # Any: DQ check values vary by check type
-    ) -> tuple[
-        dict[str, Any], int, int, int  # Any: DQ check values vary by check type
-    ]:  # Any: DQ check values vary by check type
-        """Execute all enabled DQ checks and collect results.
-
-        Args:
-            df: Polars DataFrame with Silver data.
-            enabled_checks: Set of enabled check types.
-            primary_keys: List of primary key columns.
-            input_record_count: Original record count before transforms.
-            quarantined_count: Number of quarantined records.
-            previous_schema: Previous schema for drift detection.
-
-        Returns:
-            Tuple of (checks dict, passed count, failed count, warnings count).
-        """
-        checks: dict[str, Any] = {}  # Any: DQ check values vary by check type
-        passed, failed, warnings = 0, 0, 0
-
-        if SilverDQCheckType.RECORD_COUNT in enabled_checks:
-            record_count_result = self._check_record_count(
-                df, input_record_count, quarantined_count
-            )
-            checks["record_count"] = to_dict(record_count_result)
-            passed, failed, warnings = update_counts(
-                record_count_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.NULL_RATE in enabled_checks:
-            null_results, overall_rate = self._check_null_rates(df)
-            checks["null_rate"] = {
-                "columns": {r.column_name: to_dict(r) for r in null_results},
-                "overall_null_rate": overall_rate,
-                "status": DQCheckStatus.PASS.value,
-            }
-            passed += 1
-
-        if SilverDQCheckType.UNIQUENESS in enabled_checks:
-            uniqueness_result = self._check_uniqueness(df, primary_keys)
-            checks["uniqueness"] = to_dict(uniqueness_result)
-            passed, failed, warnings = update_counts(
-                uniqueness_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.TYPE_CONFORMANCE in enabled_checks:
-            conformance_result = self._check_type_conformance(df)
-            checks["type_conformance"] = to_dict(conformance_result)
-            passed, failed, warnings = update_counts(
-                conformance_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.VALUE_DISTRIBUTION in enabled_checks:
-            distribution_result = self._check_value_distribution(df)
-            checks["value_distribution"] = self._distribution_to_dict(
-                distribution_result
-            )
-            passed += 1
-
-        if SilverDQCheckType.SCHEMA_DRIFT in enabled_checks:
-            drift_result = self._check_schema_drift(df, previous_schema)
-            checks["schema_drift"] = to_dict(drift_result)
-            passed, failed, warnings = update_counts(
-                drift_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.DEDUPLICATION_STATS in enabled_checks:
-            dedup_result = self._check_deduplication(
-                df, primary_keys, input_record_count or len(df)
-            )
-            checks["deduplication_stats"] = to_dict(dedup_result)
-            passed, failed, warnings = update_counts(
-                dedup_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.CONTENT_HASH_INTEGRITY in enabled_checks:
-            hash_result = self._check_content_hash_integrity(df)
-            checks["content_hash_integrity"] = to_dict(hash_result)
-            passed, failed, warnings = update_counts(
-                hash_result.status, passed, failed, warnings
-            )
-
-        if SilverDQCheckType.KEY_NULLABILITY in enabled_checks:
-            key_nullability_result = self._check_key_nullability(
-                df,
-                key_nullability_rules or [],
-            )
-            checks["key_nullability"] = key_nullability_result
-            passed, failed, warnings = update_counts(
-                DQCheckStatus(key_nullability_result["status"]),
-                passed,
-                failed,
-                warnings,
-            )
-
-        return checks, passed, failed, warnings
+        key_nullability_rules: list[dict[str, object]] | None,
+    ) -> tuple[dict[str, object], int, int, int]:
+        """Backward-compatible wrapper around evaluator service."""
+        return self._evaluator_service.execute_checks(
+            df=df,
+            enabled_checks=enabled_checks,
+            primary_keys=primary_keys,
+            input_record_count=input_record_count,
+            quarantined_count=quarantined_count,
+            previous_schema=previous_schema,
+            key_nullability_rules=key_nullability_rules,
+        )
 
     def _calculate_thresholds(
         self,
@@ -177,33 +78,13 @@ class SilverDQAnalyzer:
         soft_fail_threshold: float,
         hard_fail_threshold: float,
     ) -> DQThresholds:
-        """Calculate DQ thresholds and error rate status.
-
-        Args:
-            df_len: Length of the DataFrame.
-            input_record_count: Original record count before transforms.
-            quarantined_count: Number of quarantined records.
-            soft_fail_threshold: Warning threshold for error rate.
-            hard_fail_threshold: Failure threshold for error rate.
-
-        Returns:
-            DQThresholds with calculated error rate and status.
-        """
-        total_input = input_record_count or df_len + quarantined_count
-        error_rate = quarantined_count / total_input if total_input > 0 else 0.0
-
-        if error_rate >= hard_fail_threshold:
-            threshold_status = DQCheckStatus.FAIL
-        elif error_rate >= soft_fail_threshold:
-            threshold_status = DQCheckStatus.WARN
-        else:
-            threshold_status = DQCheckStatus.PASS
-
-        return DQThresholds(
+        """Backward-compatible wrapper around report assembler service."""
+        return self._report_assembler_service.calculate_thresholds(
+            df_len=df_len,
+            input_record_count=input_record_count,
+            quarantined_count=quarantined_count,
             soft_fail_threshold=soft_fail_threshold,
             hard_fail_threshold=hard_fail_threshold,
-            current_error_rate=round(error_rate, 4),
-            threshold_status=threshold_status,
         )
 
     def analyze(
@@ -222,40 +103,15 @@ class SilverDQAnalyzer:
         input_record_count: int | None = None,
         quarantined_count: int = 0,
         previous_schema: dict[str, str] | None = None,
-        key_nullability_rules: list[
-            dict[str, Any]  # Any: DQ check values vary by check type
-        ]  # Any: DQ rule definitions have heterogeneous values
-        | None = None,  # Any: DQ check values vary by check type
+        key_nullability_rules: list[dict[str, object]] | None = None,
     ) -> SilverDQReport:
-        """Analyze Silver data and generate DQ report.
-
-        Args:
-            data: Polars DataFrame or PyArrow Table with Silver data.
-            run_id: Pipeline run identifier.
-            pipeline: Pipeline name.
-            target_table: Silver table path.
-            source_batch_ids: List of Bronze batch IDs processed.
-            config: DQ report configuration.
-            timestamp: Report generation timestamp (UTC).
-            primary_keys: List of primary key columns.
-            soft_fail_threshold: Warning threshold for error rate.
-            hard_fail_threshold: Failure threshold for error rate.
-            input_record_count: Original record count before transforms.
-            quarantined_count: Number of quarantined records.
-            previous_schema: Previous schema for drift detection.
-
-        Returns:
-            SilverDQReport: Complete DQ report for Silver layer.
-        """
-        # Convert PyArrow to Polars for consistent processing
+        """Analyze Silver data and generate DQ report."""
         if isinstance(data, pa.Table):
             df: pl.DataFrame = pl.from_arrow(data)  # type: ignore[assignment]
         else:
             df = data
 
         enabled_checks = set(config.get_checks_enums())
-
-        # Execute all enabled checks
         checks, passed, failed, warnings = self._execute_checks(
             df=df,
             enabled_checks=enabled_checks,
@@ -266,7 +122,6 @@ class SilverDQAnalyzer:
             key_nullability_rules=key_nullability_rules,
         )
 
-        # Calculate thresholds
         thresholds = self._calculate_thresholds(
             df_len=len(df),
             input_record_count=input_record_count,
@@ -275,59 +130,26 @@ class SilverDQAnalyzer:
             hard_fail_threshold=hard_fail_threshold,
         )
 
-        # Build summary
-        summary = build_summary(
+        return self._report_assembler_service.assemble_report(
+            run_id=run_id,
+            pipeline=pipeline,
+            target_table=target_table,
+            source_batch_ids=source_batch_ids,
+            timestamp=timestamp,
+            checks=checks,
+            thresholds=thresholds,
             passed=passed,
             failed=failed,
             warnings=warnings,
-            threshold_status=thresholds.threshold_status,
         )
 
-        return SilverDQReport(
-            layer=MedallionLayer.SILVER,
-            timestamp=timestamp,
-            run_id=run_id,
-            pipeline=pipeline,
-            source_batch_ids=tuple(source_batch_ids),
-            target_table=target_table,
-            checks=checks,
-            thresholds=thresholds,
-            summary=summary,
-        )
-
+    # Backward-compatible wrappers for existing unit tests and external callers.
     def _check_key_nullability(
         self,
         df: pl.DataFrame,
-        key_nullability_rules: list[
-            dict[str, Any]  # Any: DQ check values vary by check type
-        ],  # Any: DQ check values vary by check type
-    ) -> dict[str, Any]:  # Any: DQ check values vary by check type
-        """Check nullability for configured merge/partition keys."""
-        violations: list[dict[str, Any]] = []  # Any: DQ check values vary by check type
-
-        for rule in key_nullability_rules:
-            if rule.get("nullable", False):
-                continue
-            field = str(rule.get("field", ""))
-            key_type = str(rule.get("key_type", "merge"))
-            if field not in df.columns:
-                continue
-            null_count = int(df[field].null_count())
-            if null_count > 0:
-                violations.append(
-                    {
-                        "field": field,
-                        "key_type": key_type,
-                        "null_count": null_count,
-                    }
-                )
-
-        status = DQCheckStatus.FAIL if violations else DQCheckStatus.PASS
-        return {
-            "status": status.value,
-            "violations": violations,
-            "rules_checked": len(key_nullability_rules),
-        }
+        key_nullability_rules: list[dict[str, object]],
+    ) -> dict[str, object]:
+        return self._evaluator_service.check_key_nullability(df, key_nullability_rules)
 
     def _check_record_count(
         self,
@@ -335,246 +157,28 @@ class SilverDQAnalyzer:
         input_count: int | None,
         quarantined_count: int,
     ) -> RecordCountResult:
-        """Check record count statistics."""
-        output_count = len(df)
-        input_records = input_count or (output_count + quarantined_count)
-        quarantine_rate = (
-            quarantined_count / input_records if input_records > 0 else 0.0
-        )
-
-        # Warn if significant data loss
-        status = DQCheckStatus.PASS
-        if quarantine_rate > 0.1:  # >10% quarantined
-            status = DQCheckStatus.WARN
-
-        return RecordCountResult(
-            value=output_count,
-            status=status,
-            input_records=input_records,
-            output_records=output_count,
-            quarantined_records=quarantined_count,
-            quarantine_rate=round(quarantine_rate, 4),
+        return self._evaluator_service.check_record_count(
+            df, input_count, quarantined_count
         )
 
     def _check_null_rates(self, df: pl.DataFrame) -> tuple[list[NullRateResult], float]:
-        """Calculate null rates per column."""
-        results = []
-        total_nulls = 0
-        total_cells = 0
-
-        for col in df.columns:
-            null_count = df[col].null_count()
-            total = len(df)
-            null_rate = null_count / total if total > 0 else 0.0
-
-            total_nulls += null_count
-            total_cells += total
-
-            # Status based on null rate
-            status = DQCheckStatus.WARN if null_rate > 0.5 else DQCheckStatus.PASS
-
-            results.append(
-                NullRateResult(
-                    column_name=col,
-                    null_rate=round(null_rate, 4),
-                    status=status,
-                )
-            )
-
-        overall_null_rate = total_nulls / total_cells if total_cells > 0 else 0.0
-        return results, round(overall_null_rate, 4)
+        return self._evaluator_service.check_null_rates(df)
 
     def _check_uniqueness(
         self, df: pl.DataFrame, primary_keys: list[str]
     ) -> UniquenessResult:
-        """Check uniqueness of primary keys."""
-        if not primary_keys:
-            return UniquenessResult(
-                primary_key="",
-                unique_count=len(df),
-                total_count=len(df),
-                duplicate_rate=0.0,
-                status=DQCheckStatus.PASS,
-            )
-
-        # Check which primary keys exist in dataframe
-        existing_keys = [k for k in primary_keys if k in df.columns]
-        if not existing_keys:
-            return UniquenessResult(
-                primary_key=",".join(primary_keys),
-                unique_count=len(df),
-                total_count=len(df),
-                duplicate_rate=0.0,
-                status=DQCheckStatus.WARN,
-                column_stats={"_note": {"message": "Primary key columns not found"}},
-            )
-
-        pk_name = ",".join(existing_keys)
-        unique_count = df.select(existing_keys).unique().height
-        total_count = len(df)
-        duplicate_count = total_count - unique_count
-        duplicate_rate = duplicate_count / total_count if total_count > 0 else 0.0
-
-        # Calculate column cardinality
-        column_stats = {}
-        for col in df.columns[:10]:  # Limit to first 10 columns
-            try:
-                cardinality = df[col].n_unique()
-                column_stats[col] = {
-                    "cardinality": cardinality,
-                    "uniqueness_ratio": round(cardinality / len(df), 4)
-                    if len(df) > 0
-                    else 0.0,
-                }
-            except _SILVER_PROFILE_ERRORS:
-                # Catch all: cardinality calculation may fail for unhashable types
-                # or invalid column access. Skip column from cardinality metrics.
-                pass
-
-        status = DQCheckStatus.PASS if duplicate_rate == 0 else DQCheckStatus.WARN
-
-        return UniquenessResult(
-            primary_key=pk_name,
-            unique_count=unique_count,
-            total_count=total_count,
-            duplicate_rate=round(duplicate_rate, 4),
-            column_stats=column_stats,
-            status=status,
-        )
+        return self._evaluator_service.check_uniqueness(df, primary_keys)
 
     def _check_type_conformance(self, df: pl.DataFrame) -> TypeConformanceResult:
-        """Check type conformance against expected schema."""
-        # For now, just validate that columns have consistent types
-        errors = []
-        type_coercions: dict[
-            str, dict[str, Any]  # Any: DQ check values vary by check type
-        ] = {}  # Any: DQ check values vary by check type
-
-        for col in df.columns:
-            dtype = df[col].dtype
-            # Check for object/mixed types that indicate inconsistency
-            if dtype == pl.Object:
-                errors.append(f"Column {col} has mixed types (Object)")
-
-        status = DQCheckStatus.PASS if not errors else DQCheckStatus.WARN
-
-        return TypeConformanceResult(
-            schema_version=None,
-            pandera_passed=len(errors) == 0,
-            errors=tuple(errors),
-            type_coercions=type_coercions,
-            status=status,
-        )
+        return self._evaluator_service.check_type_conformance(df)
 
     def _check_value_distribution(self, df: pl.DataFrame) -> ValueDistributionResult:
-        """Calculate value distributions for columns."""
-        numeric_cols: dict[str, NumericDistribution] = {}
-        categorical_cols: dict[str, CategoricalDistribution] = {}
-
-        for col in df.columns[:20]:  # Limit to first 20 columns
-            dtype = df[col].dtype
-
-            if dtype in (pl.Float64, pl.Float32, pl.Int64, pl.Int32, pl.Int16, pl.Int8):
-                try:
-                    stats = df[col].drop_nulls()
-                    if len(stats) > 0:
-                        min_val = stats.min()
-                        max_val = stats.max()
-                        mean_val = stats.mean()
-                        std_val = stats.std()
-                        median_val = stats.median()
-                        # Type narrowing: values are numeric due to dtype check above
-                        numeric_cols[col] = NumericDistribution(
-                            min=float(min_val) if min_val is not None else None,  # type: ignore[arg-type]
-                            max=float(max_val) if max_val is not None else None,  # type: ignore[arg-type]
-                            mean=float(mean_val) if mean_val is not None else None,  # type: ignore[arg-type]
-                            std=float(std_val) if std_val is not None else None,  # type: ignore[arg-type]
-                            median=float(median_val)  # type: ignore[arg-type]
-                            if median_val is not None
-                            else None,
-                        )
-                except _SILVER_PROFILE_ERRORS:
-                    # Catch all: numeric stats may fail for mixed types, NaN/Inf,
-                    # or non-numeric data in numeric column. Skip column profiling.
-                    pass
-
-            elif dtype in (pl.Utf8, pl.Categorical):
-                try:
-                    value_counts = df[col].value_counts().head(5)
-                    cardinality = df[col].n_unique()
-                    top_values = []
-                    for row in value_counts.iter_rows(named=True):
-                        val = row.get(col) or row.get("value")
-                        count = row.get("count") or row.get("counts", 0)
-                        top_values.append(
-                            {
-                                "value": str(val) if val is not None else None,
-                                "count": count,
-                                "pct": round(count / len(df), 4) if len(df) > 0 else 0,
-                            }
-                        )
-                    categorical_cols[col] = CategoricalDistribution(
-                        top_values=tuple(top_values),
-                        cardinality=cardinality,
-                    )
-                except _SILVER_PROFILE_ERRORS:
-                    # Catch all: value_counts() may fail for unhashable types or
-                    # large cardinality. Skip column from categorical profiling.
-                    pass
-
-        return ValueDistributionResult(
-            numeric_columns=numeric_cols,
-            categorical_columns=categorical_cols,
-            status=DQCheckStatus.PASS,
-        )
+        return self._statistics_service.check_value_distribution(df)
 
     def _check_schema_drift(
         self, df: pl.DataFrame, previous_schema: dict[str, str] | None
     ) -> SchemaDriftResult:
-        """Detect schema drift from previous run."""
-        current_schema = {col: str(df[col].dtype) for col in df.columns}
-
-        if previous_schema is None:
-            return SchemaDriftResult(
-                drift_level=DriftLevel.INFO,
-                status=DQCheckStatus.PASS,
-            )
-
-        new_fields = [f for f in current_schema if f not in previous_schema]
-        missing_fields = [f for f in previous_schema if f not in current_schema]
-        type_changes = []
-
-        for field in current_schema:
-            if (
-                field in previous_schema
-                and current_schema[field] != previous_schema[field]
-            ):
-                type_changes.append(
-                    {
-                        "field": field,
-                        "from": previous_schema[field],
-                        "to": current_schema[field],
-                    }
-                )
-
-        # Determine drift level
-        if missing_fields or type_changes:
-            drift_level = DriftLevel.CRITICAL
-            status = DQCheckStatus.WARN
-        elif new_fields:
-            drift_level = DriftLevel.INFO
-            status = DQCheckStatus.PASS
-        else:
-            drift_level = DriftLevel.INFO
-            status = DQCheckStatus.PASS
-
-        return SchemaDriftResult(
-            drift_level=drift_level,
-            new_fields=tuple(new_fields),
-            missing_fields=tuple(missing_fields),
-            type_changes=tuple(type_changes),
-            status=status,
-        )
+        return self._evaluator_service.check_schema_drift(df, previous_schema)
 
     def _check_deduplication(
         self,
@@ -582,72 +186,19 @@ class SilverDQAnalyzer:
         primary_keys: list[str],
         input_count: int,
     ) -> DeduplicationStatsResult:
-        """Calculate deduplication statistics."""
-        output_count = len(df)
-        dedupe_count = input_count - output_count
-
-        # Check content hash duplicates if column exists
-        content_hash_dupes = 0
-        if "_content_hash" in df.columns:
-            unique_hashes = df["_content_hash"].n_unique()
-            content_hash_dupes = output_count - unique_hashes
-
-        return DeduplicationStatsResult(
-            input_before_dedupe=input_count,
-            duplicates_by_content_hash=content_hash_dupes,
-            duplicates_by_business_key=dedupe_count - content_hash_dupes,
-            output_after_dedupe=output_count,
-            status=DQCheckStatus.PASS,
+        return self._evaluator_service.check_deduplication(
+            df, primary_keys, input_count
         )
 
     def _check_content_hash_integrity(
         self, df: pl.DataFrame
     ) -> ContentHashIntegrityResult:
-        """Check content hash integrity."""
-        if "_content_hash" not in df.columns:
-            return ContentHashIntegrityResult(
-                records_checked=0,
-                hash_collisions=0,
-                rehash_mismatches=0,
-                status=DQCheckStatus.PASS,
-            )
-
-        records_checked = len(df)
-
-        # Check for hash collisions (same hash, different content)
-        hash_counts = df["_content_hash"].value_counts()
-        duplicates = hash_counts.filter(pl.col("count") > 1)
-        hash_collisions = len(duplicates)
-
-        status = DQCheckStatus.PASS if hash_collisions == 0 else DQCheckStatus.WARN
-
-        return ContentHashIntegrityResult(
-            records_checked=records_checked,
-            hash_collisions=hash_collisions,
-            rehash_mismatches=0,  # Would need to recalculate hashes to check
-            status=status,
-        )
+        return self._evaluator_service.check_content_hash_integrity(df)
 
     def _distribution_to_dict(
         self, result: ValueDistributionResult
-    ) -> dict[str, Any]:  # Any: DQ check values vary by check type
-        """Convert distribution result to dict."""
-        output: dict[str, Any] = {  # Any: DQ check values vary by check type
-            "numeric_columns": {},
-            "categorical_columns": {},
-            "status": result.status.value,
-        }
-
-        for col, numeric_dist in result.numeric_columns.items():
-            output["numeric_columns"][col] = to_dict(numeric_dist)
-
-        for col, categorical_dist in result.categorical_columns.items():
-            output["categorical_columns"][col] = {
-                "top_values": list(categorical_dist.top_values),
-                "cardinality": categorical_dist.cardinality,
-            }
-
-        return output
+    ) -> dict[str, object]:
+        return self._statistics_service.distribution_to_dict(result)
 
 
 __all__ = ["SilverDQAnalyzer"]

--- a/src/bioetl/application/services/dq/silver_dq_checks_service.py
+++ b/src/bioetl/application/services/dq/silver_dq_checks_service.py
@@ -1,0 +1,248 @@
+"""Silver DQ check implementations."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bioetl.domain.value_objects.dq_report import (
+    ContentHashIntegrityResult,
+    DeduplicationStatsResult,
+    DQCheckStatus,
+    DriftLevel,
+    NullRateResult,
+    RecordCountResult,
+    SchemaDriftResult,
+    TypeConformanceResult,
+    UniquenessResult,
+)
+
+_SILVER_PROFILE_ERRORS = (
+    pl.exceptions.PolarsError,
+    ValueError,
+    TypeError,
+    RuntimeError,
+)
+
+
+class SilverDQChecksService:
+    """Provide single-check evaluation methods for Silver DQ."""
+
+    def check_key_nullability(
+        self,
+        df: pl.DataFrame,
+        key_nullability_rules: list[dict[str, object]],
+    ) -> dict[str, object]:
+        violations: list[dict[str, object]] = []
+        for rule in key_nullability_rules:
+            if bool(rule.get("nullable", False)):
+                continue
+            field = str(rule.get("field", ""))
+            key_type = str(rule.get("key_type", "merge"))
+            if field not in df.columns:
+                continue
+            null_count = int(df[field].null_count())
+            if null_count > 0:
+                violations.append(
+                    {"field": field, "key_type": key_type, "null_count": null_count}
+                )
+
+        status = DQCheckStatus.FAIL if violations else DQCheckStatus.PASS
+        return {
+            "status": status.value,
+            "violations": violations,
+            "rules_checked": len(key_nullability_rules),
+        }
+
+    def check_record_count(
+        self,
+        df: pl.DataFrame,
+        input_count: int | None,
+        quarantined_count: int,
+    ) -> RecordCountResult:
+        output_count = len(df)
+        input_records = input_count or (output_count + quarantined_count)
+        quarantine_rate = (
+            quarantined_count / input_records if input_records > 0 else 0.0
+        )
+        status = DQCheckStatus.WARN if quarantine_rate > 0.1 else DQCheckStatus.PASS
+
+        return RecordCountResult(
+            value=output_count,
+            status=status,
+            input_records=input_records,
+            output_records=output_count,
+            quarantined_records=quarantined_count,
+            quarantine_rate=round(quarantine_rate, 4),
+        )
+
+    def check_null_rates(self, df: pl.DataFrame) -> tuple[list[NullRateResult], float]:
+        results: list[NullRateResult] = []
+        total_nulls = 0
+        total_cells = 0
+
+        for col in df.columns:
+            null_count = df[col].null_count()
+            total = len(df)
+            null_rate = null_count / total if total > 0 else 0.0
+            total_nulls += null_count
+            total_cells += total
+            status = DQCheckStatus.WARN if null_rate > 0.5 else DQCheckStatus.PASS
+            results.append(
+                NullRateResult(
+                    column_name=col,
+                    null_rate=round(null_rate, 4),
+                    status=status,
+                )
+            )
+
+        overall_null_rate = total_nulls / total_cells if total_cells > 0 else 0.0
+        return results, round(overall_null_rate, 4)
+
+    def check_uniqueness(
+        self, df: pl.DataFrame, primary_keys: list[str]
+    ) -> UniquenessResult:
+        if not primary_keys:
+            return UniquenessResult(
+                primary_key="",
+                unique_count=len(df),
+                total_count=len(df),
+                duplicate_rate=0.0,
+                status=DQCheckStatus.PASS,
+            )
+
+        existing_keys = [k for k in primary_keys if k in df.columns]
+        if not existing_keys:
+            return UniquenessResult(
+                primary_key=",".join(primary_keys),
+                unique_count=len(df),
+                total_count=len(df),
+                duplicate_rate=0.0,
+                status=DQCheckStatus.WARN,
+                column_stats={"_note": {"message": "Primary key columns not found"}},
+            )
+
+        unique_count = df.select(existing_keys).unique().height
+        total_count = len(df)
+        duplicate_rate = (
+            (total_count - unique_count) / total_count if total_count else 0.0
+        )
+
+        column_stats: dict[str, dict[str, float | int]] = {}
+        for col in df.columns[:10]:
+            try:
+                cardinality = df[col].n_unique()
+                column_stats[col] = {
+                    "cardinality": cardinality,
+                    "uniqueness_ratio": round(cardinality / len(df), 4)
+                    if len(df)
+                    else 0.0,
+                }
+            except _SILVER_PROFILE_ERRORS:
+                pass
+
+        return UniquenessResult(
+            primary_key=",".join(existing_keys),
+            unique_count=unique_count,
+            total_count=total_count,
+            duplicate_rate=round(duplicate_rate, 4),
+            column_stats=column_stats,
+            status=DQCheckStatus.PASS if duplicate_rate == 0 else DQCheckStatus.WARN,
+        )
+
+    def check_type_conformance(self, df: pl.DataFrame) -> TypeConformanceResult:
+        errors = tuple(
+            f"Column {col} has mixed types (Object)"
+            for col in df.columns
+            if df[col].dtype == pl.Object
+        )
+
+        return TypeConformanceResult(
+            schema_version=None,
+            pandera_passed=len(errors) == 0,
+            errors=errors,
+            type_coercions={},
+            status=DQCheckStatus.PASS if not errors else DQCheckStatus.WARN,
+        )
+
+    def check_schema_drift(
+        self, df: pl.DataFrame, previous_schema: dict[str, str] | None
+    ) -> SchemaDriftResult:
+        current_schema = {col: str(df[col].dtype) for col in df.columns}
+
+        if previous_schema is None:
+            return SchemaDriftResult(
+                drift_level=DriftLevel.INFO, status=DQCheckStatus.PASS
+            )
+
+        new_fields = [f for f in current_schema if f not in previous_schema]
+        missing_fields = [f for f in previous_schema if f not in current_schema]
+        type_changes = tuple(
+            {
+                "field": field,
+                "from": previous_schema[field],
+                "to": current_schema[field],
+            }
+            for field in current_schema
+            if field in previous_schema
+            and current_schema[field] != previous_schema[field]
+        )
+
+        drift_level = (
+            DriftLevel.CRITICAL if (missing_fields or type_changes) else DriftLevel.INFO
+        )
+        status = (
+            DQCheckStatus.WARN
+            if drift_level == DriftLevel.CRITICAL
+            else DQCheckStatus.PASS
+        )
+
+        return SchemaDriftResult(
+            drift_level=drift_level,
+            new_fields=tuple(new_fields),
+            missing_fields=tuple(missing_fields),
+            type_changes=type_changes,
+            status=status,
+        )
+
+    def check_deduplication(
+        self,
+        df: pl.DataFrame,
+        input_count: int,
+    ) -> DeduplicationStatsResult:
+        output_count = len(df)
+        dedupe_count = input_count - output_count
+
+        content_hash_dupes = 0
+        if "_content_hash" in df.columns:
+            content_hash_dupes = output_count - df["_content_hash"].n_unique()
+
+        return DeduplicationStatsResult(
+            input_before_dedupe=input_count,
+            duplicates_by_content_hash=content_hash_dupes,
+            duplicates_by_business_key=dedupe_count - content_hash_dupes,
+            output_after_dedupe=output_count,
+            status=DQCheckStatus.PASS,
+        )
+
+    def check_content_hash_integrity(
+        self, df: pl.DataFrame
+    ) -> ContentHashIntegrityResult:
+        if "_content_hash" not in df.columns:
+            return ContentHashIntegrityResult(
+                records_checked=0,
+                hash_collisions=0,
+                rehash_mismatches=0,
+                status=DQCheckStatus.PASS,
+            )
+
+        duplicates = df["_content_hash"].value_counts().filter(pl.col("count") > 1)
+        hash_collisions = len(duplicates)
+        return ContentHashIntegrityResult(
+            records_checked=len(df),
+            hash_collisions=hash_collisions,
+            rehash_mismatches=0,
+            status=DQCheckStatus.PASS if hash_collisions == 0 else DQCheckStatus.WARN,
+        )
+
+
+__all__ = ["SilverDQChecksService"]

--- a/src/bioetl/application/services/dq/silver_dq_report_assembler_service.py
+++ b/src/bioetl/application/services/dq/silver_dq_report_assembler_service.py
@@ -1,0 +1,80 @@
+"""Silver DQ report assembler service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from bioetl.application.services.dq.dq_report_builders import build_summary
+from bioetl.domain.value_objects.dq_report import (
+    DQCheckStatus,
+    DQThresholds,
+    MedallionLayer,
+    SilverDQReport,
+)
+
+
+class SilverDQReportAssemblerService:
+    """Build report-level structures for Silver DQ output."""
+
+    def calculate_thresholds(
+        self,
+        df_len: int,
+        input_record_count: int | None,
+        quarantined_count: int,
+        soft_fail_threshold: float,
+        hard_fail_threshold: float,
+    ) -> DQThresholds:
+        """Calculate DQ thresholds and threshold status."""
+        total_input = input_record_count or df_len + quarantined_count
+        error_rate = quarantined_count / total_input if total_input > 0 else 0.0
+
+        if error_rate >= hard_fail_threshold:
+            threshold_status = DQCheckStatus.FAIL
+        elif error_rate >= soft_fail_threshold:
+            threshold_status = DQCheckStatus.WARN
+        else:
+            threshold_status = DQCheckStatus.PASS
+
+        return DQThresholds(
+            soft_fail_threshold=soft_fail_threshold,
+            hard_fail_threshold=hard_fail_threshold,
+            current_error_rate=round(error_rate, 4),
+            threshold_status=threshold_status,
+        )
+
+    def assemble_report(
+        self,
+        *,
+        run_id: str,
+        pipeline: str,
+        target_table: str,
+        source_batch_ids: list[str],
+        timestamp: datetime,
+        checks: dict[str, object],
+        thresholds: DQThresholds,
+        passed: int,
+        failed: int,
+        warnings: int,
+    ) -> SilverDQReport:
+        """Assemble Silver DQ report with summary from counters."""
+        summary = build_summary(
+            passed=passed,
+            failed=failed,
+            warnings=warnings,
+            threshold_status=thresholds.threshold_status,
+        )
+
+        return SilverDQReport(
+            layer=MedallionLayer.SILVER,
+            timestamp=timestamp,
+            run_id=run_id,
+            pipeline=pipeline,
+            source_batch_ids=tuple(source_batch_ids),
+            target_table=target_table,
+            checks=checks,
+            thresholds=thresholds,
+            summary=summary,
+        )
+
+
+__all__ = ["SilverDQReportAssemblerService"]

--- a/src/bioetl/application/services/dq/silver_dq_rule_evaluator_service.py
+++ b/src/bioetl/application/services/dq/silver_dq_rule_evaluator_service.py
@@ -1,0 +1,176 @@
+"""Silver DQ rule evaluator orchestration service."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bioetl.application.services.dq.dq_report_builders import update_counts
+from bioetl.application.services.dq.silver_dq_checks_service import (
+    SilverDQChecksService,
+)
+from bioetl.application.services.dq.silver_dq_statistics_service import (
+    SilverDQStatisticsService,
+)
+from bioetl.domain.services.dq_serializer import to_dict
+from bioetl.domain.value_objects.dq_report import (
+    ContentHashIntegrityResult,
+    DeduplicationStatsResult,
+    DQCheckStatus,
+    NullRateResult,
+    RecordCountResult,
+    SchemaDriftResult,
+    SilverDQCheckType,
+    TypeConformanceResult,
+    UniquenessResult,
+)
+
+
+class DQRuleEvaluatorService:
+    """Evaluate enabled checks and aggregate their statuses."""
+
+    def __init__(
+        self,
+        checks_service: SilverDQChecksService | None = None,
+        statistics_service: SilverDQStatisticsService | None = None,
+    ) -> None:
+        self._checks_service = checks_service or SilverDQChecksService()
+        self._statistics_service = statistics_service or SilverDQStatisticsService()
+
+    def execute_checks(
+        self,
+        df: pl.DataFrame,
+        enabled_checks: set[SilverDQCheckType],
+        primary_keys: list[str],
+        input_record_count: int | None,
+        quarantined_count: int,
+        previous_schema: dict[str, str] | None,
+        key_nullability_rules: list[dict[str, object]] | None,
+    ) -> tuple[dict[str, object], int, int, int]:
+        """Execute all enabled checks and collect check counters."""
+        checks: dict[str, object] = {}
+        passed, failed, warnings = 0, 0, 0
+
+        if SilverDQCheckType.RECORD_COUNT in enabled_checks:
+            record_count_result = self.check_record_count(
+                df, input_record_count, quarantined_count
+            )
+            checks["record_count"] = to_dict(record_count_result)
+            passed, failed, warnings = update_counts(
+                record_count_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.NULL_RATE in enabled_checks:
+            null_results, overall_rate = self.check_null_rates(df)
+            checks["null_rate"] = {
+                "columns": {r.column_name: to_dict(r) for r in null_results},
+                "overall_null_rate": overall_rate,
+                "status": DQCheckStatus.PASS.value,
+            }
+            passed += 1
+
+        if SilverDQCheckType.UNIQUENESS in enabled_checks:
+            uniqueness_result = self.check_uniqueness(df, primary_keys)
+            checks["uniqueness"] = to_dict(uniqueness_result)
+            passed, failed, warnings = update_counts(
+                uniqueness_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.TYPE_CONFORMANCE in enabled_checks:
+            conformance_result = self.check_type_conformance(df)
+            checks["type_conformance"] = to_dict(conformance_result)
+            passed, failed, warnings = update_counts(
+                conformance_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.VALUE_DISTRIBUTION in enabled_checks:
+            distribution_result = self._statistics_service.check_value_distribution(df)
+            checks["value_distribution"] = (
+                self._statistics_service.distribution_to_dict(distribution_result)
+            )
+            passed += 1
+
+        if SilverDQCheckType.SCHEMA_DRIFT in enabled_checks:
+            drift_result = self.check_schema_drift(df, previous_schema)
+            checks["schema_drift"] = to_dict(drift_result)
+            passed, failed, warnings = update_counts(
+                drift_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.DEDUPLICATION_STATS in enabled_checks:
+            deduplication_result = self.check_deduplication(
+                df, primary_keys, input_record_count or len(df)
+            )
+            checks["deduplication_stats"] = to_dict(deduplication_result)
+            passed, failed, warnings = update_counts(
+                deduplication_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.CONTENT_HASH_INTEGRITY in enabled_checks:
+            hash_integrity_result = self.check_content_hash_integrity(df)
+            checks["content_hash_integrity"] = to_dict(hash_integrity_result)
+            passed, failed, warnings = update_counts(
+                hash_integrity_result.status, passed, failed, warnings
+            )
+
+        if SilverDQCheckType.KEY_NULLABILITY in enabled_checks:
+            key_nullability_result = self.check_key_nullability(
+                df, key_nullability_rules or []
+            )
+            checks["key_nullability"] = key_nullability_result
+            passed, failed, warnings = update_counts(
+                DQCheckStatus(str(key_nullability_result["status"])),
+                passed,
+                failed,
+                warnings,
+            )
+
+        return checks, passed, failed, warnings
+
+    def check_key_nullability(
+        self,
+        df: pl.DataFrame,
+        key_nullability_rules: list[dict[str, object]],
+    ) -> dict[str, object]:
+        return self._checks_service.check_key_nullability(df, key_nullability_rules)
+
+    def check_record_count(
+        self,
+        df: pl.DataFrame,
+        input_count: int | None,
+        quarantined_count: int,
+    ) -> RecordCountResult:
+        return self._checks_service.check_record_count(
+            df, input_count, quarantined_count
+        )
+
+    def check_null_rates(self, df: pl.DataFrame) -> tuple[list[NullRateResult], float]:
+        return self._checks_service.check_null_rates(df)
+
+    def check_uniqueness(
+        self, df: pl.DataFrame, primary_keys: list[str]
+    ) -> UniquenessResult:
+        return self._checks_service.check_uniqueness(df, primary_keys)
+
+    def check_type_conformance(self, df: pl.DataFrame) -> TypeConformanceResult:
+        return self._checks_service.check_type_conformance(df)
+
+    def check_schema_drift(
+        self, df: pl.DataFrame, previous_schema: dict[str, str] | None
+    ) -> SchemaDriftResult:
+        return self._checks_service.check_schema_drift(df, previous_schema)
+
+    def check_deduplication(
+        self,
+        df: pl.DataFrame,
+        _primary_keys: list[str],
+        input_count: int,
+    ) -> DeduplicationStatsResult:
+        return self._checks_service.check_deduplication(df, input_count)
+
+    def check_content_hash_integrity(
+        self, df: pl.DataFrame
+    ) -> ContentHashIntegrityResult:
+        return self._checks_service.check_content_hash_integrity(df)
+
+
+__all__ = ["DQRuleEvaluatorService"]

--- a/src/bioetl/application/services/dq/silver_dq_statistics_service.py
+++ b/src/bioetl/application/services/dq/silver_dq_statistics_service.py
@@ -1,0 +1,111 @@
+"""Silver DQ statistics service.
+
+Encapsulates statistical profiling and distribution formatting for Silver DQ.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bioetl.domain.services.dq_serializer import to_dict
+from bioetl.domain.value_objects.dq_report import (
+    CategoricalDistribution,
+    DQCheckStatus,
+    NumericDistribution,
+    ValueDistributionResult,
+)
+
+_SILVER_PROFILE_ERRORS = (
+    pl.exceptions.PolarsError,
+    ValueError,
+    TypeError,
+    RuntimeError,
+)
+
+
+def _to_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+class SilverDQStatisticsService:
+    """Calculate Silver data quality statistical distributions."""
+
+    def check_value_distribution(self, df: pl.DataFrame) -> ValueDistributionResult:
+        """Calculate value distributions for a limited subset of columns."""
+        numeric_cols: dict[str, NumericDistribution] = {}
+        categorical_cols: dict[str, CategoricalDistribution] = {}
+
+        for col in df.columns[:20]:
+            dtype = df[col].dtype
+
+            if dtype in (pl.Float64, pl.Float32, pl.Int64, pl.Int32, pl.Int16, pl.Int8):
+                try:
+                    stats = df[col].drop_nulls().cast(pl.Float64)
+                    if len(stats) > 0:
+                        numeric_cols[col] = NumericDistribution(
+                            min=_to_float(stats.min()),
+                            max=_to_float(stats.max()),
+                            mean=_to_float(stats.mean()),
+                            std=_to_float(stats.std()),
+                            median=_to_float(stats.median()),
+                        )
+                except _SILVER_PROFILE_ERRORS:
+                    pass
+
+            elif dtype in (pl.Utf8, pl.Categorical):
+                try:
+                    value_counts = df[col].value_counts().head(5)
+                    cardinality = df[col].n_unique()
+                    top_values: list[dict[str, object]] = []
+                    for row in value_counts.iter_rows(named=True):
+                        val = row.get(col) or row.get("value")
+                        count = row.get("count") or row.get("counts", 0)
+                        top_values.append(
+                            {
+                                "value": str(val) if val is not None else None,
+                                "count": count,
+                                "pct": round(count / len(df), 4) if len(df) > 0 else 0,
+                            }
+                        )
+                    categorical_cols[col] = CategoricalDistribution(
+                        top_values=tuple(top_values),
+                        cardinality=cardinality,
+                    )
+                except _SILVER_PROFILE_ERRORS:
+                    pass
+
+        return ValueDistributionResult(
+            numeric_columns=numeric_cols,
+            categorical_columns=categorical_cols,
+            status=DQCheckStatus.PASS,
+        )
+
+    def distribution_to_dict(
+        self, result: ValueDistributionResult
+    ) -> dict[str, object]:
+        """Convert distribution result to transport-friendly dict."""
+        numeric_columns: dict[str, object] = {}
+        categorical_columns: dict[str, object] = {}
+
+        for col, numeric_dist in result.numeric_columns.items():
+            numeric_columns[col] = to_dict(numeric_dist)
+
+        for col, categorical_dist in result.categorical_columns.items():
+            categorical_columns[col] = {
+                "top_values": list(categorical_dist.top_values),
+                "cardinality": categorical_dist.cardinality,
+            }
+
+        return {
+            "numeric_columns": numeric_columns,
+            "categorical_columns": categorical_columns,
+            "status": result.status.value,
+        }
+
+
+__all__ = ["SilverDQStatisticsService"]

--- a/tests/unit/application/services/dq/test_silver_analyzer.py
+++ b/tests/unit/application/services/dq/test_silver_analyzer.py
@@ -1,18 +1,4 @@
-"""Unit tests for SilverDQAnalyzer.
-
-Tests for SilverDQAnalyzer comprehensive data quality checks:
-- Record count analysis with quarantine tracking
-- Null rate per column and overall
-- Uniqueness / duplicate detection
-- Type conformance checks
-- Value distribution (numeric and categorical)
-- Schema drift detection
-- Deduplication statistics
-- Content hash integrity
-- Key nullability rules
-- Threshold calculation (PASS / WARN / FAIL)
-- PyArrow → Polars conversion in analyze()
-"""
+"""Integration-style tests for SilverDQAnalyzer facade."""
 
 from __future__ import annotations
 
@@ -31,33 +17,13 @@ from bioetl.domain.value_objects.dq_report import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture()
 def analyzer() -> SilverDQAnalyzer:
-    """Create SilverDQAnalyzer instance."""
     return SilverDQAnalyzer()
 
 
 @pytest.fixture()
-def simple_df() -> pl.DataFrame:
-    """A small well-formed Silver DataFrame."""
-    return pl.DataFrame(
-        {
-            "_content_hash": ["hash_a", "hash_b", "hash_c"],
-            "record_id": [1, 2, 3],
-            "name": ["alpha", "beta", "gamma"],
-            "value": [10.0, 20.0, 30.0],
-        }
-    )
-
-
-@pytest.fixture()
 def mock_config_all_checks() -> MagicMock:
-    """Config mock that enables all Silver DQ check types."""
     config = MagicMock()
     config.get_checks_enums.return_value = list(SilverDQCheckType)
     return config
@@ -65,627 +31,94 @@ def mock_config_all_checks() -> MagicMock:
 
 @pytest.fixture()
 def mock_config_empty() -> MagicMock:
-    """Config mock that enables no checks (empty set)."""
     config = MagicMock()
     config.get_checks_enums.return_value = []
     return config
 
 
-# ---------------------------------------------------------------------------
-# _calculate_thresholds
-# ---------------------------------------------------------------------------
-
-
-class TestCalculateThresholds:
-    """Tests for _calculate_thresholds helper."""
-
-    def test_pass_status_no_quarantined(self, analyzer: SilverDQAnalyzer) -> None:
-        """No quarantined records → PASS."""
-        result = analyzer._calculate_thresholds(
-            df_len=100,
-            input_record_count=100,
-            quarantined_count=0,
-            soft_fail_threshold=0.05,
-            hard_fail_threshold=0.20,
-        )
-        assert result.threshold_status == DQCheckStatus.PASS
-        assert result.current_error_rate == 0.0
-
-    def test_warn_status_at_soft_threshold(self, analyzer: SilverDQAnalyzer) -> None:
-        """Error rate at soft threshold → WARN."""
-        result = analyzer._calculate_thresholds(
-            df_len=95,
-            input_record_count=100,
-            quarantined_count=10,  # 10% error rate ≥ 5% → WARN
-            soft_fail_threshold=0.05,
-            hard_fail_threshold=0.20,
-        )
-        assert result.threshold_status == DQCheckStatus.WARN
-        assert result.current_error_rate == 0.1
-
-    def test_fail_status_at_hard_threshold(self, analyzer: SilverDQAnalyzer) -> None:
-        """Error rate at hard threshold → FAIL."""
-        result = analyzer._calculate_thresholds(
-            df_len=80,
-            input_record_count=100,
-            quarantined_count=25,  # 25% ≥ 20% → FAIL
-            soft_fail_threshold=0.05,
-            hard_fail_threshold=0.20,
-        )
-        assert result.threshold_status == DQCheckStatus.FAIL
-
-    def test_input_count_none_uses_df_len_plus_quarantine(
-        self, analyzer: SilverDQAnalyzer
-    ) -> None:
-        """When input_record_count is None, total = df_len + quarantined_count."""
-        result = analyzer._calculate_thresholds(
-            df_len=90,
-            input_record_count=None,
-            quarantined_count=10,  # total=100, rate=0.10
-            soft_fail_threshold=0.05,
-            hard_fail_threshold=0.20,
-        )
-        assert result.current_error_rate == 0.1
-        assert result.threshold_status == DQCheckStatus.WARN
-
-    def test_zero_total_no_division_error(self, analyzer: SilverDQAnalyzer) -> None:
-        """total_input=0 → error_rate=0.0, no ZeroDivisionError."""
-        result = analyzer._calculate_thresholds(
-            df_len=0,
-            input_record_count=0,
-            quarantined_count=0,
-            soft_fail_threshold=0.05,
-            hard_fail_threshold=0.20,
-        )
-        assert result.current_error_rate == 0.0
-
-
-# ---------------------------------------------------------------------------
-# _check_record_count
-# ---------------------------------------------------------------------------
-
-
-class TestCheckRecordCount:
-    """Tests for record count check."""
-
-    def test_pass_no_quarantine(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_record_count(df, None, 0)
-        assert result.status == DQCheckStatus.PASS
-        assert result.output_records == 3
-        assert result.quarantine_rate == 0.0
-
-    def test_warn_high_quarantine_rate(self, analyzer: SilverDQAnalyzer) -> None:
-        """More than 10% quarantined → WARN."""
-        df = pl.DataFrame({"id": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
-        result = analyzer._check_record_count(df, 10, 2)  # 20% quarantined
-        assert result.status == DQCheckStatus.WARN
-        assert result.quarantined_records == 2
-
-    def test_input_count_explicit(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_record_count(df, 10, 0)
-        assert result.input_records == 10
-        assert result.output_records == 3
-
-
-# ---------------------------------------------------------------------------
-# _check_null_rates
-# ---------------------------------------------------------------------------
-
-
-class TestCheckNullRates:
-    """Tests for null rate calculation."""
-
-    def test_no_nulls(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        results, overall = analyzer._check_null_rates(df)
-        assert overall == 0.0
-        assert all(r.null_rate == 0.0 for r in results)
-        assert all(r.status == DQCheckStatus.PASS for r in results)
-
-    def test_column_with_high_null_rate_warns(self, analyzer: SilverDQAnalyzer) -> None:
-        """Column with >50% nulls → WARN."""
-        df = pl.DataFrame({"a": [1, None, None]})
-        results, overall = analyzer._check_null_rates(df)
-        assert results[0].status == DQCheckStatus.WARN
-        assert results[0].null_rate > 0.5
-
-    def test_overall_rate_calculation(self, analyzer: SilverDQAnalyzer) -> None:
-        """Overall rate is total nulls / total cells."""
-        df = pl.DataFrame({"a": [None, None], "b": [1, 1]})  # 2 nulls / 4 cells = 0.5
-        _, overall = analyzer._check_null_rates(df)
-        assert overall == 0.5
-
-    def test_empty_dataframe(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"a": pl.Series([], dtype=pl.Int64)})
-        results, overall = analyzer._check_null_rates(df)
-        assert overall == 0.0
-
-
-# ---------------------------------------------------------------------------
-# _check_uniqueness
-# ---------------------------------------------------------------------------
-
-
-class TestCheckUniqueness:
-    """Tests for uniqueness / duplicate check."""
-
-    def test_unique_records_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_uniqueness(df, ["id"])
-        assert result.status == DQCheckStatus.PASS
-        assert result.duplicate_rate == 0.0
-
-    def test_duplicates_warn(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 1, 2]})
-        result = analyzer._check_uniqueness(df, ["id"])
-        assert result.status == DQCheckStatus.WARN
-        assert result.duplicate_rate > 0
-
-    def test_no_primary_keys_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        """Empty primary_keys list → PASS with no duplicate check."""
-        df = pl.DataFrame({"id": [1, 1, 1]})
-        result = analyzer._check_uniqueness(df, [])
-        assert result.status == DQCheckStatus.PASS
-        assert result.primary_key == ""
-
-    def test_missing_primary_key_column_warn(self, analyzer: SilverDQAnalyzer) -> None:
-        """Primary key column not in DataFrame → WARN."""
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_uniqueness(df, ["nonexistent_column"])
-        assert result.status == DQCheckStatus.WARN
-
-    def test_column_cardinality_stats(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3], "category": ["a", "b", "a"]})
-        result = analyzer._check_uniqueness(df, ["id"])
-        # Column stats computed for first 10 columns
-        assert "id" in result.column_stats
-        assert result.column_stats["id"]["cardinality"] == 3
-
-
-# ---------------------------------------------------------------------------
-# _check_type_conformance
-# ---------------------------------------------------------------------------
-
-
-class TestCheckTypeConformance:
-    """Tests for type conformance check."""
-
-    def test_pass_normal_types(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2], "name": ["a", "b"], "v": [1.0, 2.0]})
-        result = analyzer._check_type_conformance(df)
-        assert result.status == DQCheckStatus.PASS
-        assert result.pandera_passed is True
-
-    def test_warn_object_column(self, analyzer: SilverDQAnalyzer) -> None:
-        """Object dtype column → type error → WARN status."""
-        df = pl.DataFrame({"mixed": pl.Series([1, "str"], dtype=pl.Object)})
-        result = analyzer._check_type_conformance(df)
-        assert result.status == DQCheckStatus.WARN
-        assert result.pandera_passed is False
-        assert len(result.errors) > 0
-
-
-# ---------------------------------------------------------------------------
-# _check_value_distribution
-# ---------------------------------------------------------------------------
-
-
-class TestCheckValueDistribution:
-    """Tests for value distribution profiling."""
-
-    def test_numeric_columns_profiled(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"score": [1.0, 2.0, 3.0, 4.0, 5.0]})
-        result = analyzer._check_value_distribution(df)
-        assert "score" in result.numeric_columns
-        stat = result.numeric_columns["score"]
-        assert stat.min == 1.0
-        assert stat.max == 5.0
-        assert stat.mean == 3.0
-
-    def test_categorical_columns_profiled(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"category": ["a", "b", "a", "c", "b", "a"]})
-        result = analyzer._check_value_distribution(df)
-        assert "category" in result.categorical_columns
-        cat = result.categorical_columns["category"]
-        assert cat.cardinality == 3
-        assert len(cat.top_values) <= 5
-
-    def test_status_always_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_value_distribution(df)
-        assert result.status == DQCheckStatus.PASS
-
-    def test_empty_numeric_column_skipped(self, analyzer: SilverDQAnalyzer) -> None:
-        """Numeric column with all nulls: no crash."""
-        df = pl.DataFrame({"v": pl.Series([None, None], dtype=pl.Float64)})
-        result = analyzer._check_value_distribution(df)
-        # Empty stats column — may be empty or may have None fields; no exception
-        assert result.status == DQCheckStatus.PASS
-
-    def test_limits_to_20_columns(self, analyzer: SilverDQAnalyzer) -> None:
-        """Only first 20 columns are profiled."""
-        data = {f"col_{i}": [i * 1.0, i * 2.0] for i in range(25)}
-        df = pl.DataFrame(data)
-        result = analyzer._check_value_distribution(df)
-        total_profiled = len(result.numeric_columns) + len(result.categorical_columns)
-        assert total_profiled <= 20
-
-
-# ---------------------------------------------------------------------------
-# _check_schema_drift
-# ---------------------------------------------------------------------------
-
-
-class TestCheckSchemaDrift:
-    """Tests for schema drift detection."""
-
-    def test_no_previous_schema_info(self, analyzer: SilverDQAnalyzer) -> None:
-        """First run (no previous schema) → INFO, PASS."""
-        from bioetl.domain.value_objects.dq_report import DriftLevel
-
-        df = pl.DataFrame({"id": [1, 2], "name": ["a", "b"]})
-        result = analyzer._check_schema_drift(df, None)
-        assert result.drift_level == DriftLevel.INFO
-        assert result.status == DQCheckStatus.PASS
-
-    def test_no_drift_same_schema(self, analyzer: SilverDQAnalyzer) -> None:
-        from bioetl.domain.value_objects.dq_report import DriftLevel
-
-        df = pl.DataFrame({"id": [1, 2], "name": ["a", "b"]})
-        previous = {"id": "Int64", "name": "String"}
-        result = analyzer._check_schema_drift(df, previous)
-        assert result.drift_level == DriftLevel.INFO
-        assert result.status == DQCheckStatus.PASS
-        assert len(result.new_fields) == 0
-        assert len(result.missing_fields) == 0
-
-    def test_new_field_added_info(self, analyzer: SilverDQAnalyzer) -> None:
-        from bioetl.domain.value_objects.dq_report import DriftLevel
-
-        df = pl.DataFrame({"id": [1], "name": ["a"], "extra": [42]})
-        previous = {"id": "Int64", "name": "String"}
-        result = analyzer._check_schema_drift(df, previous)
-        assert result.drift_level == DriftLevel.INFO
-        assert "extra" in result.new_fields
-
-    def test_missing_field_critical_warn(self, analyzer: SilverDQAnalyzer) -> None:
-        from bioetl.domain.value_objects.dq_report import DriftLevel
-
-        df = pl.DataFrame({"id": [1]})
-        previous = {"id": "Int64", "name": "String"}
-        result = analyzer._check_schema_drift(df, previous)
-        assert result.drift_level == DriftLevel.CRITICAL
-        assert result.status == DQCheckStatus.WARN
-        assert "name" in result.missing_fields
-
-    def test_type_change_critical_warn(self, analyzer: SilverDQAnalyzer) -> None:
-        from bioetl.domain.value_objects.dq_report import DriftLevel
-
-        df = pl.DataFrame({"id": pl.Series([1, 2], dtype=pl.Float64)})
-        previous = {"id": "Int64"}
-        result = analyzer._check_schema_drift(df, previous)
-        assert result.drift_level == DriftLevel.CRITICAL
-        assert len(result.type_changes) > 0
-
-
-# ---------------------------------------------------------------------------
-# _check_deduplication
-# ---------------------------------------------------------------------------
-
-
-class TestCheckDeduplication:
-    """Tests for deduplication statistics."""
-
-    def test_no_duplication(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_deduplication(df, ["id"], 3)
-        assert result.output_after_dedupe == 3
-        assert result.input_before_dedupe == 3
-        assert result.status == DQCheckStatus.PASS
-
-    def test_with_input_larger_than_output(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_deduplication(df, ["id"], 10)
-        assert result.input_before_dedupe == 10
-        assert result.output_after_dedupe == 3
-
-    def test_content_hash_duplicates_counted(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame(
-            {
-                "_content_hash": ["hash_a", "hash_a", "hash_b"],
-                "id": [1, 2, 3],
-            }
-        )
-        result = analyzer._check_deduplication(df, ["id"], 3)
-        assert result.duplicates_by_content_hash == 1  # 3 records - 2 unique hashes
-
-    def test_no_content_hash_column(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_deduplication(df, ["id"], 5)
-        assert result.duplicates_by_content_hash == 0
-
-
-# ---------------------------------------------------------------------------
-# _check_content_hash_integrity
-# ---------------------------------------------------------------------------
-
-
-class TestCheckContentHashIntegrity:
-    """Tests for content hash integrity check."""
-
-    def test_no_hash_column_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        result = analyzer._check_content_hash_integrity(df)
-        assert result.status == DQCheckStatus.PASS
-        assert result.records_checked == 0
-
-    def test_unique_hashes_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"_content_hash": ["a", "b", "c"], "id": [1, 2, 3]})
-        result = analyzer._check_content_hash_integrity(df)
-        assert result.status == DQCheckStatus.PASS
-        assert result.hash_collisions == 0
-        assert result.records_checked == 3
-
-    def test_duplicate_hashes_warn(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"_content_hash": ["a", "a", "b"], "id": [1, 2, 3]})
-        result = analyzer._check_content_hash_integrity(df)
-        assert result.status == DQCheckStatus.WARN
-        assert result.hash_collisions > 0
-
-
-# ---------------------------------------------------------------------------
-# _check_key_nullability
-# ---------------------------------------------------------------------------
-
-
-class TestCheckKeyNullability:
-    """Tests for key nullability rules enforcement."""
-
-    def test_no_rules_pass(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, None]})
-        result = analyzer._check_key_nullability(df, [])
-        assert result["status"] == DQCheckStatus.PASS.value
-        assert result["violations"] == []
-
-    def test_nullable_rule_skipped(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, None, 3]})
-        rules = [{"field": "id", "key_type": "merge", "nullable": True}]
-        result = analyzer._check_key_nullability(df, rules)
-        assert result["status"] == DQCheckStatus.PASS.value
-        assert result["violations"] == []
-
-    def test_non_nullable_violation_fail(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, None, 3]})
-        rules = [{"field": "id", "key_type": "merge", "nullable": False}]
-        result = analyzer._check_key_nullability(df, rules)
-        assert result["status"] == DQCheckStatus.FAIL.value
-        assert len(result["violations"]) == 1
-        assert result["violations"][0]["field"] == "id"
-        assert result["violations"][0]["null_count"] == 1
-
-    def test_missing_column_skipped(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"other": [1, 2, 3]})
-        rules = [{"field": "id", "key_type": "merge", "nullable": False}]
-        result = analyzer._check_key_nullability(df, rules)
-        assert result["status"] == DQCheckStatus.PASS.value
-
-    def test_rules_checked_count(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3], "key": ["a", "b", "c"]})
-        rules = [
-            {"field": "id", "key_type": "merge", "nullable": False},
-            {"field": "key", "key_type": "partition", "nullable": False},
-        ]
-        result = analyzer._check_key_nullability(df, rules)
-        assert result["rules_checked"] == 2
-
-
-# ---------------------------------------------------------------------------
-# analyze() — integration
-# ---------------------------------------------------------------------------
-
-
-class TestAnalyze:
-    """Integration tests for the main analyze() method."""
-
-    def test_analyze_with_polars_dataframe(
-        self,
-        analyzer: SilverDQAnalyzer,
-        simple_df: pl.DataFrame,
-        mock_config_all_checks: MagicMock,
-    ) -> None:
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        report = analyzer.analyze(
-            data=simple_df,
-            run_id="test-run-001",
-            pipeline="chembl.compound",
-            target_table="silver/chembl/compound",
-            source_batch_ids=["batch-001"],
-            config=mock_config_all_checks,
-            timestamp=ts,
-            primary_keys=["record_id"],
-        )
-        assert report.layer == MedallionLayer.SILVER
-        assert report.run_id == "test-run-001"
-        assert report.pipeline == "chembl.compound"
-        assert report.summary is not None
-
-    def test_analyze_with_pyarrow_table(
-        self,
-        analyzer: SilverDQAnalyzer,
-        mock_config_all_checks: MagicMock,
-    ) -> None:
-        """PyArrow Table should be converted to Polars before processing."""
-        table = pa.table(
-            {
-                "id": [1, 2, 3],
-                "name": ["a", "b", "c"],
-                "_content_hash": ["h1", "h2", "h3"],
-            }
-        )
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        report = analyzer.analyze(
-            data=table,
-            run_id="arrow-run",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=["batch-arrow"],
-            config=mock_config_all_checks,
-            timestamp=ts,
-            primary_keys=["id"],
-        )
-        assert report.layer == MedallionLayer.SILVER
-        assert "record_count" in report.checks
-
-    def test_analyze_no_checks_enabled(
-        self,
-        analyzer: SilverDQAnalyzer,
-        simple_df: pl.DataFrame,
-        mock_config_empty: MagicMock,
-    ) -> None:
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        report = analyzer.analyze(
-            data=simple_df,
-            run_id="empty-checks",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=[],
-            config=mock_config_empty,
-            timestamp=ts,
-            primary_keys=[],
-        )
-        assert report.checks == {}
-        assert report.summary.passed == 0
-        assert report.summary.failed == 0
-
-    def test_analyze_with_quarantined_records_triggers_warn(
-        self,
-        analyzer: SilverDQAnalyzer,
-        mock_config_empty: MagicMock,
-    ) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3, 4, 5]})
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        report = analyzer.analyze(
-            data=df,
-            run_id="quarantine-test",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=["batch-q"],
-            config=mock_config_empty,
-            timestamp=ts,
-            primary_keys=["id"],
-            input_record_count=100,
-            quarantined_count=10,  # 10% quarantined → ≥5% soft, <20% hard → WARN
-        )
-        assert report.thresholds.threshold_status == DQCheckStatus.WARN
-
-    def test_analyze_hard_fail_threshold(
-        self,
-        analyzer: SilverDQAnalyzer,
-        mock_config_empty: MagicMock,
-    ) -> None:
-        df = pl.DataFrame({"id": [1, 2]})
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        report = analyzer.analyze(
-            data=df,
-            run_id="hard-fail",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=[],
-            config=mock_config_empty,
-            timestamp=ts,
-            primary_keys=[],
-            input_record_count=10,
-            quarantined_count=3,  # 30% → FAIL (hard_fail_threshold=0.20)
-        )
-        assert report.thresholds.threshold_status == DQCheckStatus.FAIL
-
-    def test_analyze_with_previous_schema_drift_detection(
-        self,
-        analyzer: SilverDQAnalyzer,
-        mock_config_all_checks: MagicMock,
-    ) -> None:
-        """Schema drift check is triggered when previous_schema provided."""
-        df = pl.DataFrame({"id": [1, 2], "new_col": ["x", "y"]})
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        previous = {"id": "Int64"}  # new_col is missing from previous
-
-        report = analyzer.analyze(
-            data=df,
-            run_id="drift-test",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=["b1"],
-            config=mock_config_all_checks,
-            timestamp=ts,
-            primary_keys=["id"],
-            previous_schema=previous,
-        )
-        assert "schema_drift" in report.checks
-
-    def test_analyze_key_nullability_rules(
-        self,
-        analyzer: SilverDQAnalyzer,
-        mock_config_all_checks: MagicMock,
-    ) -> None:
-        df = pl.DataFrame({"merge_key": [1, None, 3]})
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        rules = [{"field": "merge_key", "key_type": "merge", "nullable": False}]
-
-        report = analyzer.analyze(
-            data=df,
-            run_id="key-null-test",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=[],
-            config=mock_config_all_checks,
-            timestamp=ts,
-            primary_keys=["merge_key"],
-            key_nullability_rules=rules,
-        )
-        assert "key_nullability" in report.checks
-        assert report.checks["key_nullability"]["violations"] != []
-
-    def test_analyze_source_batch_ids_in_report(
-        self,
-        analyzer: SilverDQAnalyzer,
-        simple_df: pl.DataFrame,
-        mock_config_empty: MagicMock,
-    ) -> None:
-        ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-        batches = ["batch-001", "batch-002"]
-        report = analyzer.analyze(
-            data=simple_df,
-            run_id="batch-test",
-            pipeline="test",
-            target_table="silver/test",
-            source_batch_ids=batches,
-            config=mock_config_empty,
-            timestamp=ts,
-            primary_keys=[],
-        )
-        assert report.source_batch_ids == tuple(batches)
-
-
-# ---------------------------------------------------------------------------
-# _distribution_to_dict
-# ---------------------------------------------------------------------------
-
-
-class TestDistributionToDict:
-    """Tests for the _distribution_to_dict helper."""
-
-    def test_empty_distribution_serializes(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"id": [1, 2, 3]})
-        dist_result = analyzer._check_value_distribution(df)
-        output = analyzer._distribution_to_dict(dist_result)
-        assert "numeric_columns" in output
-        assert "categorical_columns" in output
-        assert output["status"] == DQCheckStatus.PASS.value
-
-    def test_numeric_distribution_in_dict(self, analyzer: SilverDQAnalyzer) -> None:
-        df = pl.DataFrame({"score": [1.0, 2.0, 3.0]})
-        dist_result = analyzer._check_value_distribution(df)
-        output = analyzer._distribution_to_dict(dist_result)
-        assert "score" in output["numeric_columns"]
+def test_analyze_pyarrow_table_input(
+    analyzer: SilverDQAnalyzer,
+    mock_config_all_checks: MagicMock,
+) -> None:
+    table = pa.table(
+        {
+            "id": [1, 2, 3],
+            "name": ["a", "b", "c"],
+            "_content_hash": ["h1", "h2", "h3"],
+        }
+    )
+
+    report = analyzer.analyze(
+        data=table,
+        run_id="arrow-run",
+        pipeline="test",
+        target_table="silver/test",
+        source_batch_ids=["batch-arrow"],
+        config=mock_config_all_checks,
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        primary_keys=["id"],
+    )
+
+    assert report.layer == MedallionLayer.SILVER
+    assert "record_count" in report.checks
+
+
+def test_analyze_no_checks_enabled(
+    analyzer: SilverDQAnalyzer,
+    mock_config_empty: MagicMock,
+) -> None:
+    report = analyzer.analyze(
+        data=pl.DataFrame({"id": [1, 2, 3]}),
+        run_id="empty-checks",
+        pipeline="test",
+        target_table="silver/test",
+        source_batch_ids=[],
+        config=mock_config_empty,
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        primary_keys=[],
+    )
+
+    assert report.checks == {}
+    assert report.summary.passed == 0
+    assert report.summary.failed == 0
+
+
+def test_analyze_with_key_nullability_rules(
+    analyzer: SilverDQAnalyzer,
+    mock_config_all_checks: MagicMock,
+) -> None:
+    report = analyzer.analyze(
+        data=pl.DataFrame({"merge_key": [1, None, 3]}),
+        run_id="key-null-test",
+        pipeline="test",
+        target_table="silver/test",
+        source_batch_ids=[],
+        config=mock_config_all_checks,
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        primary_keys=["merge_key"],
+        key_nullability_rules=[
+            {"field": "merge_key", "key_type": "merge", "nullable": False}
+        ],
+    )
+
+    assert report.checks["key_nullability"]["violations"]
+
+
+def test_analyze_threshold_hard_fail(
+    analyzer: SilverDQAnalyzer,
+    mock_config_empty: MagicMock,
+) -> None:
+    report = analyzer.analyze(
+        data=pl.DataFrame({"id": [1, 2]}),
+        run_id="hard-fail",
+        pipeline="test",
+        target_table="silver/test",
+        source_batch_ids=[],
+        config=mock_config_empty,
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        primary_keys=[],
+        input_record_count=10,
+        quarantined_count=3,
+    )
+
+    assert report.thresholds.threshold_status == DQCheckStatus.FAIL

--- a/tests/unit/application/services/dq/test_silver_dq_report_assembler_service.py
+++ b/tests/unit/application/services/dq/test_silver_dq_report_assembler_service.py
@@ -1,0 +1,46 @@
+"""Unit tests for SilverDQReportAssemblerService."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bioetl.application.services.dq.silver_dq_report_assembler_service import (
+    SilverDQReportAssemblerService,
+)
+from bioetl.domain.value_objects.dq_report import DQCheckStatus, MedallionLayer
+
+
+def test_calculate_thresholds_warn_status() -> None:
+    service = SilverDQReportAssemblerService()
+
+    result = service.calculate_thresholds(
+        df_len=95,
+        input_record_count=100,
+        quarantined_count=10,
+        soft_fail_threshold=0.05,
+        hard_fail_threshold=0.20,
+    )
+
+    assert result.threshold_status == DQCheckStatus.WARN
+    assert result.current_error_rate == 0.1
+
+
+def test_assemble_report_sets_summary_and_layer() -> None:
+    service = SilverDQReportAssemblerService()
+    thresholds = service.calculate_thresholds(10, 10, 0, 0.05, 0.2)
+
+    report = service.assemble_report(
+        run_id="run-1",
+        pipeline="chembl",
+        target_table="silver/chembl",
+        source_batch_ids=["batch-1"],
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        checks={"record_count": {"status": "pass"}},
+        thresholds=thresholds,
+        passed=1,
+        failed=0,
+        warnings=0,
+    )
+
+    assert report.layer == MedallionLayer.SILVER
+    assert report.summary.passed == 1

--- a/tests/unit/application/services/dq/test_silver_dq_rule_evaluator_service.py
+++ b/tests/unit/application/services/dq/test_silver_dq_rule_evaluator_service.py
@@ -1,0 +1,88 @@
+"""Unit tests for DQRuleEvaluatorService."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bioetl.application.services.dq.silver_dq_rule_evaluator_service import (
+    DQRuleEvaluatorService,
+)
+from bioetl.domain.value_objects.dq_report import DQCheckStatus, DriftLevel
+
+
+def test_check_record_count_warn_high_quarantine_rate() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"id": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
+
+    result = service.check_record_count(df, 10, 2)
+
+    assert result.status == DQCheckStatus.WARN
+    assert result.quarantined_records == 2
+
+
+def test_check_null_rates_warn_on_high_null_column() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"a": [1, None, None]})
+
+    results, _overall = service.check_null_rates(df)
+
+    assert results[0].status == DQCheckStatus.WARN
+
+
+def test_check_uniqueness_warn_when_pk_missing() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"id": [1, 2, 3]})
+
+    result = service.check_uniqueness(df, ["missing"])
+
+    assert result.status == DQCheckStatus.WARN
+
+
+def test_check_type_conformance_warn_on_object_dtype() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"mixed": pl.Series([1, "str"], dtype=pl.Object)})
+
+    result = service.check_type_conformance(df)
+
+    assert result.status == DQCheckStatus.WARN
+
+
+def test_check_schema_drift_critical_on_missing_field() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"id": [1]})
+
+    result = service.check_schema_drift(df, {"id": "Int64", "name": "String"})
+
+    assert result.drift_level == DriftLevel.CRITICAL
+    assert result.status == DQCheckStatus.WARN
+
+
+def test_check_deduplication_counts_content_hash_duplicates() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"id": [1, 2, 3], "_content_hash": ["h1", "h1", "h3"]})
+
+    result = service.check_deduplication(df, ["id"], 3)
+
+    assert result.duplicates_by_content_hash == 1
+
+
+def test_check_content_hash_integrity_warn_on_collisions() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"_content_hash": ["h1", "h1", "h2"]})
+
+    result = service.check_content_hash_integrity(df)
+
+    assert result.status == DQCheckStatus.WARN
+
+
+def test_check_key_nullability_fail_on_non_nullable_violation() -> None:
+    service = DQRuleEvaluatorService()
+    df = pl.DataFrame({"merge_key": [1, None, 3]})
+
+    result = service.check_key_nullability(
+        df,
+        [{"field": "merge_key", "key_type": "merge", "nullable": False}],
+    )
+
+    assert result["status"] == DQCheckStatus.FAIL.value
+    assert result["violations"]

--- a/tests/unit/application/services/dq/test_silver_dq_statistics_service.py
+++ b/tests/unit/application/services/dq/test_silver_dq_statistics_service.py
@@ -1,0 +1,32 @@
+"""Unit tests for SilverDQStatisticsService."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bioetl.application.services.dq.silver_dq_statistics_service import (
+    SilverDQStatisticsService,
+)
+from bioetl.domain.value_objects.dq_report import DQCheckStatus
+
+
+def test_check_value_distribution_profiles_numeric_and_categorical() -> None:
+    service = SilverDQStatisticsService()
+    df = pl.DataFrame({"score": [1.0, 2.0, 3.0], "category": ["a", "b", "a"]})
+
+    result = service.check_value_distribution(df)
+
+    assert "score" in result.numeric_columns
+    assert "category" in result.categorical_columns
+    assert result.status == DQCheckStatus.PASS
+
+
+def test_distribution_to_dict_serializes_distributions() -> None:
+    service = SilverDQStatisticsService()
+    df = pl.DataFrame({"score": [1.0, 2.0, 3.0]})
+
+    result = service.check_value_distribution(df)
+    output = service.distribution_to_dict(result)
+
+    assert "score" in output["numeric_columns"]
+    assert output["status"] == DQCheckStatus.PASS.value


### PR DESCRIPTION
### Motivation
- Reduce complexity and size of the monolithic `SilverDQAnalyzer` by splitting responsibilities into focused subcomponents (evaluation, statistics/distributions, report assembly) while preserving the public `analyze(...)` contract. 
- Improve testability and follow the project's architecture rules by introducing smaller services with clear DI-friendly boundaries. 
- Minimize blast radius: keep `SilverDQAnalyzer` as an orchestration facade and provide backward-compatible private wrappers for existing callers/tests.

### Description
- Extracted check implementations into `SilverDQChecksService` which implements single-check methods (record count, null-rates, uniqueness, type conformance, schema drift, deduplication, content-hash integrity, key-nullability). (new: `src/bioetl/application/services/dq/silver_dq_checks_service.py`)
- Added `DQRuleEvaluatorService` to orchestrate enabled checks, aggregate passed/failed/warning counters and produce report-ready payloads by delegating to `SilverDQChecksService` and `SilverDQStatisticsService`. (new: `src/bioetl/application/services/dq/silver_dq_rule_evaluator_service.py`)
- Added `SilverDQStatisticsService` to encapsulate numeric/categorical profiling and distribution-to-dict formatting. (new: `src/bioetl/application/services/dq/silver_dq_statistics_service.py`)
- Added `SilverDQReportAssemblerService` to centralize thresholds calculation and final SilverDQReport assembly/summary formatting. (new: `src/bioetl/application/services/dq/silver_dq_report_assembler_service.py`)
- Kept `SilverDQAnalyzer` as a thin facade that injects/initializes the three services and delegates work to them, preserving the original `analyze(...)` signature and adding backward-compatible helper wrappers. (modified: `src/bioetl/application/services/dq/silver_analyzer.py`)
- Exported new services from the package `bioetl.application.services.dq` to make them first-class and added focused unit tests for each new service while retaining an integration-style test for the facade. (modified: `src/bioetl/application/services/dq/__init__.py`, added tests under `tests/unit/application/services/dq/`)

### Testing
- Ran unit tests for the DQ services: `uv run python -m pytest tests/unit/application/services/dq/test_silver_analyzer.py tests/unit/application/services/dq/test_silver_dq_rule_evaluator_service.py tests/unit/application/services/dq/test_silver_dq_statistics_service.py tests/unit/application/services/dq/test_silver_dq_report_assembler_service.py` — all tests passed. 
- Ran targeted structural/logic validations: `uv run python -m pytest tests/unit/application/services/dq/test_structural_validation.py tests/unit/application/services/dq/test_logical_validation.py` — passed. 
- Verified architecture metrics relevant to the refactor: `uv run python -m pytest tests/architecture/test_code_metrics.py -k "ClassSize or GodObjectDetection" -q` and `uv run python -m pytest tests/architecture/test_any_budget.py -q` — checks covering class/file sizes, delegation heuristics and unjustified `Any` budget passed after the decomposition. 
- Type-checking for the modified files: `uv run python -m mypy --strict src/bioetl/application/services/dq/silver_analyzer.py src/bioetl/application/services/dq/silver_dq_checks_service.py src/bioetl/application/services/dq/silver_dq_rule_evaluator_service.py src/bioetl/application/services/dq/silver_dq_statistics_service.py src/bioetl/application/services/dq/silver_dq_report_assembler_service.py` — `mypy --strict` reported no issues for the changed modules. 
- Formatting/linters: ran `ruff format` on the new/edited files and fixed formatting issues; import ordering and ruff checks were satisfied for the modified files. 

Notes: pre-commit hooks in the environment flagged unrelated global checks (external mypy baseline files and a missing global `pip-audit` executable) during an earlier commit attempt; those issues are outside the scope of this refactor and the refactor was validated with focused tests and type checks listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3e241388324999fc9dff6b91d25)