### PR TITLE
Replace dynamic self getattr dispatch with typed Protocol contracts and enforce rule

### DIFF
--- a/docs/00-project/CONTRIBUTING.md
+++ b/docs/00-project/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to BioETL
+
+## Typed self-dispatch rule
+
+- В production-коде (`src/bioetl/`) запрещён паттерн `getattr(self, "...")`.
+- Вместо динамического диспетча по `self` используйте явный типизированный контракт:
+  - `Protocol` с обязательными методами/атрибутами, или
+  - abstract base mixin с обязательными методами.
+- При ограничениях MRO допускается только локальный `type: ignore[...]` с пояснением причины.
+
+Проверка закреплена в `tests/architecture/test_no_getattr_self_string.py`.

--- a/src/bioetl/application/composite/runner_merge_stage_mixin.py
+++ b/src/bioetl/application/composite/runner_merge_stage_mixin.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from bioetl.application.composite.runner_constants import (
     CHECKPOINT_NON_FATAL_ERRORS,
@@ -36,6 +35,20 @@ if TYPE_CHECKING:
 __all__ = ["CompositeRunnerMergeStageHelper"]
 
 
+class _CompositeRunnerMergeSupportContract(Protocol):
+    """Contract for merge helper methods provided by sibling mixins."""
+
+    async def _save_checkpoint_safe(
+        self,
+        state: CompositeCheckpointState,
+        operation: str,
+    ) -> bool: ...
+
+    async def _generate_dq_reports(self, merge_result: MergeResult) -> None: ...
+
+    async def _write_cv_quarantine(self, merge_result: MergeResult) -> None: ...
+
+
 class CompositeRunnerMergeStageHelper:
     """Mixin containing merge execution and finalization."""
 
@@ -53,27 +66,18 @@ class CompositeRunnerMergeStageHelper:
         operation: str,
     ) -> bool:
         """Invoke support-layer checkpoint save helper."""
-        save_checkpoint = cast(
-            "Callable[[CompositeCheckpointState, str], Awaitable[bool]]",
-            getattr(self, "_save_checkpoint_safe"),
-        )
-        return await save_checkpoint(state, operation)
+        support = cast(_CompositeRunnerMergeSupportContract, self)
+        return await support._save_checkpoint_safe(state, operation)
 
     async def _call_generate_dq_reports(self, merge_result: MergeResult) -> None:
         """Invoke support-layer DQ report generation helper."""
-        generate_reports = cast(
-            "Callable[[MergeResult], Awaitable[None]]",
-            getattr(self, "_generate_dq_reports"),
-        )
-        await generate_reports(merge_result)
+        support = cast(_CompositeRunnerMergeSupportContract, self)
+        await support._generate_dq_reports(merge_result)
 
     async def _call_write_cv_quarantine(self, merge_result: MergeResult) -> None:
         """Invoke support-layer quarantine write helper."""
-        write_quarantine = cast(
-            "Callable[[MergeResult], Awaitable[None]]",
-            getattr(self, "_write_cv_quarantine"),
-        )
-        await write_quarantine(merge_result)
+        support = cast(_CompositeRunnerMergeSupportContract, self)
+        await support._write_cv_quarantine(merge_result)
 
     async def _execute_merge_stage(
         self,

--- a/src/bioetl/application/composite/runner_stage_mixin.py
+++ b/src/bioetl/application/composite/runner_stage_mixin.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol, cast
 
 from bioetl.application.composite.runner_constants import (
     CHECKPOINT_NON_FATAL_ERRORS,
@@ -43,6 +43,28 @@ if TYPE_CHECKING:
 __all__ = ["CompositeRunnerStageHelper"]
 
 
+class _CompositeRunnerStageSupportContract(Protocol):
+    """Contract for support methods provided by sibling mixins."""
+
+    async def _save_checkpoint_safe(
+        self,
+        state: CompositeCheckpointState,
+        operation: str,
+    ) -> bool: ...
+
+    async def _run_seed(self) -> SeedResult: ...
+
+    def _get_enrichers_to_run(
+        self,
+        state: CompositeCheckpointState,
+    ) -> list[EnricherConfig]: ...
+
+    def _check_required_enrichers(
+        self,
+        enrichment_results: dict[str, EnrichmentResult],
+    ) -> None: ...
+
+
 class _CompositeRunnerStageSupportMixin:
     """Shared helper calls and small guards for stage orchestration."""
 
@@ -63,41 +85,29 @@ class _CompositeRunnerStageSupportMixin:
         operation: str,
     ) -> bool:
         """Invoke support-layer checkpoint save helper."""
-        save_checkpoint = cast(
-            "Callable[[CompositeCheckpointState, str], Awaitable[bool]]",
-            getattr(self, "_save_checkpoint_safe"),
-        )
-        return await save_checkpoint(state, operation)
+        support = cast(_CompositeRunnerStageSupportContract, self)
+        return await support._save_checkpoint_safe(state, operation)
 
     async def _call_run_seed(self) -> SeedResult:
         """Invoke support-layer seed runner helper."""
-        run_seed = cast(
-            "Callable[[], Awaitable[SeedResult]]",
-            getattr(self, "_run_seed"),
-        )
-        return await run_seed()
+        support = cast(_CompositeRunnerStageSupportContract, self)
+        return await support._run_seed()
 
     def _call_get_enrichers_to_run(
         self,
         state: CompositeCheckpointState,
     ) -> list[EnricherConfig]:
         """Invoke support-layer enricher selection helper."""
-        get_enrichers = cast(
-            "Callable[[CompositeCheckpointState], list[EnricherConfig]]",
-            getattr(self, "_get_enrichers_to_run"),
-        )
-        return get_enrichers(state)
+        support = cast(_CompositeRunnerStageSupportContract, self)
+        return support._get_enrichers_to_run(state)
 
     def _call_check_required_enrichers(
         self,
         enrichment_results: dict[str, EnrichmentResult],
     ) -> None:
         """Invoke support-layer required-enricher validation helper."""
-        check_required = cast(
-            "Callable[[dict[str, EnrichmentResult]], None]",
-            getattr(self, "_check_required_enrichers"),
-        )
-        check_required(enrichment_results)
+        support = cast(_CompositeRunnerStageSupportContract, self)
+        support._check_required_enrichers(enrichment_results)
 
     def _has_dependencies_configured(self) -> bool:
         """Check if dependencies phase is configured and ready."""

--- a/src/bioetl/infrastructure/storage/gold_writer_io_mixin.py
+++ b/src/bioetl/infrastructure/storage/gold_writer_io_mixin.py
@@ -23,10 +23,10 @@ if TYPE_CHECKING:
     from bioetl.infrastructure.export.csv_exporter import CsvExporter
 
 
-class _WriteMergedMetadataCallable(Protocol):
-    """Callable contract for merged metadata sidecar writer."""
+class _GoldWriterMergedMetadataContract(Protocol):
+    """Contract for classes that can persist merged metadata."""
 
-    def __call__(
+    async def _write_gold_merged_metadata(
         self,
         *,
         table_path: str,
@@ -36,9 +36,7 @@ class _WriteMergedMetadataCallable(Protocol):
         run_id: str | None = None,
         sources_used: list[str] | None = None,
         schema: DataFrameSchema | None = None,
-    ) -> Awaitable[None]:
-        """Write metadata for merged Gold records."""
-        ...
+    ) -> None: ...
 
 
 def _load_gold_writer_module() -> ModuleType:
@@ -123,11 +121,8 @@ class GoldWriterIOMixin:
                 append=False,
             )
 
-        write_merged_metadata = cast(
-            _WriteMergedMetadataCallable,
-            getattr(self, "_write_gold_merged_metadata"),
-        )
-        await write_merged_metadata(
+        metadata_contract = cast(_GoldWriterMergedMetadataContract, self)
+        await metadata_contract._write_gold_merged_metadata(
             table_path=table_path,
             table_name=table_name,
             records=records,

--- a/tests/architecture/test_no_getattr_self_string.py
+++ b/tests/architecture/test_no_getattr_self_string.py
@@ -1,0 +1,52 @@
+"""Architecture guard: forbid getattr(self, "...") in production code."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_ROOT = Path("src/bioetl")
+
+
+def _find_getattr_self_string_calls(path: Path) -> list[tuple[int, str]]:
+    """Return (line, attr_name) for getattr(self, "...") calls."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "getattr":
+            continue
+        if len(node.args) < 2:
+            continue
+
+        target = node.args[0]
+        attr = node.args[1]
+        if (
+            isinstance(target, ast.Name)
+            and target.id == "self"
+            and isinstance(attr, ast.Constant)
+            and isinstance(attr.value, str)
+        ):
+            violations.append((node.lineno, attr.value))
+
+    return violations
+
+
+def test_no_getattr_self_string_in_production_code() -> None:
+    """Production code must use explicit typed contracts instead of dynamic self getattr."""
+    violations: list[str] = []
+
+    for py_file in SRC_ROOT.rglob("*.py"):
+        file_violations = _find_getattr_self_string_calls(py_file)
+        violations.extend(
+            f"{py_file}:{line} -> getattr(self, {attr!r})"
+            for line, attr in file_violations
+        )
+
+    assert not violations, (
+        "Dynamic self attribute dispatch is forbidden in production code. "
+        "Define a Protocol/ABC contract and call the method directly.\n"
+        + "\n".join(sorted(violations))
+    )


### PR DESCRIPTION
### Motivation
- Eliminate runtime dynamic dispatch via `getattr(self, "...")` and replace it with explicit typed contracts to improve static typing, readability and adherence to the Hexagonal/Ports architecture.
- Constrain mixin composition to well-defined contracts to reduce fragile MRO-based surprises and to make `mypy --strict` checks meaningful for these cross-mixin calls.
- Enforce the coding rule project-wide so new code follows the typed-contract pattern and avoid future regressions.

### Description
- Replaced dynamic `getattr(self, "...")` + `cast` patterns in the composite runner mixins with explicit `Protocol` contracts and typed calls in `application/composite/*mixin.py` by adding `_CompositeRunnerStageSupportContract` and `_CompositeRunnerMergeSupportContract` and invoking `support._save_checkpoint_safe(...)`, `support._run_seed()`, `support._get_enrichers_to_run(...)`, `support._check_required_enrichers(...)`, `support._generate_dq_reports(...)`, and `support._write_cv_quarantine(...)` directly (files updated: `runner_stage_mixin.py`, `runner_merge_stage_mixin.py`).
- Replaced dynamic metadata writer dispatch in Gold I/O mixin with a Protocol-backed direct call by introducing `_GoldWriterMergedMetadataContract` and invoking `metadata_contract._write_gold_merged_metadata(...)` (file updated: `gold_writer_io_mixin.py`).
- Added an AST-based architecture test `tests/architecture/test_no_getattr_self_string.py` that fails if `getattr(self, "...")` is present anywhere under `src/bioetl` to prevent regressions.
- Documented the rule and the allowed escape (local `type: ignore[...]` with justification for MRO limitations) in `docs/00-project/CONTRIBUTING.md`.

### Testing
- Ran the new architecture test: `uv run python -m pytest tests/architecture/test_no_getattr_self_string.py -q` and it passed.
- Type checking: `uv run python -m mypy --strict` (targeted files) succeeded with no issues reported for the modified sources and the new test.
- Syntax check: `python -m py_compile` on the modified modules succeeded.
- Pattern scan: `rg -n 'getattr(self,\s*"[^"]+"\)' src/bioetl` returned no matches after the change.
All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3ff11e08324b61d7fe0ca46b201)