### PR TITLE
Tighten typing for ChEMBL fetch mixins

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/fetch_adapter_mixin.py
+++ b/src/bioetl/infrastructure/adapters/chembl/fetch_adapter_mixin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from bioetl.domain.types import BronzeRecord
 from bioetl.infrastructure.adapters.chembl.fetch_multi_filter_mixin import (
@@ -16,7 +16,10 @@ from bioetl.infrastructure.adapters.chembl.fetch_resilience_mixin import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable, Iterator
+
+    from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
 
 
 class ChemblFetchAdapterMixin(
@@ -26,8 +29,15 @@ class ChemblFetchAdapterMixin(
 ):
     """Provides ChEMBL pagination, filtering, and retry fetch flows."""
 
+    logger: LoggerPort
+    _adapter_metrics: AdapterMetrics
+    _filter_batch_size: int
+    _get_api_pk_field: Callable[[str], str]
+    _get_api_dedup_fields: Callable[[str], tuple[str, ...]]
+    _batch_ids: Callable[[list[str], int], Iterator[list[str]]]
+
     async def _fetch_filtered(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchAdapterMixin,
         entity_type: str,
         limit: int | None,
         filter_ids: list[str],
@@ -39,7 +49,7 @@ class ChemblFetchAdapterMixin(
         pk_field = self._get_api_pk_field(entity_type)
         pk_fields = self._get_api_dedup_fields(entity_type)
 
-        for id_batch in self._batch_ids(filter_ids, batch_size=self._filter_batch_size):
+        for id_batch in self._batch_ids(filter_ids, self._filter_batch_size):
             async for record in self._fetch_batch_with_reduction(
                 entity_type,
                 id_batch,
@@ -55,7 +65,7 @@ class ChemblFetchAdapterMixin(
                     return
 
     async def _fetch_standard(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchAdapterMixin,
         entity_type: str,
         limit: int | None,
         offset: int = 0,
@@ -103,7 +113,7 @@ class ChemblFetchAdapterMixin(
                     return
 
     async def fetch(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchAdapterMixin,
         entity_type: str,
         limit: int | None = None,
         query: str | None = None,
@@ -127,7 +137,7 @@ class ChemblFetchAdapterMixin(
             yield record
 
     async def fetch_filtered(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchAdapterMixin,
         entity_type: str,
         filter_ids: list[str],
         filter_field: str,
@@ -143,7 +153,7 @@ class ChemblFetchAdapterMixin(
             yield record
 
     async def fetch_filtered_with_fallback(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchAdapterMixin,
         entity_type: str,
         filter_ids: list[str],
         filter_field: str,

--- a/src/bioetl/infrastructure/adapters/chembl/fetch_multi_filter_mixin.py
+++ b/src/bioetl/infrastructure/adapters/chembl/fetch_multi_filter_mixin.py
@@ -3,19 +3,37 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from bioetl.domain.types import BronzeRecord
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+
+    from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.chembl.entity_mapper import ChemblEntityMapper
 
 
 class ChemblFetchMultiFilterMixin:
     """Provides multi-field filter fetch implementation for ChEMBL."""
 
+    logger: LoggerPort
+    _mapper: ChemblEntityMapper
+    _filter_batch_size: int
+    _build_params: Callable[[int, str | None], dict[str, str | int | bool]]
+    _build_filter_in_params: Callable[[dict[str, list[str]]], dict[str, str]]
+    _get_projected_url_length: Callable[[str, dict[str, str | int | bool]], int]
+    _get_api_pk_field: Callable[[str], str]
+    _normalize_filter_field: Callable[[str, str], str]
+    _batch_ids: Callable[[list[str], int], Iterator[list[str]]]
+    _fetch_page: Callable[
+        [str, dict[str, str | int | bool], str],
+        Awaitable[tuple[list[BronzeRecord], bool]],
+    ]
+    _is_duplicate_record: Callable[[BronzeRecord, str, set[str], str], bool]
+
     def _determine_multi_filter_batch_size(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchMultiFilterMixin,
         url: str,
         filters: dict[str, list[str]],
         entity_type: str,
@@ -38,7 +56,7 @@ class ChemblFetchMultiFilterMixin:
         return batch_size
 
     async def fetch_multi_filtered(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchMultiFilterMixin,
         entity_type: str,
         filters: dict[str, list[str]],
         limit: int | None = None,

--- a/src/bioetl/infrastructure/adapters/chembl/fetch_paging_mixin.py
+++ b/src/bioetl/infrastructure/adapters/chembl/fetch_paging_mixin.py
@@ -17,7 +17,15 @@ from bioetl.domain.exceptions import (
 from bioetl.domain.types import BronzeRecord
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncIterator, Callable, Iterator
+
+    from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
+    from bioetl.infrastructure.adapters.chembl.entity_mapper import ChemblEntityMapper
+    from bioetl.infrastructure.adapters.common.api_request_collector import (
+        APIRequestCollector,
+    )
+    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 CHEMBL_ADAPTER_ERRORS = (
     BioETLError,
@@ -38,16 +46,24 @@ class ChemblFetchPagingMixin:
     """Provides ChEMBL pagination and filtered-page iteration helpers."""
 
     # Host-class attributes (provided by ChemblAdapter.__init__)
-    logger: Any  # Any: logger is injected adapter runtime dependency
+    logger: LoggerPort
     provider_name: str
-    _mapper: Any  # Any: mapper concrete type is adapter-internal
-    _adapter_metrics: Any  # Any: metrics collector protocol varies in tests/runtime
-    http_client: Any  # Any: unified HTTP client is injected infrastructure object
-    _request_collector: Any  # Any: collector contract is adapter-internal
+    _mapper: ChemblEntityMapper
+    _adapter_metrics: AdapterMetrics
+    http_client: UnifiedHTTPClient
+    _request_collector: APIRequestCollector
     _compute_composite_key: Callable[[BronzeRecord, tuple[str, ...]], str]
+    _process_response: Callable[[httpx.Response, str], tuple[list[BronzeRecord], bool]]
+    _handle_error: Callable[[Exception, str], None]
+    _build_params: Callable[[int, str | None], dict[str, Any]]
+    _build_filter_params: Callable[[str, str, list[str]], dict[str, str]]
+    _get_api_pk_field: Callable[[str], str]
+    _get_api_dedup_fields: Callable[[str], tuple[str, ...]]
+    _normalize_filter_field: Callable[[str, str], str]
+    _page_size: int
 
     async def _fetch_page(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchPagingMixin,
         url: str,
         params: dict[str, Any],  # Any: HTTP query params (str|int|bool values)
         entity_type: str,
@@ -69,7 +85,7 @@ class ChemblFetchPagingMixin:
             handle_error(error)
 
     async def _page_iterator(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchPagingMixin,
         entity_type: str,
         limit: int | None = None,
         start_offset: int = 0,
@@ -97,7 +113,7 @@ class ChemblFetchPagingMixin:
             offset += len(records)
 
     def _yield_deduplicated(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchPagingMixin,
         records: list[BronzeRecord],
         seen_ids: set[str],
         pk_field: str,
@@ -145,7 +161,7 @@ class ChemblFetchPagingMixin:
             yield record
 
     async def _paginate_filter_results(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchPagingMixin,
         url: str,
         id_batch: list[str],
         filter_field: str,
@@ -186,7 +202,7 @@ class ChemblFetchPagingMixin:
             offset += len(records)
 
     async def _fetch_with_filter(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchPagingMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,

--- a/src/bioetl/infrastructure/adapters/chembl/fetch_resilience_mixin.py
+++ b/src/bioetl/infrastructure/adapters/chembl/fetch_resilience_mixin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, cast
 
 import httpx
 
@@ -17,7 +17,16 @@ from bioetl.domain.exceptions import (
 from bioetl.domain.types import BronzeRecord
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
+
+    from bioetl.domain.ports import LoggerPort
+    from bioetl.infrastructure.adapters.base_metrics import AdapterMetrics
+    from bioetl.infrastructure.adapters.chembl.entity_mapper import ChemblEntityMapper
+    from bioetl.infrastructure.adapters.common.api_request_collector import (
+        APIRequestCollector,
+    )
+    from bioetl.infrastructure.adapters.error_handling import ErrorService
+    from bioetl.infrastructure.adapters.http.client import UnifiedHTTPClient
 
 CHEMBL_ADAPTER_ERRORS = (
     BioETLError,
@@ -38,28 +47,31 @@ class ChemblFetchResilienceMixin:
     """Provides retry, split-batch recovery, and single-ID fallback helpers."""
 
     # Host-class attributes (provided by ChemblAdapter.__init__)
-    logger: Any  # Any: logger is injected adapter runtime dependency
+    logger: LoggerPort
     provider_name: str
-    _mapper: Any  # Any: mapper concrete type is adapter-internal
-    _adapter_metrics: Any  # Any: metrics collector protocol varies in tests/runtime
-    http_client: Any  # Any: unified HTTP client is injected infrastructure object
-    _request_collector: Any  # Any: collector contract is adapter-internal
-    _error_handler: Any  # Any: error handler concrete type is adapter-internal
+    _mapper: ChemblEntityMapper
+    _adapter_metrics: AdapterMetrics
+    http_client: UnifiedHTTPClient
+    _request_collector: APIRequestCollector
+    _error_handler: ErrorService
     _compute_composite_key: Callable[[BronzeRecord, tuple[str, ...]], str]
 
     def _handle_error(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         error: Exception,
         context: str = "fetch",
     ) -> None:
         """Handle errors with unified classification."""
         failure_count = self.http_client.circuit_breaker.get_failure_count()
-        health_status = self._get_health_status()
+        health_status = cast(
+            "object",
+            self._get_health_status(),  # type: ignore[attr-defined]
+        )
 
         error_context = {
             "circuit_breaker_state": self.http_client.circuit_breaker.get_state().value,
             "circuit_breaker_failures": failure_count,
-            "health_status": health_status.value,
+            "health_status": getattr(health_status, "value", "unknown"),
         }
         wrapped = self._error_handler.handle_error(
             error=error,
@@ -70,7 +82,7 @@ class ChemblFetchResilienceMixin:
         raise wrapped from error
 
     def _is_retry_exhausted_error(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         error: Exception,
     ) -> bool:
         """Check if exception is a retry exhausted error (direct or wrapped)."""
@@ -131,7 +143,7 @@ class ChemblFetchResilienceMixin:
             return None
 
     async def _retry_with_split_batches(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,
@@ -189,7 +201,7 @@ class ChemblFetchResilienceMixin:
         return True
 
     async def _yield_deduplicated_filtered_records(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,
@@ -199,14 +211,18 @@ class ChemblFetchResilienceMixin:
         pk_fields: tuple[str, ...] | None = None,
     ) -> AsyncIterator[BronzeRecord]:
         """Yield filtered records while deduplicating by configured keys."""
-        async for record in self._fetch_with_filter(
+        fetch_with_filter = cast(
+            "Callable[[str, list[str], str, int | None], AsyncIterator[BronzeRecord]]",
+            self._fetch_with_filter,  # type: ignore[attr-defined]
+        )
+        async for record in fetch_with_filter(
             entity_type, id_batch, filter_field, limit
         ):
             if self._mark_record_as_seen(record, seen_ids, pk_field, pk_fields):
                 yield record
 
     async def _yield_single_id_fallback(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,
@@ -226,7 +242,7 @@ class ChemblFetchResilienceMixin:
             yield direct_record
 
     async def _yield_retry_exhausted_recovery(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,
@@ -263,7 +279,7 @@ class ChemblFetchResilienceMixin:
             yield record
 
     async def _fetch_batch_with_reduction(
-        self: Any,  # Any: mixin self type
+        self: ChemblFetchResilienceMixin,
         entity_type: str,
         id_batch: list[str],
         filter_field: str,


### PR DESCRIPTION
### Motivation
- Reduce the use of `Any` in canonical ChEMBL fetch mixins and make host/mixin contracts explicit to improve type-safety and IDE ergonomics.
- Ensure mixin implementations declare the attributes they expect from the host adapter so composition is verifiable by `mypy` without spreading unsafe `Any` usage.

### Description
- Canonical ChEMBL mixins were updated: `fetch_adapter_mixin.py`, `fetch_resilience_mixin.py`, `fetch_paging_mixin.py`, and `fetch_multi_filter_mixin.py` now include explicit host-attribute annotations and narrower callable types in `TYPE_CHECKING` blocks.
- Replaced `self: Any` signatures in mixin methods with typed mixin `self` (e.g. `self: ChemblFetchPagingMixin`) and added required `Callable`/`Protocol`-like host contracts where cross-mixin delegation occurs.
- Localized remaining dynamic spots with narrow mitigations: a `cast(...)` + `# type: ignore[attr-defined]` is used for cross-mixin method calls supplied at composition time, and HTTP query params remain typed as `dict[str, Any]` with an inline rationale.
- Compatibility shim (`fetch_mixin.py`) was left unchanged so existing downstream imports remain unaffected.

### Testing
- Ran strict type-check for the modified modules with `uv run python -m mypy --strict src/bioetl/infrastructure/adapters/chembl/fetch_adapter_mixin.py src/bioetl/infrastructure/adapters/chembl/fetch_resilience_mixin.py src/bioetl/infrastructure/adapters/chembl/fetch_paging_mixin.py src/bioetl/infrastructure/adapters/chembl/fetch_multi_filter_mixin.py` and it completed with no issues.
- Ran a full `uv run python -m mypy --strict src/bioetl/` and it reported pre-existing unrelated baseline failures in other modules (factory `RecordProcessor` call-sites and several `DataFrameModel`/settings subclasses) which were not introduced by these changes.
- Performed a syntax/compile sanity check via `python -m py_compile` for the edited files and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3eb23208324a4f9aef8947d8cbd)