### PR TITLE
Move inline instantiation to composition; inject BatchExecutor/Runner dependencies via constructors

### DIFF
--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from bioetl.application.composite.dependency_coordinator import (
         DependencyCoordinatorService,
     )
+    from bioetl.application.composite.fsm_helper import FSMStateHelperService
     from bioetl.application.composite.key_extractor import KeyExtractorService
     from bioetl.application.composite.merger import MergeService
     from bioetl.application.composite.preflight_validator import (
@@ -115,6 +116,7 @@ class CompositePipelineRunnerService(
         coordinator: EnrichmentCoordinatorService,
         merger: MergeService,
         checkpoint_manager: CompositeCheckpointService,
+        fsm: FSMStateHelperService,
         logger: LoggerPort,
         lock: LockPort,
         run_id: str | None = None,
@@ -137,6 +139,7 @@ class CompositePipelineRunnerService(
         self._coordinator = coordinator
         self._merger = merger
         self._checkpoint_manager = checkpoint_manager
+        self._fsm = fsm
         self._logger = logger
         self._lock = lock
         self._run_id_str = run_id or str(uuid4())
@@ -148,14 +151,6 @@ class CompositePipelineRunnerService(
         self._preflight_validator = preflight_validator
         self._quarantine_port = quarantine_port
         self._metrics = metrics
-
-        from bioetl.application.composite.fsm_helper import FSMStateHelperService
-
-        self._fsm = FSMStateHelperService(
-            config=config,
-            logger=logger,
-            run_id=self._run_id_str,
-        )
 
     @property
     def run_id(self) -> str:

--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -10,18 +10,13 @@ DQ Report Integration:
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from bioetl.application.core.batch_executor_dq_mixin import _BatchExecutorDQMixin
 from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
-from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
-from bioetl.application.core.batch_tracing import BatchTracingManagerService
-from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
-from bioetl.application.core.batch_writer import BatchWriter
-from bioetl.application.core.quarantine_manager import QuarantineManagerService
+from bioetl.application.core.batch_transformer import TransformResult
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
 from bioetl.domain.exceptions import BioETLError
 from bioetl.domain.types import BatchID
@@ -31,24 +26,17 @@ if TYPE_CHECKING:
 
     from opentelemetry.trace import Span
 
+    from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+    from bioetl.application.core.batch_tracing import BatchTracingManagerService
+    from bioetl.application.core.batch_transformer import BatchTransformer
+    from bioetl.application.core.batch_writer import BatchWriter
     from bioetl.application.core.checkpoint_manager import CheckpointManagerService
     from bioetl.application.core.config import RecordProcessorConfig
     from bioetl.application.core.pipeline_services import PipelineServices
-    from bioetl.application.core.protocols import (
-        GoldFilterCallback,
-        GoldTransformCallback,
-        TransformCallback,
-    )
     from bioetl.domain.config import MemoryConfig
     from bioetl.domain.context import PipelineContext
-    from bioetl.domain.error_classifier import ErrorClassifier
     from bioetl.domain.models.metadata import SourceMetadata
-    from bioetl.domain.ports import (
-        GoldValidatorPort,
-        LoggerPort,
-        MemoryMonitorPort,
-        TracingPort,
-    )
+    from bioetl.domain.ports import LoggerPort, MemoryMonitorPort
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,18 +84,15 @@ class BatchExecutor(_BatchExecutorDQMixin):
         services: PipelineServices,
         context: PipelineContext,
         config: RecordProcessorConfig,
-        error_classifier: ErrorClassifier,
-        transform_callback: TransformCallback,
-        gold_filter_callback: GoldFilterCallback,
-        gold_transform_callback: GoldTransformCallback,
-        gold_validator: GoldValidatorPort,
         checkpoint_manager: CheckpointManagerService,
         shutdown_signal: ShutdownSignal,
+        batch_metrics: BatchMetricsRecorderService,
+        transformer: BatchTransformer,
+        writer: BatchWriter,
+        tracing_manager: BatchTracingManagerService,
         *,
         batch_size: int | None = None,
         checkpoint_interval: int | None = None,
-        tracer: TracingPort | None = None,
-        lock_validator: Callable[[], Awaitable[bool]] | None = None,
         memory_monitor: MemoryMonitorPort | None = None,
         memory_config: MemoryConfig | None = None,
         logger: LoggerPort | None = None,
@@ -118,17 +103,14 @@ class BatchExecutor(_BatchExecutorDQMixin):
             services: Common pipeline services (data source, storage, metrics, etc.).
             context: Pipeline execution context (run_id, run_type, started_at).
             config: Record processor configuration.
-            error_classifier: Service for error classification.
-            transform_callback: Callback for Bronze → Silver transformation.
-            gold_filter_callback: Callback for filtering Silver records for Gold.
-            gold_transform_callback: Callback for Silver → Gold transformation.
-            gold_validator: Validator for Gold layer records.
             checkpoint_manager: Checkpoint manager instance.
             shutdown_signal: Signal to handle graceful shutdown.
+            batch_metrics: Metrics recorder for batch stages.
+            transformer: Batch transformer for Bronze → Silver/Gold.
+            writer: Batch writer for Bronze/Silver/Gold layers.
+            tracing_manager: Tracing manager for execution and batch spans.
             batch_size: Number of records per batch.
             checkpoint_interval: Number of records between checkpoints.
-            tracer: Optional tracing port for distributed tracing.
-            lock_validator: Async callable that validates lock ownership (Safety Guard §4.6).
             memory_monitor: Optional memory monitor for adaptive batch sizing.
             memory_config: Memory configuration (used if memory_monitor not provided).
             logger: Logger for memory-related messages.
@@ -181,46 +163,10 @@ class BatchExecutor(_BatchExecutorDQMixin):
         self._source_batch_ids: list[str] = []
         self._last_bronze_path: str | None = None
 
-        # Create internal components (from RecordProcessor)
-        pipeline_label = f"{config.provider}_{config.entity_type}"
-        self._batch_metrics = BatchMetricsRecorderService(
-            services.metrics, pipeline_label, context.run_type.value
-        )
-
-        self._transformer = BatchTransformer(
-            context=context,
-            config=config,
-            error_classifier=error_classifier,
-            quarantine_manager=QuarantineManagerService(
-                quarantine_port=services.quarantine,
-                pipeline_name=config.pipeline_name,
-                metrics=services.metrics,
-            ),
-            batch_metrics=self._batch_metrics,
-            transform_callback=transform_callback,
-            gold_filter_callback=gold_filter_callback,
-            gold_transform_callback=gold_transform_callback,
-        )
-
-        self._writer = BatchWriter(
-            storage=services.storage,
-            context=context,
-            config=config,
-            gold_validator=gold_validator,
-            error_classifier=error_classifier,
-            batch_metrics=self._batch_metrics,
-            tracer=tracer,
-            lock_validator=lock_validator,
-        )
-
-        # Tracing manager (extracted for class size reduction)
-        self._tracing = BatchTracingManagerService(
-            tracer=tracer,
-            context=context,
-            config=config,
-            initial_batch_size=self._initial_batch_size,
-            adaptive_sizing_enabled=self._memory.enabled,
-        )
+        self._batch_metrics = batch_metrics
+        self._transformer = transformer
+        self._writer = writer
+        self._tracing = tracing_manager
 
         # Query string for metadata (stored during execute())
         self._query_string: str | None = None

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -17,6 +17,7 @@ from bioetl.application.composite.cross_validator import (
 from bioetl.application.composite.dependency_coordinator import (
     DependencyCoordinatorService,
 )
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.key_extractor import KeyExtractorService
 from bioetl.application.composite.merger import MergeService
 from bioetl.application.composite.runner import (
@@ -570,6 +571,7 @@ def bootstrap_composite_runner(
         logger=logger,
         resume=runtime.resume,
     )
+    fsm = FSMStateHelperService(config=config, logger=logger, run_id=effective_run_id)
 
     # Create DQ report service for composite
     dq_report_service = _create_dq_report_service(logger, settings)
@@ -594,6 +596,7 @@ def bootstrap_composite_runner(
         coordinator=coordinator,
         merger=merger,
         checkpoint_manager=checkpoint_manager,
+        fsm=fsm,
         logger=logger,
         lock=lock,
         run_id=effective_run_id,

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -17,9 +17,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from bioetl.application.core.batch_executor import BatchExecutor
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_tracing import BatchTracingManagerService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.checkpoint_manager import CheckpointManagerService
 from bioetl.application.core.config import RecordProcessorConfig
 from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
 from bioetl.application.core.record_processor import RecordProcessor
 from bioetl.composition.bootstrap_contexts import PipelineCallbacksContext
 from bioetl.composition.factories.dq_factory import DQServicesFactory
@@ -511,16 +516,43 @@ class ServicesBuilder:
             gold_schema, strict=strict_gold_validation
         )
 
-        return RecordProcessor(
-            services=services,
-            error_classifier=error_classifier,
+        pipeline_label = f"{provider}_{entity_type}"
+        batch_metrics = BatchMetricsRecorderService(
+            services.metrics,
+            pipeline_label,
+            context.run_type.value,
+        )
+        quarantine_manager = QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=pipeline_name,
+            metrics=services.metrics,
+        )
+        transformer = BatchTransformer(
             context=context,
             config=processor_config,
+            error_classifier=error_classifier,
+            quarantine_manager=quarantine_manager,
+            batch_metrics=batch_metrics,
             transform_callback=transform_callback,
             gold_filter_callback=gold_filter_callback,
             gold_transform_callback=gold_transform_callback,
+        )
+        writer = BatchWriter(
+            storage=services.storage,
+            context=context,
+            config=processor_config,
             gold_validator=gold_validator,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
             lock_validator=lock_validator,
+        )
+
+        return RecordProcessor(
+            context=context,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            config=processor_config,
         )
 
     @staticmethod
@@ -644,21 +676,60 @@ class ServicesBuilder:
             gold_schema, strict=strict_gold_validation
         )
 
+        pipeline_label = f"{pipeline.config.provider}_{pipeline.config.entity_type}"
+        batch_metrics = BatchMetricsRecorderService(
+            pipeline.services.metrics,
+            pipeline_label,
+            pipeline.context.run_type.value,
+        )
+        quarantine_manager = QuarantineManagerService(
+            quarantine_port=pipeline.services.quarantine,
+            pipeline_name=pipeline.config.pipeline_name,
+            metrics=pipeline.services.metrics,
+        )
+        transformer = BatchTransformer(
+            context=pipeline.context,
+            config=processor_config,
+            error_classifier=error_classifier,
+            quarantine_manager=quarantine_manager,
+            batch_metrics=batch_metrics,
+            transform_callback=callbacks.transform,
+            gold_filter_callback=gold_filter,
+            gold_transform_callback=callbacks.gold_transform,
+        )
+        writer = BatchWriter(
+            storage=pipeline.services.storage,
+            context=pipeline.context,
+            config=processor_config,
+            gold_validator=gold_validator,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
+            tracer=tracer,
+            lock_validator=lock_validator,
+        )
+        tracing_manager = BatchTracingManagerService(
+            tracer=tracer,
+            context=pipeline.context,
+            config=processor_config,
+            initial_batch_size=pipeline.config.batch_size,
+            adaptive_sizing_enabled=(
+                memory_monitor is not None
+                or (memory_config is not None and memory_config.enable_adaptive_sizing)
+            ),
+        )
+
         return BatchExecutor(
             services=pipeline.services,
             context=pipeline.context,
             config=processor_config,
-            error_classifier=error_classifier,
-            transform_callback=callbacks.transform,
-            gold_filter_callback=gold_filter,
-            gold_transform_callback=callbacks.gold_transform,
-            gold_validator=gold_validator,
             checkpoint_manager=checkpoint_manager,
             shutdown_signal=shutdown_signal,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            tracing_manager=tracing_manager,
             batch_size=pipeline.config.batch_size,
             checkpoint_interval=pipeline.config.checkpoint_interval,
-            tracer=tracer,
-            lock_validator=lock_validator,
             memory_monitor=memory_monitor,
             memory_config=memory_config,
         )

--- a/tests/unit/application/composite/test_runner.py
+++ b/tests/unit/application/composite/test_runner.py
@@ -13,6 +13,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -162,6 +163,15 @@ def create_mock_merger() -> AsyncMock:
     return merger
 
 
+def create_mock_fsm(
+    config: MockCompositeConfig,
+    logger: MagicMock,
+    run_id: str,
+) -> FSMStateHelperService:
+    """Create FSM helper service for runner DI."""
+    return FSMStateHelperService(config=config, logger=logger, run_id=run_id)
+
+
 def create_runner(
     seed_runner: MockPipelineRunner | None = None,
     checkpoint_manager: AsyncMock | None = None,
@@ -175,8 +185,11 @@ def create_runner(
     if runtime is None:
         runtime = CompositeRuntimeConfig()
 
+    run_id = str(uuid4())
+    config = MockCompositeConfig()
+    logger = create_mock_logger()
     return CompositePipelineRunner(
-        config=MockCompositeConfig(),
+        config=config,
         runtime=runtime,
         seed_runner_factory=lambda: seed_runner,
         enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -184,8 +197,10 @@ def create_runner(
         coordinator=create_mock_coordinator(),
         merger=create_mock_merger(),
         checkpoint_manager=checkpoint_manager,
-        logger=create_mock_logger(),
+        fsm=FSMStateHelperService(config=config, logger=logger, run_id=run_id),
+        logger=logger,
         lock=create_mock_lock(),
+        run_id=run_id,
     )
 
 
@@ -302,9 +317,11 @@ class TestFSMSeedFailure:
         seed_runner = MockPipelineRunner(should_fail=True, error_message="API error")
         checkpoint_manager = create_mock_checkpoint_manager()
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
 
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: seed_runner,
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -312,8 +329,10 @@ class TestFSMSeedFailure:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         with pytest.raises(RuntimeError):
@@ -411,9 +430,11 @@ class TestFSMSeedResume:
         )
         checkpoint_manager = create_mock_checkpoint_manager(initial_state)
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
 
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(resume=True),
             seed_runner_factory=lambda: MockPipelineRunner(),
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -421,8 +442,10 @@ class TestFSMSeedResume:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         await runner.run()
@@ -444,8 +467,10 @@ class TestFSMTransitionLogging:
     async def test_seed_start_transition_logged(self):
         """Transition to SEED_RUNNING should be logged."""
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: MockPipelineRunner(),
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -453,8 +478,10 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         await runner.run()
@@ -469,8 +496,10 @@ class TestFSMTransitionLogging:
     async def test_seed_complete_transition_logged(self):
         """Transition to SEED_COMPLETED should be logged."""
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: MockPipelineRunner(),
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -478,8 +507,10 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         await runner.run()
@@ -495,8 +526,10 @@ class TestFSMTransitionLogging:
         """Transition to FAILED should be logged when seed fails."""
         logger = create_mock_logger()
         seed_runner = MockPipelineRunner(should_fail=True)
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: seed_runner,
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -504,8 +537,10 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         with pytest.raises(RuntimeError):
@@ -530,9 +565,11 @@ class TestCheckpointSaveErrorHandling:
             side_effect=[StorageError("Disk full"), None, None, None, None, None]
         )
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
 
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: MockPipelineRunner(),
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -540,8 +577,10 @@ class TestCheckpointSaveErrorHandling:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         # Should not raise despite checkpoint save failure
@@ -565,9 +604,11 @@ class TestCheckpointSaveErrorHandling:
             side_effect=[OSError("Permission denied"), None, None, None, None, None]
         )
         logger = create_mock_logger()
+        config = MockCompositeConfig()
+        run_id = str(uuid4())
 
         runner = CompositePipelineRunner(
-            config=MockCompositeConfig(),
+            config=config,
             runtime=CompositeRuntimeConfig(),
             seed_runner_factory=lambda: MockPipelineRunner(),
             enricher_runner_factory=lambda name, df: MockPipelineRunner(),
@@ -575,8 +616,10 @@ class TestCheckpointSaveErrorHandling:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm=create_mock_fsm(config, logger, run_id),
             logger=logger,
             lock=create_mock_lock(),
+            run_id=run_id,
         )
 
         await runner.run()

--- a/tests/unit/application/core/test_batch_executor.py
+++ b/tests/unit/application/core/test_batch_executor.py
@@ -12,9 +12,14 @@ from uuid import uuid4
 import pytest
 
 from bioetl.application.core.batch_executor import BatchExecutor, BatchResult
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_tracing import BatchTracingManagerService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.checkpoint_manager import CheckpointManager
 from bioetl.application.core.config import RecordProcessorConfig
 from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
 from bioetl.domain.config import TableConfig
 from bioetl.domain.context import PipelineContext
@@ -144,6 +149,57 @@ def processor_config():
     )
 
 
+def _build_batch_dependencies(
+    *,
+    services,
+    context,
+    config,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    tracer=None,
+):
+    error_classifier = ErrorClassifier()
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        "test_provider_test_entity",
+        context.run_type.value,
+    )
+    quarantine_manager = QuarantineManagerService(
+        quarantine_port=services.quarantine,
+        pipeline_name=config.pipeline_name,
+        metrics=services.metrics,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=quarantine_manager,
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+    )
+    tracing_manager = BatchTracingManagerService(
+        tracer=tracer,
+        context=context,
+        config=config,
+        initial_batch_size=10,
+        adaptive_sizing_enabled=False,
+    )
+    return batch_metrics, transformer, writer, tracing_manager
+
+
 @pytest.fixture
 def batch_executor(
     mock_services,
@@ -157,17 +213,26 @@ def batch_executor(
     mock_gold_validator,
 ):
     """Create BatchExecutor instance."""
-    return BatchExecutor(
+    batch_metrics, transformer, writer, tracing_manager = _build_batch_dependencies(
         services=mock_services,
         context=mock_context,
         config=processor_config,
-        error_classifier=ErrorClassifier(),
         transform_callback=transform_callback,
         gold_filter_callback=gold_filter_callback,
         gold_transform_callback=gold_transform_callback,
         gold_validator=mock_gold_validator,
+    )
+
+    return BatchExecutor(
+        services=mock_services,
+        context=mock_context,
+        config=processor_config,
         checkpoint_manager=mock_checkpoint_manager,
         shutdown_signal=shutdown_signal,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        tracing_manager=tracing_manager,
         batch_size=10,
         checkpoint_interval=5,
     )
@@ -198,17 +263,25 @@ class TestBatchExecutorInit:
         mock_gold_validator,
     ):
         """Test default batch size when not specified."""
-        executor = BatchExecutor(
+        batch_metrics, transformer, writer, tracing_manager = _build_batch_dependencies(
             services=mock_services,
             context=mock_context,
             config=processor_config,
-            error_classifier=ErrorClassifier(),
             transform_callback=transform_callback,
             gold_filter_callback=gold_filter_callback,
             gold_transform_callback=gold_transform_callback,
             gold_validator=mock_gold_validator,
+        )
+        executor = BatchExecutor(
+            services=mock_services,
+            context=mock_context,
+            config=processor_config,
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            tracing_manager=tracing_manager,
         )
         assert executor.batch_size == BatchExecutor.DEFAULT_BATCH_SIZE
 
@@ -395,17 +468,25 @@ class TestBatchExecutorProcessBatch:
                 raise DataQualityError("Invalid data")
             return {"entity_id": record.get("id"), "value": record.get("value")}
 
-        executor = BatchExecutor(
+        batch_metrics, transformer, writer, tracing_manager = _build_batch_dependencies(
             services=mock_services,
             context=mock_context,
             config=processor_config,
-            error_classifier=ErrorClassifier(),
             transform_callback=failing_transform,
             gold_filter_callback=lambda c, r: True,
             gold_transform_callback=lambda c, r: r,
             gold_validator=mock_gold_validator,
+        )
+        executor = BatchExecutor(
+            services=mock_services,
+            context=mock_context,
+            config=processor_config,
             checkpoint_manager=mock_checkpoint_manager,
             shutdown_signal=shutdown_signal,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            tracing_manager=tracing_manager,
             batch_size=10,
         )
 
@@ -454,20 +535,28 @@ def batch_executor_with_tracer(
     mock_tracer,
 ):
     """Create BatchExecutor instance with tracer."""
-    return BatchExecutor(
+    batch_metrics, transformer, writer, tracing_manager = _build_batch_dependencies(
         services=mock_services,
         context=mock_context,
         config=processor_config,
-        error_classifier=ErrorClassifier(),
         transform_callback=transform_callback,
         gold_filter_callback=gold_filter_callback,
         gold_transform_callback=gold_transform_callback,
         gold_validator=mock_gold_validator,
+        tracer=mock_tracer,
+    )
+    return BatchExecutor(
+        services=mock_services,
+        context=mock_context,
+        config=processor_config,
         checkpoint_manager=mock_checkpoint_manager,
         shutdown_signal=shutdown_signal,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        tracing_manager=tracing_manager,
         batch_size=10,
         checkpoint_interval=5,
-        tracer=mock_tracer,
     )
 
 


### PR DESCRIPTION
### Motivation

- Enforce project DI rule: application layer must not instantiate infrastructure or compose dependencies internally (move factory work into composition). 
- Remove inline-instantiation anti-patterns in `BatchExecutor` and `CompositePipelineRunnerService` to make components testable and DI-compliant. 
- Centralise construction of metrics/transformer/writer/tracing/FSM in the composition layer so wiring is discoverable and controlled by factories.

### Description

- `BatchExecutor` now accepts `batch_metrics`, `transformer`, `writer`, and `tracing_manager` via `__init__` instead of creating them internally, and only assigns them to instance attributes (file: `src/bioetl/application/core/batch_executor.py`).
- `CompositePipelineRunnerService` no longer imports/constructs `FSMStateHelperService` locally and now requires an injected `fsm` in its constructor (file: `src/bioetl/application/composite/runner.py`).
- Composition/factory updates: `ServicesBuilder.create_record_processor` and `ServicesBuilder.create_batch_executor_from_pipeline` now construct `BatchMetricsRecorderService`, `QuarantineManagerService`, `BatchTransformer`, `BatchWriter`, and `BatchTracingManagerService` (and inject them into `RecordProcessor` / `BatchExecutor`), and `bootstrap_composite_runner` now constructs and injects the `FSMStateHelperService` (files: `src/bioetl/composition/factories/services_factory.py`, `src/bioetl/composition/bootstrap/runtime/composite.py`).
- Unit tests updated to reflect new DI contracts by constructing required dependencies in tests and injecting them (files: `tests/unit/application/core/test_batch_executor.py`, `tests/unit/application/composite/test_runner.py`).

### Testing

- Ran DI architecture check: `uv run python -m pytest tests/architecture/test_di_compliance.py -q`, result: passed.
- Ran targeted unit tests: `uv run python -m pytest tests/unit/application/core/test_batch_executor.py tests/unit/composition/factories/test_services_factory.py tests/unit/application/composite/test_runner.py -q`, result: all tests passed.
- Type checks for modified modules: `uv run python -m mypy --strict src/bioetl/application/core/batch_executor.py src/bioetl/application/composite/runner.py src/bioetl/composition/factories/services_factory.py src/bioetl/composition/bootstrap/runtime/composite.py`, result: success (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3e96b5c8324b967fc295be62b93)