### PR TITLE
Refactor BatchExecutor/RecordProcessor to constructor DI via composition

### DIFF
--- a/src/bioetl/application/core/batch_executor.py
+++ b/src/bioetl/application/core/batch_executor.py
@@ -10,18 +10,12 @@ DQ Report Integration:
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from bioetl.application.core.batch_executor_dq_mixin import _BatchExecutorDQMixin
-from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
-from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
-from bioetl.application.core.batch_tracing import BatchTracingManagerService
-from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
-from bioetl.application.core.batch_writer import BatchWriter
-from bioetl.application.core.quarantine_manager import QuarantineManagerService
+from bioetl.application.core.batch_transformer import TransformResult
 from bioetl.application.core.shutdown import PipelineShutdownError, ShutdownSignal
 from bioetl.domain.exceptions import BioETLError
 from bioetl.domain.types import BatchID
@@ -31,24 +25,17 @@ if TYPE_CHECKING:
 
     from opentelemetry.trace import Span
 
+    from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
+    from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+    from bioetl.application.core.batch_tracing import BatchTracingManagerService
+    from bioetl.application.core.batch_transformer import BatchTransformer
+    from bioetl.application.core.batch_writer import BatchWriter
     from bioetl.application.core.checkpoint_manager import CheckpointManagerService
     from bioetl.application.core.config import RecordProcessorConfig
     from bioetl.application.core.pipeline_services import PipelineServices
-    from bioetl.application.core.protocols import (
-        GoldFilterCallback,
-        GoldTransformCallback,
-        TransformCallback,
-    )
-    from bioetl.domain.config import MemoryConfig
     from bioetl.domain.context import PipelineContext
-    from bioetl.domain.error_classifier import ErrorClassifier
     from bioetl.domain.models.metadata import SourceMetadata
-    from bioetl.domain.ports import (
-        GoldValidatorPort,
-        LoggerPort,
-        MemoryMonitorPort,
-        TracingPort,
-    )
+    from bioetl.domain.ports import LoggerPort
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,20 +83,16 @@ class BatchExecutor(_BatchExecutorDQMixin):
         services: PipelineServices,
         context: PipelineContext,
         config: RecordProcessorConfig,
-        error_classifier: ErrorClassifier,
-        transform_callback: TransformCallback,
-        gold_filter_callback: GoldFilterCallback,
-        gold_transform_callback: GoldTransformCallback,
-        gold_validator: GoldValidatorPort,
         checkpoint_manager: CheckpointManagerService,
         shutdown_signal: ShutdownSignal,
+        batch_metrics: BatchMetricsRecorderService,
+        transformer: BatchTransformer,
+        writer: BatchWriter,
+        memory_manager: BatchMemoryManagerService,
+        tracing_manager: BatchTracingManagerService,
         *,
         batch_size: int | None = None,
         checkpoint_interval: int | None = None,
-        tracer: TracingPort | None = None,
-        lock_validator: Callable[[], Awaitable[bool]] | None = None,
-        memory_monitor: MemoryMonitorPort | None = None,
-        memory_config: MemoryConfig | None = None,
         logger: LoggerPort | None = None,
     ) -> None:
         """Initialize batch executor.
@@ -118,19 +101,15 @@ class BatchExecutor(_BatchExecutorDQMixin):
             services: Common pipeline services (data source, storage, metrics, etc.).
             context: Pipeline execution context (run_id, run_type, started_at).
             config: Record processor configuration.
-            error_classifier: Service for error classification.
-            transform_callback: Callback for Bronze → Silver transformation.
-            gold_filter_callback: Callback for filtering Silver records for Gold.
-            gold_transform_callback: Callback for Silver → Gold transformation.
-            gold_validator: Validator for Gold layer records.
             checkpoint_manager: Checkpoint manager instance.
             shutdown_signal: Signal to handle graceful shutdown.
+            batch_metrics: Metrics recorder for Bronze/Silver/Gold stages.
+            transformer: Batch transformer for Bronze -> Silver/Gold conversion.
+            writer: Batch writer orchestrating Bronze/Silver/Gold writes.
+            memory_manager: Memory manager for adaptive batch sizing.
+            tracing_manager: Tracing manager for pipeline execution spans.
             batch_size: Number of records per batch.
             checkpoint_interval: Number of records between checkpoints.
-            tracer: Optional tracing port for distributed tracing.
-            lock_validator: Async callable that validates lock ownership (Safety Guard §4.6).
-            memory_monitor: Optional memory monitor for adaptive batch sizing.
-            memory_config: Memory configuration (used if memory_monitor not provided).
             logger: Logger for memory-related messages.
 
         """
@@ -149,12 +128,7 @@ class BatchExecutor(_BatchExecutorDQMixin):
         )
 
         # Memory management (extracted to BatchMemoryManager)
-        self._memory = BatchMemoryManagerService(
-            self._initial_batch_size,
-            memory_monitor=memory_monitor,
-            memory_config=memory_config,
-            logger=self._logger,
-        )
+        self._memory = memory_manager
 
         # Counters
         self.records_fetched = 0
@@ -181,46 +155,10 @@ class BatchExecutor(_BatchExecutorDQMixin):
         self._source_batch_ids: list[str] = []
         self._last_bronze_path: str | None = None
 
-        # Create internal components (from RecordProcessor)
-        pipeline_label = f"{config.provider}_{config.entity_type}"
-        self._batch_metrics = BatchMetricsRecorderService(
-            services.metrics, pipeline_label, context.run_type.value
-        )
-
-        self._transformer = BatchTransformer(
-            context=context,
-            config=config,
-            error_classifier=error_classifier,
-            quarantine_manager=QuarantineManagerService(
-                quarantine_port=services.quarantine,
-                pipeline_name=config.pipeline_name,
-                metrics=services.metrics,
-            ),
-            batch_metrics=self._batch_metrics,
-            transform_callback=transform_callback,
-            gold_filter_callback=gold_filter_callback,
-            gold_transform_callback=gold_transform_callback,
-        )
-
-        self._writer = BatchWriter(
-            storage=services.storage,
-            context=context,
-            config=config,
-            gold_validator=gold_validator,
-            error_classifier=error_classifier,
-            batch_metrics=self._batch_metrics,
-            tracer=tracer,
-            lock_validator=lock_validator,
-        )
-
-        # Tracing manager (extracted for class size reduction)
-        self._tracing = BatchTracingManagerService(
-            tracer=tracer,
-            context=context,
-            config=config,
-            initial_batch_size=self._initial_batch_size,
-            adaptive_sizing_enabled=self._memory.enabled,
-        )
+        self._batch_metrics = batch_metrics
+        self._transformer = transformer
+        self._writer = writer
+        self._tracing = tracing_manager
 
         # Query string for metadata (stored during execute())
         self._query_string: str | None = None

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -9,7 +9,6 @@ Safety Guard (RULES.md §4.6):
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from bioetl.application.core.batch_executor import BatchResult
@@ -19,9 +18,11 @@ if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
     from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
-    from bioetl.application.core.batch_transformer import BatchTransformer, TransformResult
+    from bioetl.application.core.batch_transformer import (
+        BatchTransformer,
+        TransformResult,
+    )
     from bioetl.application.core.batch_writer import BatchWriter
-    from bioetl.application.core.config import RecordProcessorConfig
     from bioetl.domain.context import PipelineContext
     from bioetl.domain.ports import TracingPort
     from bioetl.domain.types import BatchID
@@ -45,9 +46,8 @@ class RecordProcessor:
         batch_metrics: BatchMetricsRecorderService,
         transformer: BatchTransformer,
         writer: BatchWriter,
-        config: RecordProcessorConfig,
         tracer: TracingPort | None = None,
-    ):
+    ) -> None:
         """Initialize RecordProcessor.
 
         Args:
@@ -55,10 +55,8 @@ class RecordProcessor:
             batch_metrics: Metrics recorder for Bronze/Silver/Gold stages.
             transformer: Batch transformer for Bronze -> Silver/Gold conversion.
             writer: Batch writer orchestrating Bronze/Silver/Gold writes.
-            config: Record processor configuration.
             tracer: Optional tracing port for distributed tracing.
         """
-        _ = config
         self._context = context
         self._tracer = tracer
         self._batch_metrics = batch_metrics

--- a/src/bioetl/composition/factories/services_factory.py
+++ b/src/bioetl/composition/factories/services_factory.py
@@ -17,9 +17,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from bioetl.application.core.batch_executor import BatchExecutor
+from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_tracing import BatchTracingManagerService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.checkpoint_manager import CheckpointManagerService
 from bioetl.application.core.config import RecordProcessorConfig
 from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
 from bioetl.application.core.record_processor import RecordProcessor
 from bioetl.composition.bootstrap_contexts import PipelineCallbacksContext
 from bioetl.composition.factories.dq_factory import DQServicesFactory
@@ -429,6 +435,69 @@ class ServicesBuilder:
         )
 
     @staticmethod
+    def _create_batch_metrics(
+        services: PipelineServices,
+        provider: str,
+        entity_type: str,
+        run_type: str,
+    ) -> BatchMetricsRecorderService:
+        pipeline_label = f"{provider}_{entity_type}"
+        return BatchMetricsRecorderService(services.metrics, pipeline_label, run_type)
+
+    @staticmethod
+    def _create_batch_transformer(
+        context: PipelineContext,
+        config: RecordProcessorConfig,
+        services: PipelineServices,
+        error_classifier: ErrorClassifier,
+        batch_metrics: BatchMetricsRecorderService,
+        transform_callback: Any,
+        gold_filter_callback: Any,
+        gold_transform_callback: Any,
+    ) -> BatchTransformer:
+        quarantine_manager = QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        )
+        return BatchTransformer(
+            context=context,
+            config=config,
+            error_classifier=error_classifier,
+            quarantine_manager=quarantine_manager,
+            batch_metrics=batch_metrics,
+            transform_callback=transform_callback,
+            gold_filter_callback=gold_filter_callback,
+            gold_transform_callback=gold_transform_callback,
+        )
+
+    @staticmethod
+    def _create_batch_writer(
+        services: PipelineServices,
+        context: PipelineContext,
+        config: RecordProcessorConfig,
+        gold_schema: Any,
+        strict_gold_validation: bool,
+        error_classifier: ErrorClassifier,
+        batch_metrics: BatchMetricsRecorderService,
+        tracer: TracingPort | None,
+        lock_validator: Callable[[], Awaitable[bool]] | None,
+    ) -> BatchWriter:
+        gold_validator = PanderaGoldValidator(
+            gold_schema, strict=strict_gold_validation
+        )
+        return BatchWriter(
+            storage=services.storage,
+            context=context,
+            config=config,
+            gold_validator=gold_validator,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
+            tracer=tracer,
+            lock_validator=lock_validator,
+        )
+
+    @staticmethod
     def create_record_processor(
         services: PipelineServices,
         context: PipelineContext,
@@ -505,22 +574,40 @@ class ServicesBuilder:
             scd_config=scd_config,
         )
 
-        # Create Gold validator from schema (DI pattern)
-        # strict mode requires schema to be provided
-        gold_validator = PanderaGoldValidator(
-            gold_schema, strict=strict_gold_validation
-        )
-
-        return RecordProcessor(
+        batch_metrics = ServicesBuilder._create_batch_metrics(
             services=services,
-            error_classifier=error_classifier,
+            provider=provider,
+            entity_type=entity_type,
+            run_type=context.run_type.value,
+        )
+        transformer = ServicesBuilder._create_batch_transformer(
             context=context,
             config=processor_config,
+            services=services,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
             transform_callback=transform_callback,
             gold_filter_callback=gold_filter_callback,
             gold_transform_callback=gold_transform_callback,
-            gold_validator=gold_validator,
+        )
+        writer = ServicesBuilder._create_batch_writer(
+            services=services,
+            context=context,
+            config=processor_config,
+            gold_schema=gold_schema,
+            strict_gold_validation=strict_gold_validation,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
+            tracer=None,
             lock_validator=lock_validator,
+        )
+
+        return RecordProcessor(
+            context=context,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            tracer=None,
         )
 
     @staticmethod
@@ -639,28 +726,65 @@ class ServicesBuilder:
             scd_config=pipeline.config.scd_config,
         )
 
-        # Create Gold validator
-        gold_validator = PanderaGoldValidator(
-            gold_schema, strict=strict_gold_validation
+        batch_metrics = ServicesBuilder._create_batch_metrics(
+            services=pipeline.services,
+            provider=pipeline.config.provider,
+            entity_type=pipeline.config.entity_type,
+            run_type=pipeline.context.run_type.value,
+        )
+        transformer = ServicesBuilder._create_batch_transformer(
+            context=pipeline.context,
+            config=processor_config,
+            services=pipeline.services,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
+            transform_callback=callbacks.transform,
+            gold_filter_callback=gold_filter,
+            gold_transform_callback=callbacks.gold_transform,
+        )
+        writer = ServicesBuilder._create_batch_writer(
+            services=pipeline.services,
+            context=pipeline.context,
+            config=processor_config,
+            gold_schema=gold_schema,
+            strict_gold_validation=strict_gold_validation,
+            error_classifier=error_classifier,
+            batch_metrics=batch_metrics,
+            tracer=tracer,
+            lock_validator=lock_validator,
+        )
+        initial_batch_size = (
+            pipeline.config.batch_size
+            if pipeline.config.batch_size is not None
+            else 1000
+        )
+        memory_manager = BatchMemoryManagerService(
+            initial_batch_size,
+            memory_monitor=memory_monitor,
+            memory_config=memory_config,
+            logger=pipeline.services.logger,
+        )
+        tracing_manager = BatchTracingManagerService(
+            tracer=tracer,
+            context=pipeline.context,
+            config=processor_config,
+            initial_batch_size=initial_batch_size,
+            adaptive_sizing_enabled=memory_manager.enabled,
         )
 
         return BatchExecutor(
             services=pipeline.services,
             context=pipeline.context,
             config=processor_config,
-            error_classifier=error_classifier,
-            transform_callback=callbacks.transform,
-            gold_filter_callback=gold_filter,
-            gold_transform_callback=callbacks.gold_transform,
-            gold_validator=gold_validator,
             checkpoint_manager=checkpoint_manager,
             shutdown_signal=shutdown_signal,
+            batch_metrics=batch_metrics,
+            transformer=transformer,
+            writer=writer,
+            memory_manager=memory_manager,
+            tracing_manager=tracing_manager,
             batch_size=pipeline.config.batch_size,
             checkpoint_interval=pipeline.config.checkpoint_interval,
-            tracer=tracer,
-            lock_validator=lock_validator,
-            memory_monitor=memory_monitor,
-            memory_config=memory_config,
         )
 
 

--- a/tests/unit/application/core/test_batch_executor.py
+++ b/tests/unit/application/core/test_batch_executor.py
@@ -24,6 +24,94 @@ from bioetl.domain.ports import MetricsPort
 from bioetl.domain.types import RunType, ValidationResult
 
 
+from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_tracing import BatchTracingManagerService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
+
+
+def create_batch_executor(
+    *,
+    services,
+    context,
+    config,
+    error_classifier,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    checkpoint_manager,
+    shutdown_signal,
+    batch_size=None,
+    checkpoint_interval=None,
+    tracer=None,
+    lock_validator=None,
+    memory_monitor=None,
+    memory_config=None,
+):
+    resolved_batch_size = (
+        batch_size if batch_size is not None else BatchExecutor.DEFAULT_BATCH_SIZE
+    )
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        f"{config.provider}_{config.entity_type}",
+        context.run_type.value,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        ),
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+        lock_validator=lock_validator,
+    )
+    memory_manager = BatchMemoryManagerService(
+        resolved_batch_size,
+        memory_monitor=memory_monitor,
+        memory_config=memory_config,
+        logger=services.logger,
+    )
+    tracing_manager = BatchTracingManagerService(
+        tracer=tracer,
+        context=context,
+        config=config,
+        initial_batch_size=resolved_batch_size,
+        adaptive_sizing_enabled=memory_manager.enabled,
+    )
+    return BatchExecutor(
+        services=services,
+        context=context,
+        config=config,
+        checkpoint_manager=checkpoint_manager,
+        shutdown_signal=shutdown_signal,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        memory_manager=memory_manager,
+        tracing_manager=tracing_manager,
+        batch_size=batch_size,
+        checkpoint_interval=checkpoint_interval,
+    )
+
+
 @pytest.fixture
 def mock_storage():
     """Create mock storage."""
@@ -157,7 +245,7 @@ def batch_executor(
     mock_gold_validator,
 ):
     """Create BatchExecutor instance."""
-    return BatchExecutor(
+    return create_batch_executor(
         services=mock_services,
         context=mock_context,
         config=processor_config,
@@ -198,7 +286,7 @@ class TestBatchExecutorInit:
         mock_gold_validator,
     ):
         """Test default batch size when not specified."""
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -395,7 +483,7 @@ class TestBatchExecutorProcessBatch:
                 raise DataQualityError("Invalid data")
             return {"entity_id": record.get("id"), "value": record.get("value")}
 
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -454,7 +542,7 @@ def batch_executor_with_tracer(
     mock_tracer,
 ):
     """Create BatchExecutor instance with tracer."""
-    return BatchExecutor(
+    return create_batch_executor(
         services=mock_services,
         context=mock_context,
         config=processor_config,

--- a/tests/unit/application/core/test_batch_executor_memory.py
+++ b/tests/unit/application/core/test_batch_executor_memory.py
@@ -19,6 +19,94 @@ from bioetl.domain.ports import MemoryMonitorPort, MetricsPort
 from bioetl.domain.types import RunType, ValidationResult
 
 
+from bioetl.application.core.batch_memory_manager import BatchMemoryManagerService
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_tracing import BatchTracingManagerService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
+
+
+def create_batch_executor(
+    *,
+    services,
+    context,
+    config,
+    error_classifier,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    checkpoint_manager,
+    shutdown_signal,
+    batch_size=None,
+    checkpoint_interval=None,
+    tracer=None,
+    lock_validator=None,
+    memory_monitor=None,
+    memory_config=None,
+):
+    resolved_batch_size = (
+        batch_size if batch_size is not None else BatchExecutor.DEFAULT_BATCH_SIZE
+    )
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        f"{config.provider}_{config.entity_type}",
+        context.run_type.value,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        ),
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+        lock_validator=lock_validator,
+    )
+    memory_manager = BatchMemoryManagerService(
+        resolved_batch_size,
+        memory_monitor=memory_monitor,
+        memory_config=memory_config,
+        logger=services.logger,
+    )
+    tracing_manager = BatchTracingManagerService(
+        tracer=tracer,
+        context=context,
+        config=config,
+        initial_batch_size=resolved_batch_size,
+        adaptive_sizing_enabled=memory_manager.enabled,
+    )
+    return BatchExecutor(
+        services=services,
+        context=context,
+        config=config,
+        checkpoint_manager=checkpoint_manager,
+        shutdown_signal=shutdown_signal,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        memory_manager=memory_manager,
+        tracing_manager=tracing_manager,
+        batch_size=batch_size,
+        checkpoint_interval=checkpoint_interval,
+    )
+
+
 @pytest.fixture
 def mock_services():
     """Create mock pipeline services."""
@@ -125,7 +213,7 @@ class TestBatchExecutorMemory:
         memory_monitor,
     ):
         """Test that adaptive sizing is enabled when monitor provided."""
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -154,7 +242,7 @@ class TestBatchExecutorMemory:
         """Test that batch size is reduced under memory pressure."""
         memory_monitor.get_recommended_batch_size.return_value = 50
 
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -202,7 +290,7 @@ class TestBatchExecutorMemory:
         # 20 records, check every 1 record -> ~20 checks
         memory_monitor.get_recommended_batch_size.side_effect = [50] * 10 + [100] * 20
 
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -243,7 +331,7 @@ class TestBatchExecutorMemory:
         memory_config,
     ):
         """Test estimation from config without monitor."""
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -276,7 +364,7 @@ class TestBatchExecutorMemory:
         mock_dq_service = MagicMock()
         mock_services.dq_report_service = mock_dq_service
 
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -321,7 +409,7 @@ class TestBatchExecutorMemory:
         """Test get_dq_context returns None when service not available."""
         mock_services.dq_report_service = None  # explicit None
 
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,
@@ -347,7 +435,7 @@ class TestBatchExecutorMemory:
         mock_gold_validator,
     ):
         """Test public process() method."""
-        executor = BatchExecutor(
+        executor = create_batch_executor(
             services=mock_services,
             context=mock_context,
             config=processor_config,

--- a/tests/unit/application/core/test_record_processor.py
+++ b/tests/unit/application/core/test_record_processor.py
@@ -20,6 +20,63 @@ from bioetl.domain.types import BatchID, RunType, ValidationResult
 from bioetl.infrastructure.config import get_pipeline_config
 
 
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
+
+
+def create_record_processor(
+    *,
+    services,
+    error_classifier,
+    context,
+    config,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    tracer=None,
+    lock_validator=None,
+):
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        f"{config.provider}_{config.entity_type}",
+        context.run_type.value,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        ),
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+        lock_validator=lock_validator,
+    )
+    return RecordProcessor(
+        context=context,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        tracer=tracer,
+    )
+
+
 def _write_temp_pipeline_config(
     base_path: Path, pipeline_name: str, soft_threshold: float, hard_threshold: float
 ) -> Path:
@@ -211,7 +268,7 @@ def record_processor(
         gold_schema=MagicMock(),
         table_config=TableConfig(),
     )
-    return RecordProcessor(
+    return create_record_processor(
         services=mock_services,
         error_classifier=mock_error_classifier,
         context=mock_context,
@@ -321,7 +378,7 @@ class TestRecordProcessorProcessBatch:
         gold_validator = MagicMock()
         gold_validator.validate = MagicMock(return_value=ValidationResult(valid=True))
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -366,7 +423,7 @@ class TestRecordProcessorProcessBatch:
         gold_validator = MagicMock()
         gold_validator.validate = MagicMock(return_value=ValidationResult(valid=True))
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -430,7 +487,7 @@ class TestRecordProcessorProcessBatch:
         gold_validator = MagicMock()
         gold_validator.validate = MagicMock(return_value=ValidationResult(valid=True))
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -485,7 +542,7 @@ class TestRecordProcessorProcessBatch:
         gold_validator = MagicMock()
         gold_validator.validate = MagicMock(return_value=ValidationResult(valid=True))
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -553,7 +610,7 @@ class TestRecordProcessorTracing:
             gold_schema=MagicMock(),
             table_config=TableConfig(),
         )
-        return RecordProcessor(
+        return create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -626,7 +683,7 @@ class TestRecordProcessorTracing:
             gold_schema=MagicMock(),
             table_config=TableConfig(),
         )
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,
@@ -670,7 +727,7 @@ class TestRecordProcessorTracing:
             gold_schema=MagicMock(),
             table_config=TableConfig(),
         )
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,

--- a/tests/unit/application/core/test_record_processor_metrics.py
+++ b/tests/unit/application/core/test_record_processor_metrics.py
@@ -2,6 +2,63 @@
 
 from __future__ import annotations
 
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
+
+
+def create_record_processor(
+    *,
+    services,
+    error_classifier,
+    context,
+    config,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    tracer=None,
+    lock_validator=None,
+):
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        f"{config.provider}_{config.entity_type}",
+        context.run_type.value,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        ),
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+        lock_validator=lock_validator,
+    )
+    return RecordProcessor(
+        context=context,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        tracer=tracer,
+    )
+
+
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -76,7 +133,7 @@ def record_processor(
         silver_schema=MagicMock(),
         gold_schema=MagicMock(),
     )
-    return RecordProcessor(
+    return create_record_processor(
         services=mock_services,
         error_classifier=mock_error_classifier,
         context=mock_context,
@@ -161,7 +218,7 @@ class TestRecordProcessorMetrics:
             silver_schema=MagicMock(),
             gold_schema=MagicMock(),
         )
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=mock_error_classifier,
             context=mock_context,

--- a/tests/unit/application/core/test_run_id_propagation.py
+++ b/tests/unit/application/core/test_run_id_propagation.py
@@ -14,13 +14,68 @@ from uuid import uuid4
 import pyarrow as pa
 import pytest
 
+from bioetl.application.core.batch_metrics import BatchMetricsRecorderService
+from bioetl.application.core.batch_transformer import BatchTransformer
+from bioetl.application.core.batch_writer import BatchWriter
 from bioetl.application.core.config import RecordProcessorConfig
 from bioetl.application.core.pipeline_services import PipelineServices
+from bioetl.application.core.quarantine_manager import QuarantineManagerService
 from bioetl.application.core.record_processor import RecordProcessor
 from bioetl.domain.config import DQConfig, TableConfig
 from bioetl.domain.context import PipelineContext
 from bioetl.domain.error_classifier import ErrorClassifier
 from bioetl.domain.types import BatchID, RunID, RunType, ValidationResult
+
+
+def create_record_processor(
+    *,
+    services,
+    error_classifier,
+    context,
+    config,
+    transform_callback,
+    gold_filter_callback,
+    gold_transform_callback,
+    gold_validator,
+    tracer=None,
+    lock_validator=None,
+):
+    batch_metrics = BatchMetricsRecorderService(
+        services.metrics,
+        f"{config.provider}_{config.entity_type}",
+        context.run_type.value,
+    )
+    transformer = BatchTransformer(
+        context=context,
+        config=config,
+        error_classifier=error_classifier,
+        quarantine_manager=QuarantineManagerService(
+            quarantine_port=services.quarantine,
+            pipeline_name=config.pipeline_name,
+            metrics=services.metrics,
+        ),
+        batch_metrics=batch_metrics,
+        transform_callback=transform_callback,
+        gold_filter_callback=gold_filter_callback,
+        gold_transform_callback=gold_transform_callback,
+    )
+    writer = BatchWriter(
+        storage=services.storage,
+        context=context,
+        config=config,
+        gold_validator=gold_validator,
+        error_classifier=error_classifier,
+        batch_metrics=batch_metrics,
+        tracer=tracer,
+        lock_validator=lock_validator,
+    )
+    return RecordProcessor(
+        context=context,
+        batch_metrics=batch_metrics,
+        transformer=transformer,
+        writer=writer,
+        tracer=tracer,
+    )
 
 
 @pytest.fixture
@@ -140,7 +195,7 @@ class TestRunIdPropagation:
             table_config=TableConfig(primary_keys=["id"]),
         )
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=ErrorClassifier(),
             context=pipeline_context,
@@ -206,7 +261,7 @@ class TestRunIdPropagation:
             table_config=TableConfig(primary_keys=["id"]),
         )
 
-        processor = RecordProcessor(
+        processor = create_record_processor(
             services=mock_services,
             error_classifier=ErrorClassifier(),
             context=pipeline_context,
@@ -279,7 +334,7 @@ class TestRunIdPropagation:
                 table_config=TableConfig(primary_keys=["id"]),
             )
 
-            processor = RecordProcessor(
+            processor = create_record_processor(
                 services=mock_services,
                 error_classifier=ErrorClassifier(),
                 context=context,


### PR DESCRIPTION
### Motivation
- Remove inline instantiation of helper/infrastructure components from the application layer to enforce composition-root DI and follow project layering rules. 
- Make `BatchExecutor` and `RecordProcessor` accept ready-made collaborators (metrics, transformer, writer, memory/tracing managers) so tests and composition can control concrete implementations. 
- Centralize wiring in the composition layer to keep application code free of infrastructure construction and to improve testability. 

### Description
- `BatchExecutor` constructor now accepts `BatchMetricsRecorderService`, `BatchTransformer`, `BatchWriter`, `BatchMemoryManagerService`, and `BatchTracingManagerService` instead of building them inline in `src/bioetl/application/core/batch_executor.py`. 
- `RecordProcessor` constructor simplified to pure constructor injection of `context`, `batch_metrics`, `transformer`, `writer`, and optional `tracer` in `src/bioetl/application/core/record_processor.py`. 
- Composition/factory changes in `src/bioetl/composition/factories/services_factory.py`: added private factory helpers `_create_batch_metrics`, `_create_batch_transformer`, `_create_batch_writer`, and moved construction/wiring for both `create_record_processor` and `create_batch_executor_from_pipeline` into the composition layer. 
- Unit test helpers updated/added to create and inject the required batch components in tests under `tests/unit/application/core/` to match the new constructor signatures while preserving external behavior and assertions. 

### Testing
- Ran unit tests for the modified components: `uv run python -m pytest tests/unit/application/core/test_batch_executor.py tests/unit/application/core/test_batch_executor_memory.py tests/unit/application/core/test_record_processor.py tests/unit/application/core/test_record_processor_metrics.py tests/unit/application/core/test_run_id_propagation.py tests/unit/composition/factories/test_services_factory.py -q` and they all passed. 
- Ran linter checks: `uv run python -m ruff check ...` on the modified modules and fixed reported issues, and the ruff checks passed for the changed files. 
- Note: repository-wide pre-commit checks (mypy / pip-audit) surfaced existing baseline issues unrelated to this change; these are external to the refactor and were not introduced by the modifications in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d403f794832484fb2a916c7aa640)