### PR TITLE
Inject FSM helper dependency into CompositePipelineRunnerService

### DIFF
--- a/src/bioetl/application/composite/fsm_helper_port.py
+++ b/src/bioetl/application/composite/fsm_helper_port.py
@@ -1,0 +1,36 @@
+"""Protocol for FSM helper dependency used by composite runner mixins."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.domain.composite.state import CompositePipelineState
+
+
+class FSMStateHelperPort(Protocol):
+    """FSM helper contract for state validation/logging and resume handling."""
+
+    def log_fsm_transition(
+        self,
+        from_state: CompositePipelineState,
+        to_state: CompositePipelineState,
+        stage: str,
+        **extra: object,
+    ) -> None: ...
+
+    def validate_fsm_transition(
+        self,
+        from_state: CompositePipelineState,
+        to_state: CompositePipelineState,
+        allow_resume: bool = False,
+    ) -> bool: ...
+
+    def handle_resume_from_failed(
+        self, state: CompositeCheckpointState
+    ) -> CompositeCheckpointState: ...
+
+    def log_resume_context(self, state: CompositeCheckpointState) -> None: ...
+
+
+__all__ = ["FSMStateHelperPort"]

--- a/src/bioetl/application/composite/runner.py
+++ b/src/bioetl/application/composite/runner.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from bioetl.application.composite.dependency_coordinator import (
         DependencyCoordinatorService,
     )
+    from bioetl.application.composite.fsm_helper_port import FSMStateHelperPort
     from bioetl.application.composite.key_extractor import KeyExtractorService
     from bioetl.application.composite.merger import MergeService
     from bioetl.application.composite.preflight_validator import (
@@ -115,6 +116,7 @@ class CompositePipelineRunnerService(
         coordinator: EnrichmentCoordinatorService,
         merger: MergeService,
         checkpoint_manager: CompositeCheckpointService,
+        fsm_helper: FSMStateHelperPort,
         logger: LoggerPort,
         lock: LockPort,
         run_id: str | None = None,
@@ -137,6 +139,7 @@ class CompositePipelineRunnerService(
         self._coordinator = coordinator
         self._merger = merger
         self._checkpoint_manager = checkpoint_manager
+        self._fsm = fsm_helper
         self._logger = logger
         self._lock = lock
         self._run_id_str = run_id or str(uuid4())
@@ -148,14 +151,6 @@ class CompositePipelineRunnerService(
         self._preflight_validator = preflight_validator
         self._quarantine_port = quarantine_port
         self._metrics = metrics
-
-        from bioetl.application.composite.fsm_helper import FSMStateHelperService
-
-        self._fsm = FSMStateHelperService(
-            config=config,
-            logger=logger,
-            run_id=self._run_id_str,
-        )
 
     @property
     def run_id(self) -> str:

--- a/src/bioetl/application/composite/runner_merge_stage_mixin.py
+++ b/src/bioetl/application/composite/runner_merge_stage_mixin.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
         CompositeCheckpointService,
         CompositeCheckpointState,
     )
-    from bioetl.application.composite.fsm_helper import FSMStateHelperService
+    from bioetl.application.composite.fsm_helper_port import FSMStateHelperPort
     from bioetl.application.composite.merger import MergeService
     from bioetl.application.composite.runner import CompositeRuntimeConfig
     from bioetl.domain.composite.config import CompositeConfig
@@ -40,7 +40,7 @@ class CompositeRunnerMergeStageHelper:
     """Mixin containing merge execution and finalization."""
 
     _runtime: CompositeRuntimeConfig
-    _fsm: FSMStateHelperService
+    _fsm: FSMStateHelperPort
     _logger: LoggerPort
     _config: CompositeConfig
     _run_id_str: str
@@ -55,7 +55,7 @@ class CompositeRunnerMergeStageHelper:
         """Invoke support-layer checkpoint save helper."""
         save_checkpoint = cast(
             "Callable[[CompositeCheckpointState, str], Awaitable[bool]]",
-            getattr(self, "_save_checkpoint_safe"),
+            self._save_checkpoint_safe,
         )
         return await save_checkpoint(state, operation)
 
@@ -63,7 +63,7 @@ class CompositeRunnerMergeStageHelper:
         """Invoke support-layer DQ report generation helper."""
         generate_reports = cast(
             "Callable[[MergeResult], Awaitable[None]]",
-            getattr(self, "_generate_dq_reports"),
+            self._generate_dq_reports,
         )
         await generate_reports(merge_result)
 
@@ -71,7 +71,7 @@ class CompositeRunnerMergeStageHelper:
         """Invoke support-layer quarantine write helper."""
         write_quarantine = cast(
             "Callable[[MergeResult], Awaitable[None]]",
-            getattr(self, "_write_cv_quarantine"),
+            self._write_cv_quarantine,
         )
         await write_quarantine(merge_result)
 

--- a/src/bioetl/application/composite/runner_stage_mixin.py
+++ b/src/bioetl/application/composite/runner_stage_mixin.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from bioetl.application.composite.dependency_coordinator import (
         DependencyCoordinatorService,
     )
-    from bioetl.application.composite.fsm_helper import FSMStateHelperService
+    from bioetl.application.composite.fsm_helper_port import FSMStateHelperPort
     from bioetl.application.composite.runner import CompositeRuntimeConfig
     from bioetl.application.core.runner import PipelineRunner
     from bioetl.domain.composite.config import CompositeConfig, EnricherConfig
@@ -50,7 +50,7 @@ class _CompositeRunnerStageSupportMixin:
     _runtime: CompositeRuntimeConfig
     _logger: LoggerPort
     _run_id_str: str
-    _fsm: FSMStateHelperService
+    _fsm: FSMStateHelperPort
     _checkpoint_manager: CompositeCheckpointService
     _dependency_coordinator: DependencyCoordinatorService | None
     _dependencies_runner_factory: Callable[[str, pl.DataFrame], PipelineRunner] | None
@@ -65,7 +65,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer checkpoint save helper."""
         save_checkpoint = cast(
             "Callable[[CompositeCheckpointState, str], Awaitable[bool]]",
-            getattr(self, "_save_checkpoint_safe"),
+            self._save_checkpoint_safe,
         )
         return await save_checkpoint(state, operation)
 
@@ -73,7 +73,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer seed runner helper."""
         run_seed = cast(
             "Callable[[], Awaitable[SeedResult]]",
-            getattr(self, "_run_seed"),
+            self._run_seed,
         )
         return await run_seed()
 
@@ -84,7 +84,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer enricher selection helper."""
         get_enrichers = cast(
             "Callable[[CompositeCheckpointState], list[EnricherConfig]]",
-            getattr(self, "_get_enrichers_to_run"),
+            self._get_enrichers_to_run,
         )
         return get_enrichers(state)
 
@@ -95,7 +95,7 @@ class _CompositeRunnerStageSupportMixin:
         """Invoke support-layer required-enricher validation helper."""
         check_required = cast(
             "Callable[[dict[str, EnrichmentResult]], None]",
-            getattr(self, "_check_required_enrichers"),
+            self._check_required_enrichers,
         )
         check_required(enrichment_results)
 

--- a/src/bioetl/application/composite/runner_support_mixin.py
+++ b/src/bioetl/application/composite/runner_support_mixin.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         CompositeCheckpointService,
         CompositeCheckpointState,
     )
-    from bioetl.application.composite.fsm_helper import FSMStateHelperService
+    from bioetl.application.composite.fsm_helper_port import FSMStateHelperPort
     from bioetl.application.composite.preflight_validator import (
         CompositePreflightValidationService,
     )
@@ -51,7 +51,7 @@ class CompositeRunnerSupportHelper:
     _preflight_validator: CompositePreflightValidationService | None
     _quarantine_port: QuarantinePort | None
     _metrics: MetricsPort | None
-    _fsm: FSMStateHelperService
+    _fsm: FSMStateHelperPort
 
     def _build_composite_result(
         self,

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -17,6 +17,7 @@ from bioetl.application.composite.cross_validator import (
 from bioetl.application.composite.dependency_coordinator import (
     DependencyCoordinatorService,
 )
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.key_extractor import KeyExtractorService
 from bioetl.application.composite.merger import MergeService
 from bioetl.application.composite.runner import (
@@ -571,6 +572,12 @@ def bootstrap_composite_runner(
         resume=runtime.resume,
     )
 
+    fsm_helper = FSMStateHelperService(
+        config=config,
+        logger=logger,
+        run_id=effective_run_id,
+    )
+
     # Create DQ report service for composite
     dq_report_service = _create_dq_report_service(logger, settings)
 
@@ -594,6 +601,7 @@ def bootstrap_composite_runner(
         coordinator=coordinator,
         merger=merger,
         checkpoint_manager=checkpoint_manager,
+        fsm_helper=fsm_helper,
         logger=logger,
         lock=lock,
         run_id=effective_run_id,

--- a/tests/unit/application/composite/test_fsm_pipeline_scenarios.py
+++ b/tests/unit/application/composite/test_fsm_pipeline_scenarios.py
@@ -23,6 +23,7 @@ import polars as pl
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -471,6 +472,7 @@ def create_test_runner(
         coordinator=coordinator,
         merger=merger,
         checkpoint_manager=checkpoint_manager,
+        fsm_helper=FSMStateHelperService(config=config, logger=logger, run_id=run_id),
         logger=logger,
         lock=lock,
         run_id=run_id,

--- a/tests/unit/application/composite/test_runner.py
+++ b/tests/unit/application/composite/test_runner.py
@@ -13,6 +13,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -184,6 +185,11 @@ def create_runner(
         coordinator=create_mock_coordinator(),
         merger=create_mock_merger(),
         checkpoint_manager=checkpoint_manager,
+        fsm_helper=FSMStateHelperService(
+            config=MockCompositeConfig(),
+            logger=create_mock_logger(),
+            run_id="test-run-id",
+        ),
         logger=create_mock_logger(),
         lock=create_mock_lock(),
     )
@@ -312,6 +318,9 @@ class TestFSMSeedFailure:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -421,6 +430,9 @@ class TestFSMSeedResume:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -453,6 +465,9 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -478,6 +493,9 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -504,6 +522,9 @@ class TestFSMTransitionLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=create_mock_checkpoint_manager(),
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -540,6 +561,9 @@ class TestCheckpointSaveErrorHandling:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -575,6 +599,9 @@ class TestCheckpointSaveErrorHandling:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )

--- a/tests/unit/application/composite/test_runner_checkpoint_resume.py
+++ b/tests/unit/application/composite/test_runner_checkpoint_resume.py
@@ -17,6 +17,7 @@ from bioetl.application.composite.checkpoint import (
     CompositeCheckpointManager,
     CompositeCheckpointState,
 )
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -203,6 +204,9 @@ class TestResumeFromFailedState:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -266,6 +270,9 @@ class TestResumeFromFailedState:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=config, logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -337,6 +344,9 @@ class TestResumeFromFailedState:
             coordinator=create_mock_coordinator(),
             merger=merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=config, logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -413,6 +423,9 @@ class TestResumeContextLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=config, logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -440,6 +453,9 @@ class TestResumeContextLogging:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -617,6 +633,9 @@ class TestFSMStateTransitionOnResume:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=MockCompositeConfig(), logger=logger, run_id="test-run-id"
+            ),
             logger=logger,
             lock=create_mock_lock(),
         )
@@ -681,6 +700,9 @@ class TestFSMStateTransitionOnResume:
             coordinator=create_mock_coordinator(),
             merger=create_mock_merger(),
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=config, logger=create_mock_logger(), run_id="test-run-id"
+            ),
             logger=create_mock_logger(),
             lock=create_mock_lock(),
         )

--- a/tests/unit/application/composite/test_runner_enrichment_fsm.py
+++ b/tests/unit/application/composite/test_runner_enrichment_fsm.py
@@ -17,6 +17,7 @@ import polars as pl
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -223,6 +224,11 @@ def runner(
         coordinator=mock_coordinator,
         merger=mock_merger,
         checkpoint_manager=mock_checkpoint_manager,
+        fsm_helper=FSMStateHelperService(
+            config=sample_composite_config,
+            logger=mock_logger,
+            run_id="00000000-0000-0000-0000-000000000123",
+        ),
         logger=mock_logger,
         lock=mock_lock,
         run_id="00000000-0000-0000-0000-000000000123",
@@ -354,6 +360,11 @@ class TestEnrichmentFSMFailure:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -402,6 +413,11 @@ class TestEnrichmentFSMFailure:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -449,6 +465,11 @@ class TestEnrichmentFSMFailure:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -498,6 +519,11 @@ class TestEnrichmentSkipStage:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -542,6 +568,11 @@ class TestEnrichmentSkipStage:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -603,6 +634,11 @@ class TestOptionalEnricherFailure:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -675,6 +711,11 @@ class TestOptionalEnricherFailure:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",

--- a/tests/unit/application/composite/test_runner_fsm.py
+++ b/tests/unit/application/composite/test_runner_fsm.py
@@ -17,6 +17,7 @@ from bioetl.application.composite.checkpoint import (
     CompositeCheckpointManager,
     CompositeCheckpointState,
 )
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -173,6 +174,9 @@ class TestFSMMergeStateTransitions:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,
@@ -233,6 +237,9 @@ class TestFSMMergeStateTransitions:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,
@@ -293,6 +300,9 @@ class TestFSMDryRunMode:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,
@@ -357,6 +367,9 @@ class TestFSMEnrichmentCompletedTransition:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,
@@ -444,6 +457,9 @@ class TestFSMResumeFromFailed:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,
@@ -499,6 +515,9 @@ class TestFSMCheckpointDeletion:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=mock_config, logger=mock_logger, run_id=test_run_id
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id=test_run_id,

--- a/tests/unit/application/composite/test_runner_fsm_logging.py
+++ b/tests/unit/application/composite/test_runner_fsm_logging.py
@@ -17,6 +17,7 @@ import polars as pl
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -233,6 +234,11 @@ def runner(
         coordinator=mock_coordinator,
         merger=mock_merger,
         checkpoint_manager=mock_checkpoint_manager,
+        fsm_helper=FSMStateHelperService(
+            config=sample_composite_config,
+            logger=mock_logger,
+            run_id="00000000-0000-0000-0000-000000000123",
+        ),
         logger=mock_logger,
         lock=mock_lock,
         run_id="00000000-0000-0000-0000-000000000123",
@@ -487,6 +493,11 @@ class TestFSMFailureLogging:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -537,6 +548,11 @@ class TestFSMFailureLogging:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -587,6 +603,11 @@ class TestFSMFailureLogging:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -637,6 +658,11 @@ class TestDryRunLogging:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",
@@ -689,6 +715,11 @@ class TestNoEnrichersLogging:
             coordinator=mock_coordinator,
             merger=mock_merger,
             checkpoint_manager=mock_checkpoint_manager,
+            fsm_helper=FSMStateHelperService(
+                config=sample_composite_config,
+                logger=mock_logger,
+                run_id="00000000-0000-0000-0000-000000000123",
+            ),
             logger=mock_logger,
             lock=mock_lock,
             run_id="00000000-0000-0000-0000-000000000123",

--- a/tests/unit/application/composite/test_runner_required_flag.py
+++ b/tests/unit/application/composite/test_runner_required_flag.py
@@ -17,6 +17,7 @@ import polars as pl
 import pytest
 
 from bioetl.application.composite.checkpoint import CompositeCheckpointState
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -223,6 +224,9 @@ def create_runner(
         coordinator=coordinator,
         merger=merger,
         checkpoint_manager=checkpoint_manager,
+        fsm_helper=FSMStateHelperService(
+            config=config, logger=logger, run_id="test-run-id"
+        ),
         logger=logger,
         lock=create_mock_lock(),
     )

--- a/tests/unit/application/composite/test_runner_robustness.py
+++ b/tests/unit/application/composite/test_runner_robustness.py
@@ -20,6 +20,7 @@ from bioetl.application.composite.checkpoint import (
     CompositeCheckpointManager,
     CompositeCheckpointState,
 )
+from bioetl.application.composite.fsm_helper import FSMStateHelperService
 from bioetl.application.composite.runner import (
     CompositePipelineRunner,
     CompositeRuntimeConfig,
@@ -160,6 +161,9 @@ def create_runner(
         coordinator=mock_coordinator,
         merger=mock_merger,
         checkpoint_manager=checkpoint_manager,
+        fsm_helper=FSMStateHelperService(
+            config=mock_config, logger=mock_logger, run_id=test_run_id
+        ),
         logger=mock_logger,
         lock=mock_lock,
         run_id=test_run_id,


### PR DESCRIPTION
### Motivation

- Make the FSM helper an explicit constructor dependency of the composite runner so DI is clear and no concrete service is created inside the application layer. 
- Improve static typing so `mypy` can see the `_fsm` dependency in runner mixins without `getattr`/`cast` workarounds. 

### Description

- Added a `FSMStateHelperPort` protocol with the methods used by the runner: `log_fsm_transition`, `validate_fsm_transition`, `handle_resume_from_failed`, and `log_resume_context` (`src/bioetl/application/composite/fsm_helper_port.py`).
- Updated `CompositePipelineRunnerService` to accept `fsm_helper: FSMStateHelperPort` in its constructor and removed the in-class import/instantiation of `FSMStateHelperService` (`src/bioetl/application/composite/runner.py`).
- Replaced concrete `_fsm` typing in runner mixins with the new port (`FSMStateHelperPort`) so `mypy` recognizes the attribute on mixin classes (`runner_stage_mixin.py`, `runner_merge_stage_mixin.py`, `runner_support_mixin.py`).
- Moved creation of the concrete `FSMStateHelperService(...)` into the composition root and pass it into the runner factory (`bootstrap_composite_runner` in `src/bioetl/composition/bootstrap/runtime/composite.py`).
- Updated unit tests and test fixtures that construct `CompositePipelineRunner` to provide a `fsm_helper` (use `FSMStateHelperService(...)` in tests) so tests instantiate the runner using the new constructor argument.

### Testing

- Ran the composite unit test suite with `pytest` for composite runner tests: `tests/unit/application/composite/*` — all tests passed (full run shown as 100% passing). 
- Ran `mypy --strict` for the changed application/composition modules (`src/bioetl/application/composite` and `src/bioetl/composition/bootstrap/runtime/composite.py`) — `mypy` reported success for the checked files. 
- Ran the architecture boundary test `tests/architecture/test_composite_layer_boundaries.py` — it passed.

All automated checks exercised as part of this change (unit tests, targeted `mypy`, and architecture boundary test) completed successfully for the modified scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d40500a883248afae2b0f6fdeacf)