### PR TITLE
Reduce # type: ignore debt and add per-category budget guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,8 @@ module = [
     "psutil.*",
     "click",
     "click.*",
+    "typing_inspect",
+    "typing_inspect.*",
 ]
 ignore_missing_imports = true
 

--- a/src/bioetl/__init__.py
+++ b/src/bioetl/__init__.py
@@ -10,7 +10,7 @@ __version__ = "6.0.0"
 try:
     import typing
 
-    import typing_inspect  # type: ignore[import-untyped]
+    import typing_inspect
 
     # Fix typing_inspect.get_origin BEFORE importing pandera backends
     _orig_get_origin = typing_inspect.get_origin
@@ -71,10 +71,10 @@ try:
                 typing.Any  # Any: multipledispatch requires erased types
             ]  # Any: multipledispatch requires erased types
         if fn is None:
-            return _orig_dispatcher_call(self, *args, **kwargs)  # type: ignore[no-untyped-call]
+            return _orig_dispatcher_call(self, *args, **kwargs)  # type: ignore[no-untyped-call]  # safe: delegated to pandera dispatcher fallback
         return fn(*args, **kwargs)
 
-    Dispatcher.__call__ = _dispatcher_call_with_any_fallback  # type: ignore[method-assign]
+    Dispatcher.__call__ = _dispatcher_call_with_any_fallback  # type: ignore[method-assign]  # safe: runtime monkeypatch for pandera compatibility
 except (ImportError, AttributeError, TypeError, ValueError, RuntimeError):
     # Fail silently to avoid breaking the entire project if Pandera/Pandas are not present
     pass

--- a/src/bioetl/application/core/filtered_data_source.py
+++ b/src/bioetl/application/core/filtered_data_source.py
@@ -283,9 +283,11 @@ class FilteredDataSource(_SourceMetadataDelegationMixin):
         self._ensure_filterable_adapter("Multi-column filtering")
         assert isinstance(self._data_source, FilterableDataSourcePort)
         fetched_count = 0
+        if self._multi_filter_ids is None:
+            raise ValueError("multi_filter_ids must be set in multi-column mode")
         async for record in self._data_source.fetch_multi_filtered(
             entity_type=entity_type,
-            filters=dict(self._multi_filter_ids),  # type: ignore[arg-type]
+            filters={field: list(ids) for field, ids in self._multi_filter_ids.items()},
             limit=None,  # Don't limit server-side, we filter client-side
         ):
             if self._matches_valid_combination(record):
@@ -310,10 +312,14 @@ class FilteredDataSource(_SourceMetadataDelegationMixin):
             )
 
         # Check if we have fallback mapping (adapter implements FilterableDataSourcePort)
+        if self._filter_ids is None:
+            raise ValueError("filter_ids must be set when filtering is enabled")
+        filter_ids = list(self._filter_ids)
+
         if self._fallback_mapping:
             async for record in self._data_source.fetch_filtered_with_fallback(
                 entity_type=entity_type,
-                filter_ids=self._filter_ids,  # type: ignore[arg-type]
+                filter_ids=filter_ids,
                 filter_field=config_filter_field,
                 fallback_mapping=self._fallback_mapping,
                 limit=limit,
@@ -323,7 +329,7 @@ class FilteredDataSource(_SourceMetadataDelegationMixin):
             # Standard path without fallback
             async for record in self._data_source.fetch_filtered(
                 entity_type=entity_type,
-                filter_ids=self._filter_ids,  # type: ignore[arg-type]
+                filter_ids=filter_ids,
                 filter_field=config_filter_field,
                 limit=limit,
             ):

--- a/src/bioetl/application/core/lock_manager.py
+++ b/src/bioetl/application/core/lock_manager.py
@@ -157,7 +157,9 @@ class LockManager:
             self._fencing_token = token
             # Update shared context holder for writers
             if self._context_holder is not None:
-                self._context_holder.set(self.get_context())  # type: ignore[arg-type]
+                context = self.get_context()
+                if context is not None:
+                    self._context_holder.set(context)
             self._logger.info(
                 "lock_acquired",
                 lock_key=self._config.lock_key,

--- a/src/bioetl/application/services/dq/_checks_integrity.py
+++ b/src/bioetl/application/services/dq/_checks_integrity.py
@@ -5,7 +5,7 @@ Extracted from GoldDQAnalyzer per audit-package-structure-2026-02-07.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import polars as pl
 import pyarrow as pa
@@ -64,7 +64,7 @@ def check_referential_integrity(
             continue
 
         if isinstance(ref_table, pa.Table):
-            ref_df: pl.DataFrame = pl.from_arrow(ref_table)  # type: ignore[assignment]
+            ref_df = cast(pl.DataFrame, pl.from_arrow(ref_table))
         else:
             ref_df = ref_table
 

--- a/src/bioetl/application/services/dq/gold_analyzer.py
+++ b/src/bioetl/application/services/dq/gold_analyzer.py
@@ -15,7 +15,7 @@ Split from monolithic 761-LOC class per audit-package-structure-2026-02-07.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import polars as pl
 import pyarrow as pa
@@ -172,7 +172,7 @@ class GoldDQAnalyzer:
             GoldDQReport: Complete DQ report for Gold layer.
         """
         if isinstance(data, pa.Table):
-            df: pl.DataFrame = pl.from_arrow(data)  # type: ignore[assignment]
+            df = cast(pl.DataFrame, pl.from_arrow(data))
         else:
             df = data
 

--- a/src/bioetl/application/services/dq/silver_analyzer.py
+++ b/src/bioetl/application/services/dq/silver_analyzer.py
@@ -16,7 +16,7 @@ Follows RULES.md §3.1 DQ strategy for Silver layer.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import polars as pl
 import pyarrow as pa
@@ -249,7 +249,7 @@ class SilverDQAnalyzer:
         """
         # Convert PyArrow to Polars for consistent processing
         if isinstance(data, pa.Table):
-            df: pl.DataFrame = pl.from_arrow(data)  # type: ignore[assignment]
+            df = cast(pl.DataFrame, pl.from_arrow(data))
         else:
             df = data
 

--- a/src/bioetl/composition/bootstrap/runtime/composite.py
+++ b/src/bioetl/composition/bootstrap/runtime/composite.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import UUID, uuid4
 
 import yaml
@@ -278,10 +278,18 @@ def _extract_multi_filter_ids(
     return result
 
 
+class _CachedBronzeOptions(TypedDict):
+    """Typed kwargs subset accepted by RunOptions for cached Bronze mode."""
+
+    use_cached_bronze: bool
+    cached_bronze_path: str | None
+    cached_bronze_date: str | None
+
+
 def _resolve_bronze_opts(
     runtime: CompositeRuntimeConfig,
     phase_override: bool | None,
-) -> dict[str, object]:
+) -> _CachedBronzeOptions:
     """Resolve cached Bronze options for a specific pipeline phase.
 
     Tri-state resolution: phase_override takes precedence over master switch.
@@ -364,7 +372,7 @@ def bootstrap_composite_runner(
             run_type="incremental",
             limit=runtime.seed_limit,
             skip_gold=True,
-            **_seed_bronze_opts,  # type: ignore[arg-type]
+            **_seed_bronze_opts,
         )
         ctx = build_pipeline_context(config.seed.pipeline, options)
         return bootstrap_pipeline_runner(ctx)
@@ -422,7 +430,7 @@ def bootstrap_composite_runner(
             filter_field=filter_field,
             fallback_mapping=fallback_mapping,
             execution_context="enricher",
-            **_enricher_bronze_opts,  # type: ignore[arg-type]
+            **_enricher_bronze_opts,
         )
         ctx = build_pipeline_context(pipeline_name, options)
         return bootstrap_pipeline_runner(ctx)
@@ -510,7 +518,7 @@ def bootstrap_composite_runner(
             ignore_yaml_filter=True,
             skip_gold=True,
             execution_context="dependency",
-            **_dependency_bronze_opts,  # type: ignore[arg-type]
+            **_dependency_bronze_opts,
         )
         ctx = build_pipeline_context(pipeline_name, options)
         return bootstrap_pipeline_runner(ctx)

--- a/src/bioetl/domain/value_objects/dq_metrics.py
+++ b/src/bioetl/domain/value_objects/dq_metrics.py
@@ -9,7 +9,7 @@ Implements REQ-DQ-001: DQ metrics in Silver metadata.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from bioetl.domain.models.metadata import ColumnMetrics, DQSummary, SchemaDrift
@@ -60,7 +60,7 @@ class SchemaDriftInfo:
         missing_fields: List of missing fields detected.
     """
 
-    status: str = "info"  # Literal["info", "warn", "critical"]
+    status: Literal["info", "warn", "critical"] = "info"
     new_fields: tuple[str, ...] = ()
     missing_fields: tuple[str, ...] = ()
 
@@ -80,7 +80,7 @@ class SchemaDriftInfo:
         from bioetl.domain.models.metadata import SchemaDrift
 
         return SchemaDrift(
-            status=self.status,  # type: ignore[arg-type]
+            status=self.status,
             new_fields=list(self.new_fields),
             missing_fields=list(self.missing_fields),
         )

--- a/src/bioetl/domain/value_objects/taxonomy_id.py
+++ b/src/bioetl/domain/value_objects/taxonomy_id.py
@@ -40,7 +40,8 @@ class TaxonomyId(ValueObject[int]):
         Raises:
             ValueError: If validation fails.
         """
-        super().__init__(value)  # type: ignore[arg-type]
+        normalized = self._validate(value)
+        object.__setattr__(self, "_value", normalized)
 
     def _coerce_to_int(self, value: str | int) -> int:
         """Coerce value to integer, raising ValueError on failure."""

--- a/src/bioetl/infrastructure/schemas/filter_config.py
+++ b/src/bioetl/infrastructure/schemas/filter_config.py
@@ -100,7 +100,7 @@ class SilverFiltersFileConfig(BaseGoldFiltersConfig):
         exclude_if_present: Exclude if field has value.
     """
 
-    def to_domain(self) -> SilverFilterConfig:  # type: ignore[override]
+    def to_domain(self) -> SilverFilterConfig:  # type: ignore[override]  # safe: returns sibling domain type required by Silver pipeline contract
         """Convert to domain SilverFilterConfig dataclass.
 
         Returns:

--- a/src/bioetl/infrastructure/storage/silver_writer.py
+++ b/src/bioetl/infrastructure/storage/silver_writer.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 __all__ = ["SilverWriteMode", "SilverWriter"]
 
 
-class SilverWriter(  # type: ignore[misc]  # Callable vs async-def in MRO
+class SilverWriter(  # type: ignore[misc]  # safe: deltalake mixin MRO combines sync Callable and async protocols; runtime behavior covered by writer tests
     SilverWriterArrowMixin,
     SilverWriterValidationMixin,
     SilverWriterDeltaMixin,

--- a/src/bioetl/interfaces/cli/commands/export.py
+++ b/src/bioetl/interfaces/cli/commands/export.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import cast
 
 import click
 
 from bioetl.application.services import ExportOptions
+from bioetl.application.services.export_service import ExportFormat
 from bioetl.composition.entrypoints import get_export_service
 from bioetl.interfaces.cli.formatters import (
     echo_error,
@@ -156,7 +158,7 @@ def export_command(
 
     # Build export options
     options = ExportOptions(
-        format=output_format,  # type: ignore[arg-type]
+        format=cast(ExportFormat, output_format),
         output_path=output,
         limit=limit,
         columns=column_list,

--- a/tests/architecture/test_type_ignore_budget.py
+++ b/tests/architecture/test_type_ignore_budget.py
@@ -1,0 +1,66 @@
+"""Architecture guard: typed ``# type: ignore[...]`` debt budget.
+
+Tracks category budgets for the highest-risk ignore groups and prevents
+regressions over time.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+SRC_ROOT = Path("src/bioetl")
+IGNORE_RE = re.compile(r"type:\s*ignore(?:\[([^\]]+)\])?")
+
+# RF-008 (2026-03-04): post-cleanup baseline for key categories.
+CATEGORY_BUDGETS: dict[str, int] = {
+    "arg-type": 9,
+    "assignment": 2,
+    "misc": 1,  # MRO-specific mixin conflict in SilverWriter
+    "import-untyped": 0,
+    "override": 1,
+}
+TOTAL_BUDGET = 36
+
+
+def _collect_ignore_counts() -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = IGNORE_RE.search(line)
+            if match is None:
+                continue
+            codes = match.group(1)
+            if codes is None:
+                counts["bare"] += 1
+                continue
+            for code in codes.split(","):
+                counts[code.strip()] += 1
+    return counts
+
+
+def test_type_ignore_category_budgets() -> None:
+    """Selected type-ignore categories must stay within agreed budgets."""
+    counts = _collect_ignore_counts()
+    violations = [
+        f"{category}: {counts[category]} > {budget}"
+        for category, budget in CATEGORY_BUDGETS.items()
+        if counts[category] > budget
+    ]
+
+    assert not violations, "Type-ignore category budget exceeded:\n" + "\n".join(
+        violations
+    )
+
+
+def test_type_ignore_total_budget() -> None:
+    """Total type-ignore count must not exceed the ratcheted budget."""
+    counts = _collect_ignore_counts()
+    total = sum(counts.values())
+    assert total <= TOTAL_BUDGET, (
+        f"Total # type: ignore budget exceeded: {total} > {TOTAL_BUDGET}. "
+        "Refactor typing or tighten per-file overrides before adding new ignores."
+    )


### PR DESCRIPTION
### Motivation
- Reduce and categorize scattered `# type: ignore` usages by removing avoidable ignores and tightening types to improve mypy signal quality.
- Convert several weakly-typed callsites to precise contracts (e.g., kwargs for cached-bronze, filter IDs, Polars conversions) to eliminate `arg-type`/`assignment` ignores where possible.
- Prevent future regressions by codifying a small, ratcheted budget for the remaining, justified ignores and documenting unavoidable cases.

### Description
- Introduced a `TypedDict` `_CachedBronzeOptions` and returned that from `_resolve_bronze_opts` so cached-bronze kwargs can be expanded into `RunOptions` without `# type: ignore[arg-type]` (changes in `src/bioetl/composition/bootstrap/runtime/composite.py`).
- Tightened `FilteredDataSource` by guarding nullable containers and converting `tuple -> list` for provider calls, replacing several `type: ignore[arg-type]` sites with safe conversions (`src/bioetl/application/core/filtered_data_source.py`).
- Replaced ambiguous `pl.from_arrow(...)` assignment ignores with explicit `cast(pl.DataFrame, ...)` in DQ analyzers and integrity checks to remove `assignment` ignores (files under `src/bioetl/application/services/dq/`).
- Narrowed domain typing and constructors to remove avoids: `SchemaDriftInfo.status` is now `Literal[...]`, and `TaxonomyId` sets normalized `_value` in constructor (under `src/bioetl/domain/value_objects/`).
- Improved CLI typing by casting the `output_format` to `ExportFormat` in the export command and added targeted mypy overrides for `typing_inspect` to avoid `import-untyped` ignores (`src/bioetl/interfaces/cli/commands/export.py` and `pyproject.toml`).
- Kept a minimal set of unavoidable ignores and documented them with safety comments (MRO mixin `misc` in `SilverWriter`, an `override` case in `filter_config`, and runtime monkeypatches in `__init__` for Pandera); added explanatory comments next to those `type: ignore` usages.
- Added an architecture guard test `tests/architecture/test_type_ignore_budget.py` which enforces per-category budgets (`arg-type`, `assignment`, `misc`, `import-untyped`, `override`) and a total budget to prevent regressions.

### Testing
- Ran the new guard test with `uv run python -m pytest tests/architecture/test_type_ignore_budget.py -q` and it passed.
- Ran focused static checks with `uv run python -m mypy --strict` against the modified files (`composite.py`, `filtered_data_source.py`, `export.py`, `lock_manager.py`, `dq analyzers`, `dq checks`, `__init__.py`, `dq_metrics`, `taxonomy_id`, and the new test) and the checks passed for the targeted set.
- Executed the repository pre-commit hook suite during commit which surfaced unrelated environmental/tooling failures (missing `pip-audit` executable and broader mypy findings outside the touched files); those failures are external to the changes made and do not affect the added guard test or the targeted mypy runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d3e3bdb08324a1b55d78cb76cb05)