### PR TITLE
⚡ Async Metrics Server Startup

### DIFF
--- a/src/bioetl/application/services/metrics_service.py
+++ b/src/bioetl/application/services/metrics_service.py
@@ -46,7 +46,7 @@ class MetricsServerPort(Protocol):
     Abstracts the metrics server infrastructure for application layer.
     """
 
-    def start(
+    async def start(
         self,
         port: int,
         *,
@@ -157,7 +157,7 @@ class MetricsService:
             ) from e
         return StartResult(success=False, port=port, error=error_msg)
 
-    def start(
+    async def start(
         self,
         port: int = 8000,
         *,
@@ -190,7 +190,7 @@ class MetricsService:
             )
 
         try:
-            success = self._server.start(
+            success = await self._server.start(
                 port=port,
                 fail_fast=fail_fast,
                 retry_count=retry_count,

--- a/src/bioetl/composition/_pipeline_execution.py
+++ b/src/bioetl/composition/_pipeline_execution.py
@@ -71,7 +71,7 @@ def push_metrics_to_gateway(
     return _push(gateway=gateway, job=job, grouping_key=grouping_key)
 
 
-def ensure_metrics_server_started() -> bool:
+async def ensure_metrics_server_started() -> bool:
     """Ensure metrics server is started if enabled in settings.
 
     This function should be called at the start of pipeline execution
@@ -82,11 +82,11 @@ def ensure_metrics_server_started() -> bool:
         True if server was started or already running, False if disabled.
 
     Example:
-        >>> ensure_metrics_server_started()
+        >>> await ensure_metrics_server_started()
         True  # Server started on configured port
     """
     settings = get_settings()
-    return maybe_start_metrics_server(settings)
+    return await maybe_start_metrics_server(settings)
 
 
 @dataclass(frozen=True)
@@ -224,7 +224,7 @@ async def run_pipeline(name: str, options: RunOptions) -> RunResult:
     """Run pipeline end-to-end and return structured execution result."""
     # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
     settings = get_settings()
-    maybe_start_metrics_server(settings)
+    await maybe_start_metrics_server(settings)
 
     started_at = datetime.now(tz=UTC)
     runner = create_pipeline_runner(name, options)

--- a/src/bioetl/composition/bootstrap/runtime/observability.py
+++ b/src/bioetl/composition/bootstrap/runtime/observability.py
@@ -225,7 +225,7 @@ def bootstrap_metrics_port(settings: Settings) -> MetricsPort:
     return PrometheusMetrics()
 
 
-def maybe_start_metrics_server(settings: Settings) -> bool:
+async def maybe_start_metrics_server(settings: Settings) -> bool:
     """Start metrics server if enabled in settings.
 
     This function should be called by entrypoints (CLI, REST API) after
@@ -251,7 +251,7 @@ def maybe_start_metrics_server(settings: Settings) -> bool:
     obs = settings.observability
 
     # Start metrics server - let exceptions propagate to entrypoints
-    return start_metrics_server(
+    return await start_metrics_server(
         port=settings.metrics_port,
         addr=settings.metrics_addr,
         fail_fast=obs.metrics_fail_fast,

--- a/src/bioetl/infrastructure/observability/metrics_server_adapter.py
+++ b/src/bioetl/infrastructure/observability/metrics_server_adapter.py
@@ -44,7 +44,7 @@ class MetricsServerAdapter:
         """
         self._logger = logger
 
-    def start(
+    async def start(
         self,
         port: int = 8000,
         *,
@@ -63,7 +63,7 @@ class MetricsServerAdapter:
         Returns:
             True if server started successfully, False otherwise.
         """
-        return start_metrics_server(
+        return await start_metrics_server(
             port=port,
             fail_fast=fail_fast,
             retry_count=retry_count,

--- a/src/bioetl/infrastructure/observability/server.py
+++ b/src/bioetl/infrastructure/observability/server.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import errno
 import time
-from threading import Lock
 from typing import TYPE_CHECKING
 
 from prometheus_client import REGISTRY, start_http_server
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from bioetl.domain.ports import LoggerPort
 
 _SERVER_STARTED = False
-_SERVER_LOCK = Lock()
+_SERVER_LOCK = asyncio.Lock()
 
 # Re-export for backward compatibility
 __all__ = [
@@ -80,7 +80,7 @@ def _handle_unexpected_error(
     return False
 
 
-def start_metrics_server(
+async def start_metrics_server(
     port: int = 8000,
     addr: str = "0.0.0.0",
     *,
@@ -99,7 +99,7 @@ def start_metrics_server(
         logger.debug("Metrics server already started")
         return True
 
-    with _SERVER_LOCK:
+    async with _SERVER_LOCK:
         if _SERVER_STARTED:
             return True
 
@@ -118,7 +118,7 @@ def start_metrics_server(
                 if e.errno == errno.EADDRINUSE:
                     return _handle_port_in_use(port, e, fail_fast, logger)
                 if attempt < retry_count - 1:
-                    time.sleep(retry_delay * (2**attempt))
+                    await asyncio.sleep(retry_delay * (2**attempt))
                     continue
                 return _handle_os_error(port, e, retry_count, fail_fast, logger)
             except (RuntimeError, ValueError, TypeError, AttributeError) as e:
@@ -190,5 +190,5 @@ def push_metrics_to_gateway(
 def reset_server_state() -> None:
     """Reset server state for testing purposes only."""
     global _SERVER_STARTED
-    with _SERVER_LOCK:
-        _SERVER_STARTED = False
+    # Since it's for testing, we bypass the lock to allow sync usage
+    _SERVER_STARTED = False

--- a/src/bioetl/interfaces/cli/commands/metrics_server_integration.py
+++ b/src/bioetl/interfaces/cli/commands/metrics_server_integration.py
@@ -10,8 +10,8 @@ composition layer for server startup, keeping side-effects out of bootstrap.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from bioetl.composition.entrypoints import ensure_metrics_server_started
 
@@ -21,8 +21,8 @@ __all__ = [
 ]
 
 
-@contextmanager
-def metrics_server_context() -> Iterator[bool]:
+@asynccontextmanager
+async def metrics_server_context() -> AsyncIterator[bool]:
     """Context manager that ensures metrics server is started.
 
     Starts the Prometheus metrics HTTP server before yielding.
@@ -32,16 +32,16 @@ def metrics_server_context() -> Iterator[bool]:
         True if server was started, False if disabled.
 
     Example:
-        with metrics_server_context():
+        async with metrics_server_context():
             # Metrics server is running
             await run_pipeline()
         # Server continues running (daemon thread)
 
     Returns:
-        Iterator over results.
+        AsyncIterator over results.
     """
     # Re-exported from entrypoints, use directly
-    started = ensure_metrics_server_started()
+    started = await ensure_metrics_server_started()
     yield started
 
 

--- a/src/bioetl/interfaces/cli/commands/run.py
+++ b/src/bioetl/interfaces/cli/commands/run.py
@@ -192,7 +192,7 @@ async def _run_pipeline_async(
         RunResult object with status and metrics.
     """
     # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
-    ensure_metrics_server_started()
+    await ensure_metrics_server_started()
 
     async with health_server_context(
         enabled=health_server_enabled,

--- a/src/bioetl/interfaces/cli/commands/run_all.py
+++ b/src/bioetl/interfaces/cli/commands/run_all.py
@@ -149,7 +149,7 @@ async def _run_all_pipelines_async(
 ) -> BatchRunResult:
     """Run all pipelines sequentially with optional health server."""
     # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
-    ensure_metrics_server_started()
+    await ensure_metrics_server_started()
 
     async with health_server_context(enabled=health_server_enabled, port=health_port):
         service = get_pipeline_runner_service()

--- a/src/bioetl/interfaces/cli/commands/run_composite.py
+++ b/src/bioetl/interfaces/cli/commands/run_composite.py
@@ -112,7 +112,7 @@ async def _run_composite_async(
         Tuple of (success, error_message).
     """
     # Start metrics server if enabled (side-effect in entrypoint, not bootstrap)
-    ensure_metrics_server_started()
+    await ensure_metrics_server_started()
 
     async with health_server_context(
         enabled=health_server_enabled,

--- a/tests/unit/application/services/test_metrics_service.py
+++ b/tests/unit/application/services/test_metrics_service.py
@@ -48,7 +48,7 @@ class TestMetricsServerPort:
         """Test MetricsServerPort is runtime checkable."""
 
         class MockServer:
-            def start(
+            async def start(
                 self,
                 port: int,
                 *,
@@ -129,7 +129,11 @@ class TestMetricsService:
         """Create mock metrics server."""
         server = MagicMock()
         server.is_running.return_value = False
-        server.start.return_value = True
+
+        async def mock_start(*args, **kwargs):
+            return True
+
+        server.start = MagicMock(side_effect=mock_start)
         return server
 
     @pytest.fixture
@@ -137,11 +141,12 @@ class TestMetricsService:
         """Create MetricsService with mocked dependencies."""
         return MetricsService(logger=mock_logger, _server=mock_server)
 
-    def test_start_success(
+    @pytest.mark.asyncio
+    async def test_start_success(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test successful server start."""
-        result = service.start(port=8000)
+        result = await service.start(port=8000)
 
         assert result.success is True
         assert result.port == 8000
@@ -150,70 +155,88 @@ class TestMetricsService:
             port=8000, fail_fast=False, retry_count=3, retry_delay=1.0
         )
 
-    def test_start_already_running(
+    @pytest.mark.asyncio
+    async def test_start_already_running(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test start when server is already running."""
         mock_server.is_running.return_value = True
 
-        result = service.start(port=9000)
+        result = await service.start(port=9000)
 
         assert result.success is True
         assert result.already_running is True
         mock_server.start.assert_not_called()
 
-    def test_start_failure(
+    @pytest.mark.asyncio
+    async def test_start_failure(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test start when server fails to bind."""
-        mock_server.start.return_value = False
 
-        result = service.start(port=8000)
+        async def mock_fail(*args, **kwargs):
+            return False
+
+        mock_server.start.side_effect = mock_fail
+
+        result = await service.start(port=8000)
 
         assert result.success is False
         assert result.error == "Failed to bind port"
 
-    def test_start_with_exception(
+    @pytest.mark.asyncio
+    async def test_start_with_exception(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test start handles exceptions gracefully."""
-        mock_server.start.side_effect = OSError("Address in use")
 
-        result = service.start(port=8000, fail_fast=False)
+        async def mock_error(*args, **kwargs):
+            raise OSError("Address in use")
+
+        mock_server.start.side_effect = mock_error
+
+        result = await service.start(port=8000, fail_fast=False)
 
         assert result.success is False
         assert "Address in use" in (result.error or "")
 
-    def test_start_fail_fast(
+    @pytest.mark.asyncio
+    async def test_start_fail_fast(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test start with fail_fast raises exception."""
-        mock_server.start.side_effect = OSError("Address in use")
+
+        async def mock_error(*args, **kwargs):
+            raise OSError("Address in use")
+
+        mock_server.start.side_effect = mock_error
 
         with pytest.raises(MetricsServerError) as exc_info:
-            service.start(port=8000, fail_fast=True)
+            await service.start(port=8000, fail_fast=True)
 
         assert exc_info.value.port == 8000
         assert "Address in use" in exc_info.value.reason
 
-    def test_start_custom_params(
+    @pytest.mark.asyncio
+    async def test_start_custom_params(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test start with custom retry parameters."""
-        result = service.start(port=8080, retry_count=5, retry_delay=2.0)
+        result = await service.start(port=8080, retry_count=5, retry_delay=2.0)
 
         mock_server.start.assert_called_once_with(
             port=8080, fail_fast=False, retry_count=5, retry_delay=2.0
         )
         assert result.port == 8080
 
-    def test_get_status_running(
+    @pytest.mark.asyncio
+    async def test_get_status_running(
         self, service: MetricsService, mock_server: MagicMock
     ) -> None:
         """Test get_status when server is running."""
         # First start the server to set _port and _started_at
         mock_server.is_running.return_value = False
-        service.start(port=8000)
+        await service.start(port=8000)
         mock_server.is_running.return_value = True
 
         status = service.get_status()
@@ -251,25 +274,33 @@ class TestMetricsServiceEdgeCases:
         """Create mock logger."""
         return MagicMock()
 
-    def test_start_logs_correctly(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_start_logs_correctly(self, mock_logger: MagicMock) -> None:
         """Test that start logs appropriately."""
         mock_server = MagicMock()
         mock_server.is_running.return_value = False
-        mock_server.start.return_value = True
+
+        async def mock_start(*args, **kwargs):
+            return True
+
+        mock_server.start.side_effect = mock_start
 
         service = MetricsService(logger=mock_logger, _server=mock_server)
-        service.start(port=8000)
+        await service.start(port=8000)
 
         mock_logger.debug.assert_called()
         mock_logger.info.assert_called()
 
-    def test_start_already_running_logs_debug(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_start_already_running_logs_debug(
+        self, mock_logger: MagicMock
+    ) -> None:
         """Test that already running logs debug message."""
         mock_server = MagicMock()
         mock_server.is_running.return_value = True
 
         service = MetricsService(logger=mock_logger, _server=mock_server)
-        service.start(port=8000)
+        await service.start(port=8000)
 
         # Debug should be called for "Starting metrics server" and "already running"
         assert mock_logger.debug.call_count >= 2
@@ -302,39 +333,54 @@ class TestMetricsServiceEdgeCases:
         assert exc_info.value.port == 8000
         assert exc_info.value.original_error is exception
 
-    def test_service_default_port(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_service_default_port(self, mock_logger: MagicMock) -> None:
         """Test that service uses default port 8000."""
         mock_server = MagicMock()
         mock_server.is_running.return_value = False
-        mock_server.start.return_value = True
+
+        async def mock_start(*args, **kwargs):
+            return True
+
+        mock_server.start.side_effect = mock_start
 
         service = MetricsService(logger=mock_logger, _server=mock_server)
-        result = service.start()
+        result = await service.start()
 
         assert result.port == 8000
         mock_server.start.assert_called_with(
             port=8000, fail_fast=False, retry_count=3, retry_delay=1.0
         )
 
-    def test_start_failure_logs_warning(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_start_failure_logs_warning(self, mock_logger: MagicMock) -> None:
         """Test that start failure logs warning."""
         mock_server = MagicMock()
         mock_server.is_running.return_value = False
-        mock_server.start.return_value = False
+
+        async def mock_fail(*args, **kwargs):
+            return False
+
+        mock_server.start.side_effect = mock_fail
 
         service = MetricsService(logger=mock_logger, _server=mock_server)
-        service.start(port=8000)
+        await service.start(port=8000)
 
         mock_logger.warning.assert_called()
 
-    def test_get_status_uses_stored_port(self, mock_logger: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_get_status_uses_stored_port(self, mock_logger: MagicMock) -> None:
         """Test that get_status uses the stored port from start."""
         mock_server = MagicMock()
         mock_server.is_running.return_value = False
-        mock_server.start.return_value = True
+
+        async def mock_start(*args, **kwargs):
+            return True
+
+        mock_server.start.side_effect = mock_start
 
         service = MetricsService(logger=mock_logger, _server=mock_server)
-        service.start(port=9999)
+        await service.start(port=9999)
 
         mock_server.is_running.return_value = True
         status = service.get_status()

--- a/tests/unit/infrastructure/observability/test_server.py
+++ b/tests/unit/infrastructure/observability/test_server.py
@@ -23,33 +23,34 @@ def reset_server():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
 class TestStartMetricsServer:
     """Tests for start_metrics_server function."""
 
-    def test_returns_true_on_success(self):
+    async def test_returns_true_on_success(self):
         """Test successful server start returns True."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
         ) as mock_server:
-            result = start_metrics_server(port=9999)
+            result = await start_metrics_server(port=9999)
 
             assert result is True
             mock_server.assert_called_once_with(9999, addr="0.0.0.0")
 
-    def test_idempotent_multiple_calls(self):
+    async def test_idempotent_multiple_calls(self):
         """Test server is only started once."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
         ) as mock_server:
-            result1 = start_metrics_server(port=9999)
-            result2 = start_metrics_server(port=9999)
+            result1 = await start_metrics_server(port=9999)
+            result2 = await start_metrics_server(port=9999)
 
             assert result1 is True
             assert result2 is True
             # Should only be called once
             mock_server.assert_called_once()
 
-    def test_lenient_mode_returns_false_on_port_conflict(self):
+    async def test_lenient_mode_returns_false_on_port_conflict(self):
         """Test fail_fast=False returns False on port conflict instead of raising."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -58,11 +59,11 @@ class TestStartMetricsServer:
             error.errno = errno.EADDRINUSE
             mock_server.side_effect = error
 
-            result = start_metrics_server(port=8000, fail_fast=False)
+            result = await start_metrics_server(port=8000, fail_fast=False)
 
             assert result is False
 
-    def test_fail_fast_raises_on_port_conflict(self):
+    async def test_fail_fast_raises_on_port_conflict(self):
         """Test fail_fast=True raises MetricsServerError on port conflict."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -72,13 +73,13 @@ class TestStartMetricsServer:
             mock_server.side_effect = error
 
             with pytest.raises(MetricsServerError) as exc_info:
-                start_metrics_server(port=8000, fail_fast=True)
+                await start_metrics_server(port=8000, fail_fast=True)
 
             assert exc_info.value.port == 8000
             assert exc_info.value.reason == "port_in_use"
             assert exc_info.value.original_error is error
 
-    def test_fail_fast_raises_on_other_os_error(self):
+    async def test_fail_fast_raises_on_other_os_error(self):
         """Test fail_fast=True raises on other OS errors."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -88,11 +89,11 @@ class TestStartMetricsServer:
             mock_server.side_effect = error
 
             with pytest.raises(MetricsServerError) as exc_info:
-                start_metrics_server(port=80, fail_fast=True, retry_count=1)
+                await start_metrics_server(port=80, fail_fast=True, retry_count=1)
 
             assert exc_info.value.reason == "os_error"
 
-    def test_fail_fast_raises_on_unexpected_error(self):
+    async def test_fail_fast_raises_on_unexpected_error(self):
         """Test fail_fast=True raises on unexpected exceptions."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -100,22 +101,22 @@ class TestStartMetricsServer:
             mock_server.side_effect = RuntimeError("Unexpected")
 
             with pytest.raises(MetricsServerError) as exc_info:
-                start_metrics_server(port=8000, fail_fast=True)
+                await start_metrics_server(port=8000, fail_fast=True)
 
             assert exc_info.value.reason == "unexpected"
 
-    def test_lenient_mode_returns_false_on_unexpected_error(self):
+    async def test_lenient_mode_returns_false_on_unexpected_error(self):
         """Test fail_fast=False returns False on unexpected error."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
         ) as mock_server:
             mock_server.side_effect = RuntimeError("Unexpected")
 
-            result = start_metrics_server(port=8000, fail_fast=False)
+            result = await start_metrics_server(port=8000, fail_fast=False)
 
             assert result is False
 
-    def test_retry_on_transient_os_error(self):
+    async def test_retry_on_transient_os_error(self):
         """Test retries on transient OS errors (not EADDRINUSE)."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -125,15 +126,14 @@ class TestStartMetricsServer:
             # Fail twice, succeed on third attempt
             mock_server.side_effect = [error, error, None]
 
-            with patch("bioetl.infrastructure.observability.server.time.sleep"):
-                result = start_metrics_server(
-                    port=8000, fail_fast=False, retry_count=3, retry_delay=0.01
-                )
+            result = await start_metrics_server(
+                port=8000, fail_fast=False, retry_count=3, retry_delay=0.01
+            )
 
             assert result is True
             assert mock_server.call_count == 3
 
-    def test_no_retry_on_port_conflict(self):
+    async def test_no_retry_on_port_conflict(self):
         """Test no retries when port is in use (EADDRINUSE)."""
         with patch(
             "bioetl.infrastructure.observability.server.start_http_server"
@@ -142,7 +142,9 @@ class TestStartMetricsServer:
             error.errno = errno.EADDRINUSE
             mock_server.side_effect = error
 
-            result = start_metrics_server(port=8000, fail_fast=False, retry_count=3)
+            result = await start_metrics_server(
+                port=8000, fail_fast=False, retry_count=3
+            )
 
             assert result is False
             # Should only try once for EADDRINUSE

--- a/tests/unit/interfaces/cli/commands/test_metrics_server_integration.py
+++ b/tests/unit/interfaces/cli/commands/test_metrics_server_integration.py
@@ -12,24 +12,26 @@ from bioetl.interfaces.cli.commands.metrics_server_integration import (
 
 
 @pytest.mark.unit
-def test_metrics_server_context_yields_started_flag() -> None:
+@pytest.mark.asyncio
+async def test_metrics_server_context_yields_started_flag() -> None:
     with patch(
         "bioetl.interfaces.cli.commands.metrics_server_integration.ensure_metrics_server_started"
     ) as mock_start:
         mock_start.return_value = True
 
-        with metrics_server_context() as started:
+        async with metrics_server_context() as started:
             assert started is True
 
     mock_start.assert_called_once_with()
 
 
 @pytest.mark.unit
-def test_metrics_server_context_propagates_disabled_state() -> None:
+@pytest.mark.asyncio
+async def test_metrics_server_context_propagates_disabled_state() -> None:
     with patch(
         "bioetl.interfaces.cli.commands.metrics_server_integration.ensure_metrics_server_started"
     ) as mock_start:
         mock_start.return_value = False
 
-        with metrics_server_context() as started:
+        async with metrics_server_context() as started:
             assert started is False


### PR DESCRIPTION
💡 **What:** Converted the Prometheus metrics server startup logic and its entire call stack across all architectural layers to be asynchronous.

🎯 **Why:** The metrics server used synchronous `time.sleep` in its exponential backoff retry loop. Since metrics server startup happens within an async context in the CLI, these sleeps were blocking the entire asyncio event loop. This prevented concurrent tasks (like health checks or heartbeats) from executing during the retry period (e.g., when waiting for a port to become available).

📊 **Measured Improvement:** 
- **Baseline:** Using a reproduction script, it was confirmed that `start_metrics_server` blocked the event loop for ~3.01 seconds during retries, completely stalling background tasks.
- **Post-Optimization:** Verified with `verify_async_non_blocking.py` that background "heartbeat" tasks now continue to execute every 0.5s even while the metrics server is performing its 3-second retry backoff.
- **Correctness:** Updated all relevant unit tests (Infrastructure, Application, and Interface layers) to use `pytest-asyncio` and verified that all 38 relevant tests pass.

Key changes:
- Core: `start_metrics_server` refactored to `async def` with `asyncio.sleep`.
- Architecture: Updated `MetricsServerPort` protocol and `MetricsService` to support async startup.
- Composition: Updated `ensure_metrics_server_started` and `maybe_start_metrics_server` to be async.
- Interfaces: Updated `metrics_server_context` to `asynccontextmanager` and awaited server startup in CLI commands.

---
*PR created automatically by Jules for task [1814537927827611323](https://jules.google.com/task/1814537927827611323) started by @SatoryKono*