### PR TITLE
⚡ Bolt: optimize regex compilation in apply_entity_naming_rename_plan.py

### DIFF
--- a/src/tools/apply_entity_naming_rename_plan.py
+++ b/src/tools/apply_entity_naming_rename_plan.py
@@ -155,8 +155,16 @@ def apply_rows(rows: list[RenameRow], *, apply: bool) -> int:
     print(f"Skipped rows: {len(skipped_rows)}")
 
     file_to_rows: dict[Path, list[RenameRow]] = {}
+    unique_old_names: set[str] = set()
     for row in executable_rows:
         file_to_rows.setdefault(row.file_path, []).append(row)
+        unique_old_names.add(row.old_name)
+
+    # Pre-compile patterns to avoid re-compilation in the nested loop
+    # and bypass Python's internal regex cache limits.
+    patterns = {
+        name: re.compile(rf"\b{re.escape(name)}\b") for name in unique_old_names
+    }
 
     total_matches = 0
     modified_files = 0
@@ -171,7 +179,7 @@ def apply_rows(rows: list[RenameRow], *, apply: bool) -> int:
         file_matches = 0
 
         for row in file_to_rows[file_path]:
-            pattern = re.compile(rf"\b{re.escape(row.old_name)}\b")
+            pattern = patterns[row.old_name]
             updated_text, count = pattern.subn(row.new_name, updated_text)
             file_matches += count
             if count:


### PR DESCRIPTION
The `apply_rows` function was previously compiling the same regular expression for each row, even if the same entity name appeared across multiple files. This was happening inside a nested loop (files then rows). By collecting all unique `old_name` values and pre-compiling them into a dictionary, we significantly reduce the overhead of regex compilation and cache lookups. This is particularly beneficial for large rename operations that exceed the default 512-entry cache of the `re` module. Verified the logic for correctness (identical match counts) and confirmed the performance gain with a benchmark script. I also synchronized the branch with main and ran relevant architecture tests.

---
*PR created automatically by Jules for task [7257696906953506882](https://jules.google.com/task/7257696906953506882) started by @SatoryKono*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized processing efficiency for entity naming operations, reducing computational overhead during batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->