### PR TITLE
🧹 cleanup: remove commented-out Pandera validation logic

### DIFF
--- a/src/bioetl/domain/schemas/common/publication_base.py
+++ b/src/bioetl/domain/schemas/common/publication_base.py
@@ -176,32 +176,6 @@ class PublicationBaseSchema(ETLRecordSchema):
         description="Data source identifier (e.g., chembl, pubmed, crossref, openalex)",
     )
 
-    # @pa.check("title", name="title_not_empty")
-    # @classmethod
-    # def _check_title(cls, series: Any) -> Any:  # Any: Pandera coerce target ...
-    #     """Validate title is not empty when present (null is allowed)."""
-    #     return cast("Series[bool]", series.isna() | (series.str.len() >= 1))
-
-    # @pa.check("author_orcids", name="orcid_format")
-    # @classmethod
-    # Any: Pandera coerce target ...
-    # def _check_author_orcids(cls, series: Any) -> Any:
-    #     """Validate ORCID format in JSON array elements."""
-    #     _pattern = re.compile(ORCID_PATTERN)
-
-    #     def _valid(val: object) -> bool:
-    #         if pd.isna(val):
-    #             return True
-    #         try:
-    #             items = json.loads(str(val))
-    #             return all(
-    #                 not item or _pattern.match(item) is not None for item in items
-    #             )
-    #         except (json.JSONDecodeError, TypeError):
-    #             return False
-
-    #     return cast("Series[bool]", series.apply(_valid))
-
     class Config:
         """Pandera configuration."""
 

--- a/src/bioetl/domain/schemas/pubmed/publication.py
+++ b/src/bioetl/domain/schemas/pubmed/publication.py
@@ -90,8 +90,6 @@ class PubMedPublicationSchema(PublicationBaseSchema):
         description="Article title (required)",
     )
 
-    # title_not_empty: inherited from PublicationBaseSchema
-
     abstract_structured: Series[bool] = pa.Field(
         nullable=True, description="Whether abstract has NLM sections"
     )


### PR DESCRIPTION
🎯 **What:** Removed commented-out legacy Pandera validation logic in PublicationBaseSchema and a stale reference in PubMedPublicationSchema.
💡 **Why:** Improves maintainability and readability by removing dead code.
✅ **Verification:** Ran unit tests for all publication schemas and verified they still pass.
✨ **Result:** Cleaner codebase with no functional changes.

---
*PR created automatically by Jules for task [4743761156329924954](https://jules.google.com/task/4743761156329924954) started by @SatoryKono*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed commented-out validation check notes from schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->