### PR TITLE
🧹 fix unused imports in bioetl/domain/__init__.py

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -23,15 +23,15 @@ top-level domain facade; canonical callers should use
 
 from __future__ import annotations
 
-from bioetl.domain import composite, constants, contracts, control_plane, version  # noqa: F401
+from bioetl.domain import composite, constants, contracts, control_plane, version
 
 # Subpackage registrations (make them importable as bioetl.domain.<name>)
 from bioetl.domain import context_cached_bronze
 from bioetl.domain import context_filtering
 from bioetl.domain import lineage
-from bioetl.domain import mapping  # noqa: F401
+from bioetl.domain import mapping
 from bioetl.domain import observability_contract
-from bioetl.domain import registry  # noqa: F401
+from bioetl.domain import registry
 from bioetl.domain import types_config_validation
 
 # Events
@@ -45,6 +45,9 @@ __all__ = [
     "context_cached_bronze",
     "context_filtering",
     "get_version",
+    "mapping",
+    "registry",
+    "version",
     "lineage",
     "observability_contract",
     "types_config_validation",


### PR DESCRIPTION
🎯 **What:** Fixed unused import warnings for `version`, `mapping`, and `registry` in `src/bioetl/domain/__init__.py` by removing the `# noqa: F401` suppression comments and officially exporting them via the `__all__` declaration. 
💡 **Why:** Relying on suppression comments for implicitly exported modules hides potential linting issues and degrades maintainability. Adding them to `__all__` explicitly defines the public API of the domain layer, improving readability and tool integration.
✅ **Verification:** Ran `uv run ruff check src/bioetl/domain/__init__.py` to ensure the file now strictly passes linting, and executed the full test suite (`uv run pytest tests/unit/domain`) to confirm no functionality or external imports were broken. 
✨ **Result:** A cleaner `__init__.py` with an accurate, explicitly defined `__all__` list, eliminating suppressed linter warnings.

---
*PR created automatically by Jules for task [3664347677748073616](https://jules.google.com/task/3664347677748073616) started by @SatoryKono*