### PR TITLE
🧹 Remove unused imports in bioetl/domain/__init__.py

### DIFF
--- a/src/bioetl/domain/__init__.py
+++ b/src/bioetl/domain/__init__.py
@@ -23,15 +23,13 @@ top-level domain facade; canonical callers should use
 
 from __future__ import annotations
 
-from bioetl.domain import composite, constants, contracts, control_plane, version  # noqa: F401
+from bioetl.domain import composite, constants, contracts, control_plane
 
 # Subpackage registrations (make them importable as bioetl.domain.<name>)
 from bioetl.domain import context_cached_bronze
 from bioetl.domain import context_filtering
 from bioetl.domain import lineage
-from bioetl.domain import mapping  # noqa: F401
 from bioetl.domain import observability_contract
-from bioetl.domain import registry  # noqa: F401
 from bioetl.domain import types_config_validation
 
 # Events


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`version`, `mapping`, `registry`) and corresponding `noqa` pragmas from `src/bioetl/domain/__init__.py`.
💡 **Why:** These imports were not used within the file and were not exported in `__all__`. Removing them improves codebase readability, consistency, and removes the need for `noqa` directives.
✅ **Verification:** Ran `uv run ruff check src/bioetl/domain/__init__.py` to ensure no linting errors and `uv run pytest tests/unit/domain/` to confirm no regressions were introduced.
✨ **Result:** Cleaned up `__init__.py` and successfully resolved the unused imports code health issue without any regressions.

---
*PR created automatically by Jules for task [16117066321080392556](https://jules.google.com/task/16117066321080392556) started by @SatoryKono*