### PR TITLE
feat(ci): add Python 3.13 to test-matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -368,7 +368,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [ "3.11", "3.12" ]
+                python-version: [ "3.11", "3.12", "3.13" ]
                 test-group:
                     -   name: unit-domain
                         path: tests/unit/domain/


### PR DESCRIPTION
## CI-02: Add Python 3.13 to test-matrix

`tests.yml` only tested `["3.11", "3.12"]`, while `release.yml` already
includes `3.13` and `AGENTS.md` recommends Python 3.13.

### Changes
- Added `"3.13"` to `matrix.python-version` in `tests.yml` (job: `test-matrix`)
- Coverage collection remains on Python 3.11 only (no extra artifact noise)
- Matrix grows from 12 to 18 parallel jobs

### Risk
Low. `release.yml` already confirms Python 3.13 compatibility.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended continuous integration testing to support Python 3.13 alongside existing Python 3.11 and 3.12 test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->