### PR TITLE
fix(ci): include workflow file changes in security scans

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,6 @@ on:
       - '*.md'
       - '.ai/**'
       - '.claude/**'
-      - '.github/workflows/**'
       - 'LICENSE'
   pull_request:
     paths-ignore:
@@ -18,7 +17,6 @@ on:
       - '*.md'
       - '.ai/**'
       - '.claude/**'
-      - '.github/workflows/**'
       - 'LICENSE'
 
 concurrency:


### PR DESCRIPTION
## CI-12: Fix security.yml — scan workflow file changes

`security.yml` excluded `.github/workflows/**` from push/PR triggers.
A PR introducing a malicious workflow would bypass `detect-secrets`
and `pip-audit` scans entirely.

### Fix
Remove `.github/workflows/**` from `paths-ignore` so workflow changes
always trigger security scans.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security workflow configuration to ensure security checks execute when workflow files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->