### PR TITLE
fix(ci): propagate exit code in performance degradation gate

### DIFF
--- a/.github/workflows/performance-nightly.yml
+++ b/.github/workflows/performance-nightly.yml
@@ -61,14 +61,13 @@ jobs:
         if: always()
         run: |
           if [ -f reports/performance/hotspot-degradation.json ]; then
-            failed=$(python3 -c "
+            python3 - <<'PY'
           import json, sys
           data = json.load(open('reports/performance/hotspot-degradation.json'))
           failed = data.get('summary', {}).get('failed', 0)
-          print(failed)
+          print(f'Benchmarks over budget: {failed}')
           sys.exit(1 if failed > 0 else 0)
-          ")
-            echo "Benchmarks over budget: $failed"
+          PY
           fi
 
       - name: Upload performance artifacts


### PR DESCRIPTION
## CI-07: Fix performance gate — exit code not propagated

The gate step used `failed=$(python3 -c "... sys.exit(1)")`.
`$()` captures stdout only; the Python exit code was silently discarded.
The subsequent `echo` succeeded with code 0, so the step always passed
even when benchmarks exceeded budget.

### Fix
Replace variable-capture pattern with a heredoc — Python exits directly,
propagating the non-zero code to the step.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal CI/CD workflow performance check implementation with enhanced error messaging format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->