### PR TITLE
fix(ci): remove dead paths-ignore from docker.yml triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,13 +5,6 @@ permissions:
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '.ai/**'
-      - '.claude/**'
-      - '.github/workflows/**'
-      - 'LICENSE'
     branches: [ main, master, develop ]
     paths:
       - 'Dockerfile'
@@ -19,13 +12,6 @@ on:
       - '.dockerignore'
       - 'entrypoint.sh'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '.ai/**'
-      - '.claude/**'
-      - '.github/workflows/**'
-      - 'LICENSE'
     branches: [ main, master, develop ]
     paths:
       - 'Dockerfile'


### PR DESCRIPTION
## CI-06: Fix paths/paths-ignore conflict in docker.yml

GitHub Actions silently ignores `paths-ignore` when `paths` is present
in the same trigger block. The `docker.yml` had both filters, making
`paths-ignore` a no-op while creating confusion.

### Fix
Remove `paths-ignore` from `push` and `pull_request` triggers.
The `paths` filter already restricts the workflow to Docker-related files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker workflow configuration to run on all relevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->