### PR TITLE
fix(ci): upgrade upload-artifact@v3 → @v4 (blocks contract governance)

### DIFF
--- a/.github/workflows/contract-governance-fast-check.yml
+++ b/.github/workflows/contract-governance-fast-check.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload diagnostics
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: contract-governance-diagnostics
           path: |


### PR DESCRIPTION
## HF-A: Upgrade upload-artifact@v3 → @v4 in contract-governance-fast-check.yml

`actions/upload-artifact@v3` was deprecated and is now automatically
rejected by GitHub Actions runners — the job fails immediately without
running any steps.

### Fix
- `actions/upload-artifact@v3` → `@v4`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow tooling to latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->