### PR TITLE
fix(ci): remove invalid --require-hashes from pip-audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,5 +52,5 @@ jobs:
           uv-extras: "dev"
 
       - name: Run pip-audit
-        run: uv run pip-audit --require-hashes --disable-pip --strict
+        run: uv run pip-audit --disable-pip --strict
 


### PR DESCRIPTION
## HF-B: Fix pip-audit invocation in security.yml

`pip-audit --require-hashes` requires `--requirement (-r)` to read hashes
from a requirements file. Without `-r`, the tool exits with code 2
(argument error) before auditing anything.

### Fix
Remove `--require-hashes` flag. The `--disable-pip` and `--strict` flags
remain; pip-audit will audit the uv-managed virtual environment directly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
