### PR TITLE
fix(ci): remove --txt-report from mypy (lxml not installed)

### DIFF
--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -48,7 +48,6 @@ jobs:
           set +e
           timeout --signal=TERM --kill-after=30s 30m \
             uv run mypy --config-file pyproject.toml --strict --no-incremental src/bioetl \
-            --txt-report reports/mypy_report \
             2>&1 | tee -a reports/mypy_strict.log
           status=${PIPESTATUS[0]}
           set -e


### PR DESCRIPTION
## HF-lxml: Fix type-checking — remove --txt-report (requires missing lxml)

`mypy --txt-report` requires the `lxml` package at runtime. `lxml` is not
listed in any `[project.optional-dependencies]` group, so it is absent from
the uv virtual environment. mypy crashes immediately with an ImportError
before type-checking a single file.

### Fix
Remove `--txt-report reports/mypy_report` from the mypy invocation.
The mypy output is already captured to `reports/mypy_strict.log` via
`tee`, so no diagnostic information is lost.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->