### PR TITLE
fix(ci): remove --disable-pip from pip-audit in security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -52,5 +52,5 @@ jobs:
           uv-extras: "dev"
 
       - name: Run pip-audit
-        run: uv run pip-audit --disable-pip --strict
+        run: uv run pip-audit --strict
 


### PR DESCRIPTION
## HF-pip-disable: Fix security.yml pip-audit — remove --disable-pip

`pip-audit --disable-pip` is only valid together with `-r requirements_file`.
Without `-r`, pip-audit exits immediately with code 2 (argument error)
before auditing anything.

### Fix
Remove `--disable-pip` flag. `uv run pip-audit --strict` audits the uv
virtual environment directly without needing a requirements file.

Also re-applies `actions/checkout@v4` (overwritten by a direct commit).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security workflow tooling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->