### PR TITLE
fix(ci): add --skip-editable to pip-audit (local package not on PyPI)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,5 +52,5 @@ jobs:
           uv-extras: "dev"
 
       - name: Run pip-audit
-        run: uv run pip-audit --strict
+        run: uv run pip-audit --strict --skip-editable
 


### PR DESCRIPTION
## HF-pip-skip-editable: Fix pip-audit — skip local editable package

`pip-audit --strict` fails with:
> `bioetl: Dependency not found on PyPI and could not be audited: bioetl (6.1.0)`

The local `bioetl` package is installed in editable mode (as a dev dependency).
pip-audit cannot find it on PyPI and exits with code 1 under `--strict`.

### Fix
Add `--skip-editable` flag so pip-audit skips locally installed editable
packages and only audits third-party dependencies fetched from PyPI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to refine the auditing process while maintaining strict security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->