### PR TITLE
fix(ci): add .mcp.json to root file allowlist

### DIFF
--- a/.github/root-allowlist.txt
+++ b/.github/root-allowlist.txt
@@ -12,6 +12,7 @@
 .gitleaks.toml
 .importlinter
 .jscpd.json
+.mcp.json
 .pre-commit-config.yaml
 .secrets.baseline
 AGENTS.md


### PR DESCRIPTION
## HF-mcp-allowlist: Add .mcp.json to root file allowlist

`.mcp.json` was added to the repository root as the GitHub Copilot CLI
MCP server configuration (mirrors `.codex/settings.json`). However,
`audit_root_cleanliness.py` enforces a strict allowlist of tracked root files
via `.github/root-allowlist.txt`, and `.mcp.json` was not in it.

This caused both Root Hygiene and Block Compiled Python Artifacts CI checks
to fail with:
> `Unexpected tracked root files: .mcp.json`

### Fix
Add `.mcp.json` to `.github/root-allowlist.txt`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration allowlist to include additional supported files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->