### PR TITLE
test(ops): keep only setup scripts and architecture assertions from #2649

### DIFF
--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -50,7 +50,7 @@ python -m scripts.ops <command> [args...]
 | `update-rescope-bodies` | When the prepared full re-scope issue bodies should replace the current descriptions for the current architecture/testing governance issues | Manual, maintainer utility |
 | `close-ge-spike` | When issue `#2595` should be closed after the spike memo is committed or ready for reference | Manual, maintainer utility |
 | `close-schema-drift` | When issue `#2594` should be closed after the representative Pandera schema drift gate is merged or ready for reference | Manual, maintainer utility |
-| `setup-agents` | After cloning repo or updating `.codex/agents/` profiles | Manual, initial setup |
+| `setup-agents` | After cloning repo or updating `.claude/agents/` profiles | Manual, initial setup |
 | `setup-plugins` | After cloning repo or updating local pytest/pre-commit tooling | Manual, initial setup |
 | `setup-skills` | After cloning repo or updating skills configuration; keeps `agents/` in sync unless `--skills-only` is passed | Manual, initial setup |
 | `check-skills` | Before PR touching `.claude/skills/`; validates layout consistency | CI gate (`skills-consistency.yml`) |

--- a/scripts/ops/setup_agents.sh
+++ b/scripts/ops/setup_agents.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-SOURCE_ROOT="$REPO_ROOT/.codex/agents"
-CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+SOURCE_ROOT="$REPO_ROOT/.claude/agents"
+CODEX_HOME="${CODEX_HOME:-$HOME/.claude}"
 DEST_ROOT="$CODEX_HOME/agents"
 DRY_RUN=false
 

--- a/scripts/ops/setup_skills.sh
+++ b/scripts/ops/setup_skills.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # setup_skills.sh - Sync repository Codex skills into CODEX_HOME.
-# By default this also syncs the paired `.codex/agents` tree because many
+# By default this also syncs the paired `.claude/agents` tree because many
 # skills resolve relative agent references through CODEX_HOME.
 # Usage:
 #   bash scripts/setup_skills.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-SOURCE_ROOT="$REPO_ROOT/.codex/skills"
-CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+SOURCE_ROOT="$REPO_ROOT/.claude/skills"
+CODEX_HOME="${CODEX_HOME:-$HOME/.claude}"
 DEST_ROOT="$CODEX_HOME/skills"
 DRY_RUN=false
 SYNC_AGENTS=true

--- a/tests/architecture/test_ops_ai_setup_scripts.py
+++ b/tests/architecture/test_ops_ai_setup_scripts.py
@@ -14,7 +14,7 @@ def _project_root() -> Path:
 def test_setup_agents_dry_run_lists_expected_agent_entries(tmp_path: Path) -> None:
     """setup_agents dry-run should enumerate the agent surface it will sync."""
     root = _project_root()
-    env = os.environ | {"CODEX_HOME": str(tmp_path / ".codex-home")}
+    env = os.environ | {"CODEX_HOME": str(tmp_path / ".claude-home")}
 
     result = subprocess.run(
         ["bash", "scripts/ops/setup_agents.sh", "--dry-run"],
@@ -28,8 +28,7 @@ def test_setup_agents_dry_run_lists_expected_agent_entries(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
     assert "Would sync:" in result.stdout
     assert "ORCHESTRATION.md" in result.stdout
-    assert "py-test-bot.md" in result.stdout
-    assert "subagents" in result.stdout
+    assert "py-test-swarm.md" in result.stdout
 
 
 def test_setup_skills_dry_run_includes_paired_agent_sync_by_default(
@@ -37,7 +36,7 @@ def test_setup_skills_dry_run_includes_paired_agent_sync_by_default(
 ) -> None:
     """setup_skills should announce paired agent sync unless disabled."""
     root = _project_root()
-    env = os.environ | {"CODEX_HOME": str(tmp_path / ".codex-home")}
+    env = os.environ | {"CODEX_HOME": str(tmp_path / ".claude-home")}
 
     result = subprocess.run(
         ["bash", "scripts/ops/setup_skills.sh", "--dry-run"],
@@ -50,9 +49,9 @@ def test_setup_skills_dry_run_includes_paired_agent_sync_by_default(
 
     assert result.returncode == 0, result.stderr
     assert "Would sync:" in result.stdout
-    assert "py-test-bot ->" in result.stdout
+    assert "test-automator.md ->" in result.stdout
     assert "would also sync paired agents" in result.stdout
-    assert "py-test-bot.md" in result.stdout
+    assert "py-test-swarm.md" in result.stdout
 
 
 def test_setup_plugins_uses_repo_root_from_ops_directory() -> None:
@@ -69,6 +68,6 @@ def test_setup_plugins_prefers_local_venv_and_windows_git_fallback() -> None:
     content = (root / "scripts/ops/setup_plugins.sh").read_text(encoding="utf-8")
 
     assert 'if [[ -x ".venv/Scripts/python.exe" ]]; then' in content
-    assert "elif command -v uv >/dev/null 2>&1; then" in content
-    assert "\\$env:Path='C:\\\\Program Files\\\\Git\\\\cmd;'+\\$env:Path" in content
+    assert 'elif command -v uv >/dev/null 2>&1; then' in content
+    assert "\\$env:Path='C:\\Program Files\\Git\\cmd;'+\\$env:Path" in content
     assert "\\$env:PRE_COMMIT_HOME=" in content


### PR DESCRIPTION
## Summary
This is a sanitized consolidation PR extracted from #2649.

Included changes only:
- `scripts/ops/README.md`
- `scripts/ops/setup_agents.sh`
- `scripts/ops/setup_skills.sh`
- `tests/architecture/test_ops_ai_setup_scripts.py`

## Excluded on purpose
Dropped unrelated and noisy changes from #2649 (local config/script deletions, dependency bumps, and misc workspace artifacts).

## Consolidation note
Supersedes #2649 and keeps its intended ops setup/test adjustments in an isolated reviewable diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup and configuration scripts to use standardized internal tooling paths.
  * Adjusted test assertions to reflect updated configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->