### PR TITLE
🧪 Add tests for ValueError path in normalize_concentrations

### DIFF
--- a/tests/unit/domain/services/test_normalization_service.py
+++ b/tests/unit/domain/services/test_normalization_service.py
@@ -204,6 +204,50 @@ class TestNormalizationServiceNormalizeConcentrations:
         assert result.is_valid is False
         assert "No concentrations" in result.validation_message
 
+    def test_normalize_concentrations_value_error_zero(
+        self, service: NormalizationService
+    ) -> None:
+        """Test normalize_concentrations with zero concentration (ValueError in pChEMBL)."""
+        concs = [Concentration(0.0, ConcentrationUnit.NANOMOLAR)]
+        # This should trigger ValueError in to_pchembl and catch it
+        result = service.normalize_concentrations(concs)
+
+        assert result.value == 0.0
+        assert result.unit == "nM"
+        assert result.pchembl is None
+        assert result.is_potent is False
+        assert result.is_valid is True
+
+    def test_normalize_concentrations_value_error_too_high(
+        self, service: NormalizationService
+    ) -> None:
+        """Test normalize_concentrations with too high concentration (ValueError in pChEMBL)."""
+        # 2M is > 1M, so pChEMBL < 0, which triggers ValueError in PChemblValue.__post_init__
+        concs = [Concentration(2.0, ConcentrationUnit.MOLAR)]
+        result = service.normalize_concentrations(concs)
+
+        # Result unit is nM by default from aggregator
+        assert result.value == pytest.approx(2e9)
+        assert result.unit == "nM"
+        assert result.pchembl is None
+        assert result.is_potent is False
+        assert result.is_valid is True
+
+    def test_normalize_concentrations_value_error_too_low(
+        self, service: NormalizationService
+    ) -> None:
+        """Test normalize_concentrations with too low concentration (ValueError in pChEMBL)."""
+        # 1e-15 M is < 1e-14 M, so pChEMBL > 14, which triggers ValueError in PChemblValue.__post_init__
+        concs = [Concentration(1e-15, ConcentrationUnit.MOLAR)]
+        result = service.normalize_concentrations(concs)
+
+        # 1e-15 M = 1e-6 nM
+        assert result.value == pytest.approx(1e-6)
+        assert result.unit == "nM"
+        assert result.pchembl is None
+        assert result.is_potent is False
+        assert result.is_valid is True
+
 
 class TestNormalizationServicePotencyMethods:
     """Tests for potency classification methods."""


### PR DESCRIPTION
This change improves the reliability and coverage of the `NormalizationService` by adding unit tests for the previously untested `ValueError` exception path in the `normalize_concentrations` method.

Three new test cases were added to `tests/unit/domain/services/test_normalization_service.py`:
1. `test_normalize_concentrations_value_error_zero`: Tests with 0.0 nM, which cannot be converted to pChEMBL.
2. `test_normalize_concentrations_value_error_too_high`: Tests with 2.0 M, which results in a negative pChEMBL value (invalid).
3. `test_normalize_concentrations_value_error_too_low`: Tests with 1e-15 M, which results in a pChEMBL value > 14 (invalid).

The tests verify that in these cases, the service returns a `NormalizationResult` with `pchembl=None` and `is_potent=False`, as intended by the production code.

---
*PR created automatically by Jules for task [13101571771386145486](https://jules.google.com/task/13101571771386145486) started by @SatoryKono*