### PR TITLE
⚡ Bolt: [performance improvement] Hoist redundant column extractions in group loops

### DIFF
--- a/src/bioetl/application/composite/column_orderer.py
+++ b/src/bioetl/application/composite/column_orderer.py
@@ -113,13 +113,15 @@ def collect_explicit_group_columns(
     ordered: list[str] = []
     used: set[str] = set()
 
+    extracted_fields = {col: extract_field_fn(col) for col in available}
+
     for field_name in group.fields:
         field_matches: list[str] = []
         aliases = resolve_aliases_fn(field_name)
         for column in available:
             if column in used:
                 continue
-            extracted = extract_field_fn(column)
+            extracted = extracted_fields[column]
             if extracted in aliases or column in aliases:
                 field_matches.append(column)
                 used.add(column)

--- a/src/bioetl/application/composite/column_service.py
+++ b/src/bioetl/application/composite/column_service.py
@@ -123,13 +123,15 @@ def collect_explicit_group_columns(
     ordered: list[str] = []
     used: set[str] = set()
 
+    extracted_fields = {col: extract_field_fn(col) for col in available}
+
     for field_name in group.fields:
         field_matches: list[str] = []
         aliases = resolve_aliases_fn(field_name)
         for column in available:
             if column in used:
                 continue
-            extracted = extract_field_fn(column)
+            extracted = extracted_fields[column]
             if extracted in aliases or column in aliases:
                 field_matches.append(column)
                 used.add(column)


### PR DESCRIPTION
💡 What: Pre-computed `extract_field_fn` results into an `extracted_fields` dictionary outside the inner column extraction loop in both `column_orderer.py` and `column_service.py`.
🎯 Why: In `collect_explicit_group_columns`, the function `extract_field_fn(column)` was repeatedly called inside a nested loop for every available column, resulting in $O(N \times M)$ repeated extractions.
📊 Impact: Transforms execution time for this column extraction step from $O(N \times M)$ to $O(N)$, significantly improving performance during the schema ordering logic without mutating expected semantics.
🔬 Measurement: Run the test suites in `tests/unit/application/composite/test_column_orderer.py` and `test_merger.py` to ensure deterministic ordering is intact.
Note: Ignored unrelated linting warnings out-of-scope for this targeted optimization.

---
*PR created automatically by Jules for task [13413568324909634487](https://jules.google.com/task/13413568324909634487) started by @SatoryKono*