### PR TITLE
Define Grafana dashboard navigation contract and enforce link invariants

### DIFF
--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -1,0 +1,30 @@
+# Grafana Navigation Contract
+
+Канонический контракт навигации для shipped dashboard UIDs в `grafana/dashboards/*.json`.
+
+## Общие правила
+
+- Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
+- Cross-dashboard handoff передаёт только target-scoped `var-*` параметры.
+- `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range (`${__url_time_range}` либо `from=${__from}&to=${__to}`).
+- Explore handoff для Loki/Tempo ведёт только через drilldown-приложения:
+  - Logs: `/a/grafana-lokiexplore-app/explore?...`
+  - Traces: `/a/grafana-exploretraces-app/?...`
+
+## Обязательные блоки по UID
+
+| Dashboard UID | Обязательные top-level links | Обязательные `var-*` в cross-links |
+|---|---|---|
+| `bioetl-overview-v2` | `2. Runtime`, `Control Plane v1`, `3. Provider Health`, `4. Data Quality`, `6. Workflow Overview`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Runtime/ControlPlane/DQ: `var-pipeline`, `var-run_type`; Provider/Workflow: без `var-*` |
+| `bioetl-runtime` | `Back to Overview`, `Control Plane v1`, `3. Provider Health`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/ControlPlane: `var-pipeline`, `var-run_type`; DQ: `var-pipeline`, `var-run_type`, `var-stage`; Provider: без `var-*` |
+| `bioetl-control-plane-v1` | `Back to Overview`, `2. Runtime`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/Runtime/DQ: `var-pipeline`, `var-run_type` |
+| `bioetl-provider-health-v2` | `Back to Overview`, `2. Runtime`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | cross-dashboard `var-*` не передаются |
+| `bioetl-dq-v2` | `Back to Overview`, `Control Plane v1`, `5. Silver Reject Explorer`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/ControlPlane/Explorer: `var-pipeline`, `var-run_type` |
+| `bioetl-silver-reject-explorer` | `Back to Overview`, `Back to Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/DQ: `var-pipeline`, `var-run_type` |
+| `bioetl-workflow-overview` | `Back to Overview`, `2. Runtime`, `Control Plane v1` | cross-dashboard `var-*` не передаются |
+
+## Запрещённые handoff-паттерны
+
+- `includeVars=true`
+- legacy Explore payload route: `/explore?left=`
+- перенос Explorer-only forensic scope (`var-run_id`, `var-payload_hash`) в non-explorer dashboards

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -1,674 +1,674 @@
 {
-    "annotations": {
-        "list": [
-            {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Record-level explorer for Silver filtered_out rows (quarantine-backed, read-only, single-pipeline scoped)",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Back to Overview",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Back to Data Quality",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "logs",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Explore Logs (Loki, tracing profile)",
+      "tooltip": "",
+      "type": "link",
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+    },
+    {
+      "asDropdown": false,
+      "icon": "share-alt",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Explore Traces (Tempo, tracing profile)",
+      "tooltip": "",
+      "type": "link",
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+    }
+  ],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><small>Select exactly one pipeline. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
+        "mode": "html"
+      },
+      "title": "Scope",
+      "type": "text"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "bronze_records": true,
+              "by_field": true,
+              "by_reason_code": true,
+              "by_reason_signature": true,
+              "reject_ratio": true
+            },
+            "indexByName": {
+              "total": 0
+            },
+            "renameByName": {
+              "total": "filtered_records_total"
             }
-        ]
+          }
+        }
+      ],
+      "targets": [
+        {
+          "format": "table",
+          "json_options": {
+            "root_is_not_array": true
+          },
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "$",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Filtered Records Total",
+      "type": "table"
     },
-    "description": "Record-level explorer for Silver filtered_out rows (quarantine-backed, read-only, single-pipeline scoped)",
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 1,
-    "id": null,
-    "links": [
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "tags": [],
-            "targetBlank": false,
-            "title": "Back to Overview",
-            "tooltip": "",
-            "type": "link",
-            "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
         },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reject_ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 4
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 3
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
         {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "tags": [],
-            "targetBlank": false,
-            "title": "Back to Data Quality",
-            "tooltip": "",
-            "type": "link",
-            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "logs",
-            "includeVars": false,
-            "keepTime": true,
-            "tags": [],
-            "targetBlank": false,
-            "title": "Open Logs (Loki, tracing profile)",
-            "tooltip": "",
-            "type": "link",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-        },
-        {
-            "asDropdown": false,
-            "icon": "share-alt",
-            "includeVars": false,
-            "keepTime": true,
-            "tags": [],
-            "targetBlank": false,
-            "title": "Open Traces (Tempo, tracing profile)",
-            "tooltip": "",
-            "type": "link",
-            "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
-        }
-    ],
-    "panels": [
-        {
-            "gridPos": {
-                "h": 3,
-                "w": 24,
-                "x": 0,
-                "y": 0
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "by_field": true,
+              "by_reason_code": true,
+              "by_reason_signature": true
             },
-            "id": 1,
-            "options": {
-                "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><small>Select exactly one pipeline. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
-                "mode": "html"
+            "indexByName": {
+              "reject_ratio": 0,
+              "bronze_records": 1,
+              "total": 2
             },
-            "title": "Scope",
-            "type": "text"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 7,
-                "w": 8,
-                "x": 0,
-                "y": 3
-            },
-            "id": 2,
-            "options": {
-                "showHeader": true
-            },
-            "transformations": [
-                {
-                    "id": "organize",
-                    "options": {
-                        "excludeByName": {
-                            "bronze_records": true,
-                            "by_field": true,
-                            "by_reason_code": true,
-                            "by_reason_signature": true,
-                            "reject_ratio": true
-                        },
-                        "indexByName": {
-                            "total": 0
-                        },
-                        "renameByName": {
-                            "total": "filtered_records_total"
-                        }
-                    }
-                }
-            ],
-            "targets": [
-                {
-                    "format": "table",
-                    "json_options": {
-                        "root_is_not_array": true
-                    },
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "$",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Filtered Records Total",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": [
-                    {
-                        "matcher": {
-                            "id": "byName",
-                            "options": "reject_ratio"
-                        },
-                        "properties": [
-                            {
-                                "id": "unit",
-                                "value": "percentunit"
-                            },
-                            {
-                                "id": "decimals",
-                                "value": 4
-                            }
-                        ]
-                    }
-                ]
-            },
-            "gridPos": {
-                "h": 7,
-                "w": 8,
-                "x": 8,
-                "y": 3
-            },
-            "id": 3,
-            "options": {
-                "showHeader": true
-            },
-            "transformations": [
-                {
-                    "id": "organize",
-                    "options": {
-                        "excludeByName": {
-                            "by_field": true,
-                            "by_reason_code": true,
-                            "by_reason_signature": true
-                        },
-                        "indexByName": {
-                            "reject_ratio": 0,
-                            "bronze_records": 1,
-                            "total": 2
-                        },
-                        "renameByName": {
-                            "reject_ratio": "reject_rate_vs_bronze"
-                        }
-                    }
-                }
-            ],
-            "targets": [
-                {
-                    "format": "table",
-                    "json_options": {
-                        "root_is_not_array": true
-                    },
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "$",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Reject Rate vs Bronze",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 7,
-                "w": 8,
-                "x": 16,
-                "y": 3
-            },
-            "id": 4,
-            "options": {
-                "showHeader": true
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "json_options": {
-                        "root_is_not_array": true
-                    },
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "$",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Run Scope Summary",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 8,
-                "x": 0,
-                "y": 10
-            },
-            "id": 5,
-            "options": {
-                "showHeader": true
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "by_reason_code",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Top Reject Reasons",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 8,
-                "x": 8,
-                "y": 10
-            },
-            "id": 6,
-            "options": {
-                "showHeader": true
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "by_field",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Top Reject Fields",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 8,
-                "w": 8,
-                "x": 16,
-                "y": 10
-            },
-            "id": 7,
-            "options": {
-                "showHeader": true
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "by_reason_signature",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "title": "Top Reason Signatures",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "links": [
-                        {
-                            "title": "Open same dashboard with this payload_hash",
-                            "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=${__data.fields.pipeline}&var-run_type=${__data.fields.run_type}&var-reason_code=${__data.fields.reason_code}&var-field=${__data.fields.field}&var-run_id=${__data.fields.run_id}&var-payload_hash=${__data.fields.payload_hash}&${__url_time_range}"
-                        },
-                        {
-                            "title": "Open quarantine CLI command",
-                            "url": "data:text/plain,bioetl%20quarantine%20inspect%20--pipeline%20${__data.fields.pipeline}%20--silver-filter-only%20--run-id%20${__data.fields.run_id}%20--limit%20200"
-                        },
-                        {
-                            "title": "Open Logs",
-                            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 12,
-                "w": 24,
-                "x": 0,
-                "y": 18
-            },
-            "id": 8,
-            "options": {
-                "showHeader": true,
-                "sortBy": [
-                    {
-                        "desc": true,
-                        "displayName": "ingestion_ts"
-                    }
-                ]
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "items",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-records?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}&limit=100&offset=0&sort=ingestion_ts_desc",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "description": "Shows latest 100 records for selected scope, sorted by ingestion_ts descending.",
-            "title": "Filtered Records Table",
-            "type": "table"
-        },
-        {
-            "datasource": "Quarantine Explorer",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 10,
-                "w": 24,
-                "x": 0,
-                "y": 30
-            },
-            "id": 9,
-            "options": {
-                "showHeader": true
-            },
-            "targets": [
-                {
-                    "format": "table",
-                    "parser": "backend",
-                    "refId": "A",
-                    "root_selector": "items",
-                    "source": "url",
-                    "type": "json",
-                    "url": "/ops/quarantine/filtered-records?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&payload_hash=${payload_hash}&from=${__from:date:iso}&to=${__to:date:iso}&limit=1&offset=0&sort=ingestion_ts_desc",
-                    "url_options": {
-                        "data": "",
-                        "method": "GET"
-                    },
-                    "expr": ""
-                }
-            ],
-            "description": "Select a row or set payload_hash to inspect one specific record.",
-            "title": "Selected Record Details",
-            "type": "table"
-        }
-    ],
-    "refresh": "1m",
-    "schemaVersion": 30,
-    "style": "dark",
-    "tags": [
-        "bioetl",
-        "quarantine",
-        "silver",
-        "filtered-out",
-        "explorer"
-    ],
-    "templating": {
-        "list": [
-            {
-                "allValue": null,
-                "current": {},
-                "datasource": "Prometheus",
-                "definition": "label_values(bioetl_records_processed_total, pipeline)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Pipeline",
-                "multi": false,
-                "name": "pipeline",
-                "options": [],
-                "query": {
-                    "query": "label_values(bioetl_records_processed_total, pipeline)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": null,
-                "current": {},
-                "datasource": "Quarantine Explorer",
-                "definition": "/ops/quarantine/filter-options?dimension=run_type&pipeline=${pipeline}",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Run Type",
-                "multi": true,
-                "name": "run_type",
-                "options": [],
-                "query": {
-                    "infinityQuery": {
-                        "type": "json",
-                        "source": "url",
-                        "url": "/ops/quarantine/filter-options?dimension=run_type&pipeline=${pipeline}"
-                    }
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": null,
-                "current": {},
-                "datasource": "Quarantine Explorer",
-                "definition": "/ops/quarantine/filter-options?dimension=reason_code&pipeline=${pipeline}&run_type=${run_type:csv}",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Reason Code",
-                "multi": true,
-                "name": "reason_code",
-                "options": [],
-                "query": {
-                    "infinityQuery": {
-                        "type": "json",
-                        "source": "url",
-                        "url": "/ops/quarantine/filter-options?dimension=reason_code&pipeline=${pipeline}&run_type=${run_type:csv}"
-                    }
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": null,
-                "current": {},
-                "datasource": "Quarantine Explorer",
-                "definition": "/ops/quarantine/filter-options?dimension=field&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Field",
-                "multi": true,
-                "name": "field",
-                "options": [],
-                "query": {
-                    "infinityQuery": {
-                        "type": "json",
-                        "source": "url",
-                        "url": "/ops/quarantine/filter-options?dimension=field&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}"
-                    }
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": null,
-                "current": {},
-                "datasource": "Quarantine Explorer",
-                "definition": "/ops/quarantine/filter-options?dimension=run_id&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Run ID",
-                "multi": false,
-                "name": "run_id",
-                "options": [],
-                "query": {
-                    "infinityQuery": {
-                        "type": "json",
-                        "source": "url",
-                        "url": "/ops/quarantine/filter-options?dimension=run_id&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}"
-                    }
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "current": {
-                    "selected": false,
-                    "text": "",
-                    "value": ""
-                },
-                "hide": 0,
-                "label": "Payload Hash",
-                "name": "payload_hash",
-                "options": [],
-                "query": "",
-                "skipUrlSync": false,
-                "type": "textbox"
+            "renameByName": {
+              "reject_ratio": "reject_rate_vs_bronze"
             }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "format": "table",
+          "json_options": {
+            "root_is_not_array": true
+          },
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "$",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Reject Rate vs Bronze",
+      "type": "table"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "json_options": {
+            "root_is_not_array": true
+          },
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "$",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Run Scope Summary",
+      "type": "table"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 5,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "by_reason_code",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Top Reject Reasons",
+      "type": "table"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "by_field",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Top Reject Fields",
+      "type": "table"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "by_reason_signature",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-stats?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "title": "Top Reason Signatures",
+      "type": "table"
+    },
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "links": [
+            {
+              "title": "Open same dashboard with this payload_hash",
+              "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=${__data.fields.pipeline}&var-run_type=${__data.fields.run_type}&var-reason_code=${__data.fields.reason_code}&var-field=${__data.fields.field}&var-run_id=${__data.fields.run_id}&var-payload_hash=${__data.fields.payload_hash}&${__url_time_range}"
+            },
+            {
+              "title": "Open quarantine CLI command",
+              "url": "data:text/plain,bioetl%20quarantine%20inspect%20--pipeline%20${__data.fields.pipeline}%20--silver-filter-only%20--run-id%20${__data.fields.run_id}%20--limit%20200"
+            },
+            {
+              "title": "Open Logs",
+              "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "ingestion_ts"
+          }
         ]
+      },
+      "targets": [
+        {
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-records?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&from=${__from:date:iso}&to=${__to:date:iso}&limit=100&offset=0&sort=ingestion_ts_desc",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "description": "Shows latest 100 records for selected scope, sorted by ingestion_ts descending.",
+      "title": "Filtered Records Table",
+      "type": "table"
     },
-    "time": {
-        "from": "now-24h",
-        "to": "now"
-    },
-    "timepicker": {
-        "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-        ]
-    },
-    "timezone": "",
-    "title": "5. Silver Reject Explorer",
-    "uid": "bioetl-silver-reject-explorer",
-    "version": 1000
+    {
+      "datasource": "Quarantine Explorer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 9,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "/ops/quarantine/filtered-records?pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}&run_id=${run_id}&payload_hash=${payload_hash}&from=${__from:date:iso}&to=${__to:date:iso}&limit=1&offset=0&sort=ingestion_ts_desc",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          },
+          "expr": ""
+        }
+      ],
+      "description": "Select a row or set payload_hash to inspect one specific record.",
+      "title": "Selected Record Details",
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [
+    "bioetl",
+    "quarantine",
+    "silver",
+    "filtered-out",
+    "explorer"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(bioetl_records_processed_total, pipeline)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pipeline",
+        "multi": false,
+        "name": "pipeline",
+        "options": [],
+        "query": {
+          "query": "label_values(bioetl_records_processed_total, pipeline)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Quarantine Explorer",
+        "definition": "/ops/quarantine/filter-options?dimension=run_type&pipeline=${pipeline}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Run Type",
+        "multi": true,
+        "name": "run_type",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "type": "json",
+            "source": "url",
+            "url": "/ops/quarantine/filter-options?dimension=run_type&pipeline=${pipeline}"
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Quarantine Explorer",
+        "definition": "/ops/quarantine/filter-options?dimension=reason_code&pipeline=${pipeline}&run_type=${run_type:csv}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Reason Code",
+        "multi": true,
+        "name": "reason_code",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "type": "json",
+            "source": "url",
+            "url": "/ops/quarantine/filter-options?dimension=reason_code&pipeline=${pipeline}&run_type=${run_type:csv}"
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Quarantine Explorer",
+        "definition": "/ops/quarantine/filter-options?dimension=field&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Field",
+        "multi": true,
+        "name": "field",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "type": "json",
+            "source": "url",
+            "url": "/ops/quarantine/filter-options?dimension=field&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}"
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Quarantine Explorer",
+        "definition": "/ops/quarantine/filter-options?dimension=run_id&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Run ID",
+        "multi": false,
+        "name": "run_id",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "type": "json",
+            "source": "url",
+            "url": "/ops/quarantine/filter-options?dimension=run_id&pipeline=${pipeline}&run_type=${run_type:csv}&reason_code=${reason_code:csv}&field=${field:csv}"
+          }
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Payload Hash",
+        "name": "payload_hash",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "5. Silver Reject Explorer",
+  "uid": "bioetl-silver-reject-explorer",
+  "version": 1000
 }

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -30,6 +30,68 @@ _ALLOWED_DASHBOARD_LINK_VARS = {
 }
 
 
+_REQUIRED_TOP_LEVEL_LINKS_BY_UID = {
+    "bioetl-overview-v2": frozenset(
+        {
+            "2. Runtime",
+            "Control Plane v1",
+            "3. Provider Health",
+            "4. Data Quality",
+            "6. Workflow Overview",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-runtime": frozenset(
+        {
+            "Back to Overview",
+            "Control Plane v1",
+            "3. Provider Health",
+            "4. Data Quality",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-control-plane-v1": frozenset(
+        {
+            "Back to Overview",
+            "2. Runtime",
+            "4. Data Quality",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-provider-health-v2": frozenset(
+        {
+            "Back to Overview",
+            "2. Runtime",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-dq-v2": frozenset(
+        {
+            "Back to Overview",
+            "Control Plane v1",
+            "5. Silver Reject Explorer",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-silver-reject-explorer": frozenset(
+        {
+            "Back to Overview",
+            "Back to Data Quality",
+            "Explore Logs (Loki, tracing profile)",
+            "Explore Traces (Tempo, tracing profile)",
+        }
+    ),
+    "bioetl-workflow-overview": frozenset(
+        {"Back to Overview", "2. Runtime", "Control Plane v1"}
+    ),
+}
+
+
 def _extract_dashboard_uid(url: str) -> str | None:
     match = _DASHBOARD_UID_RE.match(url)
     return match.group(1) if match is not None else None
@@ -153,6 +215,46 @@ def test_cross_dashboard_links_pass_only_target_scoped_variables() -> None:
                 )
 
 
+
+
+def test_dashboard_top_level_navigation_contract_by_uid() -> None:
+    """Each dashboard UID must expose required top-level navigation links."""
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        uid = dashboard.get("uid")
+        assert isinstance(uid, str), f"{dashboard_path.name} must declare string uid"
+
+        required_links = _REQUIRED_TOP_LEVEL_LINKS_BY_UID.get(uid)
+        assert required_links is not None, f"Unknown dashboard uid in contract: {uid}"
+
+        titles = {
+            link.get("title")
+            for link in dashboard.get("links", [])
+            if isinstance(link.get("title"), str)
+        }
+        missing = required_links - titles
+        assert not missing, (
+            f"{dashboard_path.name} ({uid}) is missing required top-level links: "
+            f"{sorted(missing)}"
+        )
+
+
+def test_dashboard_links_forbid_universal_handoff_patterns() -> None:
+    """Dashboard links must avoid generic includeVars and legacy Explore payloads."""
+    forbidden_tokens = ("includeVars=true", "/explore?left=")
+
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        for link in _collect_dashboard_links(dashboard):
+            url = str(link.get("url", ""))
+            assert not any(token in url for token in forbidden_tokens), (
+                f"{dashboard_path.name} link uses forbidden universal handoff pattern: {url}"
+            )
+
+            if url.startswith("/d/") and link in dashboard.get("links", []):
+                assert link.get("includeVars") is False, (
+                    f"{dashboard_path.name} top-level cross-dashboard link must pin includeVars=false: {url}"
+                )
 def test_overview_and_provider_dashboards_expose_explore_drilldown_links() -> None:
     """Operational dashboards should offer Loki and Tempo drilldown."""
     expectations = (


### PR DESCRIPTION
### Motivation

- Provide a canonical navigation contract for shipped Grafana dashboards to standardize operator drilldowns and cross-dashboard handoffs.
- Prevent unsafe variable leakage and legacy Explore payload patterns (`includeVars=true`, `/explore?left=`) that can expose high-cardinality or forensic scope outside the record-level explorer.
- Align the Silver Reject Explorer JSON with the new contract so explorer handoffs and titles are consistent.

### Description

- Added the navigation contract document `docs/03-guides/dashboards/navigation-contract.md` defining required top-level links per UID, allowed `var-*` parameters, and forbidden universal handoff patterns.
- Extended `tests/integration/test_grafana_dashboard_links.py` with `_REQUIRED_TOP_LEVEL_LINKS_BY_UID` and two tests: `test_dashboard_top_level_navigation_contract_by_uid` and `test_dashboard_links_forbid_universal_handoff_patterns` to enforce required links and to forbid `includeVars=true` and legacy Explore payloads; also tightened `includeVars=false` checks to only top-level cross-dashboard links.
- Normalized and refactored `grafana/dashboards/bioetl-silver-reject-explorer.json` link block to use canonical titles (`Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)`), ensured `includeVars=false`, and cleaned panels/targets for consistent structure.

### Testing

- Ran `bash scripts/engineering/dev/run_pytest.sh tests/integration/test_grafana_dashboard_links.py -q`; initial test run failed on an assertion for a missing `includeVars` key which was then fixed, and the follow-up full run completed with all tests in that file passing.
- No other automated test suites were modified; the change was limited to the dashboards doc, one dashboard JSON, and the dashboard-links integration tests.
- Attempted to run `python -m memory.tooling.workflow pre-task` and `post-task` for pre/post-change validation but the `memory` module is not available in this environment, so those workflow checks were skipped (ModuleNotFoundError).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78f34efb08324bd581325c214ffcb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->