### PR TITLE
Add dashboard inventory parity report and CI check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,9 @@ jobs:
             --json-out reports/quality/xwalk-missing-backlog.json \
             --markdown-out reports/quality/xwalk-missing-backlog.md
 
+      - name: Check dashboard inventory parity
+        run: uv run python -m scripts.engineering.qa report-dashboard-inventory --check --json
+
   validate-mkdocs:
     needs: docs-governance
     runs-on: ubuntu-latest

--- a/docs/03-guides/dashboards/README.md
+++ b/docs/03-guides/dashboards/README.md
@@ -59,3 +59,22 @@ documented as blind spots until instrumentation exists.
 Архивные материалы перемещены в `docs/03-guides/dashboards/legacy/`.
 
 Они могут содержать устаревшие переменные (`$run-id`, `execution`) и старые формулы.
+
+
+## Regenerate and verify parity
+
+Для регенерации инвентаризации dashboard metadata (UID/title/variables/links/tags):
+
+```bash
+uv run python -m scripts.engineering.qa report-dashboard-inventory --json
+```
+
+Для проверки parity с каноническими документами (`variables-guide.md`, `monitoring-index.md`)
+и mandatory links contract:
+
+```bash
+uv run python -m scripts.engineering.qa report-dashboard-inventory --check --json
+```
+
+CI gate запускает эту проверку в `docs.yml` и фейлит pipeline при расхождении
+канонических полей.

--- a/scripts/engineering/qa/__main__.py
+++ b/scripts/engineering/qa/__main__.py
@@ -35,6 +35,7 @@ Commands:
     summarize-junit      Aggregate existing JUnit XML into test-health JSON
     test-health          Summarize recent test-health run JSON artifacts
     check-dashboard-visual-semantics Validate Grafana status-panel visual semantic invariants
+    report-dashboard-inventory Generate/check dashboard inventory parity (UID/variables/links)
 """
 
 from __future__ import annotations
@@ -75,6 +76,7 @@ COMMAND_SPECS = {
     "summarize-junit": python_command(_TEST_HEALTH_SCRIPT, "summarize-junit"),
     "test-health": python_command(_TEST_HEALTH_SCRIPT, "test-health"),
     "check-dashboard-visual-semantics": "check_dashboard_visual_semantics.py",
+    "report-dashboard-inventory": "report_dashboard_inventory.py",
 }
 COMMAND_SPECS = {
     name: spec if hasattr(spec, "runner") else python_command(spec)

--- a/scripts/engineering/qa/report_dashboard_inventory.py
+++ b/scripts/engineering/qa/report_dashboard_inventory.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Generate dashboard inventory and verify docs parity for canonical fields."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+DASHBOARDS_DIR = Path("grafana/dashboards")
+VARIABLES_GUIDE = Path("docs/03-guides/dashboards/variables-guide.md")
+MONITORING_INDEX = Path("docs/03-guides/dashboards/monitoring-index.md")
+
+MANDATORY_LINK_UIDS: dict[str, set[str]] = {
+    "bioetl-overview-v2": {
+        "bioetl-runtime",
+        "bioetl-provider-health-v2",
+        "bioetl-dq-v2",
+        "bioetl-control-plane-v1",
+        "bioetl-workflow-overview",
+    },
+    "bioetl-runtime": {"bioetl-overview-v2", "bioetl-dq-v2", "bioetl-control-plane-v1"},
+    "bioetl-provider-health-v2": {"bioetl-overview-v2", "bioetl-runtime"},
+    "bioetl-dq-v2": {"bioetl-overview-v2", "bioetl-silver-reject-explorer"},
+    "bioetl-workflow-overview": {"bioetl-overview-v2", "bioetl-runtime", "bioetl-control-plane-v1"},
+}
+
+
+def _extract_variables(payload: dict) -> list[str]:
+    templating = payload.get("templating", {}).get("list", [])
+    names = [f"${item.get('name')}" for item in templating if item.get("name")]
+    return sorted(names)
+
+
+def _extract_link_uids(payload: dict) -> list[str]:
+    links = payload.get("links", [])
+    discovered: set[str] = set()
+    for link in links:
+        url = str(link.get("url", ""))
+        matches = re.findall(r"/d/([A-Za-z0-9\-_]+)", url)
+        discovered.update(matches)
+    return sorted(discovered)
+
+
+def _load_inventory() -> list[dict[str, object]]:
+    inventory: list[dict[str, object]] = []
+    for path in sorted(DASHBOARDS_DIR.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        inventory.append(
+            {
+                "file": str(path),
+                "uid": payload.get("uid"),
+                "title": payload.get("title"),
+                "variables": _extract_variables(payload),
+                "link_uids": _extract_link_uids(payload),
+                "tags": sorted(payload.get("tags", [])),
+            }
+        )
+    return inventory
+
+
+def _parse_variables_guide(text: str) -> dict[str, list[str]]:
+    mapping: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        if not line.startswith("| `bioetl-"):
+            continue
+        parts = [part.strip() for part in line.strip("|").split("|")]
+        if len(parts) < 2:
+            continue
+        uid = parts[0].strip("`")
+        variables = sorted(re.findall(r"\$[A-Za-z0-9_]+", parts[1]))
+        mapping[uid] = variables
+    return mapping
+
+
+def _check_parity(inventory: list[dict[str, object]]) -> list[str]:
+    errors: list[str] = []
+    vars_text = VARIABLES_GUIDE.read_text(encoding="utf-8")
+    idx_text = MONITORING_INDEX.read_text(encoding="utf-8")
+    vars_map = _parse_variables_guide(vars_text)
+
+    for item in inventory:
+        uid = str(item["uid"])
+        vars_actual = list(item["variables"])
+        doc_vars = vars_map.get(uid)
+        if doc_vars is None:
+            errors.append(f"variables-guide: missing UID row for {uid}")
+        elif doc_vars != vars_actual:
+            errors.append(f"variables-guide: variables mismatch for {uid}: doc={doc_vars} actual={vars_actual}")
+
+        if uid not in idx_text:
+            errors.append(f"monitoring-index: missing UID mention for {uid}")
+
+        expected_links = MANDATORY_LINK_UIDS.get(uid)
+        if expected_links:
+            actual_links = set(item["link_uids"])
+            missing = sorted(expected_links - actual_links)
+            if missing:
+                errors.append(f"mandatory links: {uid} missing links to {missing}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--check", action="store_true", help="Fail on canonical parity mismatches")
+    args = parser.parse_args()
+
+    inventory = _load_inventory()
+    if args.json:
+        print(json.dumps(inventory, ensure_ascii=False, indent=2))
+    else:
+        for item in inventory:
+            print(f"{item['uid']}: {item['title']} vars={item['variables']} links={item['link_uids']} tags={item['tags']}")
+
+    if args.check:
+        errors = _check_parity(inventory)
+        if errors:
+            print("\nDashboard inventory parity check failed:")
+            for error in errors:
+                print(f"- {error}")
+            return 1
+        print("\nDashboard inventory parity check passed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure Grafana dashboard JSON (`grafana/dashboards/*.json`) stays in parity with canonical docs for variables, UID presence and required navigation links. 
- Provide a repeatable script to regenerate inventory and fail CI when canonical fields diverge. 

### Description
- Added a new QA script `scripts/engineering/qa/report_dashboard_inventory.py` that extracts `uid`, `title`, `variables`, `link_uids` and `tags` from shipped dashboard JSON and supports `--json` and `--check` modes. 
- The `--check` mode validates parity against `docs/03-guides/dashboards/variables-guide.md`, verifies UID mentions in `docs/03-guides/dashboards/monitoring-index.md`, and enforces a small `MANDATORY_LINK_UIDS` contract for cross-dashboard navigation. 
- Registered the new command in the unified CLI `python -m scripts.engineering.qa` as `report-dashboard-inventory`. 
- Added a docs CI gate in `.github/workflows/docs.yml` to run `uv run python -m scripts.engineering.qa report-dashboard-inventory --check --json` and updated `docs/03-guides/dashboards/README.md` with regeneration/verification instructions. 

### Testing
- Ran `python scripts/engineering/qa/report_dashboard_inventory.py --check --json` locally which emitted the inventory JSON and reported "Dashboard inventory parity check passed." (success). 
- Confirmed the command is wired into the QA CLI via `python -m scripts.engineering.qa --help` and observed `report-dashboard-inventory` in the help output (success). 
- Attempted to run the recommended memory pre-task `python -m memory.tooling.workflow pre-task ...` but the local environment lacks the `memory` module resulting in `ModuleNotFoundError`, so verification used direct repository files instead (observed and recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f790a349c883249d724f092fc73797)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->