### PR TITLE
Unify Grafana variable contract and enforce handoff rules

### DIFF
--- a/docs/03-guides/dashboards/variables-guide.md
+++ b/docs/03-guides/dashboards/variables-guide.md
@@ -1,85 +1,65 @@
 ______________________________________________________________________
 
-Version: 1.0.0
+Version: 1.1.0
 Status: active
 Class: published
 Owner: BioETL Team
 Reviewers:
 
 - BioETL Team
-  Last verified: '2026-03-29'
+  Last verified: '2026-05-03'
 
 ______________________________________________________________________
 
 # Variables Guide (Grafana Dashboards)
 
-Дата сверки: **2026-03-29**
+Дата сверки: **2026-05-03**  
 Источник истины: `grafana/dashboards/*.json`
 
-## Переменные по дашбордам
+## Unified Variable Contract
 
-| Dashboard UID                    | Переменные                                             |
-| -------------------------------- | ------------------------------------------------------ |
-| `bioetl-overview-v2`             | `$pipeline`, `$run_type`                               |
-| `bioetl-control-plane-v1`        | `$pipeline`, `$run_type`                               |
-| `bioetl-dq-v2`                   | `$pipeline`, `$run_type`, `$stage`                     |
-| `bioetl-runtime`                 | `$pipeline`, `$run_type`, `$stage`                     |
-| `bioetl-provider-health-v2`      | `$provider`, `$adapter`                                |
-| `bioetl-silver-reject-explorer`  | `$pipeline`, `$run_type`, `$reason_code`, `$field`, `$run_id`, `$payload_hash` |
-| `bioetl-workflow-overview`       | `$workflow`, `$status`                                 |
+### Scope groups
 
-## Определения переменных
+- **Core scope**: `pipeline`, `run_type`, `stage` (где есть stage-level панели).
+- **Provider scope**: `provider`, `adapter` (только provider health dashboards).
+- **Forensic-only**: `run_id`, `payload_hash` (только `bioetl-silver-reject-explorer`).
 
-| Variable    | Query                                                                                           | Multi | Include All | Refresh                 |
-| ----------- | ----------------------------------------------------------------------------------------------- | ----- | ----------- | ----------------------- |
-| `$pipeline` | `label_values(bioetl_records_processed_total, pipeline)`                                        | Yes   | Yes         | On dashboard load (`1`) |
-| `$run_type` | `label_values(bioetl_records_processed_total{pipeline=~"$pipeline"}, run_type)`                 | Yes   | Yes         | On dashboard load (`1`) |
-| `$stage`    | `label_values(bioetl_records_processed_total{pipeline=~"$pipeline",run_type=~"$run_type"}, stage)` | Yes | Yes | On dashboard load (`1`) |
-| `$provider` | `label_values({__name__=~"bioetl_health_check_(success\|degraded\|failures)_total"}, provider)` | Yes   | Yes         | On dashboard load (`1`) |
-| `$adapter`  | `label_values(bioetl_circuit_breaker_state, adapter)`                                           | Yes   | Yes         | On dashboard load (`1`) |
-| `control_plane.$pipeline` | `label_values(bioetl_control_plane_manifest_writes_total, pipeline)`             | Yes   | Yes         | On dashboard load (`1`) |
-| `workflow.$workflow` | `label_values(bioetl_workflow_runs_total, workflow)`                               | Yes   | Yes         | On dashboard load (`1`) |
-| `workflow.$status` | `label_values(bioetl_workflow_runs_total, status)`                                   | Yes   | Yes         | On dashboard load (`1`) |
-| `explorer.$pipeline` | `label_values(bioetl_records_processed_total, pipeline)` | No | No | On dashboard load (`1`) |
-| `explorer.$run_id` | `/ops/quarantine/filter-options?dimension=run_id&pipeline=${pipeline}...` | No | No | On dashboard load (`1`) |
-| `explorer.$payload_hash` | textbox | No | No | Manual |
+### Dashboard → scope contract
 
-## Важно
+| Dashboard UID | Contract |
+| --- | --- |
+| `bioetl-overview-v2` | Core: `pipeline`, `run_type` |
+| `bioetl-control-plane-v1` | Core: `pipeline`, `run_type` |
+| `bioetl-runtime` | Core: `pipeline`, `run_type`, `stage` |
+| `bioetl-dq-v2` | Core: `pipeline`, `run_type`, `stage` |
+| `bioetl-provider-health-v2` | Provider: `provider`, `adapter` |
+| `bioetl-silver-reject-explorer` | Core: `pipeline`, `run_type` + explorer fields `reason_code`, `field` + Forensic-only `run_id`, `payload_hash` |
+| `bioetl-workflow-overview` | Workflow-local: `workflow`, `status` |
 
-- В Prometheus-backed dashboards **нет** переменных `$run_id` и `execution`.
-- `bioetl-silver-reject-explorer` остаётся forensic exception:
-  `$run_id` и `$payload_hash` используются только в quarantine-backed Explorer,
-  а не в Prometheus labels или PromQL.
-- В `bioetl-dq-v2` и `bioetl-runtime` дополнительный bounded scope даёт `$stage`.
-- В `bioetl-provider-health-v2` используются `$provider` и `$adapter`.
-- В `bioetl-workflow-overview` используются только `$workflow` и `$status`.
-- Cross-dashboard links должны передавать только target-scoped `var-*`
-  параметры; generic `includeVars=true` не считается безопасным handoff.
+## Variable meanings and fallback semantics
 
-## Примеры PromQL с переменными
+| Variable | Scope | Meaning | Fallback when source dashboard does not pass it |
+| --- | --- | --- | --- |
+| `pipeline` | Core | Pipeline selection baseline | Target dashboard uses default **All pipelines** |
+| `run_type` | Core | Run mode within selected pipeline | Target dashboard uses **All run types** |
+| `stage` | Core | Stage breakdown filter (`bronze/silver/gold`) | Target uses **All stages** |
+| `provider` | Provider | Provider selection for provider health panels | Target uses **All providers** |
+| `adapter` | Provider | Adapter selection for provider health panels | Target uses **All adapters** |
+| `run_id` | Forensic-only | Exact run narrowing in reject explorer | No run_id filter (all runs in selected pipeline/run_type scope) |
+| `payload_hash` | Forensic-only | Exact record lookup in reject explorer textbox | Empty textbox disables payload filter |
 
-```promql
-# Overview/Data Quality/Runtime
-sum(bioetl_records_processed_total{pipeline=~"$pipeline", run_type=~"$run_type", stage="bronze"})
+## Cross-dashboard handoff rules (explicit)
 
-# Provider Health p95
-histogram_quantile(0.95, sum by (le, provider) (rate(bioetl_health_check_latency_seconds_bucket{provider=~"$provider"}[5m])))
+1. Передавать только `var-*`, которые входят в target contract.
+1. `includeVars=true` не используется для dashboard-to-dashboard ссылок.
+1. **Core → Core**: передавать `pipeline`, `run_type`; `stage` передаётся только если target поддерживает `stage`.
+1. **Core ↔ Provider**: provider dashboards не получают core variables; fallback через default provider/adapter selection.
+1. **Any → Forensic (Reject Explorer)**: допускаются только `pipeline`, `run_type`; forensic filters (`run_id`, `payload_hash`) всегда вводятся оператором вручную в explorer.
+1. **Forensic → Core**: передавать обратно только `pipeline`, `run_type`; не передавать `run_id`, `payload_hash`, `reason_code`, `field`.
+1. **Workflow dashboards** (`workflow`, `status`) изолированы; при переходах в runtime/control-plane действует fallback на defaults target dashboards.
 
-# Provider latency panel (ID 102)
-histogram_quantile(0.95, sum by (le, provider) (rate(bioetl_health_check_latency_seconds_bucket{provider=~"$provider"}[5m])))
-```
+## Test coverage expectations
 
-## Зависимости
-
-- Для `overview/dq/runtime`: `$run_type` зависит от `$pipeline`.
-- Для `dq/runtime`: `$stage` зависит от `$pipeline/$run_type` и остаётся bounded
-  stage breakdown filter, а не high-cardinality forensic selector.
-- Для `control-plane-v1`: `$run_type` зависит от `$pipeline`, но global
-  read-panels intentionally не фильтруют underlying metrics по `$pipeline`.
-- Для `provider-health-v2`: `$provider` и `$adapter` управляют timeseries и
-  summary/gauge панелями; pipeline filter не используется.
-- Для `bioetl-workflow-overview`: `$status` и `$workflow` зависят от
-  `bioetl_workflow_runs_total`; эти переменные не leaking в non-workflow dashboards.
-- Для `bioetl-silver-reject-explorer`: `$pipeline` всегда single-select/no-All.
-  Это fail-closed Quarantine Explorer contract; `${pipeline:csv}` здесь не
-  допускается.
+- Links contract: `tests/integration/test_grafana_dashboard_links.py`
+- Variable contract checks: `tests/integration/test_grafana_config.py` + `tests/integration/_grafana_test_support.py`
+- Forensic isolation checks: `run_id`/`payload_hash` запрещены вне reject explorer.

--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -2396,7 +2396,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
       },
       {
         "allValue": null,
@@ -2421,7 +2422,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -1616,7 +1616,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
       },
       {
         "allValue": null,
@@ -1641,7 +1642,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
       },
       {
         "allValue": null,
@@ -1666,7 +1668,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: stage selector (only where stage-level analysis exists); fallback: All stages for selected pipeline/run_type."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -2374,7 +2374,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
       },
       {
         "allValue": null,
@@ -2399,7 +2400,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -1333,7 +1333,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Provider scope: provider selector for provider health dashboards; fallback: All providers when source has no provider context."
       },
       {
         "allValue": null,
@@ -1358,7 +1359,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Provider scope: adapter selector for provider health dashboards; fallback: All adapters when source has no adapter context."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -2168,7 +2168,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
       },
       {
         "allValue": null,
@@ -2193,7 +2194,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
       },
       {
         "allValue": null,
@@ -2218,7 +2220,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: stage selector (only where stage-level analysis exists); fallback: All stages for selected pipeline/run_type."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -519,7 +519,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
       },
       {
         "allValue": null,
@@ -547,7 +548,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
       },
       {
         "allValue": null,
@@ -575,7 +577,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Explorer scope: reject reason selector for quarantine triage; fallback: All reason codes for selected pipeline/run_type."
       },
       {
         "allValue": null,
@@ -603,7 +606,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Explorer scope: rejected field selector for quarantine triage; fallback: All fields for selected pipeline/run_type."
       },
       {
         "allValue": null,
@@ -631,7 +635,8 @@
         "tags": [],
         "tagsQuery": "",
         "type": "query",
-        "useTags": false
+        "useTags": false,
+        "description": "Forensic-only: exact run identifier for reject explorer; fallback: no run_id filter (all runs in current scope)."
       },
       {
         "current": {
@@ -645,7 +650,8 @@
         "options": [],
         "query": "",
         "skipUrlSync": false,
-        "type": "textbox"
+        "type": "textbox",
+        "description": "Forensic-only: exact payload hash textbox for reject explorer; fallback: empty value disables record details filter."
       }
     ]
   },

--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -334,7 +334,8 @@
         "refresh": 1,
         "regex": "",
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "description": "Workflow scope: workflow selector for workflow dashboards; fallback: All workflows."
       },
       {
         "current": {
@@ -357,7 +358,8 @@
         "refresh": 1,
         "regex": "",
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "description": "Workflow scope: workflow status selector; fallback: All statuses."
       }
     ]
   },

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -30,6 +30,17 @@ _ALLOWED_DASHBOARD_LINK_VARS = {
 }
 
 
+
+_REQUIRED_LINK_VARS_BY_TARGET_UID = {
+    "bioetl-overview-v2": frozenset({"pipeline", "run_type"}),
+    "bioetl-control-plane-v1": frozenset({"pipeline", "run_type"}),
+    "bioetl-runtime": frozenset({"pipeline", "run_type"}),
+    "bioetl-dq-v2": frozenset({"pipeline", "run_type"}),
+    "bioetl-provider-health-v2": frozenset(),
+    "bioetl-silver-reject-explorer": frozenset({"pipeline", "run_type"}),
+    "bioetl-workflow-overview": frozenset(),
+}
+
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = {
     "bioetl-overview-v2": frozenset(
         {
@@ -901,3 +912,35 @@ def test_control_plane_dashboard_exposes_working_runbook_link() -> None:
     assert runbook_link.get("targetBlank") is True, (
         "External runbook link should open in a new tab"
     )
+
+
+def test_cross_dashboard_links_enforce_required_handoff_or_explicit_fallback() -> None:
+    """Top-level links must pass required target vars or rely on explicit fallback."""
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+
+        for link in dashboard.get("links", []):
+            url = link.get("url", "")
+            if not isinstance(url, str) or not url.startswith("/d/"):
+                continue
+
+            target_uid = _extract_dashboard_uid(url)
+            assert target_uid is not None, f"Could not parse dashboard UID from {url}"
+
+            required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID.get(target_uid)
+            assert required_vars is not None, (
+                f"Link target {target_uid} must be declared in required vars map"
+            )
+            passed_vars = _extract_link_vars(url)
+
+            source_vars = {
+                var.get("name")
+                for var in dashboard.get("templating", {}).get("list", [])
+                if var.get("name")
+            }
+            required_from_source = {var for var in required_vars if var in source_vars}
+            missing = required_from_source - passed_vars
+            assert not missing, (
+                f"{dashboard_path.name} top-level link to {target_uid} must pass available "
+                f"required vars {sorted(missing)}. URL: {url}"
+            )


### PR DESCRIPTION
### Motivation

- Сделать единый контракт по переменным для всех Grafana dashboards, чтобы пользователи понимали назначение фильтров и когда используется fallback.
- Явно отделить forensic-only переменные (`run_id`, `payload_hash`) от core/provider переменных, чтобы избежать high-cardinality leaks и неверных handoff-паттернов.
- Ввести автоматические проверки переходов между дашбордами, чтобы гарантировать корректную передачу только целевых переменных или использование ожидаемого fallback.

### Description

- Добавлен единный `variables-guide` в `docs/03-guides/dashboards/variables-guide.md` (обновлён до `Version: 1.1.0`) с группировкой scope: Core (`pipeline`, `run_type`, `stage`), Provider (`provider`, `adapter`) и Forensic-only (`run_id`, `payload_hash`), матрицей dashboard→contract и явными правилами handoff/fallback.
- Приведены к единому стилю `description` для шаблонных переменных в shipped dashboard JSONs: `grafana/dashboards/{bioetl-overview-v2,bioetl-control-plane-v1,bioetl-runtime,bioetl-dq-v2,bioetl-provider-health-v2,bioetl-silver-reject-explorer,bioetl-workflow-overview}.json`.
- Добавлено требование handoff в тесты: `tests/integration/test_grafana_dashboard_links.py` расширённой картой требуемых переменных по target и новой проверкой `test_cross_dashboard_links_enforce_required_handoff_or_explicit_fallback()` которая валидирует, что top-level ссылки передают доступные требуемые переменные или полагаются на явно описанный fallback.

### Testing

- Запущены интеграционные тесты: `uv run python -m pytest -q tests/integration/test_grafana_dashboard_links.py tests/integration/test_grafana_config.py`, результат: `198 passed`.
- JSON-валидность обновлённых дашбордов проверена через `uv run python -m json.tool grafana/dashboards/<dashboard>.json` для всех затронутых файлов и возвращает OK.
- Попытки выполнить project memory workflow `python -m memory.tooling.workflow pre-task` / `post-task` были предприняты, но в среде отсутствует модуль `memory` (skipped/failed with `ModuleNotFoundError`), поэтому pre/post-task hooks не были выполнены here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79305f5dc8324b416ddaf3c6dcf78)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->