### PR TITLE
Add DQ deliverability KPI + trend, Pareto reject reasons and docs sync for bioetl-dq-v2

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-updates.md
+++ b/docs/03-guides/dashboards/dashboard-v2-updates.md
@@ -122,11 +122,20 @@ histogram_quantile(0.95, sum by (le, provider) (rate(bioetl_health_check_latency
   `6. Workflow Overview` встроены в shipped operator flow и используют
   target-scoped handoffs без variable leakage.
 
+
+12. Усилен DQ surface для deliverability и reject-triage:
+
+- добавлен KPI `DQ Impact on Deliverability (Blocked Share)` (panel `id=154`) — доля записей, заблокированных DQ;
+- добавлен тренд `DQ Impact on Deliverability Trend (Blocked Share %)` (panel `id=155`) для изменения blocked-share во времени по выбранному scope;
+- добавлен отдельный `Data Quality Score Trend (Volume-weighted)` (panel `id=153`) и явно разведён с operational gating indicators;
+- operational gating indicators оставлены в panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`), а quality score вынесен в отдельный trend-panel `id=153`;
+- `Top Silver Reject Reasons` обновлён до `Top Silver Reject Reasons (Pareto)` с dashboard drilldown в `bioetl-silver-reject-explorer`.
+
 ## Актуальные ключевые панели
 
 - `bioetl-overview-v2`: `id=99`, `id=101`, `id=1..4`, `id=110..114`, `id=116`, `id=118..120`, `id=221`
 - `bioetl-control-plane-v1`: checkpoint/replay/audit/global-read + lineage detail
-- `bioetl-dq-v2`: `id=99`, `id=101`, `id=1..12`, `id=116`
+- `bioetl-dq-v2`: `id=99`, `id=101`, `id=1..12`, `id=116`, `id=121`, `id=153..155`
 - `bioetl-provider-health-v2`: row `id=91` + панели `1,2,104,7,102`
 - `bioetl-runtime`: `id=1..9`, `Back to Overview`, links в `Explore`
 - `bioetl-workflow-overview`: `id=1..5` с `$workflow/$status` scope

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -97,7 +97,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Bounded reason summary only. Use quarantine CLI for exact record-level causes and stable reason signatures.",
+      "description": "Operational gating/flow counters (Bronze→Silver→Gold and invariants). Separate from quality score trend.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -980,8 +980,20 @@
           "refId": "A"
         }
       ],
-      "title": "Top Silver Reject Reasons",
-      "type": "bargauge"
+      "title": "Top Silver Reject Reasons (Pareto)",
+      "type": "bargauge",
+      "description": "Pareto ranking of rejection reasons. Use panel link to drill down into reject explorer.",
+      "links": [
+        {
+          "title": "Drilldown: Silver Reject Explorer",
+          "type": "dashboard",
+          "uid": "bioetl-silver-reject-explorer",
+          "keepTime": true,
+          "includeVars": false,
+          "targetBlank": false,
+          "params": "var-pipeline=${pipeline}&var-run_type=${run_type}"
+        }
+      ]
     },
     {
       "datasource": "Prometheus",
@@ -1494,7 +1506,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 68
       },
       "id": 150,
       "options": {
@@ -1548,7 +1560,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 64
+        "y": 72
       },
       "id": 151,
       "options": {
@@ -1579,6 +1591,246 @@
       ],
       "title": "Gold Strict Validation Failures",
       "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Share of records blocked by DQ filters within the selected scope/time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "percent",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 58
+      },
+      "id": 154,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * ((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__range])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__range])) or vector(0)), 1))",
+          "legendFormat": "blocked %",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DQ Impact on Deliverability (Blocked Share)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Time trend of blocked share for the selected scope (pipeline/run_type/stage selector applies to dashboard scope).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "percent",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 58
+      },
+      "id": 155,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * ((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__interval])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__interval])) or vector(0)), 1))",
+          "legendFormat": "blocked %",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DQ Impact on Deliverability Trend (Blocked Share %)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Quality score trend over selected time range. Kept separate from operational gating indicators.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 58
+      },
+      "id": 153,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "((sum((bioetl_dq_validation_score{pipeline=~\"$pipeline\"} * bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"})) or vector(0)) / clamp_min((sum(bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}) or vector(0)), 1))",
+          "legendFormat": "DQ score",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Data Quality Score Trend (Volume-weighted)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
### Motivation
- Реализовать KPI «DQ impact on deliverability» и дать возможность смотреть его изменение по выбранному scope;
- Добавить ранжирование top failure reasons (Pareto) с drilldown в reject explorer для ускорения triage;
- Явно отделить тренд quality score от operational gating indicators и синхронизировать описание в документации.

### Description
- Изменён дашборд `grafana/dashboards/bioetl-dq-v2.json` с добавлением трёх новых панелей: `Data Quality Score Trend (Volume-weighted)` (`id=153`) как timeseries, `DQ Impact on Deliverability (Blocked Share)` (`id=154`) как stat и `DQ Impact on Deliverability Trend (Blocked Share %)` (`id=155`) как timeseries; все запросы Prometheus настроены на выбранный `pipeline`/`run_type`/time-scope.
- Обновлён панель `Top Silver Reject Reasons` → `Top Silver Reject Reasons (Pareto)` (`id=121`) и добавлен dashboard drilldown link в `bioetl-silver-reject-explorer`, передаёт `var-pipeline` и `var-run_type` и сохраняет временной диапазон.
- Сохранены operational gating indicators в существующей панели `Data Flow in Range: Bronze -> Silver -> Gold` (`id=1`) и добавлено явное описание/разделение между gating counters и quality score.
- Синхронизированы изменения в `docs/03-guides/dashboards/dashboard-v2-updates.md` с перечислением новых панелей и обновлённого набора ключевых панелей для `bioetl-dq-v2`.

### Testing
- Проверка JSON валидности выполнилась командой `uv run python -m json.tool grafana/dashboards/bioetl-dq-v2.json` и прошла успешно.
- Запуск интеграционных проверок `uv run python -m pytest -q tests/integration/test_grafana_config.py` в итоге завершился успешно с `162 passed` (первичная итерация привела к 2 падениям из-за временных переименований панелей, заголовки были скорректированы и тесты снова пройдены).
- Попытки записать pre/post-task в memory workflow (`python -m memory.tooling.workflow ...`) завершились неудачно в этой среде из‑за отсутствия модуля `memory`, что не повлияло на автоматические тесты.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79339de8c832491f6ef3a88af6465)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->