### PR TITLE
Добавить CTA Control Plane в DQ-дашборд и сохранить отдельный CTA Silver Reject Explorer

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -126,7 +126,10 @@ ______________________________________________________________________
      `Silver Rejects Count + Rate` / `Silver Filter Rejects` в текущем time range.
   1. Перейдите в `4. Data Quality` и проверьте `Top Silver Reject Reasons` /
      `Top Silver Reject Fields`, чтобы сузить проблему до bounded cause summary.
-  1. Откройте `5. Silver Reject Explorer` для record-level списка, выбора
+  1. Если spike сопровождается replay/resume рисками, используйте top-level CTA
+     `Control Plane v1` (bounded `$pipeline/$run_type` + тот же time range) для
+     проверки manifest/ledger/checkpoint before action.
+  1. Откройте `5. Silver Reject Explorer` как отдельный CTA для record-level списка, выбора
      `reason_code/field/run_id` и detail по конкретному `payload_hash`.
   1. Используйте quarantine CLI для action-операций (`replay/resolve/purge`) и
      финального подтверждения remediation.
@@ -193,7 +196,7 @@ Variable handoff policy for these links is strict and bounded:
   `bioetl_control_plane_read_duration_seconds_bucket` глобальны по
   `store/operation/status`.
 - `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime`, `Explore Logs` и `Explore Traces` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
-- `bioetl-dq-v2`: dashboard link `Back to Overview` плюс `5. Silver Reject Explorer`, `Explore Logs` и `Explore Traces` дают тот же переход для DQ incidents и freshness investigation. Handoff в Explorer передаёт только bounded `$pipeline/$run_type` scope, а не generic `includeVars` leakage. Panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`) дублирует Explore handoff через data links.
+- `bioetl-dq-v2`: dashboard links `Back to Overview`, `Next Recommended Drilldown` (Control Plane v1), `5. Silver Reject Explorer`, `Explore Logs` и `Explore Traces` дают тот же переход для DQ incidents и freshness investigation. Handoff в Control Plane и Explorer передаёт только bounded `$pipeline/$run_type` scope (для Control Plane ещё и active time range), а не generic `includeVars` leakage. Panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`) дублирует Explore handoff через data links.
 - `bioetl-silver-reject-explorer`: dashboard links `Back to Overview`, `Back to Data Quality`, `Open Logs`, `Open Traces`; back-links возвращают только `$pipeline/$run_type`, не leaking `payload_hash` или other forensic filters. Main table поддерживает data links для self-drilldown по `payload_hash` и CLI handoff.
 - `bioetl-workflow-overview`: dashboard links `Back to Overview`, `2. Runtime`, `Control Plane / Replay Safety`; cross-dashboard handoffs не leaking `$workflow/$status` into non-workflow targets. Prometheus panels use only bounded workflow labels (`workflow`, `status`, `step_kind`) and never require `run_id`/`step_id` labels.
 - Loki drilldown использует безопасный low-cardinality entrypoint `{job="bioetl"}` без dashboard-variable interpolation внутри encoded Explore payload. Это сознательный baseline: Grafana надёжно не подставляет `$pipeline/$provider` в `left=...`, поэтому дополнительное сужение оператор делает уже в самом Explore. Tempo drilldown открывает trace search в том же временном окне; детальная correlation идёт через `trace_id` / `span_id`, а не через Prometheus labels.

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -38,6 +38,17 @@
       "targetBlank": false,
       "title": "Next Recommended Drilldown",
       "type": "link",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?from=${__from}&to=${__to}&var-pipeline=$pipeline&var-run_type=$run_type"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "5. Silver Reject Explorer",
+      "type": "link",
       "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=$pipeline&var-run_type=$run_type"
     },
     {


### PR DESCRIPTION
### Motivation
- Обеспечить быстрый и безопасный переход из `bioetl-dq-v2` в контрольную панель replay/resume (`bioetl-control-plane-v1`) с передачей ограниченного скоупа и временного диапазона перед выполнением действий по карантину.
- Сохранить отдельный CTA для record-level расследования (`5. Silver Reject Explorer`) чтобы не заменять существующий handoff на control-plane.
- Обновить документацию triage-последовательности, чтобы операторы знали, когда проверять control plane перед переходом в record-level explorer.

### Description
- В `grafana/dashboards/bioetl-dq-v2.json` изменил top-level ссылку `Next Recommended Drilldown` так, чтобы она открывала `bioetl-control-plane-v1` с передачей `from=${__from}&to=${__to}` и bounded vars (`var-pipeline=$pipeline`, `var-run_type=$run_type`).
- В том же JSON добавил отдельный CTA `5. Silver Reject Explorer` и сохранил его bounded handoff по `$pipeline/$run_type` вместо замены control-plane перехода.
- Обновил `docs/03-guides/dashboards/dashboard-v2-usage.md` в секции DQ drilldown sequence, добавив шаг с использованием `Control Plane v1` перед record-level exploration для сценариев с рисками replay/resume и задокументировал оба CTA и политику bounded handoff.

### Testing
- Выполнил валидацию JSON: `python -m json.tool grafana/dashboards/bioetl-dq-v2.json` успешно прошла.
- Попытки запустить проектный memory workflow `python -m memory.tooling.workflow pre-task ...` и `post-task ...` завершились неудачей из-за отсутствия локального модуля `memory` (`ModuleNotFoundError`).
- Просмотрел диффы и закоммитил изменения (`git commit`) в локальном репозитории; изменения подготовлены для PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79947913883248156a7886ae0c7f2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->