### PR TITLE
Replace self-referential 'Back to Overview' with L1 runtime link in overview dashboard

### DIFF
--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -25,9 +25,9 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Back to Overview",
-      "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type"
+      "title": "Open L1 Runtime Dashboard",
+      "type": "link",
+      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
     {
       "asDropdown": false,


### PR DESCRIPTION
### Motivation
- Убрать бесполезную самоссылку "Back to Overview" из L0 overview и заменить её на полезный переход к уровню L1 (runtime) чтобы дать оператору явный следующий шаг при расследовании инцидентов. 
- Сохранить паттерн "Back to Overview" в остальных dashboard'ах как обязательный навигационный элемент.

### Description
- Обновлён `grafana/dashboards/bioetl-overview-v2.json`: верхняя ссылка заменена с `"title": "Back to Overview"` (self-link) на `"title": "Open L1 Runtime Dashboard"` типа `link`, указывающую на `/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}`, сохраняя контекст `pipeline`, `run_type` и time range. 
- Больше файлы dashboard'ов не изменялись.
- Подтверждён сохранённый паттерн `Back to Overview` в остальных dashboard'ах: `bioetl-control-plane-v1.json`, `bioetl-dq-v2.json`, `bioetl-provider-health-v2.json`, `bioetl-runtime.json`, `bioetl-silver-reject-explorer.json`, `bioetl-workflow-overview.json`.

### Testing
- Запуск проверки наличия паттерна: `for f in grafana/dashboards/*.json; do bn=$(basename "$f"); if [ "$bn" != "bioetl-overview-v2.json" ]; then if rg -q '"title": "Back to Overview"' "$f"; then echo "OK $bn"; else echo "MISSING $bn"; fi; fi; done` подтвердил, что все не-overview dashboards содержат `"title": "Back to Overview"` (успешно). 
- Инспекция изменений через `git diff --stat` показала один изменённый файл `grafana/dashboards/bioetl-overview-v2.json` с 4 insertions/4 deletions. 
- Попытки запустить проектный memory workflow (`python -m memory.tooling.workflow pre-task` / `post-task`) завершились ошибкой из-за отсутствия модуля `memory` в этом окружении (ModuleNotFoundError). 
- Нет затронутых unit/integration/architecture тестов в этом патче, поэтому дополнительных автоматизированных тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79969c5d88324830dd2009960ef4f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->