### PR TITLE
Fix provider health dashboard overview handoff defaults

### DIFF
--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -27,7 +27,7 @@
       "targetBlank": false,
       "title": "Back to Overview",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All"
     },
     {
       "asDropdown": false,


### PR DESCRIPTION
### Motivation
- Avoid passing unresolved local template variables from the provider-health dashboard and ensure links follow the documented target-dashboard variable contract by providing explicit fallback values.

### Description
- Update `grafana/dashboards/bioetl-provider-health-v2.json` to replace the "Back to Overview" URL with the explicit documented defaults: `/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All` (replacing the previous `?var-pipeline=$pipeline&var-run_type=$run_type`).

### Testing
- Executed the focused integration selection of `tests/integration/test_grafana_dashboard_links.py` via `uv run python -m pytest -q ... -k 'cross_dashboard_links_pass_only_target_scoped_variables or cross_dashboard_links_enforce_required_handoff_or_explicit_fallback'` and observed `2 passed, 34 deselected`; note an earlier `pytest` invocation failed in this environment due to the configured `--timeout` option, but the targeted contract tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7997ce4308324be7689e72b0fb49a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->