### PR TITLE
Add Control Plane v1 top-level link and separate Silver Reject Explorer CTA in DQ v2

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -126,8 +126,11 @@ ______________________________________________________________________
      `Silver Rejects Count + Rate` / `Silver Filter Rejects` в текущем time range.
   1. Перейдите в `4. Data Quality` и проверьте `Top Silver Reject Reasons` /
      `Top Silver Reject Fields`, чтобы сузить проблему до bounded cause summary.
-  1. Откройте `5. Silver Reject Explorer` для record-level списка, выбора
-     `reason_code/field/run_id` и detail по конкретному `payload_hash`.
+  1. При необходимости L1/L2 операционного контекста откройте top-level ссылку
+     `Control Plane v1` (handoff только с bounded vars `$pipeline/$run_type` и
+     тем же time range).
+  1. Для record-level разбора откройте отдельный CTA `5. Silver Reject Explorer`
+     и выберите `reason_code/field/run_id` с detail по конкретному `payload_hash`.
   1. Используйте quarantine CLI для action-операций (`replay/resolve/purge`) и
      финального подтверждения remediation.
 - Эти панели отвечают на вопросы:

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -36,8 +36,19 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Next Recommended Drilldown",
-      "type": "link",
+      "title": "Control Plane v1",
+      "type": "dashboards",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "5. Silver Reject Explorer",
+      "type": "dashboards",
       "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=$pipeline&var-run_type=$run_type"
     },
     {


### PR DESCRIPTION
### Motivation
- Provide an explicit L1/L2 operational handoff from the Data Quality dashboard to the Control Plane while keeping the record-level Explorer as a separate CTA for quarantine/forensic workflows. 
- Ensure the dashboard-to-explorer variable handoff remains strictly bounded (`$pipeline`/`$run_type`) and preserves the selected time range for operator context.

### Description
- Updated `grafana/dashboards/bioetl-dq-v2.json` to add a top-level `Control Plane v1` dashboard link with bounded vars (`var-pipeline=$pipeline&var-run_type=$run_type`) and `keepTime: true`. 
- Added a separate top-level CTA `5. Silver Reject Explorer` in `bioetl-dq-v2.json` so Explorer does not replace the control-plane transition. 
- Removed the previous `Next Recommended Drilldown` link in favor of the explicit `Control Plane v1` and `5. Silver Reject Explorer` entries. 
- Updated the DQ drilldown sequence in `docs/03-guides/dashboards/dashboard-v2-usage.md` to call out `Control Plane v1` as the L1/L2 operational context and keep `5. Silver Reject Explorer` as the record-level drilldown step.

### Testing
- Ran `python -m json.tool grafana/dashboards/bioetl-dq-v2.json` to validate JSON formatting and it passed. 
- Verified link titles and presence with `rg -n '"title": "Control Plane v1"|"title": "5. Silver Reject Explorer"' grafana/dashboards/bioetl-dq-v2.json` and the patterns were found. 
- Verified documentation update with `rg -n 'Короткая triage sequence|Control Plane v1|5\. Silver Reject Explorer' docs/03-guides/dashboards/dashboard-v2-usage.md` and the updated sequence was found. 
- Attempts to run the repository memory pre/post workflow via `python -m memory.tooling.workflow` failed in this environment due to a missing `memory` module (`ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79c75efa083248d8edb4c57350453)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->