### PR TITLE
Unify Grafana L0/L1 default windows and document L2 forensic baseline

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -164,6 +164,15 @@ Variable handoff policy for these links is strict and bounded:
 - For provider flow pass only `$provider/$adapter` (or explicit `All` defaults when opening non-provider dashboards).
 - Workflow-specific variables (`$workflow`, `$status`) and forensic IDs (`$run_id`, `$payload_hash`) MUST NOT be propagated into non-target dashboards.
 
+## Default dashboard windows (L0/L1 baseline + L2 forensic exception)
+
+- Единый baseline для operator-facing L0/L1 dashboards:
+  - `overview`, `runtime`, `dq`, `control-plane`, `workflow-overview` -> `time.from=now-12h`, `refresh=30s`.
+- Forensic L2 exception:
+  - `silver-reject-explorer` -> `time.from=now-24h`, `refresh=1m`.
+  - Justification: forensic-поиск по reject payload обычно начинается с более широкого окна и не требует 30s polling; более медленный refresh снижает ненужные перезапросы при row-level drilldown.
+- Любое отклонение от baseline MUST сопровождаться явным обоснованием в документации и в PR (почему это не L0/L1 operator window).
+
 ## Drilldown
 
 - `bioetl-overview-v2`: L0 Overview отвечает на один primary question:

--- a/docs/03-guides/dashboards/variables-guide.md
+++ b/docs/03-guides/dashboards/variables-guide.md
@@ -65,6 +65,19 @@ ______________________________________________________________________
 - Для всех `links[].url` с Explore route (`/explore`, `/a/grafana-lokiexplore-app/explore`, `/a/grafana-exploretraces-app/`) используем `from=${__from}&to=${__to}`.
 - Смешанные/legacy варианты (`from=$__from`, отсутствие time-range, `includeVars=true`) не допускаются.
 
+## Default time window policy by dashboard class
+
+- **L0/L1 baseline (must be unified unless justified):**
+  - `overview`: `time.from=now-12h`, `refresh=30s`
+  - `runtime`: `time.from=now-12h`, `refresh=30s`
+  - `dq`: `time.from=now-12h`, `refresh=30s`
+  - `control-plane`: `time.from=now-12h`, `refresh=30s`
+- **Forensic L2 exception (must include explicit justification in docs/PR):**
+  - `explorer` (`bioetl-silver-reject-explorer`): `time.from=now-24h`, `refresh=1m`
+  - Justification: forensic/reject investigation требует больше стартового горизонта для редких инцидентов и сниженной частоты auto-refresh, чтобы уменьшить шум и нагрузку при row-level анализе.
+- **Workflow dashboard class:**
+  - `workflow-overview`: `time.from=now-12h`, `refresh=30s` (align with L0/L1 operator baseline for run-step triage).
+
 ## Test coverage expectations
 
 - Links contract: `tests/integration/test_grafana_dashboard_links.py`

--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -2677,7 +2677,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
### Motivation

- Установить единый operator-facing baseline для L0/L1 dashboards (снизить случайный дрейф времени обзора и частоты обновления). 
- Зафиксировать отдельное, обоснованное поведение для forensic L2 (explorer) чтобы снизить шум и нагрузку при row-level расследованиях.

### Description

- Обновлён `grafana/dashboards/bioetl-control-plane-v1.json` — `time.from` изменён с `now-6h` на `now-12h` при сохранении `refresh=30s` для L0/L1 operator baseline.
- Добавлено правило default time window в `docs/03-guides/dashboards/variables-guide.md` с явным набором: L0/L1 (`overview`, `runtime`, `dq`, `control-plane`, `workflow-overview`) → `time.from=now-12h`, `refresh=30s`; forensic L2 (`bioetl-silver-reject-explorer`) → `time.from=now-24h`, `refresh=1m` и краткой justification для исключения.
- Добавлен резюмирующий раздел в `docs/03-guides/dashboards/dashboard-v2-usage.md`, требующий явного обоснования в документации/PR для любых отклонений от baseline.

### Testing

- Выполнена проверка JSON валидности: `python -m json.tool grafana/dashboards/bioetl-control-plane-v1.json` — успешно.
- Просканированы dashboards на соответствие `time.from`/`refresh`: `rg -n '"refresh": "(30s|1m)"|"from": "now-(12h|24h)"' grafana/dashboards/bioetl-*.json` — подтверждена унификация и намеренное исключение для explorer.
- Попытки запустить repository memory workflow `python -m memory.tooling.workflow pre-task` / `post-task` были предприняты, но в среде отсутствует модуль `memory.tooling.workflow` (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79e8aba9c8324a18757fa120d991b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->