### PR TITLE
Add Runtime dashboard top-level links for Control Plane v1 and Data Quality

### DIFF
--- a/docs/03-guides/dashboards/README.md
+++ b/docs/03-guides/dashboards/README.md
@@ -33,11 +33,11 @@ ______________________________________________________________________
 
 Текущая навигационная модель:
 
-- `1. BioETL Overview` -> `2. Runtime` / `Control Plane / Replay Safety` / `3. Provider Health` / `4. Data Quality` / `6. Workflow Overview`
-- `2. Runtime` -> `Back to Overview` / `Control Plane / Replay Safety` / `4. Data Quality`
+- `1. BioETL Overview` -> `2. Runtime` / `Control Plane v1` / `3. Provider Health` / `4. Data Quality` / `6. Workflow Overview`
+- `2. Runtime` -> `Back to Overview` / `Control Plane v1` / `4. Data Quality`
 - `3. Provider Health` -> `Back to Overview` / `2. Runtime`
 - `4. Data Quality` -> `Back to Overview` / `5. Silver Reject Explorer`
-- `6. Workflow Overview` -> `Back to Overview` / `2. Runtime` / `Control Plane / Replay Safety`
+- `6. Workflow Overview` -> `Back to Overview` / `2. Runtime` / `Control Plane v1`
 
 `bioetl-overview-v2` is the L0 answer-first surface. It answers one question:
 what is currently broken or degraded in BioETL, and where should the operator

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -30,6 +30,17 @@
     },
     {
       "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Control Plane v1",
+      "type": "link",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
       "icon": "external link",
       "includeVars": false,
       "keepTime": true,
@@ -38,6 +49,17 @@
       "title": "3. Provider Health",
       "type": "link",
       "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "4. Data Quality",
+      "type": "link",
+      "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
     },
     {
       "asDropdown": false,


### PR DESCRIPTION
### Motivation
- Ensure `bioetl-runtime` dashboard conforms to the canonical navigation contract by exposing direct top-level handoffs to Control Plane and Data Quality with explicit `var-*` scoping and time-range propagation.
- Keep documentation in sync with the dashboard JSON to avoid UX/operational drift in the navigation model.

### Description
- Added a top-level link `Control Plane v1` to `grafana/dashboards/bioetl-runtime.json` that forwards `var-pipeline` and `var-run_type` plus `${__url_time_range}`.
- Added a top-level link `4. Data Quality` to `grafana/dashboards/bioetl-runtime.json` that forwards `var-pipeline`, `var-run_type`, `var-stage` plus `${__url_time_range}`.
- Updated `docs/03-guides/dashboards/README.md` to replace the legacy label `Control Plane / Replay Safety` with the canonical `Control Plane v1` in the navigation model.
- Verified that `docs/03-guides/dashboards/navigation-contract.md` already matches the required contract, so no edits were needed there.

### Testing
- Ran JSON syntax validation with `python -m json.tool grafana/dashboards/bioetl-runtime.json`, which succeeded.
- Reviewed diffs with `git diff` to confirm only the intended files (`grafana/dashboards/bioetl-runtime.json` and `docs/03-guides/dashboards/README.md`) were modified and the navigation-contract file was left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ec446c083248ffb05b6c245b9ae)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->