### PR TITLE
grafana: add Control Plane v1 top-level link to bioetl-dq-v2

### DIFF
--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -31,6 +31,17 @@
     },
     {
       "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Control Plane v1",
+      "type": "dashboards",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
       "icon": "external link",
       "includeVars": false,
       "keepTime": true,


### PR DESCRIPTION
### Motivation
- Conform to the dashboard navigation contract by exposing the canonical `Control Plane v1` top-level link from the Data Quality dashboard and ensure handoff is scoped to `var-pipeline` and `var-run_type` while preserving the current time range.

### Description
- Added a top-level link entry to `grafana/dashboards/bioetl-dq-v2.json` with `title` = `Control Plane v1`, `includeVars: false`, `keepTime: true`, and `url` = `/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}` inserted after `Back to Overview`.

### Testing
- Ran JSON validation with `uv run python -m json.tool grafana/dashboards/bioetl-dq-v2.json` which succeeded.
- Executed a Python assertion script that verifies the link exists, `title == "Control Plane v1"`, `includeVars` is `false`, the URL contains `var-pipeline`, `var-run_type` and `${__url_time_range}`, and does not contain `includeVars=true`, which all passed.
- Ran the integration suite with `uv run python -m pytest -q tests/integration/test_grafana_config.py`; the test run completed but reported 3 failing tests (`test_dashboard_queries_use_real_metric_label_schemas[bioetl-control-plane-v1.json]`, `test_control_plane_answer_row_has_max_seven_panels`, `test_runtime_dashboard_keeps_loki_log_hygiene_in_collapsed_tracing_row`) that are pre-existing and not caused by this change to `bioetl-dq-v2.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79eca2bcc83248e6ae6b260d3a8a7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->