### PR TITLE
Normalize dashboard Explore links to Grafana app drilldown routes

### DIFF
--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -60,7 +60,7 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"67f\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{job=\\\"bioetl\\\"}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
     {
       "asDropdown": false,
@@ -71,7 +71,7 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"q9t\":{\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{ span.\\\"bioetl.pipeline\\\" = \\\"$pipeline\\\" && span.\\\"bioetl.run_type\\\" = \\\"$run_type\\\" }\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -88,7 +88,7 @@
       "title": "Explore Logs (Loki, tracing profile)",
       "tooltip": "Open Loki Explore with tracing profile and selected time range",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"67f\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{job=\\\"bioetl\\\"}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
     {
       "asDropdown": false,
@@ -100,7 +100,7 @@
       "title": "Explore Traces (Tempo, tracing profile)",
       "tooltip": "Open Tempo Explore with tracing profile and selected time range",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"q9t\":{\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{ span.\\\"bioetl.pipeline\\\" = \\\"$pipeline\\\" && span.\\\"bioetl.run_type\\\" = \\\"$run_type\\\" }\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -49,7 +49,7 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"67f\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{job=\\\"bioetl\\\"}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
     {
       "asDropdown": false,
@@ -60,7 +60,7 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"q9t\":{\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{ span.\\\"bioetl.provider\\\" = \\\"$provider\\\" }\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.provider%22%20%3D~%20%22${provider:regex}%22%20%7D"
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -70,7 +70,7 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"67f\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{job=\\\"bioetl\\\"}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
     {
       "asDropdown": false,
@@ -81,7 +81,7 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"q9t\":{\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{ span.\\\"bioetl.pipeline\\\" = \\\"$pipeline\\\" && span.\\\"bioetl.run_type\\\" = \\\"$run_type\\\" }\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -48,7 +48,7 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"67f\":{\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{job=\\\"bioetl\\\"}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
     {
       "asDropdown": false,
@@ -59,7 +59,7 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/explore?schemaVersion=1&panes={\"q9t\":{\"datasource\":\"tempo\",\"queries\":[{\"query\":\"{}\"}],\"range\":{\"from\":\"$__from\",\"to\":\"$__to\"}}}&orgId=1&from=${__from}&to=${__to}"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%7D"
     }
   ],
   "panels": [


### PR DESCRIPTION
### Motivation
- Replace legacy inline `/explore?...` drilldowns with Grafana app routes so Explore handoff uses the dedicated Loki/Tempo apps and matches the navigation contract. 
- Preserve operator context when drilling down by keeping time range (`from/to`) and TraceQL scope filters (pipeline/run_type/provider) intact. 
- Ensure dashboards follow the documented navigation contract in `docs/03-guides/dashboards/navigation-contract.md` and the README. 

### Description
- Rewrote top-level dashboard links for "Explore Logs (Loki, tracing profile)" to use the Loki app route `/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=...`. 
- Rewrote top-level dashboard links for "Explore Traces (Tempo, tracing profile)" to use the Tempo app route `/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=...` and kept TraceQL filters: pipeline+run_type (regex) for pipeline-scoped dashboards, `provider` (regex) for provider-scoped dashboard, and `{}` for unscoped workflow overview. 
- Files modified: `grafana/dashboards/bioetl-runtime.json`, `grafana/dashboards/bioetl-overview-v2.json`, `grafana/dashboards/bioetl-dq-v2.json`, `grafana/dashboards/bioetl-provider-health-v2.json`, and `grafana/dashboards/bioetl-workflow-overview.json`. 
- No documentation edits were required because the navigation contract in `docs/03-guides/dashboards/navigation-contract.md` and `docs/03-guides/dashboards/README.md` already described the app routes and contextual TraceQL behavior. 

### Testing
- Validated modified JSON syntax with `python -m json.tool` for each updated file and the command completed successfully. 
- Verified there are no remaining legacy `/explore?` links using `rg` and confirmed presence of the new `/a/grafana-lokiexplore-app/explore` and `/a/grafana-exploretraces-app/` routes. 
- Re-checked docs alignment by searching `docs/03-guides/dashboards/navigation-contract.md` and `docs/03-guides/dashboards/README.md` for the expected app-route and TraceQL scope statements, and found they already match the implemented behavior. 
- Post-change memory workflow (`python -m memory.tooling.workflow pre-task` / `post-task`) could not be run due to missing `memory` module in the environment (skipped), so that verification step is reported as not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a1e4e09083249813b18d990f1698)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->