### PR TITLE
grafana: add explicit title for DQ dashboard panel 150

### DIFF
--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -1508,6 +1508,7 @@
         "content": "### Control-plane aggregates available\n- Open `BioETL Control Plane v1` for aggregated manifest writes, ledger appends, checkpoint compatibility outcomes, and control-plane read failures.\n- Use the `Observability Checklist (runbook)` dashboard link when `BioETLControlPlaneReadFailureRate` or related aggregate signals require operator follow-up.\n",
         "mode": "markdown"
       },
+      "title": "Control-plane aggregates note",
       "type": "text"
     },
     {


### PR DESCRIPTION
### Motivation
- Make the markdown/text panel in the DQ dashboard explicitly named so its purpose (a control-plane aggregates note/annotation) is clear for maintainers and docs sync.

### Description
- Added a `title` with value `"Control-plane aggregates note"` to the panel with `id: 150` in `grafana/dashboards/bioetl-dq-v2.json` so the markdown section is explicitly labeled.

### Testing
- Validated the dashboard JSON with `python -m json.tool`, which passed.
- Searched the docs with `rg` to confirm no documentation references required updating, which found no conflicting references.
- Inspected the panel object via a short Python check to confirm `id: 150` and the unchanged `options.content` before and after the change.
- Attempted `python -m memory.tooling.workflow pre-task ...` but the environment lacked the `memory` module, raising `ModuleNotFoundError` (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a1fbe6988324846c8d89c1d79233)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->