### PR TITLE
grafana: Make Back-to-Overview handoff use explicit core fallbacks

### DIFF
--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -26,7 +26,7 @@
       "targetBlank": false,
       "title": "Back to Overview",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },
     {
       "asDropdown": false,


### PR DESCRIPTION
### Motivation
- Избежать передачи неопределённых переменных `$pipeline`/`$run_type` из Workflow dashboard и привести поведение handoff в соответствие с documented fallback semantics и `docs/03-guides/dashboards/variables-guide.md`.

### Description
- В `grafana/dashboards/bioetl-workflow-overview.json` исправлена ссылка «Back to Overview», теперь она передаёт явный fallback `var-pipeline=All&var-run_type=All&${__url_time_range}` вместо `var-pipeline=$pipeline&var-run_type=$run_type` (изменение в файле около строк 27–30).

### Testing
- Проверил валидность JSON через `python -m json.tool grafana/dashboards/bioetl-workflow-overview.json` (успешно) и запустил интеграционные проверки `uv run python -m pytest -q tests/integration/test_grafana_dashboard_links.py`, при этом данная правка не вызвала новых регрессий; в раннере зафиксированы 3 pre-existing failures в unrelated handoff assertions (см. вывод тестов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a3c6ca7c83249c356a07d8c6b28b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->