### PR TITLE
Unify Grafana dashboards' root `timezone` to "browser" and document invariant

### DIFF
--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -109,3 +109,16 @@ uv run python -m scripts.engineering.qa check-dashboard-visual-semantics
 - Explore-ссылки MUST использовать полные названия: `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)`.
 - Формулировки вида `Explore Logs`, `Explore Traces`, `Next Recommended Drilldown` считаются legacy-лексикой и не допускаются в shipped dashboards.
 
+## 8) JSON invariant: timezone (обязательно)
+
+Для всех shipped dashboards в `grafana/dashboards/*.json` применяется единый JSON-invariant:
+
+- корневое поле `timezone` MUST быть `"browser"`.
+
+Пример:
+
+```json
+{
+  "timezone": "browser"
+}
+```

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -1939,7 +1939,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "4. Data Quality",
   "uid": "bioetl-dq-v2",
   "version": 4

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -2465,7 +2465,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "1. BioETL Overview",
   "uid": "bioetl-overview-v2",
   "version": 5

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -1378,7 +1378,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "3. Provider Health",
   "uid": "bioetl-provider-health-v2",
   "version": 6

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -2327,7 +2327,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "2. Runtime",
   "uid": "bioetl-runtime",
   "version": 2

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -673,7 +673,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "5. Silver Reject Explorer",
   "uid": "bioetl-silver-reject-explorer",
   "version": 1000


### PR DESCRIPTION
### Motivation

- Свести к единому значению поведение shipped Grafana dashboards по отображению временной зоны для визуальной и поведенческой консистентности. 
- Зафиксировать правило как JSON-инвариант в дизайн-системе dashboards для предотвращения регрессий и единообразия при будущих правках.

### Description

- Установлено корневое поле `timezone` со значением `"browser"` в все файлы `grafana/dashboards/*.json`, где ранее было пустое значение. 
- Добавлена секция в `docs/03-guides/dashboards/design-system.md` с обязательным JSON-invariant: `timezone MUST be "browser"`.
- Изменённые файлы: `grafana/dashboards/bioetl-runtime.json`, `grafana/dashboards/bioetl-overview-v2.json`, `grafana/dashboards/bioetl-silver-reject-explorer.json`, `grafana/dashboards/bioetl-dq-v2.json`, `grafana/dashboards/bioetl-provider-health-v2.json`, и `docs/03-guides/dashboards/design-system.md`.

### Testing

- Валидация JSON: выполнена команда `python -m json.tool` над всеми изменёнными dashboard-файлами (успешно).
- Интеграционные проверки: запущено `uv run python -m pytest -q tests/integration/test_grafana_config.py`, в результате 3 падающих теста (см. ниже) — падения выглядят не связаны с изменением `timezone` (ошибки по label-schemas / layout-панелей в control-plane/runtime).
- Репозиторный чек: `uv run python -m scripts.engineering.repo check-inventory --check` выявил drift manifest (`configs/quality/scripts_inventory_manifest.json`) и завершился с ошибкой; требуется `--update` для синхронизации manifest.
- Предпроверка memory workflow: `python -m memory.tooling.workflow pre-task ...` не выполнилась из-за отсутствия модуля в окружении (`ModuleNotFoundError: No module named 'memory'`) и помечена как пропущенная в этой среде.

Примечание: все изменения документации (design system) включены в тот же набор правок, поэтому docs-mirror синхронизирован в этом change set; остающиеся падающие тесты и manifest-drift требуют отдельного follow-up и не блокируют само правило `timezone`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a3bdf4d483249d3b23337584f400)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->