### PR TITLE
docs(dashboards): unify drilldown navigation requirement across contracts

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -149,14 +149,9 @@ ______________________________________________________________________
 
 ## Unified Top Navigation CTA (v2)
 
-All primary dashboards (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`, `6. Workflow Overview`) MUST expose the same top navigation block in this exact order:
+Primary dashboards (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`, `6. Workflow Overview`) MUST follow the canonical navigation contract in `navigation-contract.md`; top navigation is dashboard-specific and does **not** require a universal `Next Recommended Drilldown` link.
 
-1. `Back to Overview`
-2. `Next Recommended Drilldown`
-3. `Explore Logs (Loki, tracing profile)`
-4. `Explore Traces (Tempo, tracing profile)`
-
-Variable handoff policy for these links is strict and bounded:
+Variable handoff policy for dashboard links remains strict and bounded:
 
 - `includeVars=false` for every link (no implicit variable leakage).
 - Pass only target-scoped variables directly in URL (`var-*`) when required by the destination dashboard.

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -9,6 +9,7 @@
 - `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
   - dashboard links (`/d/...`): `${__url_time_range}`
   - Explore links (`/explore` и `/a/grafana-*-explore-app/...`): `from=${__from}&to=${__to}`
+- Universal top-level link `Next Recommended Drilldown` is **optional**; when present, it MUST resolve to an existing shipped dashboard/Explore target and obey the same explicit `var-*` + time-range handoff rules.
 - Explore handoff для Loki/Tempo ведёт только через drilldown-приложения:
   - Logs: `/a/grafana-lokiexplore-app/explore?...`
   - Traces: `/a/grafana-exploretraces-app/?...`


### PR DESCRIPTION
### Motivation
- Resolve conflicting guidance about a universal `Next Recommended Drilldown` link across primary dashboards so the navigation contract is singular and verifiable.
- Ensure the canonical navigation contract is the source of truth and that the dashboard usage guide references it rather than imposing a second, conflicting requirement.

### Description
- Marked the `Next Recommended Drilldown` top-level link as **optional** in `docs/03-guides/dashboards/navigation-contract.md` and required that, when present, it resolves to a shipped dashboard/Explore target and obeys explicit `var-*` + time-range handoff rules.
- Updated `docs/03-guides/dashboards/dashboard-v2-usage.md` to remove the universal `Next Recommended Drilldown` requirement and to point primary dashboards to the canonical `navigation-contract.md` for top-navigation rules.
- Both documentation edits were applied together in a single change-set so the contract and usage guide are consistent and testable.

### Testing
- Confirmed the updated references and the absence of the conflicting requirement using `rg -n "Next Recommended Drilldown|Unified Top Navigation CTA|Universal top-level link" docs/03-guides/dashboards/navigation-contract.md docs/03-guides/dashboards/dashboard-v2-usage.md`, which returned the expected results.
- Visually inspected the changed sections with `nl -ba` to verify the new wording appears at the intended locations in both files.
- Published PR metadata using the repository helper (`make_pr`) to record the change-set and rationale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a664f94c83249321ae949fbbfe29)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->