### PR TITLE
Add Control Plane v1 top-level link to workflow overview Grafana dashboard

### DIFF
--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -41,6 +41,17 @@
     },
     {
       "asDropdown": false,
+      "icon": "apps",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Control Plane v1",
+      "type": "link",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
       "icon": "logs",
       "includeVars": false,
       "keepTime": true,


### PR DESCRIPTION
### Motivation
- Ensure `bioetl-workflow-overview` exposes the required top-level navigation into the control plane per the Grafana navigation contract by adding a `Control Plane v1` link while preserving the project’s target-scoped variable policy.

### Description
- Inserted a new top-level link object into `grafana/dashboards/bioetl-workflow-overview.json` with `title: "Control Plane v1"`, `type: "link"`, `icon: "apps"`, `includeVars: false`, and `url: "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?${__url_time_range}"` to meet the contract requirements.

### Testing
- Ran the integration test file `tests/integration/test_grafana_dashboard_links.py`, but test execution could not complete in this environment: initial `pytest` invocation failed due to the local `pytest.ini` expecting unavailable timeout plugin/options, and a subsequent run with `-o addopts=''` failed during collection with `ModuleNotFoundError: No module named 'yaml'`, so the automated test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a661a45c8324804fe48ef5625156)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->