### PR TITLE
docs(dashboards): add threshold semantics and next-action descriptions for key overview/dq/runtime/control-plane panels

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -228,6 +228,14 @@ Variable handoff policy for these links is strict and bounded:
 
 ## Важные пороги (из JSON)
 
+- `overview.id=214 (System Status)`: `BROKEN` при runtime blocker `>0`, DQ hard fail `>0` или control-plane blocker `>0`; `DEGRADED` при warning-only сигналах; `UNKNOWN` при no recent samples. Next action: follow `overview.id=215`.
+- `overview.id=215 (Next Action)`: priority order `Runtime > Control Plane > DQ > Provider > Workflow > Monitor`. Next action: open first non-OK surface with same `$pipeline/$run_type`.
+- `dq.id=2 (DQ Score Snapshot)`: no-data остается `UNKNOWN`, не `0`; hard-fail signals блокируют promotion, warning-only означает drift. Next action: hard-fail -> reject/quarantine diagnostics; warning-only -> trend + top reasons.
+- `dq.id=154 (Blocked Share Trend)`: sustained growth = filter pressure, spike = incident. Next action: `Top Silver Reject Reasons` + `Silver Reject Explorer`/quarantine CLI.
+- `runtime.id=16 (Failed Runs / 15m)`: non-zero = runtime blocker. Next action: runtime blockers table + culprit stage panels, затем logs/traces при необходимости.
+- `runtime.id=220 (Runtime Error Rate / 30m)`: elevated ratio with meaningful Bronze denominator = degradation risk. Next action: `Runtime Errors by Stage/Error Code` + failed runs/backlog/lag panels.
+- `control-plane.id=130 (Replay / Resume Blockers)`: green `0`, red `>=1`. Next action: stop replay/resume и investigate first failing signal (manifest/ledger/checkpoint/replay/lineage).
+
 - `overview.System Status`: `BROKEN` при failed runs `>0`, stage backlog `>0`,
   worst lag `>=300s`, DQ hard fail `>0` или control-plane blocker `>0`;
   `DEGRADED` при warning-сигналах provider/DQ/freshness/workflow; `UNKNOWN`

--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -343,7 +343,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Non-zero means replay/resume is not safe without investigation. Derived from manifest, ledger, checkpoint compatibility, replay reconstructability, replay drift, and lineage reference signals. Alerts: BioETLControlPlaneManifestWriteFailed, BioETLRunLedgerAppendFailed, BioETLCheckpointCompatibilityBlocked, BioETLReplayNotReconstructable, BioETLReplayDriftDetected, BioETLLineageRefsMissing.",
+      "description": "Threshold semantics: replay/resume blockers are binary—green at 0, red at >=1. Next action: stop replay/resume and investigate the first failing signal (manifest, ledger, checkpoint, replay drift, or lineage refs).",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -183,7 +183,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Bounded field summary only. Use quarantine CLI when you need exact record-level field failures and payload context.",
+      "description": "Threshold semantics: keep no-data as UNKNOWN (not score 0); warnings indicate drift, hard-fail signals block data promotion. Next action: if hard-fail>0 open reject/quarantine diagnostics; if warning-only, review trend and top reject causes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1590,7 +1590,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Share of records blocked by DQ filters within the selected scope/time range.",
+      "description": "Threshold semantics: blocked-share trend should stay near baseline; sustained growth indicates DQ filter pressure, spikes indicate incident. Next action: open Top Silver Reject Reasons and Silver Reject Explorer (or quarantine CLI) for exact causes.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -229,7 +229,7 @@
       ],
       "title": "System Status",
       "type": "stat",
-      "description": "L0 answer. BROKEN if any recording-rule runtime blocker (failed runs, stage backlog, stage lag, gold write missing), DQ hard fail, or control-plane blocker is active. DEGRADED for provider/DQ/freshness/workflow warnings. UNKNOWN means no recent activity. Uses same recording rules as Runtime dashboard for guaranteed L0/L2 consistency."
+      "description": "Thresholds: BROKEN when runtime blocker>0, DQ hard fail>0, or control-plane blocker>0; DEGRADED on warning-only signals; UNKNOWN when no recent samples. Next action: open dashboard indicated by Next Action (Runtime first, then Control Plane, DQ, Provider, Workflow)."
     },
     {
       "datasource": "Prometheus",
@@ -364,7 +364,7 @@
       ],
       "title": "Next Action",
       "type": "stat",
-      "description": "Explicit operator routing using recording rules. Priority: Runtime blockers > Control Plane > DQ > Provider > Workflow > Monitor. Uses same recording rules as Runtime dashboard for L0/L2 consistency."
+      "description": "Threshold semantics: Runtime blockers > Control Plane > DQ > Provider > Workflow > Monitor. Next action: follow this priority order; investigate first non-OK domain and keep the same pipeline/run_type scope."
     },
     {
       "datasource": "Prometheus",

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -117,7 +117,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Combined runtime blocker count from shipped 15m/30m recording rules: preflight, infrastructure, failed runs, invariant violations, stage backlog (all stages incl. output), stage lag, gold write missing, no terminal run, no-record runs, and memory pressure. Stage filter is intentionally removed from aggregate blocker count to ensure output/gold stages are always visible.",
+      "description": "Threshold semantics: any non-zero failed runs in 15m is a runtime blocker; zero is healthy only with recent runtime activity. Next action: inspect runtime blockers table and stage culprit panels, then correlate in logs/traces if needed.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -371,7 +371,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Runtime errors normalized by bronze input over the last 30 minutes.",
+      "description": "Threshold semantics: error rate is normalized by Bronze input; elevated ratio with non-trivial denominator means runtime degradation/blocker risk. Next action: open Runtime Errors by Stage/Error Code and check failed runs/backlog/lag to isolate culprit stage.",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
### Motivation
- Make operator-facing panels explicitly actionable by encoding concise threshold semantics and the expected next action in panel `description` fields. 
- Align the live Grafana JSON descriptions with the operator guidance in `dashboard-v2-usage.md` so wording is consistent across dashboards and runbooks. 
- Avoid behavioral changes by keeping this strictly descriptive so triage flows remain unchanged while reducing operator ambiguity.

### Description
- Added/updated panel `description` text for `overview` panels `id=214` (System Status) and `id=215` (Next Action) in `grafana/dashboards/bioetl-overview-v2.json`. 
- Added/updated panel `description` text for `dq` panels `id=2` and `id=154` in `grafana/dashboards/bioetl-dq-v2.json`. 
- Added/updated panel `description` text for `runtime` panels `id=16` and `id=220` in `grafana/dashboards/bioetl-runtime.json`. 
- Added/updated panel `description` text for `control-plane` panel `id=130` in `grafana/dashboards/bioetl-control-plane-v1.json` and synchronized the same ID-specific bullets into `docs/03-guides/dashboards/dashboard-v2-usage.md`; no PromQL, thresholds, or alert rules were changed.

### Testing
- Verified JSON validity by running `python -m json.tool grafana/dashboards/bioetl-overview-v2.json` and it succeeded. 
- Verified JSON validity by running `python -m json.tool grafana/dashboards/bioetl-dq-v2.json` and it succeeded. 
- Verified JSON validity by running `python -m json.tool grafana/dashboards/bioetl-runtime.json` and `python -m json.tool grafana/dashboards/bioetl-control-plane-v1.json` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a6bc964083249d4b344ac7d05c91)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->