### PR TITLE
Normalize top-level Grafana dashboard URLs to /d/<uid>/<slug> and refresh navigation contract

### DIFF
--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -7,11 +7,18 @@
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
 - Cross-dashboard handoff передаёт только target-scoped `var-*` параметры и **MUST** включать `${__url_time_range}` во всех dashboard URL (`/d/...`).
 - `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
-  - dashboard links (`/d/...`): `${__url_time_range}`
+  - dashboard links (`/d/<uid>/<slug>?...`): `${__url_time_range}`
   - Explore links (`/explore` и `/a/grafana-*-explore-app/...`): `from=${__from}&to=${__to}`
 - Explore handoff для Loki/Tempo ведёт только через drilldown-приложения:
   - Logs: `/a/grafana-lokiexplore-app/explore?...`
   - Traces: `/a/grafana-exploretraces-app/?...`
+
+
+## Примеры URL (нормализованный формат)
+
+- Dashboard: `/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}`
+- Dashboard: `/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}`
+- Dashboard: `/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}`
 
 ## Обязательные блоки по UID
 

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -64,7 +64,7 @@
       "title": "4. Data Quality",
       "tooltip": "Data quality drilldown with bounded scope handoff",
       "type": "link",
-      "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+      "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
     {
       "asDropdown": false,
@@ -189,7 +189,7 @@
             },
             {
               "title": "Open 4. Data Quality",
-              "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
             },
             {
               "title": "Open Control Plane v1",
@@ -316,7 +316,7 @@
             },
             {
               "title": "Open 4. Data Quality",
-              "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
             },
             {
               "title": "Open 3. Provider Health",
@@ -605,7 +605,7 @@
           "links": [
             {
               "title": "Open 4. Data Quality",
-              "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
             }
           ]
         },
@@ -1108,7 +1108,7 @@
               "links": [
                 {
                   "title": "Open 4. Data Quality",
-                  "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+                  "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
                 }
               ]
             },
@@ -1676,7 +1676,7 @@
               "links": [
                 {
                   "title": "Open 4. Data Quality",
-                  "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+                  "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
                 }
               ]
             },
@@ -1847,7 +1847,7 @@
               "links": [
                 {
                   "title": "Open 4. Data Quality",
-                  "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+                  "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
                 }
               ]
             },
@@ -2322,7 +2322,7 @@
               "links": [
                 {
                   "title": "Open 4. Data Quality",
-                  "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+                  "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
                 }
               ]
             },
@@ -2369,7 +2369,7 @@
           },
           "id": 213,
           "options": {
-            "content": "<div style=\"padding:0.4rem 0.6rem;line-height:1.6\"><strong>Next dashboard:</strong> <a href=\"/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">2. Runtime</a> for failed runs/backlog/lag; <a href=\"/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">4. Data Quality</a> for DQ blockers, flow balance and Silver rejects; <a href=\"/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}\">3. Provider Health</a> for provider degradation; <a href=\"/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">Control Plane v1</a> for manifest/ledger/checkpoint/lineage; <a href=\"/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}\">6. Workflow Overview</a> for declarative workflow failures; <a href=\"/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D\">Loki Explore</a> and <a href=\"/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D\">Tempo Explore</a> for tracing-profile correlation.</div>",
+            "content": "<div style=\"padding:0.4rem 0.6rem;line-height:1.6\"><strong>Next dashboard:</strong> <a href=\"/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">2. Runtime</a> for failed runs/backlog/lag; <a href=\"/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">4. Data Quality</a> for DQ blockers, flow balance and Silver rejects; <a href=\"/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}\">3. Provider Health</a> for provider degradation; <a href=\"/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">Control Plane v1</a> for manifest/ledger/checkpoint/lineage; <a href=\"/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}\">6. Workflow Overview</a> for declarative workflow failures; <a href=\"/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D\">Loki Explore</a> and <a href=\"/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D\">Tempo Explore</a> for tracing-profile correlation.</div>",
             "mode": "html"
           },
           "title": "Drilldown Links",

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -59,7 +59,7 @@
       "targetBlank": false,
       "title": "4. Data Quality",
       "type": "link",
-      "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+      "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
     },
     {
       "asDropdown": false,
@@ -184,7 +184,7 @@
           },
           {
             "title": "Open Data Quality v2",
-            "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
           },
           {
             "title": "Open Runtime Troubleshooting Runbook",
@@ -1400,7 +1400,7 @@
         "dataLinks": [
           {
             "title": "Open Data Quality v2",
-            "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
           },
           {
             "title": "Open DQ Failure Runbook",
@@ -1646,7 +1646,7 @@
         "dataLinks": [
           {
             "title": "Open Data Quality v2",
-            "url": "/d/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
           },
           {
             "title": "Open DQ Freshness Runbook",


### PR DESCRIPTION
### Motivation
- Привести top-level ссылки на Grafana-дашборды к единому каноническому формату `/d/<uid>/<slug>?...` для предсказуемого cross-dashboard handoff и корректного учета `var-*` и `${__url_time_range}`. 
- Устранить смешение укороченного формата `/d/<uid>?...` и полной формы в shipped JSON dashboards и синхронизировать документацию контракта навигации. 

### Description
- Нормализованы top-level dashboard-ссылки в `grafana/dashboards/bioetl-overview-v2.json` и `grafana/dashboards/bioetl-runtime.json`, заменив в местах вида `/d/<uid>?...` на `/d/<uid>/<slug>?...` для целевых cross-links и drilldowns. 
- Обновлён `docs/03-guides/dashboards/navigation-contract.md` для явной фиксации формата ` /d/<uid>/<slug>?...` и добавлены примерные нормализованные URL. 
- Изменения выполнены скриптом/регулярным выражением (small Python substitution) и ограничены только форматом dashboard-ссылок; Explore-приложения и внешние URL оставлены без изменений. 

### Testing
- Запущен поиск паттернов `rg -n '/d/[^/"?]+\?' grafana/dashboards/*.json docs/03-guides/dashboards/navigation-contract.md` и подтверждено отсутствие ссылок в укороченном формате, команда завершилась успешно. 
- Проверена валидность изменённых JSON-файлов через `python -m json.tool grafana/dashboards/bioetl-runtime.json` и `python -m json.tool grafana/dashboards/bioetl-overview-v2.json`, обе проверки прошли успешно. 
- Зафиксированы изменения в репозитории (`git commit`) и подготовлен PR с описанием затронутых файлов и валидаций.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a6c488a4832490bb24cef3b1cebb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->