### PR TITLE
Add filter-order guidance to Silver Reject Explorer scope and dashboard docs

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -128,6 +128,7 @@ ______________________________________________________________________
      `Top Silver Reject Fields`, чтобы сузить проблему до bounded cause summary.
   1. Откройте `5. Silver Reject Explorer` для record-level списка, выбора
      `reason_code/field/run_id` и detail по конкретному `payload_hash`.
+     Последовательность фильтров: `pipeline → run_type → reason/field → run_id → payload_hash`.
   1. Используйте quarantine CLI для action-операций (`replay/resolve/purge`) и
      финального подтверждения remediation.
 - Эти панели отвечают на вопросы:

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -77,7 +77,7 @@
       },
       "id": 1,
       "options": {
-        "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><small>Select exactly one pipeline. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
+        "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><small>Select exactly one pipeline. Filter order: pipeline → run_type → reason/field → run_id → payload_hash. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
         "mode": "html"
       },
       "title": "Scope",


### PR DESCRIPTION
### Motivation
- Сформализовать ожидаемый порядок применения фильтров в Quarantine / Silver Reject Explorer для единообразного triage: `pipeline → run_type → reason/field → run_id → payload_hash`.
- Обеспечить, чтобы оперативная документация (`dashboard-v2-usage.md`) и визуальная подсказка в панели совпадали для снижения ошибок при расследовании инцидентов качества данных.

### Description
- Обновлён файл `grafana/dashboards/bioetl-silver-reject-explorer.json`: в панели `Scope` (``id=1``) добавлена компактная инструкция с последовательностью фильтров: `pipeline → run_type → reason/field → run_id → payload_hash`.
- Обновлён файл `docs/03-guides/dashboards/dashboard-v2-usage.md`: в разделе forensic/triage workflow добавлена та же строка с последовательностью фильтров для операционной последовательности.
- В строках подсказки и документации использована единая фразировка для консистентности между UI и руководством.

### Testing
- Проверена корректность JSON после правок командой `python -m json.tool grafana/dashboards/bioetl-silver-reject-explorer.json`, проверка прошла успешно.
- Попытка выполнить `python -m memory.tooling.workflow pre-task --task-id scope-filter-order ...` завершилась с `ModuleNotFoundError: No module named 'memory'`, поэтому pre-task memory validation не была выполнена в этой среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a8e57270832489961b4fe93a8b46)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->