### PR TITLE
docs(visual-semantics): unify L0 vs diagnostic status mapping and add L0 terminology lint

### DIFF
--- a/docs/03-guides/dashboards/dashboard-extension-human.md
+++ b/docs/03-guides/dashboards/dashboard-extension-human.md
@@ -120,10 +120,10 @@ uv run python -m pytest -q tests/integration/test_grafana_config.py
 - [ ] Для всех `stat`/`gauge` панелей используется единый `color.mode=thresholds`.
 - [ ] Для всех `stat`/`gauge` панелей используется единый `thresholds.steps`: green/null, orange/1, red/2.
 - [ ] Для всех status-панелей задано единое no-data поведение: `null -> UNKNOWN (gray)`.
-- [ ] Для всех status-панелей используется единая терминология `OK/WARN/CRIT/UNKNOWN` (без смешения с `DEGRADED/BROKEN`).
+- [ ] Для терминов статусов применяется единая таблица mapping из `docs/03-guides/dashboards/design-system.md` (раздел **1.1 Canonical mapping: L0 vs diagnostic dashboards**).
+- [ ] В L0 dashboards используется только `OK/WARN/CRIT/UNKNOWN`; alias-термины (`DEGRADED/BROKEN/HEALTHY`) допустимы только в диагностических deep-dive поверхностях и с явным alias mapping в description.
 - [ ] Для схожих KPI в разных dashboards совпадают `unit` и `decimals` (например, event counts = `short/0`, timestamps = `dateTimeAsIso/0`).
 - [ ] Заголовки новых/переименованных панелей соответствуют action-first шаблону (`Monitor/Inspect/Track/...: ...`).
-- [ ] Семантика `OK/DEGRADED/BROKEN/UNKNOWN` совпадает с `docs/03-guides/dashboards/design-system.md`.
 - [ ] Заголовки и описания новых панелей соответствуют шаблонам из design system.
 - [ ] Пройдена автоматическая проверка:
 

--- a/docs/03-guides/dashboards/dashboard-extension-llm.md
+++ b/docs/03-guides/dashboards/dashboard-extension-llm.md
@@ -146,7 +146,8 @@ uv run python -m pytest -q tests/integration/test_grafana_config.py
 - [ ] Для всех `stat`/`gauge` панелей используется единый `color.mode=thresholds`.
 - [ ] Для всех `stat`/`gauge` панелей используется единый `thresholds.steps`: green/null, orange/1, red/2.
 - [ ] Для всех status-панелей задано единое no-data поведение: `null -> UNKNOWN (gray)`.
-- [ ] Семантика `OK/DEGRADED/BROKEN/UNKNOWN` совпадает с `docs/03-guides/dashboards/design-system.md`.
+- [ ] Для терминов статусов применяется единая таблица mapping из `docs/03-guides/dashboards/design-system.md` (раздел **1.1 Canonical mapping: L0 vs diagnostic dashboards**).
+- [ ] В L0 dashboards используется только `OK/WARN/CRIT/UNKNOWN`; alias-термины (`DEGRADED/BROKEN/HEALTHY`) допустимы только в диагностических deep-dive поверхностях и с явным alias mapping в description.
 - [ ] Заголовки и описания новых панелей соответствуют шаблонам из design system.
 - [ ] Пройдена автоматическая проверка:
 

--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -15,6 +15,24 @@
 `UNKNOWN` обязателен как явное отображение no-data/null через mapping:
 - `null` → текст `UNKNOWN` + цвет `gray`.
 
+### 1.1 Canonical mapping: L0 vs diagnostic dashboards
+
+| Dashboard surface | Numeric range | Canonical status term | Visualization color |
+| --- | --- | --- | --- |
+| **L0 operator dashboards** (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`) | `0` | `OK` | `green` |
+| **L0 operator dashboards** (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`) | `1` | `WARN` | `orange` |
+| **L0 operator dashboards** (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`) | `>=2` | `CRIT` | `red` |
+| **L0 operator dashboards** (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`) | `null` | `UNKNOWN` | `gray` |
+| **Diagnostic dashboards only** (drilldown / deep-dive) | `<1` | `OK` *(alias `HEALTHY` optional)* | `green` |
+| **Diagnostic dashboards only** (drilldown / deep-dive) | `>=1 and <2` | `WARN` *(alias `DEGRADED` optional)* | `orange` |
+| **Diagnostic dashboards only** (drilldown / deep-dive) | `>=2` | `CRIT` *(alias `BROKEN` optional)* | `red` |
+| **Diagnostic dashboards only** (drilldown / deep-dive) | `null` / no data | `UNKNOWN` | `gray` |
+
+Норматив:
+- В **L0 operator dashboards** MUST использоваться только термины `OK/WARN/CRIT/UNKNOWN`.
+- Термины `DEGRADED/BROKEN/HEALTHY` допускаются только в диагностических deep-dive поверхностях и MUST быть явно привязаны к этой таблице.
+- Если в диагностическом UI используются alias-термины, в description MUST присутствовать строка вида `Alias mapping: DEGRADED=WARN, BROKEN=CRIT`.
+
 ## 2) Единые threshold ranges (обязательно)
 
 ### 2.1 Stat/Gauge

--- a/scripts/engineering/qa/check_dashboard_visual_semantics.py
+++ b/scripts/engineering/qa/check_dashboard_visual_semantics.py
@@ -16,6 +16,13 @@ EXPECTED_UNKNOWN_MAPPING = {
     "type": "special",
     "options": {"match": "null", "result": {"text": "UNKNOWN", "color": "gray"}},
 }
+L0_DASHBOARD_FILES = {
+    "bioetl-overview-v2.json",
+    "bioetl-runtime.json",
+    "bioetl-provider-health-v2.json",
+    "bioetl-dq-v2.json",
+}
+FORBIDDEN_L0_TERMS = {"DEGRADED", "BROKEN", "HEALTHY"}
 
 
 def iter_panels(panels: list[dict]) -> list[dict]:
@@ -47,6 +54,15 @@ def main() -> int:
             mappings = defaults.get("mappings", [])
             if EXPECTED_UNKNOWN_MAPPING not in mappings:
                 errors.append(f"{dashboard_path}: panel '{title}' must map null to UNKNOWN/gray")
+            dashboard_name = dashboard_path.name
+            if dashboard_name in L0_DASHBOARD_FILES:
+                text_fields = [str(title), str(panel.get("description", ""))]
+                for term in FORBIDDEN_L0_TERMS:
+                    if any(term in text.upper() for text in text_fields):
+                        errors.append(
+                            f"{dashboard_path}: panel '{title}' uses '{term}' in L0 dashboard; "
+                            "use OK/WARN/CRIT/UNKNOWN terminology"
+                        )
 
     if errors:
         print("Dashboard visual semantics check failed:")


### PR DESCRIPTION
### Motivation
- Establish a single authoritative mapping for status semantics so L0 operator dashboards and diagnostic deep-dive dashboards do not use ambiguous or overlapping terms.
- Remove ambiguity in the human and LLM dashboard extension guides by pointing both to one canonical table rather than duplicating semantics.
- Enforce the mapping via automation so regressions in shipped dashboard JSON are detected earlier in CI.

### Description
- Added a canonical mapping table `1.1 Canonical mapping: L0 vs diagnostic dashboards` to `docs/03-guides/dashboards/design-system.md` that explicitly distinguishes L0 operator surfaces from diagnostic/deep-dive surfaces and documents allowed alias rules.
- Updated `docs/03-guides/dashboards/dashboard-extension-human.md` to reference the canonical table and require explicit alias mapping in descriptions when alias terms are used in diagnostics.
- Updated `docs/03-guides/dashboards/dashboard-extension-llm.md` to mirror the same reference and checklist wording for LLM-driven changes.
- Extended the linter `scripts/engineering/qa/check_dashboard_visual_semantics.py` to (a) recognize the L0 shipped dashboard filenames and (b) fail if forbidden L0 alias terms (`DEGRADED`, `BROKEN`, `HEALTHY`) appear in `stat`/`gauge` panel titles or descriptions, while keeping existing threshold/mapping checks.

### Testing
- Ran the automated QA check `uv run python -m scripts.engineering.qa check-dashboard-visual-semantics`, which executed the updated linter and correctly reported pre-existing violations in shipped dashboard JSON (threshold mismatch and legacy L0 terminology), causing the check to fail.
- The linter change behaved as intended by surfacing specific panels using forbidden L0 alias terms in `grafana/dashboards/` files, demonstrating the QA gate will catch regressions going forward.
- No other automated test suites were modified in this change set and `python -m memory.tooling.workflow` invocations in this environment failed due to a missing `memory` module (environment limitation), not due to code changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab60fe0883248f23548226c10bdd)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dashboard extension guidelines with clarified status terminology requirements and canonical mappings for L0 and diagnostic dashboards.
  * Added explicit guidance for status alias handling in diagnostic surfaces.

* **Tests**
  * Enhanced dashboard validation to enforce visual consistency and terminology standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->