### PR TITLE
Add Open dataLinks contract and actionable links for critical Grafana panels

### DIFF
--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -122,3 +122,28 @@ uv run python -m scripts.engineering.qa check-dashboard-visual-semantics
   "timezone": "browser"
 }
 ```
+
+
+## 9) Actionable links for critical panels (обязательно)
+
+Для критичных (`P1`/`P2`) operator panels типов `stat`/`gauge`/`table` MUST быть минимум один actionable `options.dataLinks` entry.
+
+Минимальный контракт:
+- `options.dataLinks` содержит хотя бы один объект;
+- `title` начинается с шаблона `Open <target>`;
+- `url` ведёт в целевой dashboard/runbook для drilldown.
+
+Пример:
+
+```json
+"options": {
+  "dataLinks": [
+    {
+      "title": "Open bioetl-runtime",
+      "url": "/d/bioetl-runtime/bioetl-runtime",
+      "targetBlank": false
+    }
+  ]
+}
+```
+

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -218,7 +218,14 @@
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "dataLinks": [
+          {
+            "title": "Open bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "targetBlank": false
+          }
+        ]
       },
       "targets": [
         {
@@ -496,7 +503,14 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "dataLinks": [
+          {
+            "title": "Open bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "targetBlank": false
+          }
+        ]
       },
       "pluginVersion": "10.4.0",
       "targets": [
@@ -562,7 +576,14 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "dataLinks": [
+          {
+            "title": "Open bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "targetBlank": false
+          }
+        ]
       },
       "pluginVersion": "10.4.0",
       "targets": [
@@ -1029,7 +1050,14 @@
               "fields": "",
               "values": false
             },
-            "textMode": "value_and_name"
+            "textMode": "value_and_name",
+            "dataLinks": [
+              {
+                "title": "Open bioetl-runtime",
+                "url": "/d/bioetl-runtime/bioetl-runtime",
+                "targetBlank": false
+              }
+            ]
           },
           "targets": [
             {
@@ -1133,7 +1161,14 @@
               "fields": "",
               "values": false
             },
-            "textMode": "value_and_name"
+            "textMode": "value_and_name",
+            "dataLinks": [
+              {
+                "title": "Open bioetl-dq-v2",
+                "url": "/d/bioetl-dq-v2/bioetl-dq-v2",
+                "targetBlank": false
+              }
+            ]
           },
           "targets": [
             {
@@ -1238,7 +1273,14 @@
               "fields": "",
               "values": false
             },
-            "textMode": "value_and_name"
+            "textMode": "value_and_name",
+            "dataLinks": [
+              {
+                "title": "Open bioetl-control-plane-v1",
+                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1",
+                "targetBlank": false
+              }
+            ]
           },
           "targets": [
             {
@@ -1342,7 +1384,14 @@
               "fields": "",
               "values": false
             },
-            "textMode": "value_and_name"
+            "textMode": "value_and_name",
+            "dataLinks": [
+              {
+                "title": "Open bioetl-provider-health-v2",
+                "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2",
+                "targetBlank": false
+              }
+            ]
           },
           "targets": [
             {
@@ -1446,7 +1495,14 @@
               "fields": "",
               "values": false
             },
-            "textMode": "value_and_name"
+            "textMode": "value_and_name",
+            "dataLinks": [
+              {
+                "title": "Open bioetl-workflow-overview",
+                "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview",
+                "targetBlank": false
+              }
+            ]
           },
           "targets": [
             {

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -813,6 +813,47 @@ def test_overview_backlog_and_lag_panels_expose_stage() -> None:
         assert "[$__range]" in expr
 
 
+
+def test_critical_panels_expose_open_actionable_datalinks() -> None:
+    """Critical stat/gauge/table panels must expose at least one Open <target> data link."""
+    critical_panel_titles = {
+        "bioetl-overview-v2.json": {
+            "System Status",
+            "Runtime Status",
+            "Data Quality Status",
+            "Control Plane Status",
+            "Provider Status",
+            "Workflow Status",
+            "Worst Backlog Stage",
+            "Worst Lag Stage",
+        }
+    }
+
+    for dashboard_name, titles in critical_panel_titles.items():
+        dashboard = load_dashboard(Path(f"grafana/dashboards/{dashboard_name}"))
+        panels = {
+            panel.get("title"): panel
+            for panel in get_dashboard_panels(dashboard)
+            if panel.get("title")
+        }
+
+        for panel_title in titles:
+            panel = panels.get(panel_title)
+            assert panel is not None, f"Missing critical panel: {panel_title} in {dashboard_name}"
+            assert panel.get("type") in {"stat", "gauge", "table"}
+
+            data_links = panel.get("options", {}).get("dataLinks", [])
+            assert data_links, f"{panel_title} must define at least one data link"
+            assert any(
+                isinstance(link, dict)
+                and isinstance(link.get("title"), str)
+                and link["title"].startswith("Open ")
+                and isinstance(link.get("url"), str)
+                and link["url"].strip()
+                for link in data_links
+            ), f"{panel_title} must expose an actionable Open <target> link"
+
+
 def test_overview_handoff_cards_show_status_and_reason() -> None:
     dashboard = load_dashboard(Path("grafana/dashboards/bioetl-overview-v2.json"))
     panels = {


### PR DESCRIPTION
### Motivation

- Ensure P1/P2 critical operator panels (`stat`/`gauge`/`table`) provide an immediate drilldown so operators can act quickly when a critical condition appears. 
- Codify the minimum actionable-link requirement in the dashboards design system so future edits maintain the contract.
- Prevent regressions by adding an automated test that enforces the presence of an `Open <target>` actionable data link for a curated set of critical panels.

### Description

- Added `options.dataLinks` entries to critical panels in `grafana/dashboards/bioetl-overview-v2.json` (panels updated include `System Status`, `Runtime Status`, `Data Quality Status`, `Control Plane Status`, `Provider Status`, `Workflow Status`, `Worst Backlog Stage`, and `Worst Lag Stage`) with the `title` pattern `Open <target>` and `targetBlank: false`.
- Documented the new minimum contract in `docs/03-guides/dashboards/design-system.md` under a new section `Actionable links for critical panels` describing the `options.dataLinks` requirement and showing a JSON example.
- Added an integration test `test_critical_panels_expose_open_actionable_datalinks` to `tests/integration/test_grafana_config.py` which asserts each critical panel defines at least one `options.dataLinks` entry whose `title` starts with `Open ` and has a non-empty `url`.

### Testing

- Ran the focused integration tests with `uv run pytest -q tests/integration/test_grafana_config.py -k 'critical_panels_expose_open_actionable_datalinks or overview_handoff_cards_show_status_and_reason'` and the selection passed: `2 passed, 161 deselected`.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab5cb54083248ec1f1a2f149c5f1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->