### PR TITLE
Refine Overview navigation: add collapsed ‘Additional Navigation & Forensics’ row and UX checks

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -151,6 +151,8 @@ ______________________________________________________________________
 
 Primary dashboards (`1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`, `6. Workflow Overview`) MUST follow the canonical navigation contract in `navigation-contract.md`; top navigation is dashboard-specific and does **not** require a universal `Next Recommended Drilldown` link.
 
+For `bioetl-overview-v2`, mandatory top-level links are preserved per navigation contract. To reduce first-screen overload, less frequent actions are duplicated into one collapsed row `Additional Navigation & Forensics` via row-level `dataLinks`/links, so operators can use a compact first-pass path and still keep full one-click access.
+
 Variable handoff policy for dashboard links remains strict and bounded:
 
 - `includeVars=false` for every link (no implicit variable leakage).
@@ -172,16 +174,23 @@ Variable handoff policy for dashboard links remains strict and bounded:
 
 - `bioetl-overview-v2`: L0 Overview отвечает на один primary question:
   what is currently broken or degraded in BioETL, and where should the
-  operator drill down first? Dashboard links `2. Runtime`,
+  operator drill down first? Top-level dashboard links `2. Runtime`,
   `Control Plane v1`, `3. Provider Health`, `4. Data Quality`,
-  `6. Workflow Overview`,
-  `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)`
-  открывают соседние dashboards и Grafana Explore в текущем time range.
+  `6. Workflow Overview`, `Explore Logs` и `Explore Traces`
+  остаются на верхнем уровне по контракту; одновременно less-frequent actions
+  дублируются в collapsed row `Additional Navigation & Forensics`.
   Cross-dashboard URLs передают только target-scoped variables; provider/workflow
   dashboards не наследуют `$pipeline/$run_type` leakage. `System Status` and
   `Next Action` are the first operator answer; subsystem status cards show
   `Reason:` and `Next:` in legends. Panel `id=1`
   (`Processing Volume by Stage`) дублирует Explore handoff через data links.
+
+## First 2 clicks scenario (operator)
+
+1. **Click #1:** открыть `bioetl-overview-v2`, прочитать `System Status` + `Next Action`.
+2. **Click #2:** открыть рекомендуемый dashboard из top-level minimum (`2. Runtime`, `Control Plane v1`, `4. Data Quality`) или при forensic/pattern-specific нужде раскрыть `Additional Navigation & Forensics` и перейти в `Provider Health`/`Workflow`/`Explore`.
+
+Цель сценария: root-cause направление должно быть определено максимум за 2 клика без обязательной прокрутки по нечастым CTA.
 - `bioetl-runtime`: top-level links `Back to Overview`, `Control Plane v1`,
   `3. Provider Health`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`,
   `Explore Traces (Tempo, tracing profile)` и `Runtime Runbook` дают явный

--- a/docs/03-guides/dashboards/monitoring-index.md
+++ b/docs/03-guides/dashboards/monitoring-index.md
@@ -60,6 +60,22 @@ Use these UX KPIs as mandatory acceptance checks after any dashboard UX change.
   first selected link/action in `1. Overview` leads to the correct L1 dashboard
   or evidence surface without corrective backtracking.
 
+### Manual acceptance check (required)
+
+For every navigation UX change, run and record this manual check:
+
+1. Start on `bioetl-overview-v2` default window (`now-12h`, refresh `30s`).
+2. Validate **time-to-first-action**: operator identifies and executes the first correct handoff from `System Status`/`Next Action` within target SLA.
+3. Validate **click-depth**: likely root-cause surface is reached in **<= 2 clicks** for common runtime/control-plane/dq incidents.
+4. Validate fallback path: less frequent actions are reachable via collapsed `Additional Navigation & Forensics` row without broken links or scope leakage.
+
+Record outcome in change notes as: `pass/fail`, measured time-to-first-action, measured click-depth, and incident pattern used.
+
+## First 2 clicks scenario (overview-first)
+
+- Click 1: open `bioetl-overview-v2` and read `System Status` + `Next Action`.
+- Click 2: follow recommended top-level route (`2. Runtime`, `Control Plane v1`, `4. Data Quality`) or expand `Additional Navigation & Forensics` for `Provider Health`/`Workflow`/`Explore`.
+
 ## Architecture Map
 
 | Layer / surface | Responsibility | Source of truth |

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -43,16 +43,12 @@
       "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
       "title": "3. Provider Health",
-      "tooltip": "Cross-scope handoff: opens Provider Health with All provider/adapter scope (core filters do not transfer).",
+      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}",
       "type": "link",
-      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}"
+      "asDropdown": false,
+      "keepTime": true,
+      "targetBlank": false
     },
     {
       "asDropdown": false,
@@ -67,40 +63,28 @@
       "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
       "title": "6. Workflow Overview",
-      "tooltip": "Cross-scope handoff: opens Workflow Overview with All workflow/status scope (core filters do not transfer).",
+      "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}",
       "type": "link",
-      "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}"
+      "asDropdown": false,
+      "keepTime": true,
+      "targetBlank": false
     },
     {
-      "asDropdown": false,
-      "icon": "logs",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
-      "tooltip": "Open Loki Explore with tracing profile and selected time range",
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
       "type": "link",
-      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+      "asDropdown": false,
+      "keepTime": true,
+      "targetBlank": false
     },
     {
-      "asDropdown": false,
-      "icon": "search",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
-      "tooltip": "Open Tempo Explore with tracing profile and selected time range",
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+      "asDropdown": false,
+      "keepTime": true,
+      "targetBlank": false
     }
   ],
   "panels": [
@@ -2378,6 +2362,69 @@
       ],
       "title": "Extended distributions",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 9001,
+      "panels": [],
+      "title": "Additional Navigation & Forensics",
+      "type": "row",
+      "links": [
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "3. Provider Health",
+          "tooltip": "Cross-scope handoff: opens Provider Health with All provider/adapter scope (core filters do not transfer).",
+          "type": "link",
+          "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}"
+        },
+        {
+          "asDropdown": false,
+          "icon": "dashboard",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "6. Workflow Overview",
+          "tooltip": "Cross-scope handoff: opens Workflow Overview with All workflow/status scope (core filters do not transfer).",
+          "type": "link",
+          "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}"
+        },
+        {
+          "asDropdown": false,
+          "icon": "logs",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Explore Logs (Loki, tracing profile)",
+          "tooltip": "Open Loki Explore with tracing profile and selected time range",
+          "type": "link",
+          "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+        },
+        {
+          "asDropdown": false,
+          "icon": "search",
+          "includeVars": false,
+          "keepTime": true,
+          "tags": [],
+          "targetBlank": false,
+          "title": "Explore Traces (Tempo, tracing profile)",
+          "tooltip": "Open Tempo Explore with tracing profile and selected time range",
+          "type": "link",
+          "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
### Motivation

- Reduce first-screen cognitive load on the L0 overview while keeping all mandatory navigation per the navigation contract. 
- Make the common operator path explicit (answer + “first 2 clicks”) so root-cause direction is determined quickly. 
- Add a manual UX acceptance check to ensure dashboard navigation changes preserve operator SLAs for time-to-first-action and click-depth.

### Description

- Added a collapsed row panel `Additional Navigation & Forensics` to `bioetl-overview-v2` and moved less-frequent actions (Provider Health, Workflow, Explore Logs/Traces) into row-level `links`, while preserving required top-level links and time-range handoff semantics in the overview JSON (`grafana/dashboards/bioetl-overview-v2.json`).
- Updated operator guidance in `docs/03-guides/dashboards/dashboard-v2-usage.md` with an explicit “First 2 clicks” scenario describing the recommended L0→L1/L2 flow and how the collapsed row is intended to be used.
- Added a required manual acceptance check to `docs/03-guides/dashboards/monitoring-index.md` that records `time-to-first-action`, `click-depth`, and pass/fail outcomes for navigation UX changes.
- Ensured the overview still exposes Explore (Loki/Tempo) drilldowns and preserved explicit `keepTime`/`${__url_time_range}` behavior for cross-dashboard links.

### Testing

- Ran targeted navigation-contract tests: `tests/integration/test_grafana_dashboard_links.py::test_dashboard_top_level_navigation_contract_by_uid` and `tests/integration/test_grafana_dashboard_links.py::test_overview_and_provider_dashboards_expose_explore_drilldown_links`; both passed.
- Ran a broader combined test run `pytest tests/integration/test_grafana_dashboard_links.py tests/unit/grafana/test_workflow_dashboard_json_valid.py` which exposed 9 failures; these failures are in control-plane handoff/time-range assertions outside the scope of the overview collapsed-row change and require separate follow-up (observed during validation). 
- Attempted to run the memory workflow helper `python -m memory.tooling.workflow pre-task ...` but the runtime environment lacked the `memory` package, so the pre-task workflow could not be executed in this session (ModuleNotFoundError).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aaf76d5883248acd7a6f4cc02a31)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->