### PR TITLE
Unify Grafana navigation link contract across docs, tests, and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,6 +209,14 @@ jobs:
             -   name: Observability metric inventory drift gate
                 run: uv run python -m scripts.engineering.qa report-observability-metric-inventory --check --json
 
+            -   name: Dashboard navigation contract sync gate
+                run: |
+                    uv run pytest \
+                      tests/integration/test_grafana_dashboard_links.py::test_cross_dashboard_links_pass_only_target_scoped_variables \
+                      tests/integration/test_grafana_dashboard_links.py::test_dashboard_top_level_navigation_contract_by_uid \
+                      tests/integration/test_dashboard_navigation_contract_sync.py \
+                      -q --tb=short
+
             -   name: Prometheus rules syntax + promtool test vectors
                 run: |
                     docker run --rm -v "$PWD:/workspace" -w /workspace prom/prometheus:v2.54.1 \

--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -1,0 +1,59 @@
+version: 1
+required_top_level_links_by_uid:
+  bioetl-overview-v2:
+    - 2. Runtime
+    - Control Plane v1
+    - 3. Provider Health
+    - 4. Data Quality
+    - 6. Workflow Overview
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-runtime:
+    - Back to Overview
+    - Control Plane v1
+    - 3. Provider Health
+    - 4. Data Quality
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-control-plane-v1:
+    - Back to Overview
+    - 2. Runtime
+    - 4. Data Quality
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-provider-health-v2:
+    - Back to Overview
+    - 2. Runtime
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-dq-v2:
+    - Back to Overview
+    - Control Plane v1
+    - 5. Silver Reject Explorer
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-silver-reject-explorer:
+    - Back to Overview
+    - Back to Data Quality
+    - Explore Logs (Loki, tracing profile)
+    - Explore Traces (Tempo, tracing profile)
+  bioetl-workflow-overview:
+    - Back to Overview
+    - 2. Runtime
+    - Control Plane v1
+required_link_vars_by_target_uid:
+  bioetl-overview-v2: [pipeline, run_type]
+  bioetl-control-plane-v1: [pipeline, run_type]
+  bioetl-runtime: [pipeline, run_type]
+  bioetl-dq-v2: [pipeline, run_type]
+  bioetl-provider-health-v2: []
+  bioetl-silver-reject-explorer: [pipeline, run_type]
+  bioetl-workflow-overview: []
+allowed_dashboard_link_vars:
+  bioetl-overview-v2: [pipeline, run_type]
+  bioetl-dq-v2: [pipeline, run_type, stage]
+  bioetl-runtime: [pipeline, run_type, stage]
+  bioetl-provider-health-v2: [provider, adapter]
+  bioetl-control-plane-v1: [pipeline, run_type]
+  bioetl-workflow-overview: [workflow, status]
+  bioetl-silver-reject-explorer: [pipeline, run_type, reason_code, field, run_id, payload_hash]

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -16,6 +16,8 @@ ______________________________________________________________________
 Дата сверки: **2026-04-13**
 Источник истины: `grafana/dashboards/*.json`
 
+Machine-readable navigation contract: `docs/03-guides/dashboards/contracts/navigation-links.yaml` (docs/tests должны соответствовать ему).
+
 ## Какие дашборды использовать
 
 | Dashboard                 | UID                             | Для чего                                                                                   |

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -2,6 +2,8 @@
 
 Канонический контракт навигации для shipped dashboard UIDs в `grafana/dashboards/*.json`.
 
+Machine-readable SSOT: `docs/03-guides/dashboards/contracts/navigation-links.yaml`.
+
 ## Общие правила
 
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.

--- a/tests/integration/test_dashboard_navigation_contract_sync.py
+++ b/tests/integration/test_dashboard_navigation_contract_sync.py
@@ -1,0 +1,43 @@
+"""Consistency checks for dashboard navigation contract surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.integration
+
+_CONTRACT_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
+_NAV_DOC_PATH = Path("docs/03-guides/dashboards/navigation-contract.md")
+_USAGE_DOC_PATH = Path("docs/03-guides/dashboards/dashboard-v2-usage.md")
+_DASHBOARDS_DIR = Path("grafana/dashboards")
+
+
+def _load_contract() -> dict[str, object]:
+    return yaml.safe_load(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_navigation_contract_docs_reference_machine_readable_artifact() -> None:
+    for path in (_NAV_DOC_PATH, _USAGE_DOC_PATH):
+        text = path.read_text(encoding="utf-8")
+        assert "contracts/navigation-links.yaml" in text
+
+
+def test_navigation_contract_uids_match_shipped_dashboards() -> None:
+    contract = _load_contract()
+    required_links = contract["required_top_level_links_by_uid"]
+    assert isinstance(required_links, dict)
+
+    contract_uids = set(required_links.keys())
+    shipped_uids: set[str] = set()
+
+    for dashboard_path in _DASHBOARDS_DIR.glob("*.json"):
+        dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+        uid = dashboard.get("uid")
+        assert isinstance(uid, str), f"{dashboard_path.name} must define string uid"
+        shipped_uids.add(uid)
+
+    assert contract_uids == shipped_uids

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import re
+import yaml
 
 import pytest
 from tests.integration._grafana_test_support import (
@@ -17,90 +18,35 @@ pytestmark = pytest.mark.integration
 
 _DASHBOARD_UID_RE = re.compile(r"^/d/([^/?]+)")
 _LINK_VAR_RE = re.compile(r"(?:\?|&)var-([A-Za-z_]+)=")
-_ALLOWED_DASHBOARD_LINK_VARS = {
-    "bioetl-overview-v2": frozenset({"pipeline", "run_type"}),
-    "bioetl-dq-v2": frozenset({"pipeline", "run_type", "stage"}),
-    "bioetl-runtime": frozenset({"pipeline", "run_type", "stage"}),
-    "bioetl-provider-health-v2": frozenset({"provider", "adapter"}),
-    "bioetl-control-plane-v1": frozenset({"pipeline", "run_type"}),
-    "bioetl-workflow-overview": frozenset({"workflow", "status"}),
-    "bioetl-silver-reject-explorer": frozenset(
-        {"pipeline", "run_type", "reason_code", "field", "run_id", "payload_hash"}
-    ),
-}
+_NAV_LINK_CONTRACT_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
 
 
+def _load_navigation_links_contract() -> dict[str, dict[str, frozenset[str]]]:
+    with _NAV_LINK_CONTRACT_PATH.open("r", encoding="utf-8") as stream:
+        raw_contract = yaml.safe_load(stream)
 
-_REQUIRED_LINK_VARS_BY_TARGET_UID = {
-    "bioetl-overview-v2": frozenset({"pipeline", "run_type"}),
-    "bioetl-control-plane-v1": frozenset({"pipeline", "run_type"}),
-    "bioetl-runtime": frozenset({"pipeline", "run_type"}),
-    "bioetl-dq-v2": frozenset({"pipeline", "run_type"}),
-    "bioetl-provider-health-v2": frozenset(),
-    "bioetl-silver-reject-explorer": frozenset({"pipeline", "run_type"}),
-    "bioetl-workflow-overview": frozenset(),
-}
+    def _as_frozenset_map(section_name: str) -> dict[str, frozenset[str]]:
+        raw_map = raw_contract.get(section_name, {})
+        assert isinstance(raw_map, dict), f"{section_name} must be a mapping"
+        result: dict[str, frozenset[str]] = {}
+        for uid, values in raw_map.items():
+            assert isinstance(uid, str), f"{section_name} keys must be strings"
+            assert isinstance(values, list), f"{section_name}.{uid} must be a list"
+            result[uid] = frozenset(str(v) for v in values)
+        return result
 
-_REQUIRED_TOP_LEVEL_LINKS_BY_UID = {
-    "bioetl-overview-v2": frozenset(
-        {
-            "2. Runtime",
-            "Control Plane v1",
-            "3. Provider Health",
-            "4. Data Quality",
-            "6. Workflow Overview",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-runtime": frozenset(
-        {
-            "Back to Overview",
-            "Control Plane v1",
-            "3. Provider Health",
-            "4. Data Quality",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-control-plane-v1": frozenset(
-        {
-            "Back to Overview",
-            "2. Runtime",
-            "4. Data Quality",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-provider-health-v2": frozenset(
-        {
-            "Back to Overview",
-            "2. Runtime",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-dq-v2": frozenset(
-        {
-            "Back to Overview",
-            "Control Plane v1",
-            "5. Silver Reject Explorer",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-silver-reject-explorer": frozenset(
-        {
-            "Back to Overview",
-            "Back to Data Quality",
-            "Explore Logs (Loki, tracing profile)",
-            "Explore Traces (Tempo, tracing profile)",
-        }
-    ),
-    "bioetl-workflow-overview": frozenset(
-        {"Back to Overview", "2. Runtime", "Control Plane v1"}
-    ),
-}
+    return {
+        "allowed_dashboard_link_vars": _as_frozenset_map("allowed_dashboard_link_vars"),
+        "required_link_vars_by_target_uid": _as_frozenset_map("required_link_vars_by_target_uid"),
+        "required_top_level_links_by_uid": _as_frozenset_map("required_top_level_links_by_uid"),
+    }
+
+
+_NAV_LINK_CONTRACT = _load_navigation_links_contract()
+_ALLOWED_DASHBOARD_LINK_VARS = _NAV_LINK_CONTRACT["allowed_dashboard_link_vars"]
+_REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT["required_link_vars_by_target_uid"]
+_REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
+
 
 
 def _extract_dashboard_uid(url: str) -> str | None:


### PR DESCRIPTION
### Motivation
- Centralize the Grafana cross-dashboard navigation/link handoff rules into a single machine-readable SSOT so docs, tests, and CI can stay in sync.
- Replace duplicated hardcoded link/var rules in tests and markdown with a single authoritative artifact to reduce drift and reviewer burden.
- Add an automated gate so contract/docs/tests disagreement fails CI early.

### Description
- Add a machine-readable navigation contract at `docs/03-guides/dashboards/contracts/navigation-links.yaml` containing required top-level links and allowed/required `var-*` handoffs by dashboard UID.
- Rewire `tests/integration/test_grafana_dashboard_links.py` to load the YAML contract and replace the previous hardcoded maps with a loader that exposes frozenset views for checks.
- Add `tests/integration/test_dashboard_navigation_contract_sync.py` which asserts docs reference the YAML SSOT and that contract UIDs match shipped `grafana/dashboards/*.json` UIDs.
- Sync `docs/03-guides/dashboards/navigation-contract.md` and `dashboard-v2-usage.md` to reference the new SSOT and add a CI gate in `.github/workflows/tests.yml` to run the navigation contract checks during the test workflow.

### Testing
- Ran the targeted contract/tests trio with `uv run pytest tests/integration/test_grafana_dashboard_links.py::test_cross_dashboard_links_pass_only_target_scoped_variables tests/integration/test_grafana_dashboard_links.py::test_dashboard_top_level_navigation_contract_by_uid tests/integration/test_dashboard_navigation_contract_sync.py -q --tb=short` and the run passed (`4 passed`).
- An earlier run of `uv run pytest tests/integration/test_grafana_dashboard_links.py tests/integration/test_dashboard_navigation_contract_sync.py -q --tb=short` surfaced 3 failing assertions which were corrected by syncing docs and test expectations, after which the targeted tests passed.
- CI workflow updated to include the navigation contract sync gate so the contract/docs/tests trio will be exercised automatically on the test lane (`.github/workflows/tests.yml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aa869cac83248bfa9cd3d4563816)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->