### PR TITLE
Align Grafana dashboard default time windows and enforce UID-specific time.from policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ______________________________________________________________________
 - **Deterministic Writes**: Reproducible outputs and deterministic retries ([ADR-014](docs/02-architecture/decisions/ADR-014-deterministic-writes.md)).
 - **Run Control Plane**: Immutable run manifests and append-only ledgers for provenance, replay analysis, and artifact linkage ([ADR-044](docs/02-architecture/decisions/ADR-044-run-manifest-ledger-control-plane.md)).
 - **Observability by Design**: Metrics, tracing, and logging ports ([ADR-017](docs/02-architecture/decisions/ADR-017-observability-architecture.md)).
+- **Operator Dashboards**: Unified L0/L1 Grafana default window `time.from=now-12h` (`time.to=now`, `refresh=30s`) including `bioetl-control-plane-v1`; `bioetl-silver-reject-explorer` is the explicit `time.from=now-24h` forensic exception (see `docs/03-guides/dashboards/variables-guide.md`).
 - **Unified HTTP Client**: Standardized rate limiting, retry, and telemetry ([ADR-032](docs/02-architecture/decisions/ADR-032-unified-http-client.md)).
 - **Strict Governance**: Comprehensive rules for schema evolution, data contracts, and operational procedures.
 

--- a/docs/03-guides/dashboards/dashboard-v2-updates.md
+++ b/docs/03-guides/dashboards/dashboard-v2-updates.md
@@ -30,7 +30,7 @@ ______________________________________________________________________
 - Все shipped dashboards, кроме `bioetl-silver-reject-explorer`, используют `refresh: 30s`.
 - `bioetl-silver-reject-explorer` использует `refresh: 1m` и `time.from: now-24h`.
 - `time.from` для `overview/runtime/provider-health/dq/workflow` = `now-12h`.
-- `time.from` для `control-plane-v1` = `now-6h`.
+- `time.from` для `control-plane-v1` = `now-12h`.
 - Переменные `overview`: `$pipeline`, `$run_type`.
 - Переменные `control-plane-v1`: `$pipeline`, `$run_type`.
 - Переменные `dq/runtime`: `$pipeline`, `$run_type`, `$stage`.
@@ -139,6 +139,22 @@ histogram_quantile(0.95, sum by (le, provider) (rate(bioetl_health_check_latency
 - `bioetl-provider-health-v2`: row `id=91` + панели `1,2,104,7,102`
 - `bioetl-runtime`: `id=1..9`, `Back to Overview`, links в `Explore`
 - `bioetl-workflow-overview`: `id=1..5` с `$workflow/$status` scope
+
+## Canonical decision: default time windows (single source for docs sync)
+
+- Decision ID: `DASH-TIMEWINDOW-2026-05-03`
+- Canonical source: `grafana/dashboards/*.json` (dashboard-as-code), validated by
+  `tests/integration/test_grafana_config.py`.
+- Rule:
+  - L0/L1 operator dashboards (`bioetl-overview-v2`, `bioetl-runtime`,
+    `bioetl-dq-v2`, `bioetl-provider-health-v2`, `bioetl-workflow-overview`,
+    `bioetl-control-plane-v1`) MUST keep `time.from=now-12h`, `time.to=now`,
+    `refresh=30s`.
+  - Forensic dashboard `bioetl-silver-reject-explorer` is the explicit
+    exception with `time.from=now-24h`, `time.to=now`, `refresh=1m`.
+- Rationale: единый операторский baseline снижает когнитивный drift между
+  дашбордами и уменьшает риск ложной интерпретации при cross-dashboard triage;
+  forensic surface сохраняет более длинный горизонт для редких reject-инцидентов.
 
 ## Примечание по старым гайдам
 

--- a/docs/03-guides/dashboards/monitoring-index.md
+++ b/docs/03-guides/dashboards/monitoring-index.md
@@ -110,6 +110,8 @@ surface с answer-first `Trust Summary` в самом верху: replay safety 
 checkpoint freshness proxy и ledger/manifest consistency. В этом же верхнем
 блоке явно отображается список `Known Blind Spots` (что пока не
 инструментировано), чтобы оператор не трактовал отсутствие сигнала как `OK`.
+По умолчанию этот dashboard открывается с окном `time.from=now-12h`
+(`time.to=now`, `refresh=30s`) — наравне с другими L0/L1 operator dashboards.
 
 GLOBAL read-path panels остаются отдельно в блоке
 `Global diagnostics (non-pipeline scoped)` и не фильтруются по `$pipeline` /

--- a/docs/03-guides/dashboards/variables-guide.md
+++ b/docs/03-guides/dashboards/variables-guide.md
@@ -84,7 +84,7 @@ UX цель: убрать ложное ожидание, что source filters �
   - `overview`: `time.from=now-12h`, `refresh=30s`
   - `runtime`: `time.from=now-12h`, `refresh=30s`
   - `dq`: `time.from=now-12h`, `refresh=30s`
-  - `control-plane`: `time.from=now-12h`, `refresh=30s`
+  - `control-plane` (`uid=bioetl-control-plane-v1`): `time.from=now-12h`, `refresh=30s`
 - **Forensic L2 exception (must include explicit justification in docs/PR):**
   - `explorer` (`bioetl-silver-reject-explorer`): `time.from=now-24h`, `refresh=1m`
   - Justification: forensic/reject investigation требует больше стартового горизонта для редких инцидентов и сниженной частоты auto-refresh, чтобы уменьшить шум и нагрузку при row-level анализе.

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -2216,6 +2216,31 @@ def test_replay_panels_are_split_by_semantics(dashboard_file: str) -> None:
     assert lag.get("fieldConfig", {}).get("defaults", {}).get("unit") == "s"
 
 
+def test_dashboard_default_time_from_policy_by_uid() -> None:
+    """Shipped dashboards must keep canonical default time.from policy by UID."""
+    expected_time_from_by_uid = {
+        "bioetl-overview-v2": "now-12h",
+        "bioetl-runtime": "now-12h",
+        "bioetl-dq-v2": "now-12h",
+        "bioetl-provider-health-v2": "now-12h",
+        "bioetl-workflow-overview": "now-12h",
+        "bioetl-control-plane-v1": "now-12h",
+        "bioetl-silver-reject-explorer": "now-24h",
+    }
+
+    for uid, expected_time_from in expected_time_from_by_uid.items():
+        dashboard = load_dashboard(Path("grafana/dashboards") / f"{uid}.json")
+        actual_uid = dashboard.get("uid")
+        assert actual_uid == uid, f"Dashboard UID mismatch for {uid}.json"
+
+        time_cfg = dashboard.get("time", {})
+        assert isinstance(time_cfg, dict), f"{uid} time config must be an object"
+        assert time_cfg.get("from") == expected_time_from, (
+            f"{uid} must keep time.from={expected_time_from!r}, "
+            f"got {time_cfg.get('from')!r}"
+        )
+
+
 def test_provider_health_selected_provider_detail_row_is_collapsed() -> None:
     """Provider detail repeat row should be explicit and collapsed by default."""
     dashboard = load_dashboard(


### PR DESCRIPTION
### Motivation

- Fix documentation drift where `bioetl-control-plane-v1` default window in docs did not match the actual `grafana/dashboards/bioetl-control-plane-v1.json` payload. 
- Provide a single canonical decision for operator dashboard time windows to reduce cross-dashboard cognitive drift and avoid inconsistent triage behavior. 
- Make the dashboard-as-code expectation verifiable by tests so future edits remain in sync with JSON sources. 

### Description

- Updated `docs/03-guides/dashboards/variables-guide.md` to explicitly mark `control-plane` as `uid=bioetl-control-plane-v1` with `time.from=now-12h`, `time.to=now`, `refresh=30s`.
- Clarified the same default window in `docs/03-guides/dashboards/monitoring-index.md` and added the operator-window note to the `README.md` feature bullet.
- Corrected `docs/03-guides/dashboards/dashboard-v2-updates.md` to change the `control-plane-v1` window from `now-6h` to `now-12h` and added a canonical decision block `DASH-TIMEWINDOW-2026-05-03` documenting the rule and rationale.
- Added `test_dashboard_default_time_from_policy_by_uid` to `tests/integration/test_grafana_config.py` to assert `time.from` per UID (including the forensic exception `bioetl-silver-reject-explorer=now-24h`).

### Testing

- Ran the focused integration test with `uv run python -m pytest -q tests/integration/test_grafana_config.py -k "default_time_from_policy_by_uid"`, which passed (`1 passed, 162 deselected`).
- No Grafana JSON payloads were modified as part of this change; tests validate existing dashboard-as-code values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aae3cbb48324b2c168a35e64a824)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->