### PR TITLE
Add reset-scope communication for cross-scope Grafana links

### DIFF
--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -6,6 +6,7 @@
 
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
 - Cross-dashboard handoff передаёт только target-scoped `var-*` параметры и **MUST** включать `${__url_time_range}` во всех dashboard URL (`/d/...`).
+- Каждый cross-scope link (Core↔Provider, Workflow→Core) **MUST** иметь reset-коммуникацию в `links[]` через `tooltip` или `description`: явно указать `var-*=All` reset и какие source-scope переменные не переносятся.
 - `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
   - dashboard links (`/d/<uid>/<slug>?...`): `${__url_time_range}`
   - Explore links (`/explore` и `/a/grafana-*-explore-app/...`): `from=${__from}&to=${__to}`

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -50,9 +50,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "3. Provider Health",
-      "tooltip": "Cross-scope handoff: opens Provider Health with All provider/adapter scope (core filters do not transfer).",
+      "tooltip": "Cross-scope reset: opens Provider Health with var-provider=All and var-adapter=All; core vars pipeline/run_type do not transfer.",
       "type": "link",
-      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}"
+      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}",
+      "description": "Cross-scope reset: opens Provider Health with var-provider=All and var-adapter=All; core vars pipeline/run_type do not transfer."
     },
     {
       "asDropdown": false,
@@ -74,9 +75,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "6. Workflow Overview",
-      "tooltip": "Cross-scope handoff: opens Workflow Overview with All workflow/status scope (core filters do not transfer).",
+      "tooltip": "Cross-scope reset: opens Workflow Overview with var-workflow=All and var-status=All; core vars pipeline/run_type do not transfer.",
       "type": "link",
-      "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}"
+      "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}",
+      "description": "Cross-scope reset: opens Workflow Overview with var-workflow=All and var-status=All; core vars pipeline/run_type do not transfer."
     },
     {
       "asDropdown": false,

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -26,9 +26,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Overview",
-      "tooltip": "Cross-scope handoff: opens Overview with var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "tooltip": "Cross-scope reset: opens Overview with var-pipeline=All and var-run_type=All; provider vars provider/adapter do not transfer.",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}",
+      "description": "Cross-scope reset: opens Overview with var-pipeline=All and var-run_type=All; provider vars provider/adapter do not transfer."
     },
     {
       "asDropdown": false,
@@ -38,9 +39,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer.",
+      "tooltip": "Cross-scope reset: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; provider vars provider/adapter do not transfer.",
       "type": "link",
-      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
+      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}",
+      "description": "Cross-scope reset: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; provider vars provider/adapter do not transfer."
     },
     {
       "asDropdown": false,

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -47,9 +47,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "3. Provider Health",
-      "tooltip": "Cross-scope handoff: opens Provider Health with var-provider=All and var-adapter=All; pipeline/run_type/stage do not transfer.",
+      "tooltip": "Cross-scope reset: opens Provider Health with var-provider=All and var-adapter=All; core vars pipeline/run_type/stage do not transfer.",
       "type": "link",
-      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}"
+      "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}",
+      "description": "Cross-scope reset: opens Provider Health with var-provider=All and var-adapter=All; core vars pipeline/run_type/stage do not transfer."
     },
     {
       "asDropdown": false,

--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -25,9 +25,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Overview",
-      "tooltip": "Cross-scope handoff: opens Overview with var-pipeline=All and var-run_type=All; workflow/status do not transfer.",
+      "tooltip": "Cross-scope reset: opens Overview with var-pipeline=All and var-run_type=All; workflow vars workflow/status do not transfer.",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}",
+      "description": "Cross-scope reset: opens Overview with var-pipeline=All and var-run_type=All; workflow vars workflow/status do not transfer."
     },
     {
       "asDropdown": false,
@@ -37,9 +38,10 @@
       "tags": [],
       "targetBlank": false,
       "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; workflow/status do not transfer.",
+      "tooltip": "Cross-scope reset: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; workflow vars workflow/status do not transfer.",
       "type": "link",
-      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
+      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}",
+      "description": "Cross-scope reset: opens Runtime with var-pipeline=All, var-run_type=All, var-stage=All; workflow vars workflow/status do not transfer."
     },
     {
       "asDropdown": false,

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -41,6 +41,15 @@ _REQUIRED_LINK_VARS_BY_TARGET_UID = {
     "bioetl-workflow-overview": frozenset(),
 }
 
+
+
+_CROSS_SCOPE_RESET_LINK_TITLES_BY_UID = {
+    "bioetl-overview-v2": frozenset({"3. Provider Health", "6. Workflow Overview"}),
+    "bioetl-runtime": frozenset({"3. Provider Health"}),
+    "bioetl-provider-health-v2": frozenset({"Back to Overview", "2. Runtime"}),
+    "bioetl-workflow-overview": frozenset({"Back to Overview", "2. Runtime"}),
+}
+
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = {
     "bioetl-overview-v2": frozenset(
         {
@@ -226,6 +235,37 @@ def test_cross_dashboard_links_pass_only_target_scoped_variables() -> None:
                 )
 
 
+
+
+
+def test_cross_scope_links_expose_reset_scope_hint() -> None:
+    """Cross-scope links must disclose reset-to-All communication via tooltip/description."""
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        uid = dashboard.get("uid")
+        if not isinstance(uid, str):
+            continue
+
+        required_titles = _CROSS_SCOPE_RESET_LINK_TITLES_BY_UID.get(uid)
+        if not required_titles:
+            continue
+
+        top_links = {
+            link.get("title"): link
+            for link in dashboard.get("links", [])
+            if isinstance(link.get("title"), str)
+        }
+        for title in required_titles:
+            link = top_links.get(title)
+            assert link is not None, f"{dashboard_path.name} is missing cross-scope link {title}"
+            hint = str(link.get("tooltip") or link.get("description") or "")
+            hint_lc = hint.lower()
+            assert "all" in hint_lc, (
+                f"{dashboard_path.name} link '{title}' must disclose reset-to-All scope"
+            )
+            assert "do not transfer" in hint_lc or "не перено" in hint_lc, (
+                f"{dashboard_path.name} link '{title}' must disclose source-scope reset semantics"
+            )
 
 
 def test_dashboard_top_level_navigation_contract_by_uid() -> None:


### PR DESCRIPTION
### Motivation
- Ensure cross-scope dashboard handoffs (Core↔Provider and Workflow→Core) explicitly communicate that target scope is reset to `All` and which source-scoped variables are not transferred. 
- Make the navigation contract machine-testable so operators and dashboards remain consistent and avoid silent scope leaks. 

### Description
- Require reset communication in the canonical navigation contract by adding an explicit rule to `docs/03-guides/dashboards/navigation-contract.md` that cross-scope links **MUST** include reset hints in `links[]` via `tooltip` or `description`.
- Enriched `links[]` in shipped dashboards without changing canonical `title` values by adding informative `tooltip`/`description` entries in `grafana/dashboards/bioetl-overview-v2.json`, `grafana/dashboards/bioetl-runtime.json`, `grafana/dashboards/bioetl-provider-health-v2.json`, and `grafana/dashboards/bioetl-workflow-overview.json` to state the `var-*=All` reset and what does not transfer.
- Added an integration assertion in `tests/integration/test_grafana_dashboard_links.py`: new `_CROSS_SCOPE_RESET_LINK_TITLES_BY_UID` map and `test_cross_scope_links_expose_reset_scope_hint` which verifies each required cross-scope link exposes a reset-to-All hint (`All` + phrasing like “do not transfer”).

### Testing
- Ran the targeted new integration assertion with `bash scripts/engineering/dev/run_pytest.sh tests/integration/test_grafana_dashboard_links.py -k cross_scope_links_expose_reset_scope_hint` and it passed (1 passed, 36 deselected).
- Ran a full run of the dashboard-links integration file via `bash scripts/engineering/dev/run_pytest.sh tests/integration/test_grafana_dashboard_links.py` and observed one pre-existing failure unrelated to these edits: `test_runtime_incident_panels_link_to_control_plane_dashboard` expecting `from=${__from}&to=${__to}` while some dashboard URLs use `${__url_time_range}`.
- Direct `pytest -q` failed in this environment due to test runner config (`--timeout=300` in `pytest.ini`) not available when invoked directly; this is an environment/CI plugin issue, not caused by these changes.
- Checks run: targeted integration test (run, pass); full dashboard-links integration (run, 1 unrelated fail); skipped: full test suite and CI pipeline (not executed here). Mirror-sync status: canonical docs updated (`navigation-contract.md`) and dashboard JSONs edited in-repo; no external docs mirrors were changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7aaf1f6b88324a40e586a0c6e1c97)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->