### PR TITLE
Add 24h forensic-window banner and DQ→Explorer handoff guidance; update docs and tests

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -213,7 +213,22 @@ Variable handoff policy for dashboard links remains strict and bounded:
   `store/operation/status`.
 - `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
 - `bioetl-dq-v2`: dashboard link `Back to Overview` плюс `5. Silver Reject Explorer`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают тот же переход для DQ incidents и freshness investigation. Handoff в Explorer передаёт только bounded `$pipeline/$run_type` scope, а не generic `includeVars` leakage. Panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`) дублирует Explore handoff через data links.
-- `bioetl-silver-reject-explorer`: dashboard links `Back to Overview`, `Back to Data Quality`, `Open Logs`, `Open Traces`; back-links возвращают только `$pipeline/$run_type`, не leaking `payload_hash` или other forensic filters. Main table поддерживает data links для self-drilldown по `payload_hash` и CLI handoff.
+- `bioetl-silver-reject-explorer`: dashboard links `Back to Overview`, `Back to Data Quality`, `Open Logs`, `Open Traces`; back-links возвращают только `$pipeline/$run_type`, не leaking `payload_hash` или other forensic filters. Main table поддерживает data links для self-drilldown по `payload_hash` и CLI handoff. Верхняя explanatory panel явно показывает banner `default 24h forensic window`, чтобы оператор не интерпретировал explorer как обычное `now-12h` окно.
+
+### Expected operator behavior for DQ -> Explorer handoff
+
+- Из `4. Data Quality` переход в `5. Silver Reject Explorer` передаёт только
+  `$pipeline/$run_type`, но intentionally открывает более широкое окно
+  `now-24h` (forensic default) для редких инцидентов и sparse reject events.
+- Оператор SHOULD сначала подтвердить, что текущий spike/аномалия видны в
+  summary-панелях DQ (`Top Silver Reject Reasons/Fields`) и только затем делать
+  record-level drilldown в Explorer.
+- После перехода оператор SHOULD проверить explanatory banner
+  `default 24h forensic window`; при шуме или слишком большом объёме данных
+  окно можно сузить вручную до operational range.
+- Для очень редких инцидентов оператор MAY оставить 24h окно и уточнить
+  контекст через `reason_code`, `field`, `run_id` и `payload_hash` перед
+  action-операциями в CLI.
 - `bioetl-workflow-overview`: dashboard links `Back to Overview`, `2. Runtime`, `Control Plane v1`; cross-dashboard handoffs не leaking `$workflow/$status` into non-workflow targets. Prometheus panels use only bounded workflow labels (`workflow`, `status`, `step_kind`) and never require `run_id`/`step_id` labels.
 - Loki drilldown использует безопасный low-cardinality entrypoint `{job="bioetl"}` без dashboard-variable interpolation внутри encoded Explore payload. Это сознательный baseline: Grafana надёжно не подставляет `$pipeline/$provider` в `left=...`, поэтому дополнительное сужение оператор делает уже в самом Explore. Tempo drilldown открывает trace search в том же временном окне; детальная correlation идёт через `trace_id` / `span_id`, а не через Prometheus labels.
 - Tempo drilldown теперь тоже открывается contextual: dashboards с `$pipeline/$run_type` предварительно фильтруют TraceQL по `span."bioetl.pipeline"` и `span."bioetl.run_type"`, а provider dashboard — по `span."bioetl.provider"`. Это не заменяет correlation по `trace_id` / `span_id`, но убирает пустой `{}` и делает handoff полезнее уже на первом клике.

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -49,7 +49,8 @@
       "targetBlank": false,
       "title": "5. Silver Reject Explorer",
       "type": "link",
-      "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+      "url": "/d/bioetl-silver-reject-explorer/bioetl-silver-reject-explorer?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+      "tooltip": "Explorer opens with a wider default time range for rare incidents (24h)."
     },
     {
       "asDropdown": false,
@@ -92,7 +93,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Operational gating/flow counters (Bronze→Silver→Gold and invariants). Separate from quality score trend.",
+      "description": "Operational gating/flow counters (Bronze\u2192Silver\u2192Gold and invariants). Separate from quality score trend.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -77,7 +77,7 @@
       },
       "id": 1,
       "options": {
-        "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><small>Select exactly one pipeline. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
+        "content": "<center><h2>Pipeline: $pipeline | Run Type: $run_type | Reason: $reason_code | Field: $field | Run ID: $run_id</h2><div><strong style='color:#ffb347'>default 24h forensic window</strong></div><div><small>Select exactly one pipeline. Quarantine Explorer is fail-closed and forensic filters like run_id/payload_hash stay explorer-only, not Prometheus labels.</small></div></center>",
         "mode": "html"
       },
       "title": "Scope",

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -559,6 +559,9 @@ def test_data_quality_dashboard_exposes_silver_reject_explorer_handoff() -> None
     assert "var-pipeline=$pipeline" in url and "var-run_type=$run_type" in url, (
         "Data Quality handoff must pass only bounded explorer pipeline/run_type scope"
     )
+    assert "wider default time range for rare incidents" in str(
+        silver_link.get("tooltip", "")
+    ), "Data Quality handoff should explain 24h forensic default for rare incidents"
 
 
 def test_runtime_incident_panels_link_to_control_plane_dashboard() -> None:

--- a/tests/integration/test_grafana_silver_reject_config.py
+++ b/tests/integration/test_grafana_silver_reject_config.py
@@ -144,6 +144,9 @@ def test_silver_reject_explorer_pipeline_scope_is_single_select_and_fail_closed(
     content = note_panel.get("options", {}).get("content", "")
     assert "Select exactly one pipeline" in content
     assert "explorer-only" in content
+    assert "default 24h forensic window" in content, (
+        "Silver Reject Explorer scope note must include default forensic window banner"
+    )
 
     for panel in get_dashboard_panels(dashboard):
         for target in panel.get("targets", []):


### PR DESCRIPTION
### Motivation

- Make the Silver Reject Explorer explicitly visible as a forensic surface by surfacing the `default 24h forensic window` banner so operators do not assume the normal `now-12h` L0/L1 window. 
- Clarify and document expected operator behavior when drilling from Data Quality into the Explorer so handoffs and time-window assumptions are explicit. 
- Enforce the UX/contract via automated checks to prevent regressions in dashboard JSONs and navigation links.

### Description

- Added a prominent banner `default 24h forensic window` to the Explorer `Scope` text panel in `grafana/dashboards/bioetl-silver-reject-explorer.json` so the top explanatory panel shows the forensic default. 
- Updated the Data Quality dashboard link in `grafana/dashboards/bioetl-dq-v2.json` to include a `tooltip` that explains the Explorer opens with a wider default time range for rare incidents. 
- Documented expected operator behavior and the DQ→Explorer handoff in `docs/03-guides/dashboards/dashboard-v2-usage.md` under a new `Expected operator behavior for DQ -> Explorer handoff` section. 
- Added/updated integration assertions in `tests/integration/test_grafana_silver_reject_config.py` and `tests/integration/test_grafana_dashboard_links.py` to check the presence of the explanatory banner and the DQ→Explorer handoff tooltip respectively.

### Testing

- Attempted to run targeted integration tests: `tests/integration/test_grafana_silver_reject_config.py::test_silver_reject_explorer_enforces_single_pipeline_scope` and `tests/integration/test_grafana_dashboard_links.py::test_data_quality_dashboard_exposes_silver_reject_explorer_handoff`, but the test runner could not execute due to environment issues. 
- First `pytest` invocation failed because `pytest.ini` adds `--timeout=300` and the environment did not accept the default addopts in that invocation. 
- Re-ran `pytest` with `-o addopts=''` which exposed import-time failures (`ModuleNotFoundError: No module named 'yaml'`) caused by missing test dependencies (`PyYAML`) and missing pytest plugins, so the updated tests could not be executed to completion in this environment. 
- Automated checks that parse/patch the JSON and update docs were exercised locally in the edit session and the modified files are present for the CI to validate the new assertions in a fully provisioned test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b1447f488324aa6417143e65e06a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->