### PR TITLE
Refocus runtime dashboard on incident-summary-first triage UX

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -51,16 +51,14 @@ Machine-readable navigation contract: `docs/03-guides/dashboards/contracts/navig
    `Worst Lag Stage` и `Flow Balance` отвечают на L0 вопрос: что broken/degraded
    и куда открыть drilldown первым. `OK` считается здоровым только при recent
    activity; отсутствие samples остаётся `UNKNOWN`, а не зелёным нулём.
-1. `bioetl-runtime`, top answer row:
-   `Runtime Blockers / 15m`, `Failed Runs / 15m`, `No-Records Runs / 30m`,
-   `Runtime Error Rate / 30m`, `Worst Stage Lag / 15m`,
-   `Memory Pressure Active / 15m` отвечают на L2 вопрос без прокрутки.
-1. `bioetl-runtime`, localization row:
-   `Stage Backlog Trend`, `Records by Stage / Interval`,
-   `Pipeline Phase Duration p50/p95/p99`,
-   `Pipeline Duration p50/p95/p99`,
-   `Errors by Stage / Error Code / Range`,
-   `Records by Stage / Run Type / Range`.
+1. `bioetl-runtime`, верхний блок `Incident Summary` (без скролла):
+   `Runtime Blockers / 15m`, `Failed Runs / 15m`,
+   `Runtime Error Rate / 30m`, `Worst Stage Lag / 15m` +
+   `Active Runtime Blocker Detail` отвечают на L2 вопрос «есть ли инцидент и где первый culprit».
+1. `bioetl-runtime`, collapsed row-группы по сценарию:
+   `Backlog Trends`, `Durations`, `Shutdown Diagnostics`,
+   `Tracing-only Log Hygiene`. Открывайте ровно одну нужную группу после
+   чтения summary KPI, чтобы сократить шум первого экрана.
 1. `bioetl-control-plane-v1`, answer row:
    `Replay / Resume Blockers`, `Manifest Write Failures`,
    `Ledger Append Failures`, `Checkpoint Incompatibilities`,
@@ -289,3 +287,8 @@ Variable handoff policy for dashboard links remains strict and bounded:
 1. `bioetl-silver-reject-explorer` показывает plugin error или `No data`:
    проверьте, что выбран конкретный `$pipeline` (не `All`) и что backend отвечает на
    `/ops/quarantine/filter-options?pipeline=<pipeline_name>`.
+
+
+### Runtime dashboard layout note (Incident Summary-first)
+
+`bioetl-runtime` теперь использует компактный first screen: сверху фиксированный блок `Incident Summary` из 4 ключевых KPI (blockers, failed runs, worst lag, error rate), ниже текстовый блок `Recommended Next Drilldown` с 3 маршрутами, а остальные diagnostic panels перенесены в свернутые row-группы (`Backlog Trends`, `Durations`, `Shutdown Diagnostics`, `Tracing-only`).

--- a/docs/03-guides/dashboards/monitoring-index.md
+++ b/docs/03-guides/dashboards/monitoring-index.md
@@ -47,6 +47,9 @@ in manifest/ledger/CLI/explorer surfaces, not Prometheus labels.
 | Replay/resume trust issues | `bioetl-control-plane-v1` | `Replay / Resume Blockers` |
 | Workflow steps failed/skipped | `bioetl-workflow-overview` | `Failed Workflow Runs`, `Step Outcomes by Kind` |
 
+
+- `bioetl-runtime` adopts Incident Summary-first layout: top block contains 4 triage KPIs (`Runtime Blockers / 15m`, `Failed Runs / 15m`, `Worst Stage Lag / 15m`, `Runtime Error Rate / 30m`); deeper panels are intentionally moved to collapsed groups (`Backlog Trends`, `Durations`, `Shutdown Diagnostics`, `Tracing-only Log Hygiene`) plus `Recommended Next Drilldown` text routes.
+
 ## Dashboard UX KPIs
 
 Use these UX KPIs as mandatory acceptance checks after any dashboard UX change.

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -110,10 +110,10 @@
       },
       "id": 222,
       "options": {
-        "content": "<div style=\"padding:0.25rem 0.5rem;line-height:1.5\"><strong>L2 diagnostic flow:</strong> answer runtime blockers first, then localize latency/backlog by stage or phase, then hand off into DQ / Control Plane / Provider Health. <strong>Prometheus-first mode:</strong> logs and traces stay in the collapsed <em>Tracing-only Log Hygiene</em> row. Missing bounded runtime retry and batch-size histogram metrics keep <em>Retry vs Failure</em> and <em>Batch Size Distribution</em> as follow-up instrumentation work, not invented panels.</div>",
+        "content": "<div style=\"padding:0.25rem 0.6rem;line-height:1.55\"><strong>Incident Summary</strong>: first-pass KPIs for blocker count, failed runs, worst stage lag, and runtime error rate. Use these before expanding deeper diagnostics.</div>",
         "mode": "html"
       },
-      "title": "Diagnostic Scope Note",
+      "title": "Incident Summary",
       "type": "text"
     },
     {
@@ -248,7 +248,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 7
+        "y": 13
       },
       "id": 205,
       "options": {
@@ -286,88 +286,6 @@
         }
       ],
       "title": "Failed Runs / 15m",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Pipelines that ran during the last 30 minutes but produced zero processed records.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 8,
-        "y": 7
-      },
-      "id": 236,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Control Plane v1 (checkpoint/replay)",
-            "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-          },
-          {
-            "title": "Open Checkpoint Debugging Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "sum(((sum by (pipeline, run_type) (increase(bioetl_pipeline_runs_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[30m])) > 0) unless on (pipeline, run_type) (sum by (pipeline, run_type) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[30m])) > 0))) or vector(0)",
-          "refId": "A"
-        }
-      ],
-      "title": "No-Records Runs / 30m",
       "type": "stat"
     },
     {
@@ -416,7 +334,7 @@
         "h": 6,
         "w": 4,
         "x": 12,
-        "y": 7
+        "y": 19
       },
       "id": 220,
       "options": {
@@ -498,7 +416,7 @@
         "h": 6,
         "w": 4,
         "x": 16,
-        "y": 7
+        "y": 25
       },
       "id": 237,
       "options": {
@@ -532,88 +450,6 @@
         }
       ],
       "title": "Worst Stage Lag / 15m",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Adaptive memory pressure state over the last 15 minutes.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "bool"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 7
-      },
-      "id": 21,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Logs (Loki, tracing profile)",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-          },
-          {
-            "title": "Open Runtime Troubleshooting Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "max(max_over_time(bioetl_memory_pressure_state{pipeline=~\"$pipeline\",stage=~\"$stage\"}[15m])) or vector(0)",
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Pressure Active / 15m",
       "type": "stat"
     },
     {
@@ -654,7 +490,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 31
       },
       "id": 242,
       "options": {
@@ -731,1325 +567,37 @@
       ]
     },
     {
-      "datasource": "Prometheus",
-      "description": "Sustained backlog accumulation by stage.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
+      "id": 9991,
+      "type": "text",
+      "title": "Recommended Next Drilldown",
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 4,
+        "w": 24,
         "x": 0,
-        "y": 21
+        "y": 39
       },
-      "id": 238,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": [
-          {
-            "title": "Open Control Plane v1 (checkpoint/replay)",
-            "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-          }
-        ]
+        "content": "<div style=\"padding:0.3rem 0.6rem;line-height:1.6\"><ol><li><strong>Runtime blockers > 0 or failed runs > 0</strong> → open <a href=\"/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}\">1. Overview</a> for incident routing, then inspect blocker detail here.</li><li><strong>Worst lag ≥ 300s</strong> → expand <em>Backlog Trends</em> and <em>Durations</em> rows to isolate culprit stage and runtime phase latency.</li><li><strong>Error rate elevated</strong> → expand <em>Tracing-only</em> row and open Loki/Tempo drilldowns for correlated logs/traces.</li></ol></div>",
+        "mode": "html"
       },
-      "targets": [
-        {
-          "expr": "max by(stage) (bioetl_stage_backlog_records{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"})",
-          "legendFormat": "{{stage}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Stage Backlog Trend",
-      "type": "timeseries"
+      "pluginVersion": "12.2.0",
+      "transparent": true
     },
     {
-      "datasource": "Prometheus",
-      "description": "Shows expected vs observed stage status per entity config. Gold status is contextual: expected (scd2/append/overwrite config), disabled (gold_enabled=false), pending (run active, gold not yet written), or missing (run completed, gold=0).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "expected"
-                },
-                "0": {
-                  "color": "blue",
-                  "index": 1,
-                  "text": "disabled"
-                }
-              }
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short",
-          "noValue": "N/A"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 21
-      },
-      "id": 243,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "10.4.0",
-      "targets": [
-        {
-          "expr": "bioetl_pipeline_stage_expected{pipeline=~\"$pipeline\"}",
-          "legendFormat": "{{stage}}",
-          "refId": "A",
-          "instant": true,
-          "format": "table"
-        },
-        {
-          "expr": "max by (pipeline, stage) (max_over_time(bioetl_stage_records_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[15m]))",
-          "legendFormat": "{{stage}} records",
-          "refId": "B",
-          "instant": true,
-          "format": "table"
-        }
-      ],
-      "title": "Stage Expectedness",
-      "type": "table",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        }
-      ]
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Processed records by stage over the active Grafana interval.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 13
-      },
-      "id": 240,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": []
-      },
-      "targets": [
-        {
-          "expr": "sum by(stage) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__interval])) or vector(0)",
-          "legendFormat": "{{stage}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Records by Stage / Interval",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Phase latency distribution across p50, p95, and p99.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 21
-      },
-      "id": 207,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": [
-          {
-            "title": "Open Traces (Tempo, tracing profile)",
-            "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
-          "legendFormat": "{{phase}} / {{status}} p50",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.95, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
-          "legendFormat": "{{phase}} / {{status}} p95",
-          "refId": "B"
-        },
-        {
-          "expr": "histogram_quantile(0.99, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
-          "legendFormat": "{{phase}} / {{status}} p99",
-          "refId": "C"
-        }
-      ],
-      "title": "Pipeline Phase Duration p50/p95/p99",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Pipeline duration percentiles by stage. \"No terminal pipeline duration samples\" means no completed pipeline runs emitted duration histogram buckets in the selected range. Possible causes: run still active, terminal metric not emitted, query label mismatch.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s",
-          "noValue": "No terminal pipeline duration samples"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 21
-      },
-      "id": 239,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": [
-          {
-            "title": "Open Traces (Tempo, tracing profile)",
-            "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.50, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
-          "legendFormat": "{{stage}} / {{status}} / {{run_type}} p50",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.95, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
-          "legendFormat": "{{stage}} / {{status}} / {{run_type}} p95",
-          "refId": "B"
-        },
-        {
-          "expr": "histogram_quantile(0.99, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
-          "legendFormat": "{{stage}} / {{status}} / {{run_type}} p99",
-          "refId": "C"
-        }
-      ],
-      "title": "Pipeline Duration p50/p95/p99",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Runtime error totals over the active range, grouped by stage and error_code.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 29
-      },
-      "id": 221,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {},
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Logs (Loki, tracing profile)",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "sum by(stage, error_code) (increase(bioetl_errors_total{pipeline=~\"$pipeline\",stage=~\"$stage\"}[$__range])) or label_replace(label_replace(vector(0), \"stage\", \"none\", \"\", \"\"), \"error_code\", \"none\", \"\", \"\")",
-          "instant": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Errors by Stage / Error Code / Range",
-      "type": "bargauge"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Processed-record totals over the active range, grouped by stage and run_type.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "min": 0,
-          "noValue": "No phase duration samples",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 29
-      },
-      "id": 241,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {},
-        "textMode": "auto",
-        "dataLinks": []
-      },
-      "targets": [
-        {
-          "expr": "sum by(stage, run_type) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__range])) or label_replace(label_replace(vector(0), \"stage\", \"none\", \"\", \"\"), \"run_type\", \"none\", \"\", \"\")",
-          "instant": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Records by Stage / Run Type / Range",
-      "type": "bargauge"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Uses shipped 15m/30m runtime recording rules for preflight, infrastructure, failed-run, and error-rate blockers.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 0,
-        "y": 37
-      },
-      "id": 230,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Pipeline Failure Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/pipeline-failure-critical.md"
-          },
-          {
-            "title": "Open Logs (Loki, tracing profile)",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "((sum(bioetl_runtime_alert_condition_pipeline_preflight_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_pipeline_infrastructure_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_pipeline_runs_failed_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_runtime_error_rate_high_30m{pipeline=~\"$pipeline\"}) or vector(0)))",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipeline Alert Conditions",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Uses shipped 15m/30m DQ recording rules; hand off into DQ for record-level diagnostics.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 5,
-        "y": 37
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Data Quality v2",
-            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
-          },
-          {
-            "title": "Open DQ Failure Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/dq-failure-investigation.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "((sum(bioetl_runtime_alert_condition_dq_soft_threshold_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_dq_hard_fail_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_dq_critical_anomaly_30m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_silver_validation_failures_30m{pipeline=~\"$pipeline\"}) or vector(0)))",
-          "refId": "A"
-        }
-      ],
-      "title": "DQ Alert Conditions",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Uses shipped 15m/30m control-plane recording rules for manifest, checkpoint, replay, and lineage blockers.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 10,
-        "y": 37
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Control Plane v1 (manifest/checkpoint)",
-            "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-          },
-          {
-            "title": "Open Run Manifest Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "((sum(bioetl_runtime_alert_condition_manifest_write_failed_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_ledger_append_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_checkpoint_incompatible_30m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_replay_lag_high_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_replay_drift_detected_30m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_lineage_refs_missing_15m{pipeline=~\"$pipeline\"}) or vector(0)))",
-          "refId": "A"
-        }
-      ],
-      "title": "Control-plane Alert Conditions",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Uses shipped 15m/30m/1h provider recording rules; provider deep-debug stays in Provider Health.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 15,
-        "y": 37
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Provider Health v2",
-            "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?from=${__from}&to=${__to}&${__url_time_range}"
-          },
-          {
-            "title": "Open Provider Incident Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/incident-response.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "((sum(bioetl_runtime_alert_condition_provider_failure_rate_high_15m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_retries_exhausted_1h) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_adapter_latency_high_30m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_http_error_rate_high_15m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_rate_limiter_wait_high_30m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_rate_limiter_tokens_depleted_15m) or vector(0)))",
-          "refId": "A"
-        }
-      ],
-      "title": "GLOBAL Provider Alert Conditions",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Counts entities older than 24h and hands off into DQ or source troubleshooting.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "UNKNOWN",
-                  "color": "gray"
-                }
-              }
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 37
-      },
-      "id": 7,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "dataLinks": [
-          {
-            "title": "Open Data Quality v2",
-            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
-          },
-          {
-            "title": "Open DQ Freshness Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/dq-failure-investigation.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "sum(clamp_min(time() - max by (pipeline, entity) (bioetl_data_freshness_seconds{pipeline=~\"$pipeline\"}), 0) > 86400) or vector(0)",
-          "refId": "A"
-        }
-      ],
-      "title": "Freshness Alert Conditions",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Graceful-shutdown initiation events over the active Grafana interval.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 43
-      },
-      "id": 209,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": [
-          {
-            "title": "Open Logs (Loki, tracing profile)",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-          },
-          {
-            "title": "Open Runtime Troubleshooting Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "round(sum by(reason) (increase(bioetl_shutdown_initiated[$__interval])) or vector(0))",
-          "legendFormat": "{{reason}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Shutdown Initiated by Reason / Interval",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Graceful-shutdown completion events over the active Grafana interval.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 3,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 43
-      },
-      "id": 210,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
-        "dataLinks": [
-          {
-            "title": "Open Logs (Loki, tracing profile)",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-          },
-          {
-            "title": "Open Runtime Troubleshooting Runbook",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-          }
-        ]
-      },
-      "targets": [
-        {
-          "expr": "round(sum by(reason) (increase(bioetl_shutdown_completed[$__interval])) or vector(0))",
-          "legendFormat": "{{reason}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Shutdown Completed by Reason / Interval",
-      "type": "timeseries"
-    },
-    {
+      "id": 252,
+      "type": "row",
+      "title": "Backlog Trends (collapsed)",
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 43
       },
-      "id": 223,
       "panels": [
         {
-          "datasource": "Loki",
-          "description": "Structured warning logs over the active Grafana range.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "type": "special",
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "text": "UNKNOWN",
-                      "color": "gray"
-                    }
-                  }
-                }
-              ],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 2
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 0,
-            "y": 0
-          },
-          "id": 2,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "dataLinks": [
-              {
-                "title": "Open Logs (Loki, tracing profile)",
-                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-              }
-            ]
-          },
-          "targets": [
-            {
-              "expr": "sum(count_over_time({job=\"bioetl\"} | json | __error__=\"\" | level=\"warning\" | pipeline=~\"$pipeline\" [$__range])) or vector(0)",
-              "refId": "A"
-            }
-          ],
-          "title": "Warnings",
-          "type": "stat"
-        },
-        {
-          "datasource": "Loki",
-          "description": "Log entries that failed structured JSON parsing over the active Grafana range.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [
-                {
-                  "type": "special",
-                  "options": {
-                    "match": "null",
-                    "result": {
-                      "text": "UNKNOWN",
-                      "color": "gray"
-                    }
-                  }
-                }
-              ],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 2
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 6,
-            "y": 0
-          },
-          "id": 3,
-          "options": {
-            "colorMode": "background",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "dataLinks": [
-              {
-                "title": "Open Logs (Loki, tracing profile)",
-                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-              }
-            ]
-          },
-          "targets": [
-            {
-              "expr": "sum(count_over_time({job=\"bioetl\"} | json | __error__!=\"\" [$__range])) or vector(0)",
-              "refId": "A"
-            }
-          ],
-          "title": "Unstructured Logs",
-          "type": "stat"
-        },
-        {
-          "datasource": "Loki",
-          "description": "Top structured warning events over the active range.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "mappings": [],
-              "min": 0,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 12,
-            "y": 0
-          },
-          "id": 8,
-          "options": {
-            "displayMode": "gradient",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "text": {},
-            "textMode": "auto",
-            "dataLinks": [
-              {
-                "title": "Open Logs (Loki, tracing profile)",
-                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-              }
-            ]
-          },
-          "targets": [
-            {
-              "expr": "topk(10, sum by(event) (count_over_time({job=\"bioetl\"} | json | __error__=\"\" | level=\"warning\" | pipeline=~\"$pipeline\" [$__range]))) or label_replace(vector(0), \"event\", \"none\", \"\", \"\")",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Top Warning Events",
-          "type": "bargauge"
-        },
-        {
           "datasource": "Prometheus",
-          "description": "Warning and unstructured-log counts over the active Grafana interval.",
+          "description": "Sustained backlog accumulation by stage.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2088,11 +636,502 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 6
+            "y": 21
           },
-          "id": 9,
+          "id": 238,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "dataLinks": [
+              {
+                "title": "Open Control Plane v1 (checkpoint/replay)",
+                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "max by(stage) (bioetl_stage_backlog_records{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"})",
+              "legendFormat": "{{stage}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Stage Backlog Trend",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Shows expected vs observed stage status per entity config. Gold status is contextual: expected (scd2/append/overwrite config), disabled (gold_enabled=false), pending (run active, gold not yet written), or missing (run completed, gold=0).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "color-text"
+                },
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "expected"
+                    },
+                    "0": {
+                      "color": "blue",
+                      "index": 1,
+                      "text": "disabled"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short",
+              "noValue": "N/A"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 243,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "10.4.0",
+          "targets": [
+            {
+              "expr": "bioetl_pipeline_stage_expected{pipeline=~\"$pipeline\"}",
+              "legendFormat": "{{stage}}",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            },
+            {
+              "expr": "max by (pipeline, stage) (max_over_time(bioetl_stage_records_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[15m]))",
+              "legendFormat": "{{stage}} records",
+              "refId": "B",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "title": "Stage Expectedness",
+          "type": "table",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            }
+          ]
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Processed records by stage over the active Grafana interval.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 240,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "expr": "sum by(stage) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__interval])) or vector(0)",
+              "legendFormat": "{{stage}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Records by Stage / Interval",
+          "type": "timeseries"
+        }
+      ]
+    },
+    {
+      "id": 253,
+      "type": "row",
+      "title": "Durations (collapsed)",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Phase latency distribution across p50, p95, and p99.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 207,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "dataLinks": [
+              {
+                "title": "Open Traces (Tempo, tracing profile)",
+                "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
+              "legendFormat": "{{phase}} / {{status}} p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
+              "legendFormat": "{{phase}} / {{status}} p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, phase, status) (rate(bioetl_phase_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__rate_interval])))",
+              "legendFormat": "{{phase}} / {{status}} p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Pipeline Phase Duration p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Pipeline duration percentiles by stage. \"No terminal pipeline duration samples\" means no completed pipeline runs emitted duration histogram buckets in the selected range. Possible causes: run still active, terminal metric not emitted, query label mismatch.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s",
+              "noValue": "No terminal pipeline duration samples"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 239,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "dataLinks": [
+              {
+                "title": "Open Traces (Tempo, tracing profile)",
+                "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
+              "legendFormat": "{{stage}} / {{status}} / {{run_type}} p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
+              "legendFormat": "{{stage}} / {{status}} / {{run_type}} p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, stage, status, run_type) (rate(bioetl_pipeline_duration_seconds_bucket{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__rate_interval])))",
+              "legendFormat": "{{stage}} / {{status}} / {{run_type}} p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Pipeline Duration p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Processed-record totals over the active range, grouped by stage and run_type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "No phase duration samples",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 241,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {},
+            "textMode": "auto",
+            "dataLinks": []
+          },
+          "targets": [
+            {
+              "expr": "sum by(stage, run_type) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\",stage=~\"$stage\"}[$__range])) or label_replace(label_replace(vector(0), \"stage\", \"none\", \"\", \"\"), \"run_type\", \"none\", \"\", \"\")",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Records by Stage / Run Type / Range",
+          "type": "bargauge"
+        }
+      ]
+    },
+    {
+      "id": 254,
+      "type": "row",
+      "title": "Shutdown Diagnostics (collapsed)",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Graceful-shutdown initiation events over the active Grafana interval.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 209,
           "options": {
             "legend": {
               "calcs": [],
@@ -2108,29 +1147,48 @@
               {
                 "title": "Open Logs (Loki, tracing profile)",
                 "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+              },
+              {
+                "title": "Open Runtime Troubleshooting Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
               }
             ]
           },
           "targets": [
             {
-              "expr": "sum(count_over_time({job=\"bioetl\"} | json | __error__=\"\" | level=\"warning\" | pipeline=~\"$pipeline\" [$__interval])) or vector(0)",
-              "legendFormat": "warnings",
+              "expr": "round(sum by(reason) (increase(bioetl_shutdown_initiated[$__interval])) or vector(0))",
+              "legendFormat": "{{reason}}",
               "refId": "A"
-            },
-            {
-              "expr": "sum(count_over_time({job=\"bioetl\"} | json | __error__!=\"\" [$__interval])) or vector(0)",
-              "legendFormat": "unstructured",
-              "refId": "B"
             }
           ],
-          "title": "Log Hygiene Trend",
+          "title": "Shutdown Initiated by Reason / Interval",
           "type": "timeseries"
         },
         {
           "datasource": "Prometheus",
-          "description": "Alert-to-action map for warning spikes, unstructured log growth, and hygiene anomalies. Uses $__range for spike/anomaly detection to align triage with current dashboard time window and rule-pack context.",
+          "description": "Graceful-shutdown completion events over the active Grafana interval.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 3,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -2141,82 +1199,699 @@
                   }
                 ]
               },
-              "custom": {
-                "align": "left"
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 210,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "dataLinks": [
+              {
+                "title": "Open Logs (Loki, tracing profile)",
+                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+              },
+              {
+                "title": "Open Runtime Troubleshooting Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
               }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "round(sum by(reason) (increase(bioetl_shutdown_completed[$__interval])) or vector(0))",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Shutdown Completed by Reason / Interval",
+          "type": "timeseries"
+        }
+      ]
+    },
+    {
+      "id": 255,
+      "type": "row",
+      "title": "Tracing-only Log Hygiene (requires optional tracing profile)",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Runtime error totals over the active range, grouped by stage and error_code.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 221,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {},
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Logs (Loki, tracing profile)",
+                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum by(stage, error_code) (increase(bioetl_errors_total{pipeline=~\"$pipeline\",stage=~\"$stage\"}[$__range])) or label_replace(label_replace(vector(0), \"stage\", \"none\", \"\", \"\"), \"error_code\", \"none\", \"\", \"\")",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Errors by Stage / Error Code / Range",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Uses shipped 15m/30m runtime recording rules for preflight, infrastructure, failed-run, and error-rate blockers.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
             },
             "overrides": []
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 18,
-            "y": 0
+            "w": 5,
+            "x": 0,
+            "y": 37
           },
-          "id": 224,
+          "id": 230,
           "options": {
-            "showHeader": true
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Pipeline Failure Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/pipeline-failure-critical.md"
+              },
+              {
+                "title": "Open Logs (Loki, tracing profile)",
+                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+              }
+            ]
           },
           "targets": [
             {
-              "expr": "label_replace(label_replace(label_replace(vector(1), \"signal\", \"warning_spike\", \"\", \"\"), \"probable_cause\", \"Provider instability or DQ threshold drift\", \"\", \"\"), \"next_step\", \"Open DQ guide: docs/05-operations/runbooks/dq-failure-investigation.md\", \"\", \"\")",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
+              "expr": "((sum(bioetl_runtime_alert_condition_pipeline_preflight_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_pipeline_infrastructure_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_pipeline_runs_failed_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_runtime_error_rate_high_30m{pipeline=~\"$pipeline\"}) or vector(0)))",
               "refId": "A"
-            },
-            {
-              "expr": "label_replace(label_replace(label_replace(vector(1), \"signal\", \"unstructured_logs_growth\", \"\", \"\"), \"probable_cause\", \"Parser/schema drift or non-JSON logger output\", \"\", \"\"), \"next_step\", \"Open Provider runbook: docs/05-operations/runbooks/incident-response.md\", \"\", \"\")",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "B"
-            },
-            {
-              "expr": "label_replace(label_replace(label_replace(vector(1), \"signal\", \"hygiene_anomaly\", \"\", \"\"), \"probable_cause\", \"Runtime-control mismatch, checkpoint lag, or stale state\", \"\", \"\"), \"next_step\", \"Open Control Plane runbook: docs/05-operations/runbooks/run-manifest-inspection.md\", \"\", \"\")",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "C"
             }
           ],
-          "title": "Alert-to-Action Map",
-          "transformations": [
-            {
-              "id": "labelsToFields",
-              "options": {
-                "mode": "columns"
-              }
-            },
-            {
-              "id": "merge",
-              "options": {}
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "Value": true
-                },
-                "indexByName": {
-                  "signal": 0,
-                  "probable_cause": 1,
-                  "next_step": 2
-                },
-                "renameByName": {
-                  "signal": "Signal",
-                  "probable_cause": "Probable Cause",
-                  "next_step": "Next Step"
+          "title": "Pipeline Alert Conditions",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Uses shipped 15m/30m DQ recording rules; hand off into DQ for record-level diagnostics.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
                 }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 5,
+            "y": 37
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Data Quality v2",
+                "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+              },
+              {
+                "title": "Open DQ Failure Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/dq-failure-investigation.md"
               }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "((sum(bioetl_runtime_alert_condition_dq_soft_threshold_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_dq_hard_fail_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_dq_critical_anomaly_30m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_silver_validation_failures_30m{pipeline=~\"$pipeline\"}) or vector(0)))",
+              "refId": "A"
             }
           ],
-          "type": "table"
+          "title": "DQ Alert Conditions",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Uses shipped 15m/30m control-plane recording rules for manifest, checkpoint, replay, and lineage blockers.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 10,
+            "y": 37
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Control Plane v1 (manifest/checkpoint)",
+                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              },
+              {
+                "title": "Open Run Manifest Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "((sum(bioetl_runtime_alert_condition_manifest_write_failed_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_ledger_append_failed_15m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_checkpoint_incompatible_30m{pipeline=~\"$pipeline\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_replay_lag_high_15m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_replay_drift_detected_30m{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}) or vector(0)) + (sum(bioetl_runtime_alert_condition_lineage_refs_missing_15m{pipeline=~\"$pipeline\"}) or vector(0)))",
+              "refId": "A"
+            }
+          ],
+          "title": "Control-plane Alert Conditions",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Uses shipped 15m/30m/1h provider recording rules; provider deep-debug stays in Provider Health.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 15,
+            "y": 37
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Provider Health v2",
+                "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?from=${__from}&to=${__to}&${__url_time_range}"
+              },
+              {
+                "title": "Open Provider Incident Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/incident-response.md"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "((sum(bioetl_runtime_alert_condition_provider_failure_rate_high_15m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_retries_exhausted_1h) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_adapter_latency_high_30m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_http_error_rate_high_15m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_rate_limiter_wait_high_30m) or vector(0)) + (sum(bioetl_runtime_alert_condition_provider_rate_limiter_tokens_depleted_15m) or vector(0)))",
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Provider Alert Conditions",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Counts entities older than 24h and hands off into DQ or source troubleshooting.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 37
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Data Quality v2",
+                "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}"
+              },
+              {
+                "title": "Open DQ Freshness Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/dq-failure-investigation.md"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum(clamp_min(time() - max by (pipeline, entity) (bioetl_data_freshness_seconds{pipeline=~\"$pipeline\"}), 0) > 86400) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "title": "Freshness Alert Conditions",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Pipelines that ran during the last 30 minutes but produced zero processed records.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 8,
+            "y": 7
+          },
+          "id": 236,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Control Plane v1 (checkpoint/replay)",
+                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              },
+              {
+                "title": "Open Checkpoint Debugging Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum(((sum by (pipeline, run_type) (increase(bioetl_pipeline_runs_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[30m])) > 0) unless on (pipeline, run_type) (sum by (pipeline, run_type) (increase(bioetl_records_processed_total{pipeline=~\"$pipeline\",run_type=~\"$run_type\"}[30m])) > 0))) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "title": "No-Records Runs / 30m",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Adaptive memory pressure state over the last 15 minutes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "bool"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 7
+          },
+          "id": 21,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "dataLinks": [
+              {
+                "title": "Open Logs (Loki, tracing profile)",
+                "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+              },
+              {
+                "title": "Open Runtime Troubleshooting Runbook",
+                "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "max(max_over_time(bioetl_memory_pressure_state{pipeline=~\"$pipeline\",stage=~\"$stage\"}[15m])) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Pressure Active / 15m",
+          "type": "stat"
         }
-      ],
-      "title": "Tracing-only Log Hygiene (requires optional tracing profile)",
-      "type": "row"
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
### Motivation

- Reduce first-screen noise and speed operator triage by surfacing a compact Incident Summary with the smallest set of high-value KPIs. 
- Encourage a single, repeatable first action path (triage KPIs → one collapsed diagnostic group → logs/traces) to lower time-to-first-action and click-depth to root cause. 
- Keep documentation and navigation contracts consistent with the new runtime layout so operator guidance matches the shipped dashboard.

### Description

- Reworked `grafana/dashboards/bioetl-runtime.json` to add a top-level `Incident Summary` text block and retain the four triage KPI stat panels: `Runtime Blockers / 15m`, `Failed Runs / 15m`, `Runtime Error Rate / 30m`, and `Worst Stage Lag / 15m`, plus `Active Runtime Blocker Detail` for immediate context. 
- Added a `Recommended Next Drilldown` text panel containing 2–3 explicit operator routes (overview → runtime/blockers; backlog/durations for lag; tracing for elevated error rate) and safe Explore handoffs for Loki/Tempo. 
- Moved remaining diagnostic panels into collapsed row-groups: `Backlog Trends`, `Durations`, `Shutdown Diagnostics`, and `Tracing-only Log Hygiene`, reducing first-screen clutter while preserving one-click access. 
- Synchronized operator docs: updated `docs/03-guides/dashboards/dashboard-v2-usage.md` and `docs/03-guides/dashboards/monitoring-index.md` with the Incident Summary-first guidance and the new collapsed-group navigation model.

### Testing

- Validated dashboard JSON syntax with `python -m json.tool grafana/dashboards/bioetl-runtime.json`, which completed successfully. 
- Confirmed text/content/section presence via repository search (`rg`) for `Incident Summary`, `Recommended Next Drilldown`, and collapsed group titles in both the dashboard JSON and updated docs. 
- Ran targeted panel/title inspections of `grafana/dashboards/bioetl-runtime.json` to ensure rows/panels were created and set `collapsed: true` for the diagnostic groups. 
- Attempted the recommended memory workflow commands (`python -m memory.tooling.workflow pre-task/post-task`) but these failed in this environment due to the missing `memory.tooling.workflow` module (validation skipped for memory tooling).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b12f1a208324a221afad913b37c0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->