### PR TITLE
docs(dashboards): add KPI ownership matrix and mirror-link policy

### DIFF
--- a/docs/03-guides/dashboards/README.md
+++ b/docs/03-guides/dashboards/README.md
@@ -60,6 +60,37 @@ Global lookup/read-path panels stay separated in a dedicated
 **Global diagnostics (non-pipeline scoped)** block and MUST remain unfiltered by
 `$pipeline` / `$run_type`.
 
+## KPI ownership (canonical vs mirrors)
+
+Правило: KPI имеет один canonical dashboard (источник ответа) и может иметь
+secondary mirrors только как shortcut для triage.
+
+| KPI | Canonical dashboard | Secondary mirrors (MUST show link `Open canonical KPI view`) |
+| --- | --- | --- |
+| System Status | `1. BioETL Overview` | `2. Runtime`, `BioETL Control Plane v1`, `6. Workflow Overview` |
+| Next Action | `1. BioETL Overview` | `2. Runtime`, `3. Provider Health` |
+| Failed Runs in Range | `1. BioETL Overview` | `2. Runtime`, `BioETL Control Plane v1` |
+| Worst Backlog Stage | `1. BioETL Overview` | `2. Runtime`, `6. Workflow Overview` |
+| Worst Lag Stage | `1. BioETL Overview` | `2. Runtime`, `6. Workflow Overview` |
+| Flow Balance | `1. BioETL Overview` | `2. Runtime`, `6. Workflow Overview` |
+| Replay Safety State | `BioETL Control Plane v1` | `1. BioETL Overview`, `2. Runtime` |
+| Checkpoint Freshness Proxy | `BioETL Control Plane v1` | `2. Runtime` |
+| Ledger/Manifest Consistency | `BioETL Control Plane v1` | `2. Runtime` |
+| Provider Health (aggregated) | `3. Provider Health` | `1. BioETL Overview`, `2. Runtime` |
+| DQ Status (Silver Reject / quality posture) | `4. Data Quality` | `1. BioETL Overview`, `2. Runtime` |
+
+### Mirror policy for KPI cards
+
+- Secondary dashboard cards, которые дублируют canonical KPI без нового
+  измерения (другая гранулярность, иной период, дополнительный action context),
+  MUST быть удалены или переименованы как navigational shortcut.
+- Для сохранённых mirror-карточек title/description MUST явно указывать, что
+  это mirror, а не primary source of truth.
+- Каждая secondary mirror-карточка MUST иметь explicit link с текстом
+  `Open canonical KPI view` на canonical dashboard KPI.
+- Если зеркало добавляет value (например, provider-scoped breakdown), укажи это
+  в description и оставь `Open canonical KPI view` как fallback к canonical answer.
+
 ## Legacy-документы
 
 Архивные материалы перемещены в `docs/03-guides/dashboards/legacy/`.


### PR DESCRIPTION
### Motivation

- Establish a single canonical source of truth for core dashboard KPIs to avoid operator confusion and divergent answers across mirrors. 
- Ensure secondary/shortcut KPI cards provide a reliable handoff back to the authoritative view by requiring an explicit link.

### Description

- Inserted a `KPI ownership` matrix into `docs/03-guides/dashboards/README.md` mapping each KPI to its canonical dashboard and typical secondary mirrors. 
- Added a `Mirror policy for KPI cards` section that requires removal or renaming of duplicate cards unless they add value and mandates an explicit `Open canonical KPI view` link on every secondary mirror.

### Testing

- No automated tests were run because this is a documentation-only change; if dashboard JSONs are updated to enforce this policy, run `uv run python -m scripts.engineering.qa report-dashboard-inventory --check --json` as a follow-up verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b3c9229483248fe83add0304494f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->