### PR TITLE
Add L1 “Next Recommended Drilldown” docs and validation test

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -187,6 +187,38 @@ Variable handoff policy for dashboard links remains strict and bounded:
 2. **Click #2:** открыть рекомендуемый dashboard из top-level minimum (`2. Runtime`, `Control Plane v1`, `4. Data Quality`) или при forensic/pattern-specific нужде раскрыть `Additional Navigation & Forensics` и перейти в `Provider Health`/`Workflow`/`Explore`.
 
 Цель сценария: root-cause направление должно быть определено максимум за 2 клика без обязательной прокрутки по нечастым CTA.
+
+## Standard L1 text block examples: `Next Recommended Drilldown`
+
+Ниже — канонические примеры для panel description/annotation в L1 surfaces.
+Формат соответствует `design-system.md` и использует только contract titles.
+
+### DQ-centric incident (4. Data Quality)
+
+```text
+Next Recommended Drilldown
+• 5. Silver Reject Explorer — isolate top reason_code/field and inspect payload-level rejects.
+• 2. Runtime — confirm whether runtime failures/backlog are secondary effects.
+• 6. Workflow Overview — verify step-level failures for the affected pipeline.
+```
+
+### Provider-centric incident (3. Provider Health)
+
+```text
+Next Recommended Drilldown
+• 2. Runtime — check failed runs and stage lag caused by provider instability.
+• 4. Data Quality — confirm whether provider degradation increased quarantine/reject pressure.
+• 6. Workflow Overview — verify whether provider issues map to workflow step failures.
+```
+
+### Workflow-centric incident (6. Workflow Overview)
+
+```text
+Next Recommended Drilldown
+• 2. Runtime — inspect runtime blockers and error-rate impact for failed workflow steps.
+• Control Plane v1 — validate replay/resume safety before remediation.
+• 4. Data Quality — check downstream data-quality fallout after workflow failure.
+```
 - `bioetl-runtime`: top-level links `Back to Overview`, `Control Plane v1`,
   `3. Provider Health`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`,
   `Explore Traces (Tempo, tracing profile)` и `Runtime Runbook` дают явный

--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -165,3 +165,26 @@ uv run python -m scripts.engineering.qa check-dashboard-visual-semantics
 }
 ```
 
+## 10) Standard L1 block: `Next Recommended Drilldown` (обязательно для guide/examples)
+
+Для документационных примеров L1-panels MUST использовать единый markdown/text блок:
+
+- Заголовок блока: `Next Recommended Drilldown`
+- Формат строки: `<Target Dashboard> — <why this is next>`
+- `Target Dashboard` MUST совпадать с canonical title из `navigation-contract.md`
+- Причина MUST быть bounded (1 короткая фраза без runbook-эссе)
+
+Нормативный шаблон:
+
+```text
+Next Recommended Drilldown
+• 2. Runtime — incident is runtime-centric (errors/backlog/failed runs).
+• 4. Data Quality — reject/quarantine pressure dominates incident.
+• 3. Provider Health — provider-side latency/failure dominates incident.
+• 6. Workflow Overview — orchestration/step-level failure dominates incident.
+```
+
+Ограничения:
+- Этот блок — **guide-level standard** для panel descriptions, annotation texts и doc-примеров.
+- В shipped top-level `links[].title` нельзя использовать строку `Next Recommended Drilldown` (см. раздел UI-лексики).
+- Блок не отменяет контракт `includeVars=false` + target-scoped `var-*` handoff.

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -18,6 +18,10 @@ pytestmark = pytest.mark.integration
 
 _DASHBOARD_UID_RE = re.compile(r"^/d/([^/?]+)")
 _LINK_VAR_RE = re.compile(r"(?:\?|&)var-([A-Za-z_]+)=")
+_NEXT_RECOMMENDED_TITLE_RE = re.compile(
+    r"^Next Recommended Drilldown:\s+"
+    r"(2\. Runtime|3\. Provider Health|4\. Data Quality|5\. Silver Reject Explorer|6\. Workflow Overview|Control Plane v1)$"
+)
 _NAV_LINK_CONTRACT_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
 
 
@@ -212,6 +216,40 @@ def test_dashboard_links_forbid_universal_handoff_patterns() -> None:
                 assert link.get("includeVars") is False, (
                     f"{dashboard_path.name} top-level cross-dashboard link must pin includeVars=false: {url}"
                 )
+
+
+def test_next_recommended_drilldown_links_use_valid_format_and_target() -> None:
+    """If present, Next Recommended Drilldown links must use canonical title and dashboard target."""
+    title_to_uid = {
+        "2. Runtime": "bioetl-runtime",
+        "3. Provider Health": "bioetl-provider-health-v2",
+        "4. Data Quality": "bioetl-dq-v2",
+        "5. Silver Reject Explorer": "bioetl-silver-reject-explorer",
+        "6. Workflow Overview": "bioetl-workflow-overview",
+        "Control Plane v1": "bioetl-control-plane-v1",
+    }
+
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        for link in _collect_dashboard_links(dashboard):
+            title = link.get("title")
+            if not isinstance(title, str) or not title.startswith(
+                "Next Recommended Drilldown"
+            ):
+                continue
+
+            assert _NEXT_RECOMMENDED_TITLE_RE.match(title), (
+                f"{dashboard_path.name} has invalid Next Recommended Drilldown "
+                f"title format: {title}"
+            )
+            target_title = title.split(": ", maxsplit=1)[1]
+            expected_uid = title_to_uid[target_title]
+            url = str(link.get("url", ""))
+            actual_uid = _extract_dashboard_uid(url)
+            assert actual_uid == expected_uid, (
+                f"{dashboard_path.name} link '{title}' must target uid "
+                f"{expected_uid}, got {actual_uid} via {url}"
+            )
 def test_overview_and_provider_dashboards_expose_explore_drilldown_links() -> None:
     """Operational dashboards should offer Loki and Tempo drilldown."""
     expectations = (


### PR DESCRIPTION
### Motivation

- Standardize a concise L1 guidance block that documents the immediate recommended drilldown for operator-facing panels to reduce cognitive friction during incident triage. 
- Provide concrete usage examples for common incident types (DQ / Provider / Workflow) so authors re-use a uniform, contract-aligned pattern in panel descriptions and doc examples. 
- Enforce the new guide-level convention with an automated test to prevent regressions and ensure links point to canonical targets.

### Description

- Added a guide-level standard L1 block `Next Recommended Drilldown` to `docs/03-guides/dashboards/design-system.md` describing title/format/constraints and canonical targets. 
- Extended `docs/03-guides/dashboards/dashboard-v2-usage.md` with three canonical `Next Recommended Drilldown` examples for DQ-centric, Provider-centric, and Workflow-centric incidents. 
- Added validation to `tests/integration/test_grafana_dashboard_links.py` including a regex and the test `test_next_recommended_drilldown_links_use_valid_format_and_target` to verify `Next Recommended Drilldown` link titles use the allowed format and that the link URL targets the expected dashboard UID. 

### Testing

- Ran the focused test for the new behavior with `uv run pytest tests/integration/test_grafana_dashboard_links.py -q -k "next_recommended_drilldown"`, which passed. 
- Ran the full integration file with `uv run pytest tests/integration/test_grafana_dashboard_links.py -q`, which showed 5 pre-existing failures unrelated to the new test: `test_runtime_incident_panels_link_to_control_plane_dashboard`, `test_data_quality_incident_panels_link_to_control_plane_dashboard`, and three `bioetl-silver-reject-explorer` related tests; the new `next_recommended_drilldown` test did not cause these failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b61edcb083248ba88c46e037b0ab)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->