### PR TITLE
Externalize dashboard/explore time handoff tokens to YAML and read from tests

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -57,3 +57,13 @@ allowed_dashboard_link_vars:
   bioetl-control-plane-v1: [pipeline, run_type]
   bioetl-workflow-overview: [workflow, status]
   bioetl-silver-reject-explorer: [pipeline, run_type, reason_code, field, run_id, payload_hash]
+
+time_handoff_requirements:
+  dashboard_links:
+    required_tokens:
+      - ${__url_time_range}
+  explore_links:
+    required_tokens:
+      - from=${__from}
+      - to=${__to}
+

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -4,6 +4,10 @@
 
 Machine-readable SSOT: `docs/03-guides/dashboards/contracts/navigation-links.yaml`.
 
+YAML также фиксирует time handoff policy в `time_handoff_requirements`:
+- `dashboard_links.required_tokens`: `${__url_time_range}`
+- `explore_links.required_tokens`: `from=${__from}`, `to=${__to}`
+
 ## Общие правила
 
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -21,7 +21,7 @@ _LINK_VAR_RE = re.compile(r"(?:\?|&)var-([A-Za-z_]+)=")
 _NAV_LINK_CONTRACT_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
 
 
-def _load_navigation_links_contract() -> dict[str, dict[str, frozenset[str]]]:
+def _load_navigation_links_contract() -> dict[str, object]:
     with _NAV_LINK_CONTRACT_PATH.open("r", encoding="utf-8") as stream:
         raw_contract = yaml.safe_load(stream)
 
@@ -47,6 +47,24 @@ _ALLOWED_DASHBOARD_LINK_VARS = _NAV_LINK_CONTRACT["allowed_dashboard_link_vars"]
 _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT["required_link_vars_by_target_uid"]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
 
+
+def _extract_required_time_tokens(section: str) -> tuple[str, ...]:
+    requirements = _NAV_LINK_CONTRACT.get("time_handoff_requirements", {})
+    assert isinstance(requirements, dict), "time_handoff_requirements must be a mapping"
+    section_payload = requirements.get(section, {})
+    assert isinstance(section_payload, dict), f"time_handoff_requirements.{section} must be a mapping"
+    tokens = section_payload.get("required_tokens", [])
+    assert isinstance(tokens, list), f"time_handoff_requirements.{section}.required_tokens must be a list"
+    return tuple(str(token) for token in tokens)
+
+
+def _assert_required_time_tokens(url: str, *, tokens: tuple[str, ...], context: str) -> None:
+    for token in tokens:
+        assert token in url, f"{context} must include time token '{token}': {url}"
+
+
+_DASHBOARD_TIME_HANDOFF_TOKENS = _extract_required_time_tokens("dashboard_links")
+_EXPLORE_TIME_HANDOFF_TOKENS = _extract_required_time_tokens("explore_links")
 
 
 def _extract_dashboard_uid(url: str) -> str | None:
@@ -170,6 +188,11 @@ def test_cross_dashboard_links_pass_only_target_scoped_variables() -> None:
                     f"{dashboard_path.name} top-level link to {target_uid} must not "
                     "use generic includeVars leakage"
                 )
+                _assert_required_time_tokens(
+                    url,
+                    tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+                    context=f"{dashboard_path.name} top-level link to {target_uid}",
+                )
 
 
 
@@ -251,8 +274,10 @@ def test_overview_and_provider_dashboards_expose_explore_drilldown_links() -> No
             f"{dashboard_name} must expose Grafana Drilldown app URLs"
         )
         for url in drilldown_urls:
-            assert "from=${__from}" in url and "to=${__to}" in url, (
-                f"{dashboard_name} drilldown URL must preserve dashboard time range"
+            _assert_required_time_tokens(
+                url,
+                tokens=_EXPLORE_TIME_HANDOFF_TOKENS,
+                context=f"{dashboard_name} drilldown URL",
             )
             assert "/explore?left=" not in url, (
                 f"{dashboard_name} drilldown URL must not use legacy /explore payload links"
@@ -292,8 +317,10 @@ def test_explore_links_use_drilldown_routes_and_time_range() -> None:
 
         for link in drilldown_links:
             url = link.get("url", "")
-            assert "from=${__from}" in url and "to=${__to}" in url, (
-                f"{dashboard_name} drilldown link must preserve current time range"
+            _assert_required_time_tokens(
+                url,
+                tokens=_EXPLORE_TIME_HANDOFF_TOKENS,
+                context=f"{dashboard_name} drilldown link",
             )
             assert "/explore?left=" not in url, (
                 f"{dashboard_name} drilldown link must not use legacy Explore payload URL"
@@ -323,7 +350,7 @@ def test_tempo_drilldown_routes_to_traces_drilldown_app() -> None:
         )
         for link in tempo_links:
             url = link.get("url", "")
-            assert "from=${__from}" in url and "to=${__to}" in url
+            _assert_required_time_tokens(url, tokens=_EXPLORE_TIME_HANDOFF_TOKENS, context=f"{dashboard_name} traces drilldown link")
 
 
 def test_loki_drilldown_links_use_safe_bioetl_baseline_query() -> None:
@@ -596,7 +623,7 @@ def test_runtime_incident_panels_link_to_control_plane_dashboard() -> None:
         assert url.startswith("/d/bioetl-control-plane-v1/bioetl-control-plane-v1"), (
             f"Panel '{panel_title}' must hand off into control-plane dashboard"
         )
-        assert "from=${__from}" in url and "to=${__to}" in url, (
+        _assert_required_time_tokens(url, tokens=_EXPLORE_TIME_HANDOFF_TOKENS, context=f"{dashboard_name} traces drilldown link"), (
             f"Panel '{panel_title}' handoff must preserve current time range"
         )
         assert "var-pipeline=$pipeline" in url and "var-run_type=$run_type" in url, (
@@ -695,7 +722,7 @@ def test_data_quality_incident_panels_link_to_control_plane_dashboard() -> None:
         assert url.startswith("/d/bioetl-control-plane-v1/bioetl-control-plane-v1"), (
             f"Panel '{panel_title}' must hand off into control-plane dashboard"
         )
-        assert "from=${__from}" in url and "to=${__to}" in url, (
+        _assert_required_time_tokens(url, tokens=_EXPLORE_TIME_HANDOFF_TOKENS, context=f"{dashboard_name} traces drilldown link"), (
             f"Panel '{panel_title}' handoff must preserve current time range"
         )
         assert "var-pipeline=$pipeline" in url and "var-run_type=$run_type" in url, (


### PR DESCRIPTION
### Motivation
- Make the canonical navigation contract the single source of truth for time-handoff requirements so tests and docs derive behavior from the YAML SSOT instead of hardcoded tokens. 
- Ensure cross-dashboard and Explore drilldown time-range expectations are configurable and visible to both machine and human readers.

### Description
- Added `time_handoff_requirements` to `docs/03-guides/dashboards/contracts/navigation-links.yaml` with `dashboard_links.required_tokens: [${__url_time_range}]` and `explore_links.required_tokens: [from=${__from}, to=${__to}]`.
- Updated `tests/integration/test_grafana_dashboard_links.py` to load required time tokens from the YAML contract and to use helper functions `_extract_required_time_tokens` and `_assert_required_time_tokens` when asserting time handoff on dashboard links and Explore drilldowns.
- Updated `docs/03-guides/dashboards/navigation-contract.md` to include a human-readable mirror of the new `time_handoff_requirements` section.
- Left `tests/integration/test_dashboard_navigation_contract_sync.py` unchanged since it already reads UID/link sections from the YAML SSOT.

### Testing
- Ran `python -m py_compile` on the two modified test modules and compilation succeeded.
- Attempted `pytest` runs for the affected integration tests but collection/execution failed in this environment due to missing system test dependencies: the test runner raised errors for an expected `--timeout` pytest plugin option from `pytest.ini` and `ModuleNotFoundError: No module named 'yaml'` in the interpreter, so full test execution could not be completed here.
- No other automated checks were changed or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b63488f08324996d94ff0602b6aa)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->