### PR TITLE
Fix overview status-card drilldowns to pass scoped vars and time handoff

### DIFF
--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -213,7 +213,7 @@
         "dataLinks": [
           {
             "title": "Open bioetl-runtime",
-            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
             "targetBlank": false
           }
         ]
@@ -498,7 +498,7 @@
         "dataLinks": [
           {
             "title": "Open bioetl-runtime",
-            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
             "targetBlank": false
           }
         ]
@@ -571,7 +571,7 @@
         "dataLinks": [
           {
             "title": "Open bioetl-runtime",
-            "url": "/d/bioetl-runtime/bioetl-runtime",
+            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
             "targetBlank": false
           }
         ]
@@ -1045,7 +1045,7 @@
             "dataLinks": [
               {
                 "title": "Open bioetl-runtime",
-                "url": "/d/bioetl-runtime/bioetl-runtime",
+                "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
                 "targetBlank": false
               }
             ]
@@ -1156,7 +1156,7 @@
             "dataLinks": [
               {
                 "title": "Open bioetl-dq-v2",
-                "url": "/d/bioetl-dq-v2/bioetl-dq-v2",
+                "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
                 "targetBlank": false
               }
             ]
@@ -1268,7 +1268,7 @@
             "dataLinks": [
               {
                 "title": "Open bioetl-control-plane-v1",
-                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1",
+                "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
                 "targetBlank": false
               }
             ]
@@ -1379,7 +1379,7 @@
             "dataLinks": [
               {
                 "title": "Open bioetl-provider-health-v2",
-                "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2",
+                "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}",
                 "targetBlank": false
               }
             ]
@@ -1490,7 +1490,7 @@
             "dataLinks": [
               {
                 "title": "Open bioetl-workflow-overview",
-                "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview",
+                "url": "/d/bioetl-workflow-overview/bioetl-workflow-overview?${__url_time_range}",
                 "targetBlank": false
               }
             ]

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -84,6 +84,63 @@ def _is_traces_drilldown_url(url: str) -> bool:
     return "/a/grafana-exploretraces-app/" in url
 
 
+_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: dict[int, str] = {
+    208: "bioetl-runtime",
+    209: "bioetl-dq-v2",
+    210: "bioetl-control-plane-v1",
+    211: "bioetl-provider-health-v2",
+    212: "bioetl-workflow-overview",
+}
+
+
+def _iter_panel_data_links(panel: dict[str, object]) -> list[dict[str, object]]:
+    options = panel.get("options")
+    if not isinstance(options, dict):
+        return []
+    links = options.get("dataLinks", [])
+    if not isinstance(links, list):
+        return []
+    return [link for link in links if isinstance(link, dict)]
+
+
+def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
+    """Overview status cards must use scoped links and preserve time range."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-overview-v2.json"))
+    panels = {
+        panel.get("id"): panel
+        for panel in get_dashboard_panels(dashboard)
+        if isinstance(panel.get("id"), int)
+    }
+
+    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID.items():
+        panel = panels.get(panel_id)
+        assert isinstance(panel, dict), f"Missing overview status panel id={panel_id}"
+
+        data_links = _iter_panel_data_links(panel)
+        assert data_links, f"Panel id={panel_id} must expose at least one data link"
+
+        for link in data_links:
+            url = link.get("url", "")
+            assert isinstance(url, str), f"Panel id={panel_id} data link URL must be string"
+            assert url.startswith(f"/d/{target_uid}/"), (
+                f"Panel id={panel_id} must point to /d/{target_uid}/: {url}"
+            )
+            assert "?" in url, f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
+
+            passed_vars = _extract_link_vars(url)
+            required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID[target_uid]
+            assert required_vars <= passed_vars, (
+                f"Panel id={panel_id} link to {target_uid} missing required vars "
+                f"{sorted(required_vars - passed_vars)} via {url}"
+            )
+
+            _assert_required_time_tokens(
+                url,
+                tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+                context=f"Overview status panel id={panel_id} link to {target_uid}",
+            )
+
+
 @pytest.mark.parametrize("dashboard_path", get_dashboard_files(), ids=lambda p: p.name)
 def test_dashboard_queries_do_not_filter_by_run_id_label(dashboard_path):
     """Dashboards must avoid run_id label filters to prevent high cardinality usage."""
@@ -290,6 +347,63 @@ def _is_logs_drilldown_url(url: str) -> bool:
 
 def _is_traces_drilldown_url(url: str) -> bool:
     return "/a/grafana-exploretraces-app/" in url
+
+
+_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: dict[int, str] = {
+    208: "bioetl-runtime",
+    209: "bioetl-dq-v2",
+    210: "bioetl-control-plane-v1",
+    211: "bioetl-provider-health-v2",
+    212: "bioetl-workflow-overview",
+}
+
+
+def _iter_panel_data_links(panel: dict[str, object]) -> list[dict[str, object]]:
+    options = panel.get("options")
+    if not isinstance(options, dict):
+        return []
+    links = options.get("dataLinks", [])
+    if not isinstance(links, list):
+        return []
+    return [link for link in links if isinstance(link, dict)]
+
+
+def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
+    """Overview status cards must use scoped links and preserve time range."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-overview-v2.json"))
+    panels = {
+        panel.get("id"): panel
+        for panel in get_dashboard_panels(dashboard)
+        if isinstance(panel.get("id"), int)
+    }
+
+    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID.items():
+        panel = panels.get(panel_id)
+        assert isinstance(panel, dict), f"Missing overview status panel id={panel_id}"
+
+        data_links = _iter_panel_data_links(panel)
+        assert data_links, f"Panel id={panel_id} must expose at least one data link"
+
+        for link in data_links:
+            url = link.get("url", "")
+            assert isinstance(url, str), f"Panel id={panel_id} data link URL must be string"
+            assert url.startswith(f"/d/{target_uid}/"), (
+                f"Panel id={panel_id} must point to /d/{target_uid}/: {url}"
+            )
+            assert "?" in url, f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
+
+            passed_vars = _extract_link_vars(url)
+            required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID[target_uid]
+            assert required_vars <= passed_vars, (
+                f"Panel id={panel_id} link to {target_uid} missing required vars "
+                f"{sorted(required_vars - passed_vars)} via {url}"
+            )
+
+            _assert_required_time_tokens(
+                url,
+                tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+                context=f"Overview status panel id={panel_id} link to {target_uid}",
+            )
 
 
 def test_explore_links_use_drilldown_routes_and_time_range() -> None:


### PR DESCRIPTION
### Motivation
- Ensure Overview status/health stat cards link to other dashboards using scoped, contract-compliant URLs so unrelated vars (forensic keys) are not leaked. 
- Preserve the dashboard time range when navigating (per `docs/03-guides/dashboards/contracts/navigation-links.yaml`).
- Make cross-dashboard drilldowns safer and more testable by pinning only the required variables for each target UID.

### Description
- Updated `grafana/dashboards/bioetl-overview-v2.json` status/health card `dataLinks` so Runtime, Data Quality, Control Plane, Provider Health, and Workflow cards use scoped `/d/<uid>?...` URLs that pass only the required vars and include the time handoff token `${__url_time_range}`. 
- Added test helpers and a new integration test in `tests/integration/test_grafana_dashboard_links.py` (`_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID`, `_iter_panel_data_links`, and `test_overview_status_cards_use_scoped_drilldown_urls`) that assert no bare `/d/<uid>` links for overview status cards, required vars are present per target UID, and time-preservation tokens are included. 
- Committed changes with message: `Fix overview status card drilldowns to use scoped links`.

### Testing
- Ran `uv run pytest -q tests/integration/test_grafana_dashboard_links.py` which executed the integration suite and produced 33 passed and 5 failed tests. 
- Direct `pytest -q tests/integration/test_grafana_dashboard_links.py` invocation failed due to an unrecognized `--timeout` pytest ini argument in this environment, so the `uv run` invocation was used for validation. 
- The failing tests are existing runtime/Explorer-related assertions (observed in the run) and appear unrelated to the overview-link changes introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81d7c1a10832485c80160693322ce)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated Grafana dashboard drilldown links to include scope parameters and time range information for enhanced navigation context.

* **Tests**
  * Added integration test validating drilldown links include required parameters and target the correct dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->