### PR TITLE
Add 'First Action' CTA row to Runtime dashboard with scoped CTA links

### DIFF
--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -87,6 +87,24 @@ Machine-readable navigation contract: `docs/03-guides/dashboards/contracts/navig
    используйте его, когда pipeline summary выглядит здоровым, но orchestration
    path показывает `failed/skipped/blocked` status.
 
+## Incident first steps (Runtime `First Action` row)
+
+В `2. Runtime` внутри collapsed row `Tracing-only Log Hygiene` добавлен
+верхний CTA-блок `First Action` с фиксированным операторским порядком:
+
+1. `Pipeline conditions`
+1. `DQ conditions`
+1. `Control Plane conditions`
+1. `Provider health checks`
+
+Правило handoff для каждого CTA остаётся bounded:
+- `includeVars=false`;
+- передаются только allowlisted `var-*` параметры для target dashboard;
+- временное окно сохраняется через `${__url_time_range}`.
+
+Это нужно для быстрого старта triage: сначала выбрать домен инцидента,
+потом переходить к детальным condition cards и runbook links ниже.
+
 
 
 ### Screenshot map: `bioetl-overview-v2` (новая структура первого экрана)

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -1318,6 +1318,243 @@
           "type": "bargauge"
         },
         {
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 299,
+          "title": "First Action",
+          "type": "row",
+          "collapsed": false,
+          "panels": []
+        },
+        {
+          "datasource": "-- Grafana --",
+          "description": "First action CTA. includeVars=false equivalent by explicit allowlisted vars and preserved time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 300,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "targets": [],
+          "title": "Pipeline conditions",
+          "type": "text",
+          "links": [
+            {
+              "title": "Open Pipeline conditions",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+              "targetBlank": false,
+              "includeVars": false,
+              "keepTime": true,
+              "type": "link",
+              "icon": "dashboard"
+            }
+          ]
+        },
+        {
+          "datasource": "-- Grafana --",
+          "description": "First action CTA. includeVars=false equivalent by explicit allowlisted vars and preserved time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
+          "id": 301,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "targets": [],
+          "title": "DQ conditions",
+          "type": "text",
+          "links": [
+            {
+              "title": "Open DQ conditions",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}",
+              "targetBlank": false,
+              "includeVars": false,
+              "keepTime": true,
+              "type": "link",
+              "icon": "dashboard"
+            }
+          ]
+        },
+        {
+          "datasource": "-- Grafana --",
+          "description": "First action CTA. includeVars=false equivalent by explicit allowlisted vars and preserved time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "id": 302,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "targets": [],
+          "title": "Control Plane conditions",
+          "type": "text",
+          "links": [
+            {
+              "title": "Open Control Plane conditions",
+              "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+              "targetBlank": false,
+              "includeVars": false,
+              "keepTime": true,
+              "type": "link",
+              "icon": "dashboard"
+            }
+          ]
+        },
+        {
+          "datasource": "-- Grafana --",
+          "description": "First action CTA. includeVars=false equivalent by explicit allowlisted vars and preserved time range.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "id": 303,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "targets": [],
+          "title": "Provider health checks",
+          "type": "text",
+          "links": [
+            {
+              "title": "Open Provider health checks",
+              "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}",
+              "targetBlank": false,
+              "includeVars": false,
+              "keepTime": true,
+              "type": "link",
+              "icon": "dashboard"
+            }
+          ]
+        },
+        {
           "datasource": "Prometheus",
           "description": "Uses shipped 15m/30m runtime recording rules for preflight, infrastructure, failed-run, and error-rate blockers.",
           "fieldConfig": {

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -2020,6 +2020,43 @@ def test_runtime_alert_condition_panels_use_recording_rules(
         )
 
 
+def test_runtime_first_action_row_precedes_condition_cards_in_order() -> None:
+    """Runtime tracing row should expose First Action CTA block before condition cards."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-runtime.json"))
+    tracing_row = next(
+        (
+            panel
+            for panel in dashboard.get("panels", [])
+            if panel.get("type") == "row"
+            and panel.get("title")
+            == "Tracing-only Log Hygiene (requires optional tracing profile)"
+        ),
+        None,
+    )
+    assert tracing_row is not None, "Runtime tracing row not found"
+    nested = tracing_row.get("panels", [])
+    titles = [panel.get("title") for panel in nested]
+    expected_sequence = [
+        "First Action",
+        "Pipeline conditions",
+        "DQ conditions",
+        "Control Plane conditions",
+        "Provider health checks",
+        "Pipeline Alert Conditions",
+        "DQ Alert Conditions",
+        "Control-plane Alert Conditions",
+        "GLOBAL Provider Alert Conditions",
+    ]
+    for title in expected_sequence:
+        assert title in titles, f"Runtime tracing row missing panel '{title}'"
+
+    indices = [titles.index(title) for title in expected_sequence]
+    assert indices == sorted(indices), (
+        "Runtime First Action CTA panels must appear before existing condition cards "
+        "in the expected order"
+    )
+
+
 @pytest.mark.parametrize(
     ("dashboard_file", "panel_title"),
     [

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -689,6 +689,45 @@ def test_runtime_alert_condition_panels_expose_direct_runbook_links() -> None:
         )
 
 
+def test_runtime_first_action_cta_links_preserve_scoped_vars_and_time() -> None:
+    """Runtime First Action row must use explicit allowlisted vars and preserve time."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-runtime.json"))
+    expected = {
+        "Pipeline conditions": ("var-pipeline=$pipeline", "var-run_type=$run_type"),
+        "DQ conditions": (
+            "var-pipeline=$pipeline",
+            "var-run_type=$run_type",
+            "var-stage=$stage",
+        ),
+        "Control Plane conditions": ("var-pipeline=$pipeline", "var-run_type=$run_type"),
+        "Provider health checks": ("var-provider=All", "var-adapter=All"),
+    }
+    forbidden = ("var-workflow=", "var-status=", "var-run_id=", "var-payload_hash=")
+
+    for panel_title, required_tokens in expected.items():
+        panel = next(
+            (item for item in get_dashboard_panels(dashboard) if item.get("title") == panel_title),
+            None,
+        )
+        assert panel is not None, f"Panel '{panel_title}' not found in bioetl-runtime.json"
+        links = panel.get("links", [])
+        assert links, f"Panel '{panel_title}' must expose a CTA link"
+        link = links[0]
+        assert link.get("includeVars") is False, (
+            f"Panel '{panel_title}' must keep includeVars=false"
+        )
+        url = str(link.get("url", ""))
+        _assert_required_time_tokens(
+            url,
+            tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+            context=f"{panel_title} CTA link",
+        )
+        for token in required_tokens:
+            assert token in url, f"Panel '{panel_title}' must include token {token}"
+        for token in forbidden:
+            assert token not in url, f"Panel '{panel_title}' must not leak {token}"
+
+
 def test_data_quality_incident_panels_link_to_control_plane_dashboard() -> None:
     """DQ panels should link into control-plane investigation for replay/lineage paths."""
     dashboard = load_dashboard(Path("grafana/dashboards/bioetl-dq-v2.json"))
@@ -961,4 +1000,3 @@ def test_provider_dashboard_runtime_links_include_contextual_variant_next_to_res
     assert "var-pipeline=${provider:queryparam}" in contextual_url
     assert "var-run_type=${adapter:queryparam}" in contextual_url
     assert "var-stage=All" in contextual_url
-


### PR DESCRIPTION
### Motivation
- Provide a predictable, operator-first triage entrypoint in the `2. Runtime` dashboard so operators can choose the correct incident domain quickly. 
- Ensure cross-dashboard handoffs are bounded: preserve only allowlisted scoped variables and the active time window while avoiding generic `includeVars` leakage.

### Description
- Inserted a new `First Action` row and four ordered CTA panels (`Pipeline conditions`, `DQ conditions`, `Control Plane conditions`, `Provider health checks`) into `grafana/dashboards/bioetl-runtime.json` inside the existing `Tracing-only Log Hygiene` collapsed row. 
- Each CTA link preserves time via `${__url_time_range}` / `${__from}&${__to}`, sets `includeVars=false`, and passes only explicit allowlisted `var-*` parameters for the target (runtime/control-plane: `pipeline`/`run_type`; DQ adds `stage`; provider uses `provider`/`adapter`).
- Added link/panel assertions to `tests/integration/test_grafana_dashboard_links.py` to validate CTA link shape, time-preservation, and variable scoping.
- Added ordering/presence assertions to `tests/integration/test_grafana_config.py` to ensure the `First Action` block and its four CTA panels appear before the existing condition cards.
- Updated usage guidance in `docs/03-guides/dashboards/dashboard-v2-usage.md` with a short “Incident first steps” section describing the new row and handoff rules.

### Testing
- Ran JSON validation: `python -m json.tool grafana/dashboards/bioetl-runtime.json` and it succeeded. 
- Ran targeted integration tests via project wrapper: `uv run python -m pytest -q tests/integration/test_grafana_dashboard_links.py -k "runtime_first_action_cta_links_preserve_scoped_vars_and_time or runtime_alert_condition_panels_expose_direct_runbook_links"` and `uv run python -m pytest -q tests/integration/test_grafana_config.py -k "runtime_first_action_row_precedes_condition_cards_in_order"`; both succeeded (targeted tests passed). 
- A direct plain `pytest` invocation failed earlier due to an environment `pytest.ini` argument (`--timeout=300`) not honored by the plain invocation; this was resolved by running tests through the repository `uv` wrapper and the targeted test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81d73f6ec8324b1b0f0a1ef16cfb6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->