### PR TITLE
Add Control Plane shortcut to provider-health dashboard links

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -24,6 +24,7 @@ required_top_level_links_by_uid:
   bioetl-provider-health-v2:
     - Back to Overview
     - 2. Runtime
+    - Control Plane v1
     - Explore Logs (Loki, tracing profile)
     - Explore Traces (Tempo, tracing profile)
   bioetl-dq-v2:
@@ -57,6 +58,14 @@ allowed_dashboard_link_vars:
   bioetl-control-plane-v1: [pipeline, run_type]
   bioetl-workflow-overview: [workflow, status]
   bioetl-silver-reject-explorer: [pipeline, run_type, reason_code, field, run_id, payload_hash]
+forbidden_dashboard_link_vars_by_target_uid:
+  bioetl-overview-v2: [run_id, payload_hash]
+  bioetl-control-plane-v1: [run_id, payload_hash]
+  bioetl-runtime: [run_id, payload_hash]
+  bioetl-dq-v2: [run_id, payload_hash]
+  bioetl-provider-health-v2: [run_id, payload_hash]
+  bioetl-workflow-overview: [run_id, payload_hash]
+  bioetl-silver-reject-explorer: []
 
 time_handoff_requirements:
   dashboard_links:
@@ -66,4 +75,3 @@ time_handoff_requirements:
     required_tokens:
       - from=${__from}
       - to=${__to}
-

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -67,6 +67,18 @@
     },
     {
       "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Control Plane v1",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "type": "link",
+      "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=All&var-run_type=All&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
       "icon": "bolt",
       "includeVars": false,
       "keepTime": true,

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -37,6 +37,9 @@ def _load_navigation_links_contract() -> dict[str, object]:
 
     return {
         "allowed_dashboard_link_vars": _as_frozenset_map("allowed_dashboard_link_vars"),
+        "forbidden_dashboard_link_vars_by_target_uid": _as_frozenset_map(
+            "forbidden_dashboard_link_vars_by_target_uid"
+        ),
         "required_link_vars_by_target_uid": _as_frozenset_map("required_link_vars_by_target_uid"),
         "required_top_level_links_by_uid": _as_frozenset_map("required_top_level_links_by_uid"),
     }
@@ -44,6 +47,9 @@ def _load_navigation_links_contract() -> dict[str, object]:
 
 _NAV_LINK_CONTRACT = _load_navigation_links_contract()
 _ALLOWED_DASHBOARD_LINK_VARS = _NAV_LINK_CONTRACT["allowed_dashboard_link_vars"]
+_FORBIDDEN_DASHBOARD_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT[
+    "forbidden_dashboard_link_vars_by_target_uid"
+]
 _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT["required_link_vars_by_target_uid"]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
 
@@ -181,6 +187,14 @@ def test_cross_dashboard_links_pass_only_target_scoped_variables() -> None:
             assert passed_vars <= allowed_vars, (
                 f"{dashboard_path.name} link to {target_uid} passes unknown vars: "
                 f"{sorted(passed_vars - allowed_vars)} via {url}"
+            )
+            forbidden_vars = _FORBIDDEN_DASHBOARD_LINK_VARS_BY_TARGET_UID.get(target_uid)
+            assert forbidden_vars is not None, (
+                f"Link target {target_uid} must be declared in forbidden vars map"
+            )
+            assert not (passed_vars & forbidden_vars), (
+                f"{dashboard_path.name} link to {target_uid} leaks forbidden vars: "
+                f"{sorted(passed_vars & forbidden_vars)} via {url}"
             )
 
             if target_uid != current_uid and link in dashboard.get("links", []):
@@ -623,8 +637,10 @@ def test_runtime_incident_panels_link_to_control_plane_dashboard() -> None:
         assert url.startswith("/d/bioetl-control-plane-v1/bioetl-control-plane-v1"), (
             f"Panel '{panel_title}' must hand off into control-plane dashboard"
         )
-        _assert_required_time_tokens(url, tokens=_EXPLORE_TIME_HANDOFF_TOKENS, context=f"{dashboard_name} traces drilldown link"), (
-            f"Panel '{panel_title}' handoff must preserve current time range"
+        _assert_required_time_tokens(
+            url,
+            tokens=_EXPLORE_TIME_HANDOFF_TOKENS,
+            context=f"runtime incident panel '{panel_title}'",
         )
         assert "var-pipeline=$pipeline" in url and "var-run_type=$run_type" in url, (
             f"Panel '{panel_title}' handoff must preserve runtime pipeline scope"
@@ -722,8 +738,10 @@ def test_data_quality_incident_panels_link_to_control_plane_dashboard() -> None:
         assert url.startswith("/d/bioetl-control-plane-v1/bioetl-control-plane-v1"), (
             f"Panel '{panel_title}' must hand off into control-plane dashboard"
         )
-        _assert_required_time_tokens(url, tokens=_EXPLORE_TIME_HANDOFF_TOKENS, context=f"{dashboard_name} traces drilldown link"), (
-            f"Panel '{panel_title}' handoff must preserve current time range"
+        _assert_required_time_tokens(
+            url,
+            tokens=_EXPLORE_TIME_HANDOFF_TOKENS,
+            context=f"dq incident panel '{panel_title}'",
         )
         assert "var-pipeline=$pipeline" in url and "var-run_type=$run_type" in url, (
             f"Panel '{panel_title}' handoff must preserve DQ pipeline scope"
@@ -961,4 +979,3 @@ def test_provider_dashboard_runtime_links_include_contextual_variant_next_to_res
     assert "var-pipeline=${provider:queryparam}" in contextual_url
     assert "var-run_type=${adapter:queryparam}" in contextual_url
     assert "var-stage=All" in contextual_url
-


### PR DESCRIPTION
### Motivation
- Provide a direct Control Plane triage shortcut from the Provider Health dashboard while preserving time context and avoiding leakage of forensic variables.
- Encode the cross-dashboard variable contract to ensure only allowlisted, non-forensic variables (e.g., `pipeline`, `run_type`) are passed to non-explorer targets.

### Description
- Added a top-level `Control Plane v1` navigation link to `grafana/dashboards/bioetl-provider-health-v2.json` that preserves time (`${__url_time_range}`), sets `includeVars=false`, and uses `var-pipeline=All&var-run_type=All`.
- Updated `docs/03-guides/dashboards/contracts/navigation-links.yaml` to require the new top-level link for `bioetl-provider-health-v2` and added `forbidden_dashboard_link_vars_by_target_uid` to explicitly block forensic vars (`run_id`, `payload_hash`) for non-explorer targets.
- Extended `tests/integration/test_grafana_dashboard_links.py` to load and enforce the new `forbidden_dashboard_link_vars_by_target_uid` contract and assert cross-dashboard links do not leak forbidden variables, and adjusted two test assertion contexts that referenced an undefined `dashboard_name` variable.

### Testing
- Executed targeted integration checks for the modified contract and links; the updated link/contract assertions passed in targeted runs (`cross_dashboard_links_pass_only_target_scoped_variables` and `dashboard_top_level_navigation_contract_by_uid`).
- Ran `tests/integration/test_grafana_config.py` selection for variable contract checks and it passed (`dashboard_has_required_variables`).
- Ran the combined dashboard-links + config suite via the repository test wrapper and encountered a pre-existing unrelated failure in the silver reject explorer panel expectation; this failure is not caused by the introduced link/contract changes and remains present in the environment.
- Notes on validation: full repository test invocation via plain `pytest` was impacted by environment `pytest.ini` arg handling so targeted script-driven test runs were used instead; documentation contract mirror (`docs/.../navigation-links.yaml`) was updated as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81d8418f48324a924cb5b2ba6299f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->