### PR TITLE
Add dashboard navigation transition contract and integration tests

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -67,3 +67,51 @@ time_handoff_requirements:
       - from=${__from}
       - to=${__to}
 
+
+navigation_transition_contract:
+  dashboard_levels:
+    L0:
+      dashboards: [bioetl-overview-v2]
+      required_outbound: [bioetl-runtime, bioetl-control-plane-v1, bioetl-provider-health-v2, bioetl-dq-v2, bioetl-workflow-overview]
+      required_inbound: []
+    L1:
+      dashboards: [bioetl-runtime, bioetl-control-plane-v1, bioetl-provider-health-v2, bioetl-dq-v2, bioetl-workflow-overview]
+      required_outbound: [bioetl-overview-v2]
+      required_inbound: [bioetl-overview-v2]
+    L2:
+      dashboards: [bioetl-silver-reject-explorer]
+      required_outbound: [bioetl-overview-v2, bioetl-dq-v2]
+      required_inbound: [bioetl-dq-v2]
+  default_semantics_by_route_class:
+    global_navigation:
+      allowed_default_values: [All]
+    scoped_handoff:
+      allowed_default_values: []
+      inherit_scoped_values: true
+  route_class_by_transition:
+    bioetl-overview-v2->bioetl-runtime: scoped_handoff
+    bioetl-overview-v2->bioetl-control-plane-v1: scoped_handoff
+    bioetl-overview-v2->bioetl-provider-health-v2: global_navigation
+    bioetl-overview-v2->bioetl-dq-v2: scoped_handoff
+    bioetl-overview-v2->bioetl-workflow-overview: global_navigation
+    bioetl-runtime->bioetl-overview-v2: scoped_handoff
+    bioetl-runtime->bioetl-control-plane-v1: scoped_handoff
+    bioetl-runtime->bioetl-provider-health-v2: global_navigation
+    bioetl-runtime->bioetl-dq-v2: scoped_handoff
+    bioetl-control-plane-v1->bioetl-overview-v2: scoped_handoff
+    bioetl-control-plane-v1->bioetl-runtime: scoped_handoff
+    bioetl-control-plane-v1->bioetl-dq-v2: scoped_handoff
+    bioetl-provider-health-v2->bioetl-overview-v2: global_navigation
+    bioetl-provider-health-v2->bioetl-runtime: global_navigation
+    bioetl-dq-v2->bioetl-overview-v2: scoped_handoff
+    bioetl-dq-v2->bioetl-control-plane-v1: scoped_handoff
+    bioetl-dq-v2->bioetl-silver-reject-explorer: scoped_handoff
+    bioetl-silver-reject-explorer->bioetl-overview-v2: scoped_handoff
+    bioetl-silver-reject-explorer->bioetl-dq-v2: scoped_handoff
+    bioetl-workflow-overview->bioetl-overview-v2: global_navigation
+    bioetl-workflow-overview->bioetl-runtime: global_navigation
+    bioetl-workflow-overview->bioetl-control-plane-v1: global_navigation
+  incident_critical_reciprocal_paths:
+    - [bioetl-runtime, bioetl-control-plane-v1]
+    - [bioetl-control-plane-v1, bioetl-dq-v2]
+    - [bioetl-dq-v2, bioetl-silver-reject-explorer]

--- a/tests/integration/test_grafana_navigation_matrix.py
+++ b/tests/integration/test_grafana_navigation_matrix.py
@@ -1,0 +1,141 @@
+"""Integration tests for dashboard level navigation transition matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+import yaml
+from tests.integration._grafana_test_support import load_dashboard
+
+pytestmark = pytest.mark.integration
+
+_DASHBOARDS_DIR = Path("grafana/dashboards")
+_CONTRACT_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
+_DASHBOARD_UID_RE = re.compile(r"^/d/([^/?]+)")
+_LINK_VAR_VALUE_RE = re.compile(r"(?:\?|&)var-([A-Za-z_]+)=([^&#]+)")
+
+
+def _load_contract() -> dict[str, object]:
+    return yaml.safe_load(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _build_top_level_edges() -> dict[str, set[str]]:
+    edges: dict[str, set[str]] = {}
+    for path in _DASHBOARDS_DIR.glob("*.json"):
+        payload = load_dashboard(path)
+        source_uid = payload.get("uid")
+        assert isinstance(source_uid, str), f"{path.name} must define string uid"
+        edges.setdefault(source_uid, set())
+
+        for link in payload.get("links", []):
+            url = link.get("url")
+            if not isinstance(url, str):
+                continue
+            match = _DASHBOARD_UID_RE.match(url)
+            if match is None:
+                continue
+            edges[source_uid].add(match.group(1))
+    return edges
+
+
+def _iter_top_level_uid_links() -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for path in _DASHBOARDS_DIR.glob("*.json"):
+        payload = load_dashboard(path)
+        source_uid = payload.get("uid")
+        assert isinstance(source_uid, str), f"{path.name} must define string uid"
+        for link in payload.get("links", []):
+            url = link.get("url")
+            if not isinstance(url, str):
+                continue
+            match = _DASHBOARD_UID_RE.match(url)
+            if match is None:
+                continue
+            rows.append((source_uid, match.group(1), url))
+    return rows
+
+
+def test_level_matrix_required_inbound_outbound_transitions_present() -> None:
+    contract = _load_contract()["navigation_transition_contract"]
+    assert isinstance(contract, dict)
+
+    matrix = contract["dashboard_levels"]
+    assert isinstance(matrix, dict)
+    edges = _build_top_level_edges()
+
+    for level_name, level_payload in matrix.items():
+        assert isinstance(level_payload, dict), f"{level_name} payload must be mapping"
+        dashboards = set(level_payload["dashboards"])
+        required_outbound = set(level_payload["required_outbound"])
+        required_inbound = set(level_payload["required_inbound"])
+
+        for uid in dashboards:
+            outbound = edges.get(uid, set())
+            missing_outbound = required_outbound - outbound
+            assert not missing_outbound, (
+                f"{level_name}:{uid} missing required outbound transitions: {sorted(missing_outbound)}"
+            )
+
+            inbound = {src for src, targets in edges.items() if uid in targets}
+            missing_inbound = required_inbound - inbound
+            assert not missing_inbound, (
+                f"{level_name}:{uid} missing required inbound transitions: {sorted(missing_inbound)}"
+            )
+
+
+def test_scoped_route_class_forbids_default_all_values() -> None:
+    contract = _load_contract()["navigation_transition_contract"]
+    assert isinstance(contract, dict)
+
+    route_class_by_transition = contract["route_class_by_transition"]
+    default_semantics = contract["default_semantics_by_route_class"]
+    assert isinstance(route_class_by_transition, dict)
+    assert isinstance(default_semantics, dict)
+
+    for source_uid, target_uid, url in _iter_top_level_uid_links():
+        transition_key = f"{source_uid}->{target_uid}"
+        route_class = route_class_by_transition.get(transition_key)
+        if route_class != "scoped_handoff":
+            continue
+
+        for variable_name, variable_value in _LINK_VAR_VALUE_RE.findall(url):
+            decoded_value = variable_value.replace("%20", " ")
+            assert decoded_value != "All", (
+                f"Scoped transition {transition_key} must not pass var-{variable_name}=All: {url}"
+            )
+
+        class_defaults = default_semantics["scoped_handoff"]["allowed_default_values"]
+        assert "All" not in class_defaults, (
+            "scoped_handoff route class must not allow default 'All' semantics"
+        )
+
+
+def test_incident_critical_paths_are_reciprocal_and_non_terminal() -> None:
+    contract = _load_contract()["navigation_transition_contract"]
+    assert isinstance(contract, dict)
+
+    critical_pairs = contract["incident_critical_reciprocal_paths"]
+    assert isinstance(critical_pairs, list)
+
+    edges = _build_top_level_edges()
+
+    critical_nodes: set[str] = set()
+    for pair in critical_pairs:
+        assert isinstance(pair, list) and len(pair) == 2
+        left, right = pair
+        assert isinstance(left, str) and isinstance(right, str)
+        critical_nodes.update({left, right})
+
+        assert right in edges.get(left, set()), (
+            f"Incident-critical forward path missing: {left} -> {right}"
+        )
+        assert left in edges.get(right, set()), (
+            f"Incident-critical reciprocal return path missing: {right} -> {left}"
+        )
+
+    terminal_nodes = [uid for uid in critical_nodes if not edges.get(uid)]
+    assert not terminal_nodes, (
+        f"Incident-critical dashboards must not be terminal nodes: {sorted(terminal_nodes)}"
+    )


### PR DESCRIPTION
### Motivation
- Define an explicit contract for required inbound/outbound transitions across dashboard levels (L0/L1/L2) to enforce consistent navigation flows.
- Constrain default semantics for route classes so scoped handoffs cannot leak global defaults (e.g., `All`).
- Require reciprocal back-paths for incident-critical flows so triage journeys remain navigable and non-terminal during active incidents.

### Description
- Extended `docs/03-guides/dashboards/contracts/navigation-links.yaml` with a `navigation_transition_contract` section that declares `dashboard_levels` (L0/L1/L2), `default_semantics_by_route_class`, `route_class_by_transition`, and `incident_critical_reciprocal_paths`.
- Added integration tests in `tests/integration/test_grafana_navigation_matrix.py` that validate required forward/return transitions, forbid `var-*=All` on `scoped_handoff` transitions, and assert incident-critical reciprocal/non-terminal connectivity.
- Tests use existing dashboard loaders and helpers from `tests/integration/_grafana_test_support.py` and integrate with the pre-existing navigation contract checks in `tests/integration/test_dashboard_navigation_contract_sync.py`.

### Testing
- Ran the new integration checks with `PYTEST_ADDOPTS='' uv run python -m pytest -q tests/integration/test_grafana_navigation_matrix.py tests/integration/test_dashboard_navigation_contract_sync.py` and observed `5 passed` (all tests passed).
- An initial `pytest` invocation failed in this environment due to global `pytest.ini` args (`--timeout`) being present; the failure was addressed by clearing `PYTEST_ADDOPTS` as shown above and re-running successfully.
- The repository `pre-task` memory workflow command `python -m memory.tooling.workflow pre-task ...` was attempted but unavailable here (`ModuleNotFoundError: No module named 'memory'`), so that pre-change workflow step was skipped and checks were performed directly against repository files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81d9d0c988324a228ebe3f5c27762)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->