### PR TITLE
Make workflow Tempo drilldown query context-aware

### DIFF
--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -72,7 +72,7 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%7D"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.workflow%22%20%3D~%20%22${workflow:regex}%22%20%26%26%20span.%22bioetl.status%22%20%3D~%20%22${status:regex}%22%20%7D"
     }
   ],
   "panels": [

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -244,6 +244,7 @@ def test_overview_and_provider_dashboards_expose_explore_drilldown_links() -> No
         "bioetl-control-plane-v1.json",
         "bioetl-provider-health-v2.json",
         "bioetl-silver-reject-explorer.json",
+        "bioetl-workflow-overview.json",
     )
 
     for dashboard_name in expectations:
@@ -301,6 +302,7 @@ def test_explore_links_use_drilldown_routes_and_time_range() -> None:
         "bioetl-control-plane-v1.json",
         "bioetl-provider-health-v2.json",
         "bioetl-silver-reject-explorer.json",
+        "bioetl-workflow-overview.json",
     )
 
     for dashboard_name in expectations:
@@ -336,6 +338,7 @@ def test_tempo_drilldown_routes_to_traces_drilldown_app() -> None:
         "bioetl-control-plane-v1.json",
         "bioetl-provider-health-v2.json",
         "bioetl-silver-reject-explorer.json",
+        "bioetl-workflow-overview.json",
     )
 
     for dashboard_name in expectations:
@@ -392,6 +395,7 @@ def test_tempo_drilldown_links_are_contextual() -> None:
         "bioetl-control-plane-v1.json",
         "bioetl-silver-reject-explorer.json",
     )
+    workflow_scoped = ("bioetl-workflow-overview.json",)
     provider_scoped = ("bioetl-provider-health-v2.json",)
 
     for dashboard_name in pipeline_scoped:
@@ -407,11 +411,33 @@ def test_tempo_drilldown_links_are_contextual() -> None:
             assert "queryType=traceqlSearch" in url, (
                 f"{dashboard_name} Tempo drilldown must declare TraceQL search mode"
             )
+            assert "query=%7B%7D" not in url and "query={}" not in url, (
+                f"{dashboard_name} Tempo drilldown must not use empty trace query payload"
+            )
             assert "bioetl.pipeline" in url and "bioetl.run_type" in url, (
                 f"{dashboard_name} Tempo drilldown must scope by pipeline/run_type"
             )
             assert "bioetl.provider" not in url, (
                 f"{dashboard_name} pipeline drilldown must not switch to provider-only scope"
+            )
+
+    for dashboard_name in workflow_scoped:
+        dashboard = load_dashboard(Path("grafana/dashboards") / dashboard_name)
+        tempo_links = [
+            link
+            for link in _collect_dashboard_links(dashboard)
+            if _is_traces_drilldown_url(link.get("url", ""))
+        ]
+        assert tempo_links, f"{dashboard_name} must expose Tempo drilldown links"
+        for link in tempo_links:
+            url = link.get("url", "")
+            assert "queryType=traceqlSearch" in url
+            assert "query=%7B%7D" not in url and "query={}" not in url
+            assert "bioetl.workflow" in url and "bioetl.status" in url, (
+                f"{dashboard_name} workflow drilldown must scope by workflow/status"
+            )
+            assert "bioetl.pipeline" not in url and "bioetl.run_type" not in url, (
+                f"{dashboard_name} workflow drilldown must not fake pipeline scope"
             )
 
     for dashboard_name in provider_scoped:
@@ -425,6 +451,7 @@ def test_tempo_drilldown_links_are_contextual() -> None:
         for link in tempo_links:
             url = link.get("url", "")
             assert "queryType=traceqlSearch" in url
+            assert "query=%7B%7D" not in url and "query={}" not in url
             assert "bioetl.provider" in url, (
                 f"{dashboard_name} provider drilldown must scope by provider"
             )


### PR DESCRIPTION
### Motivation
- Ensure the workflow dashboard's "Explore Traces" drilldown supplies a meaningful, non-empty TraceQL query scoped to `workflow` and `status` while preserving the dashboard time range.
- Prevent baking unrelated dashboard variables or empty trace payloads into Tempo drilldowns and add test coverage to catch regressions.

### Description
- Replaced the empty TraceQL payload for the workflow dashboard in `grafana/dashboards/bioetl-workflow-overview.json` with a TraceQL query scoped to `span."bioetl.workflow" =~ "${workflow:regex}" && span."bioetl.status" =~ "${status:regex}"` while preserving the `from=${__from}&to=${__to}` time handoff.
- Updated `tests/integration/test_grafana_dashboard_links.py` to include `bioetl-workflow-overview.json` in the drilldown expectations, to assert that Tempo links do not use an empty trace query payload (reject `query=%7B%7D`/`query={}`), and to enforce scope-specific TraceQL context for pipeline, workflow, and provider dashboards.
- Retained explicit time-handoff checks and avoided adding implicit or forensic var leakage into encoded trace queries.

### Testing
- Executed the focused integration test selection via the project wrapper: `uv run pytest -q tests/integration/test_grafana_dashboard_links.py -k 'tempo_drilldown_links_are_contextual or explore_links_use_drilldown_routes_and_time_range or tempo_drilldown_routes_to_traces_drilldown_app or overview_and_provider_dashboards_expose_explore_drilldown_links'`, resulting in `4 passed, 33 deselected`.
- A direct `pytest` invocation failed in this environment due to `pytest.ini` argument handling (`--timeout`), which was resolved by running tests through the `uv` wrapper.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81d92b6c08324ba88540f022a4a4a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->