### PR TITLE
Standardize Grafana link style-guide, align top-level dashboard links, and add link lint

### DIFF
--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -127,6 +127,32 @@ uv run python -m scripts.engineering.qa check-dashboard-visual-semantics
 - Explore-ссылки MUST использовать полные названия: `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)`.
 - Формулировки вида `Explore Logs`, `Explore Traces`, `Next Recommended Drilldown` считаются legacy-лексикой и не допускаются в shipped dashboards.
 
+### 7.1) Link title style-guide: Back / Open / Investigate
+
+Используй единый шаблон для операторских ссылок:
+
+- `Back to <Dashboard>` — только для возврата на предыдущий L0 уровень.
+- `Open <Target>` — переход в соседний dashboard или внешний runbook без forensic-контекста.
+- `Investigate <Target>` — переход в forensic/deep-dive surface (например, reject explorer, incident drilldown).
+
+Норматив:
+- Для top-level `links[]` в `grafana/dashboards/*.json` MUST использоваться только эти глаголы для action-link лексики (`Back`, `Open`, `Investigate`), кроме канонических имен dashboard (`2. Runtime`, `3. Provider Health`, и т.д.).
+- Для `options.dataLinks` в критичных панелях предпочтителен `Open ...`; `Investigate ...` допустим для incident/deep-dive панелей.
+
+### 7.2) Scope reset suffix в tooltip (обязательно)
+
+Если link меняет scope (например, принудительно ставит `var-pipeline=All`, `var-run_type=All`, сбрасывает provider/adapter или stage), tooltip MUST содержать явный suffix:
+
+- `Scope reset: ...`
+
+Рекомендуемый шаблон:
+
+- `Cross-scope handoff ... Scope reset: pipeline=All, run_type=All; provider/adapter not transferred.`
+
+Если scope не меняется, используй нейтральный tooltip:
+
+- `Preserves selected scope and time range.`
+
 ## 7.1) L1 layout rule: answer-first above fold (обязательно)
 
 Для L1 control-plane dashboards первый экран (above fold) MUST отвечать на

--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -1,2779 +1,2782 @@
 {
-    "annotations": {
-        "list": [
-            {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-            }
-        ]
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Answers whether manifest, ledger, checkpoint, replay, and lineage state are trustworthy enough to allow replay/resume for the selected pipeline/run_type/time range. Primary question: Can we trust manifest/ledger/checkpoint/lineage state and safely replay/resume? GLOBAL read-path panels are not pipeline-scoped and must not use $pipeline or $run_type filtering.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 2,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Back to Overview",
+      "type": "link",
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+      "tooltip": "Return to 1. Overview and preserve the selected time range."
     },
-    "description": "Answers whether manifest, ledger, checkpoint, replay, and lineage state are trustworthy enough to allow replay/resume for the selected pipeline/run_type/time range. Primary question: Can we trust manifest/ledger/checkpoint/lineage state and safely replay/resume? GLOBAL read-path panels are not pipeline-scoped and must not use $pipeline or $run_type filtering.",
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 1,
-    "id": null,
-    "iteration": 2,
-    "links": [
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Back to Overview",
-            "type": "link",
-            "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "2. Runtime",
-            "type": "link",
-            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "4. Data Quality",
-            "type": "link",
-            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "logs",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Explore Logs (Loki, tracing profile)",
-            "type": "link",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-        },
-        {
-            "asDropdown": false,
-            "icon": "share-alt",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Explore Traces (Tempo, tracing profile)",
-            "type": "link",
-            "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": false,
-            "targetBlank": true,
-            "title": "Observability Checklist (runbook)",
-            "type": "link",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-        }
-    ],
-    "panels": [
-        {
-            "collapsed": false,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 0
-            },
-            "id": 900,
-            "panels": [],
-            "title": "Answer: Replay / Resume Safety",
-            "type": "row"
-        },
-        {
-            "collapsed": false,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 1
-            },
-            "id": 890,
-            "panels": [],
-            "title": "Trust Summary (Answer-First)",
-            "type": "row"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Replay safety state for selected pipeline/run_type. Zero means no blockers detected in selected range.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 0,
-                "y": 2
-            },
-            "id": 891,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)) + (sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
-                    "instant": true,
-                    "refId": "A"
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "2. Runtime",
+      "type": "link",
+      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "4. Data Quality",
+      "type": "link",
+      "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "logs",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Explore Logs (Loki, tracing profile)",
+      "type": "link",
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
+    },
+    {
+      "asDropdown": false,
+      "icon": "share-alt",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Explore Traces (Tempo, tracing profile)",
+      "type": "link",
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
+      "title": "Observability Checklist (runbook)",
+      "type": "link",
+      "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 900,
+      "panels": [],
+      "title": "Answer: Replay / Resume Safety",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 890,
+      "panels": [],
+      "title": "Trust Summary (Answer-First)",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Replay safety state for selected pipeline/run_type. Zero means no blockers detected in selected range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
                 }
-            ],
-            "title": "Replay Safety State",
-            "type": "stat"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Checkpoint freshness proxy for selected pipeline. Shows hours since most recent checkpoint operation event.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "yellow",
-                                "value": 6
-                            },
-                            {
-                                "color": "red",
-                                "value": 24
-                            }
-                        ]
-                    },
-                    "unit": "h",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 6,
-                "y": 2
-            },
-            "id": 892,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "clamp_min((time() - max(max_over_time(bioetl_checkpoint_operator_duration_seconds_count{pipeline=~\"$pipeline\"}[$__range]))) / 3600, 0)",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Checkpoint Freshness (hours since last op)",
-            "type": "stat"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Ledger/manifest consistency proxy for selected pipeline/run_type. Non-zero means either manifest write or ledger append failures were observed.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 12,
-                "y": 2
-            },
-            "id": 893,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)))",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Ledger / Manifest Consistency",
-            "type": "stat"
-        },
-        {
-            "id": 906,
-            "type": "text",
-            "title": "Next Drilldown: Replay Safety Diagnostics",
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 18,
-                "y": 2
-            },
-            "options": {
-                "content": "### Next step\nOpen Replay Safety diagnostics row for checkpoint/replay root-cause triage.",
-                "mode": "markdown"
-            },
-            "transparent": false,
-            "links": [
-                {
-                    "title": "Open Replay Safety diagnostics",
-                    "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?viewPanel=130&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
-                    "targetBlank": false
-                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
             ]
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Threshold semantics: replay/resume blockers are binary\u2014green at 0, red at >=1. Next action: stop replay/resume and investigate the first failing signal (manifest, ledger, checkpoint, replay drift, or lineage refs).",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ],
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 0,
-                "y": 15
-            },
-            "id": 130,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round(\n  (\n    sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)\n  )\n)",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Replay / Resume Blockers",
-            "type": "stat"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 31
-            },
-            "id": 902,
-            "panels": [
-                {
-                    "gridPos": {
-                        "h": 5,
-                        "w": 6,
-                        "x": 18,
-                        "y": 2
-                    },
-                    "id": 894,
-                    "options": {
-                        "content": "### Known blind spots\n- Checkpoint freshness by expected schedule/RPO is not instrumented yet.\n- Replay duplicate/overwrite risk signal is not instrumented yet.\n- Manifest-to-ledger referential integrity ratio is not instrumented yet.",
-                        "mode": "markdown"
-                    },
-                    "title": "Known Blind Spots",
-                    "type": "text"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range incompatible checkpoint compatibility decisions. Alert: BioETLCheckpointCompatibilityBlocked. Non-zero blocks resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short",
-                            "decimals": 0
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 4,
-                        "x": 10,
-                        "y": 8
-                    },
-                    "id": 3,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Incompatibilities",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range not_reconstructable replay observations. Alert: BioETLReplayNotReconstructable. Non-zero blocks replay.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 14,
-                        "y": 8
-                    },
-                    "id": 104,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Not Reconstructable",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range replay drift events. Alert: BioETLReplayDriftDetected. Non-zero means stop replay and inspect drift type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 17,
-                        "y": 8
-                    },
-                    "id": 120,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Drift",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range checkpoint load failures. Alert: BioETLCheckpointLoadFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 0,
-                        "y": 32
-                    },
-                    "id": 101,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_load_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Load Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range checkpoint save failures. Alert: BioETLCheckpointSaveFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 6,
-                        "y": 32
-                    },
-                    "id": 102,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_save_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Save Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "GLOBAL operator/admin checkpoint failures. Alert: BioETLCheckpointOperatorFailed. Not filtered by $pipeline or $run_type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 12,
-                        "y": 32
-                    },
-                    "id": 103,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_operator_operations_total{status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Checkpoint Operator Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Current replay lag seconds for selected pipeline/run_type. Alert: BioETLReplayLagHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 18,
-                        "y": 32
-                    },
-                    "id": 121,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "max(max_over_time(bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Lag Seconds",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Checkpoint compatibility outcomes grouped by disposition.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 0,
-                        "y": 38
-                    },
-                    "id": 5,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (disposition) (increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\"}[$__interval])) or label_replace(vector(0), \"disposition\", \"no_events\", \"\", \"\")",
-                            "legendFormat": "{{disposition}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Compatibility Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Replay drift trend by capability, drift type, and status. Alert: BioETLReplayDriftDetected.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 8,
-                        "y": 38
-                    },
-                    "id": 134,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (replay_capability, drift_type, status) (increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
-                            "legendFormat": "{{replay_capability}} / {{drift_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Drift by Type",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Replay lag trend by replay capability and status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 300
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 900
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 16,
-                        "y": 38
-                    },
-                    "id": 135,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "max by (replay_capability, status) (bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"})",
-                            "legendFormat": "{{replay_capability}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Lag Trend",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Checkpoint save latency quantiles. No data means no latency samples, not zero latency. Alerts: BioETLCheckpointSaveLatencyHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 46
-                    },
-                    "id": 105,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p50 {{pipeline}} / {{operation}}",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p95 {{pipeline}} / {{operation}}",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p99 {{pipeline}} / {{operation}}",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Checkpoint Save Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "GLOBAL checkpoint operator/admin latency quantiles. Not filtered by $pipeline or $run_type. Alerts: BioETLCheckpointOperatorLatencyHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 46
-                    },
-                    "id": 106,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50 {{operation}}",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95 {{operation}}",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99 {{operation}}",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "GLOBAL Checkpoint Operator Latency p50/p95/p99",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Replay Safety (Checkpoint / Replay)",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 15
-            },
-            "id": 901,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range manifest persistence failures. Alert: BioETLControlPlaneManifestWriteFailed. Action: inspect manifest persistence before replay/resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 4,
-                        "y": 8
-                    },
-                    "id": 1,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Write Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range run-ledger append failures. Alert: BioETLRunLedgerAppendFailed. Action: inspect run ledger before replay/resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 7,
-                        "y": 8
-                    },
-                    "id": 2,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Append Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Manifest write attempts grouped by status/run_type for the active pipeline/run_type scope.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 16
-                    },
-                    "id": 131,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (status, run_type) (increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
-                            "legendFormat": "{{run_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Writes by Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Run-ledger append attempts grouped by event type and status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 16
-                    },
-                    "id": 7,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (event_type, status) (increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[$__interval]))",
-                            "legendFormat": "{{event_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Appends by Event Type / Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "30m manifest write failure ratio. Alert: BioETLControlPlaneManifestWriteFailureRatioHigh. Ratio >0.10 is red.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 0,
-                        "y": 24
-                    },
-                    "id": 132,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Write Failure Ratio",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "30m ledger append failure ratio. Alert: BioETLRunLedgerAppendFailureRatioHigh. Ratio >0.10 is red.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 12,
-                        "y": 24
-                    },
-                    "id": 133,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Append Failure Ratio",
-                    "type": "stat"
-                }
-            ],
-            "title": "Incident Drilldown: Manifest / Ledger Integrity",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 55
-            },
-            "id": 903,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. Alert: BioETLControlPlaneReadFailureRate.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 0,
-                        "y": 56
-                    },
-                    "id": 4,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. 30m failure ratio by global read path. Alert: BioETLControlPlaneReadFailureRate.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 6,
-                        "y": 56
-                    },
-                    "id": 136,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_reads_total[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Failure Ratio",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 12,
-                        "y": 56
-                    },
-                    "id": 6,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (store, operation, status) (increase(bioetl_control_plane_reads_total[$__interval]))",
-                            "legendFormat": "{{store}} / {{operation}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Reads by Store / Operation / Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 24,
-                        "x": 0,
-                        "y": 62
-                    },
-                    "id": 111,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Latency p50/p95/p99",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Global Control-Plane Store Reliability",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 71
-            },
-            "id": 904,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range missing upstream lineage references. Alert: BioETLLineageRefsMissing. Missing lineage can make replay evidence incomplete.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short",
-                            "decimals": 0
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 4,
-                        "x": 20,
-                        "y": 8
-                    },
-                    "id": 122,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Refs Missing",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range lineage fragment persistence failures. Alert: BioETLLineageFragmentPersistenceFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 0,
-                        "y": 88
-                    },
-                    "id": 137,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Fragment Persistence Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range missing lineage refs by layer/ref_type. Alert: BioETLLineageRefsMissing.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 10
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 16,
-                        "y": 88
-                    },
-                    "id": 138,
-                    "options": {
-                        "showHeader": true
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (layer, ref_type) (increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range]))",
-                            "instant": true,
-                            "legendFormat": "{{layer}} / {{ref_type}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Refs Missing by Layer / Ref Type",
-                    "type": "table"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit write outcomes by layer, operation, and status. Supporting evidence for replay safety, not answer-row decision.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 72
-                    },
-                    "id": 107,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "round(sum by (layer, operation, status) (increase(bioetl_audit_write_events_total[$__interval])) or vector(0))",
-                            "legendFormat": "{{layer}} / {{operation}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Audit Write Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit query outcomes by layer filter and status. Supporting evidence for replay safety, not answer-row decision.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 72
-                    },
-                    "id": 108,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "round(sum by (layer_filter, status) (increase(bioetl_audit_query_events_total[$__interval])) or vector(0))",
-                            "legendFormat": "{{layer_filter}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Audit Query Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit write latency quantiles. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 80
-                    },
-                    "id": 109,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Audit Write Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit query latency quantiles. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 80
-                    },
-                    "id": 110,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Audit Query Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Lineage fragment persistence outcomes by layer/status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 8,
-                        "y": 88
-                    },
-                    "id": 112,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (layer, status) (increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\"}[$__interval]))",
-                            "legendFormat": "{{layer}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Fragment Outcomes",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Audit / Lineage Completeness",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 95
-            },
-            "id": 905,
-            "panels": [
-                {
-                    "gridPos": {
-                        "h": 8,
-                        "w": 24,
-                        "x": 0,
-                        "y": 89
-                    },
-                    "id": 139,
-                    "options": {
-                        "content": "### Missing replay-safety signals\n\nThe dashboard cannot currently verify these invariants because no metric was found:\n\n- checkpoint_age <= recovery window / RPO\n- replay does not create unexplained duplicate records\n\nDo not add PromQL panels for these until metrics exist.\nOpen a separate instrumentation issue for:\n\n- bioetl_checkpoint_age_seconds\n- bioetl_replay_duplicate_records_total\n\n| Missing signal | Required future metric | Why it matters |\n| --- | --- | --- |\n| Checkpoint age vs recovery window | `bioetl_checkpoint_age_seconds` | Cannot visually prove checkpoint age is within RPO |\n| Replay duplicate records | `bioetl_replay_duplicate_records_total` | Cannot visually prove replay did not create unexplained duplicates |\n",
-                        "mode": "markdown"
-                    },
-                    "title": "Known Missing Replay-Safety Signals",
-                    "type": "text"
-                }
-            ],
-            "title": "Known missing replay-safety signals",
-            "type": "row"
-        }
-    ],
-    "refresh": "30s",
-    "schemaVersion": 30,
-    "style": "dark",
-    "tags": [
-        "control-plane",
-        "replay-safety",
-        "dashboard",
-        "traceability",
-        "observability"
-    ],
-    "templating": {
-        "list": [
+          },
+          "unit": "short",
+          "links": [
             {
-                "allValue": null,
-                "current": {},
-                "datasource": "Prometheus",
-                "definition": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Pipeline",
-                "multi": true,
-                "name": "pipeline",
-                "options": [],
-                "query": {
-                    "query": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false,
-                "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
             },
             {
-                "allValue": null,
-                "current": {},
-                "datasource": "Prometheus",
-                "definition": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Run Type",
-                "multi": true,
-                "name": "run_type",
-                "options": [],
-                "query": {
-                    "query": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false,
-                "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
             }
-        ]
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 2
+      },
+      "id": 891,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)) + (sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replay Safety State",
+      "type": "stat"
     },
-    "time": {
-        "from": "now-12h",
-        "to": "now"
+    {
+      "datasource": "Prometheus",
+      "description": "Checkpoint freshness proxy for selected pipeline. Shows hours since most recent checkpoint operation event.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 6
+              },
+              {
+                "color": "red",
+                "value": 24
+              }
+            ]
+          },
+          "unit": "h",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 2
+      },
+      "id": 892,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "clamp_min((time() - max(max_over_time(bioetl_checkpoint_operator_duration_seconds_count{pipeline=~\"$pipeline\"}[$__range]))) / 3600, 0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Checkpoint Freshness (hours since last op)",
+      "type": "stat"
     },
-    "timepicker": {
-        "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-        ]
+    {
+      "datasource": "Prometheus",
+      "description": "Ledger/manifest consistency proxy for selected pipeline/run_type. Non-zero means either manifest write or ledger append failures were observed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 2
+      },
+      "id": 893,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ledger / Manifest Consistency",
+      "type": "stat"
     },
-    "timezone": "browser",
-    "title": "Control Plane / Replay Safety",
-    "uid": "bioetl-control-plane-v1",
-    "version": 2
+    {
+      "id": 906,
+      "type": "text",
+      "title": "Next Drilldown: Replay Safety Diagnostics",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 2
+      },
+      "options": {
+        "content": "### Next step\nOpen Replay Safety diagnostics row for checkpoint/replay root-cause triage.",
+        "mode": "markdown"
+      },
+      "transparent": false,
+      "links": [
+        {
+          "title": "Open Replay Safety diagnostics",
+          "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?viewPanel=130&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+          "targetBlank": false
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Threshold semantics: replay/resume blockers are binary—green at 0, red at >=1. Next action: stop replay/resume and investigate the first failing signal (manifest, ledger, checkpoint, replay drift, or lineage refs).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ],
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 15
+      },
+      "id": 130,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round(\n  (\n    sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)\n  )\n)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replay / Resume Blockers",
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 902,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 2
+          },
+          "id": 894,
+          "options": {
+            "content": "### Known blind spots\n- Checkpoint freshness by expected schedule/RPO is not instrumented yet.\n- Replay duplicate/overwrite risk signal is not instrumented yet.\n- Manifest-to-ledger referential integrity ratio is not instrumented yet.",
+            "mode": "markdown"
+          },
+          "title": "Known Blind Spots",
+          "type": "text"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range incompatible checkpoint compatibility decisions. Alert: BioETLCheckpointCompatibilityBlocked. Non-zero blocks resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 10,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Incompatibilities",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range not_reconstructable replay observations. Alert: BioETLReplayNotReconstructable. Non-zero blocks replay.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 14,
+            "y": 8
+          },
+          "id": 104,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Not Reconstructable",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range replay drift events. Alert: BioETLReplayDriftDetected. Non-zero means stop replay and inspect drift type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 17,
+            "y": 8
+          },
+          "id": 120,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Drift",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range checkpoint load failures. Alert: BioETLCheckpointLoadFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 32
+          },
+          "id": 101,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_load_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Load Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range checkpoint save failures. Alert: BioETLCheckpointSaveFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 32
+          },
+          "id": 102,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_save_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Save Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "GLOBAL operator/admin checkpoint failures. Alert: BioETLCheckpointOperatorFailed. Not filtered by $pipeline or $run_type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 32
+          },
+          "id": 103,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_operator_operations_total{status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Checkpoint Operator Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Current replay lag seconds for selected pipeline/run_type. Alert: BioETLReplayLagHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 32
+          },
+          "id": 121,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "max(max_over_time(bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Lag Seconds",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Checkpoint compatibility outcomes grouped by disposition.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 38
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (disposition) (increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\"}[$__interval])) or label_replace(vector(0), \"disposition\", \"no_events\", \"\", \"\")",
+              "legendFormat": "{{disposition}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Compatibility Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Replay drift trend by capability, drift type, and status. Alert: BioETLReplayDriftDetected.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 38
+          },
+          "id": 134,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (replay_capability, drift_type, status) (increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
+              "legendFormat": "{{replay_capability}} / {{drift_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Drift by Type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Replay lag trend by replay capability and status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 300
+                  },
+                  {
+                    "color": "red",
+                    "value": 900
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 38
+          },
+          "id": 135,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (replay_capability, status) (bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"})",
+              "legendFormat": "{{replay_capability}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Lag Trend",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Checkpoint save latency quantiles. No data means no latency samples, not zero latency. Alerts: BioETLCheckpointSaveLatencyHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 105,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p50 {{pipeline}} / {{operation}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p95 {{pipeline}} / {{operation}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p99 {{pipeline}} / {{operation}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Checkpoint Save Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "GLOBAL checkpoint operator/admin latency quantiles. Not filtered by $pipeline or $run_type. Alerts: BioETLCheckpointOperatorLatencyHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50 {{operation}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95 {{operation}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99 {{operation}}",
+              "refId": "C"
+            }
+          ],
+          "title": "GLOBAL Checkpoint Operator Latency p50/p95/p99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Replay Safety (Checkpoint / Replay)",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 901,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range manifest persistence failures. Alert: BioETLControlPlaneManifestWriteFailed. Action: inspect manifest persistence before replay/resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 4,
+            "y": 8
+          },
+          "id": 1,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Write Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range run-ledger append failures. Alert: BioETLRunLedgerAppendFailed. Action: inspect run ledger before replay/resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 7,
+            "y": 8
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Append Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Manifest write attempts grouped by status/run_type for the active pipeline/run_type scope.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 131,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (status, run_type) (increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
+              "legendFormat": "{{run_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Writes by Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Run-ledger append attempts grouped by event type and status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (event_type, status) (increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[$__interval]))",
+              "legendFormat": "{{event_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Appends by Event Type / Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "30m manifest write failure ratio. Alert: BioETLControlPlaneManifestWriteFailureRatioHigh. Ratio >0.10 is red.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 132,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Write Failure Ratio",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "30m ledger append failure ratio. Alert: BioETLRunLedgerAppendFailureRatioHigh. Ratio >0.10 is red.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 133,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Append Failure Ratio",
+          "type": "stat"
+        }
+      ],
+      "title": "Incident Drilldown: Manifest / Ledger Integrity",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "id": 903,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. Alert: BioETLControlPlaneReadFailureRate.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 56
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. 30m failure ratio by global read path. Alert: BioETLControlPlaneReadFailureRate.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 56
+          },
+          "id": 136,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_reads_total[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Failure Ratio",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 56
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (store, operation, status) (increase(bioetl_control_plane_reads_total[$__interval]))",
+              "legendFormat": "{{store}} / {{operation}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Reads by Store / Operation / Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 62
+          },
+          "id": 111,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Latency p50/p95/p99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Global Control-Plane Store Reliability",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 904,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range missing upstream lineage references. Alert: BioETLLineageRefsMissing. Missing lineage can make replay evidence incomplete.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 8
+          },
+          "id": 122,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Refs Missing",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range lineage fragment persistence failures. Alert: BioETLLineageFragmentPersistenceFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 88
+          },
+          "id": 137,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Fragment Persistence Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range missing lineage refs by layer/ref_type. Alert: BioETLLineageRefsMissing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 88
+          },
+          "id": 138,
+          "options": {
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "expr": "sum by (layer, ref_type) (increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range]))",
+              "instant": true,
+              "legendFormat": "{{layer}} / {{ref_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Refs Missing by Layer / Ref Type",
+          "type": "table"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit write outcomes by layer, operation, and status. Supporting evidence for replay safety, not answer-row decision.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 72
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "round(sum by (layer, operation, status) (increase(bioetl_audit_write_events_total[$__interval])) or vector(0))",
+              "legendFormat": "{{layer}} / {{operation}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Audit Write Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit query outcomes by layer filter and status. Supporting evidence for replay safety, not answer-row decision.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 72
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "round(sum by (layer_filter, status) (increase(bioetl_audit_query_events_total[$__interval])) or vector(0))",
+              "legendFormat": "{{layer_filter}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Audit Query Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit write latency quantiles. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Audit Write Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit query latency quantiles. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 80
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Audit Query Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Lineage fragment persistence outcomes by layer/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 88
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (layer, status) (increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\"}[$__interval]))",
+              "legendFormat": "{{layer}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Fragment Outcomes",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Audit / Lineage Completeness",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 905,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 89
+          },
+          "id": 139,
+          "options": {
+            "content": "### Missing replay-safety signals\n\nThe dashboard cannot currently verify these invariants because no metric was found:\n\n- checkpoint_age <= recovery window / RPO\n- replay does not create unexplained duplicate records\n\nDo not add PromQL panels for these until metrics exist.\nOpen a separate instrumentation issue for:\n\n- bioetl_checkpoint_age_seconds\n- bioetl_replay_duplicate_records_total\n\n| Missing signal | Required future metric | Why it matters |\n| --- | --- | --- |\n| Checkpoint age vs recovery window | `bioetl_checkpoint_age_seconds` | Cannot visually prove checkpoint age is within RPO |\n| Replay duplicate records | `bioetl_replay_duplicate_records_total` | Cannot visually prove replay did not create unexplained duplicates |\n",
+            "mode": "markdown"
+          },
+          "title": "Known Missing Replay-Safety Signals",
+          "type": "text"
+        }
+      ],
+      "title": "Known missing replay-safety signals",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [
+    "control-plane",
+    "replay-safety",
+    "dashboard",
+    "traceability",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pipeline",
+        "multi": true,
+        "name": "pipeline",
+        "options": [],
+        "query": {
+          "query": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Run Type",
+        "multi": true,
+        "name": "run_type",
+        "options": [],
+        "query": {
+          "query": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Control Plane / Replay Safety",
+  "uid": "bioetl-control-plane-v1",
+  "version": 2
 }

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -27,7 +27,8 @@
       "targetBlank": false,
       "title": "Back to Overview",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+      "tooltip": "Return to 1. Overview and preserve the selected time range."
     },
     {
       "asDropdown": false,
@@ -61,7 +62,8 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
     },
     {
       "asDropdown": false,
@@ -72,7 +74,8 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
     }
   ],
   "panels": [
@@ -93,7 +96,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Operational gating/flow counters (Bronze\u2192Silver\u2192Gold and invariants). Separate from quality score trend.",
+      "description": "Operational gating/flow counters (Bronze→Silver→Gold and invariants). Separate from quality score trend.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -50,7 +50,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "3. Provider Health",
-      "tooltip": "Cross-scope handoff (opens with All provider scope): var-provider=All and var-adapter=All; pipeline/run_type do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All provider scope): var-provider=All and var-adapter=All; pipeline/run_type do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}",
       "type": "link"
     },
@@ -83,7 +83,8 @@
       "type": "link",
       "asDropdown": false,
       "keepTime": true,
-      "targetBlank": false
+      "targetBlank": false,
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
     },
     {
       "title": "Explore Traces (Tempo, tracing profile)",
@@ -91,7 +92,8 @@
       "type": "link",
       "asDropdown": false,
       "keepTime": true,
-      "targetBlank": false
+      "targetBlank": false,
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
     }
   ],
   "panels": [
@@ -249,27 +251,27 @@
                 "1": {
                   "color": "yellow",
                   "index": 1,
-                  "text": "Open 3. Provider Health → degradation/failure evidence"
+                  "text": "Open 3. Provider Health \u2192 degradation/failure evidence"
                 },
                 "2": {
                   "color": "red",
                   "index": 2,
-                  "text": "Open Control Plane v1 → manifest/ledger/checkpoint failure"
+                  "text": "Open Control Plane v1 \u2192 manifest/ledger/checkpoint failure"
                 },
                 "3": {
                   "color": "yellow",
                   "index": 3,
-                  "text": "Open 4. Data Quality → rejects/quarantine/freshness"
+                  "text": "Open 4. Data Quality \u2192 rejects/quarantine/freshness"
                 },
                 "4": {
                   "color": "red",
                   "index": 4,
-                  "text": "Open 2. Runtime → blocker detail (backlog/lag/gold missing)"
+                  "text": "Open 2. Runtime \u2192 blocker detail (backlog/lag/gold missing)"
                 },
                 "5": {
                   "color": "red",
                   "index": 5,
-                  "text": "Open 6. Workflow Overview → failed runs"
+                  "text": "Open 6. Workflow Overview \u2192 failed runs"
                 },
                 "6": {
                   "color": "green",

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -26,7 +26,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Overview",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "dashboards",
       "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },
@@ -38,7 +38,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
     },
@@ -50,7 +50,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "2. Runtime (provider context)",
-      "tooltip": "Cross-scope handoff (provider-derived context mapping): provider/adapter map to runtime pipeline/run_type when mapping exists; fallback var-pipeline=All&var-run_type=All&var-stage=All.",
+      "tooltip": "Cross-scope handoff (provider-derived context mapping): provider/adapter map to runtime pipeline/run_type when mapping exists; fallback var-pipeline=All&var-run_type=All&var-stage=All. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=${provider:queryparam}&var-run_type=${adapter:queryparam}&var-stage=All&${__url_time_range}"
     },
@@ -63,7 +63,8 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
     },
     {
       "asDropdown": false,
@@ -73,7 +74,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Control Plane v1",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "link",
       "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },
@@ -86,7 +87,8 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.provider%22%20%3D~%20%22${provider:regex}%22%20%7D"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.provider%22%20%3D~%20%22${provider:regex}%22%20%7D",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -26,7 +26,8 @@
       "targetBlank": false,
       "title": "Back to Overview",
       "type": "dashboards",
-      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+      "tooltip": "Return to 1. Overview and preserve the selected time range."
     },
     {
       "asDropdown": false,
@@ -47,7 +48,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "3. Provider Health",
-      "tooltip": "Cross-scope handoff (opens with All provider scope): var-provider=All and var-adapter=All; pipeline/run_type/stage do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All provider scope): var-provider=All and var-adapter=All; pipeline/run_type/stage do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "link",
       "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}"
     },
@@ -71,7 +72,8 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
     },
     {
       "asDropdown": false,
@@ -82,7 +84,8 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
     }
   ],
   "panels": [

--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -26,7 +26,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Overview",
-      "tooltip": "",
+      "tooltip": "Return to 1. Overview and preserve the selected time range.",
       "type": "link",
       "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
@@ -38,7 +38,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Data Quality",
-      "tooltip": "",
+      "tooltip": "Return to 4. Data Quality with current time range and dashboard scope.",
       "type": "link",
       "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
@@ -50,7 +50,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
-      "tooltip": "",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range.",
       "type": "link",
       "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
     },
@@ -62,7 +62,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
-      "tooltip": "",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range.",
       "type": "link",
       "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
     }

--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -25,7 +25,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "Back to Overview",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; workflow/status do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; workflow/status do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "dashboards",
       "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },
@@ -37,7 +37,7 @@
       "tags": [],
       "targetBlank": false,
       "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; workflow/status do not transfer.",
+      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; workflow/status do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
     },
@@ -61,7 +61,8 @@
       "targetBlank": false,
       "title": "Explore Logs (Loki, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+      "tooltip": "Open Loki Explore with tracing profile and selected time range."
     },
     {
       "asDropdown": false,
@@ -72,7 +73,8 @@
       "targetBlank": false,
       "title": "Explore Traces (Tempo, tracing profile)",
       "type": "link",
-      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.workflow%22%20%3D~%20%22${workflow:regex}%22%20%26%26%20span.%22bioetl.status%22%20%3D~%20%22${status:regex}%22%20%7D"
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.workflow%22%20%3D~%20%22${workflow:regex}%22%20%26%26%20span.%22bioetl.status%22%20%3D~%20%22${status:regex}%22%20%7D",
+      "tooltip": "Open Tempo Explore with tracing profile and selected time range."
     }
   ],
   "panels": [

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -60,6 +60,18 @@ _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT[
     "required_link_vars_by_target_uid"
 ]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
+_TOP_LEVEL_LINK_TITLE_RE = re.compile(
+    r"^(Back to .+|Open .+|Investigate .+|[1-6]\. .+|Control Plane v1|Explore (Logs|Traces) \(.*\)|Observability Checklist \(runbook\))$"
+)
+_SCOPE_RESET_LINK_TITLES = frozenset(
+    {
+        "2. Runtime (provider context)",
+        "3. Provider Health",
+        "Back to Overview",
+        "Control Plane v1",
+        "2. Runtime",
+    }
+)
 
 
 def _extract_required_time_tokens(section: str) -> tuple[str, ...]:
@@ -306,6 +318,30 @@ def test_dashboard_top_level_navigation_contract_by_uid() -> None:
             f"{dashboard_path.name} ({uid}) is missing required top-level links: "
             f"{sorted(missing)}"
         )
+
+
+def test_critical_top_level_links_follow_title_allowlist_and_scope_reset_suffix() -> None:
+    """Critical top-level links must follow title style-guide and scope-reset tooltip contract."""
+    critical_dashboards = (
+        "bioetl-overview-v2.json",
+        "bioetl-runtime.json",
+        "bioetl-provider-health-v2.json",
+        "bioetl-dq-v2.json",
+        "bioetl-control-plane-v1.json",
+        "bioetl-workflow-overview.json",
+    )
+    for dashboard_name in critical_dashboards:
+        dashboard = load_dashboard(Path("grafana/dashboards") / dashboard_name)
+        for link in dashboard.get("links", []):
+            title = str(link.get("title", ""))
+            assert _TOP_LEVEL_LINK_TITLE_RE.match(title), (
+                f"{dashboard_name} contains non-conforming top-level link title: {title}"
+            )
+            tooltip = str(link.get("tooltip", "") or "")
+            if "Cross-scope handoff" in tooltip:
+                assert "Scope reset:" in tooltip, (
+                    f"{dashboard_name} link '{title}' must include 'Scope reset:' suffix"
+                )
 
 
 def test_dashboard_links_forbid_universal_handoff_patterns() -> None:


### PR DESCRIPTION
### Motivation
- Ensure consistent operator-facing link UX across shipped Grafana dashboards by prescribing action-verb templates for top-level links and explicit scope-reset language in tooltips.
- Make cross-dashboard handoffs explicit and machine-verifiable to reduce accidental variable leakage and improve operator guidance during drilldowns.
- Add an automated lint to catch regressions in top-level navigation phrasing for critical dashboards.

### Description
- Extended `docs/03-guides/dashboards/design-system.md` with a Link title style-guide (use `Back / Open / Investigate`) and a mandatory `Scope reset:` suffix requirement for tooltips that perform cross-scope handoffs.
- Normalized top-level `links[].title` and `links[].tooltip` across several `grafana/dashboards/*.json` files to follow the new style-guide and to add consistent tooltips for Explore/Back/Scope-reset flows.
- Added a new integration lint in `tests/integration/test_grafana_dashboard_links.py` that enforces a title allowlist regex for critical top-level links and requires `Scope reset:` in tooltips when a link performs cross-scope handoff.
- Limited edits to dashboard metadata and docs only; no pipeline runtime code was modified.

### Testing
- Ran JSON sanity checks with `python -m json.tool` against the edited dashboards and they validated successfully (OK).
- Ran the targeted pytest selection for the new navigation lint and the existing top-level navigation contract and those checks passed (`uv run python -m pytest -q tests/integration/test_grafana_dashboard_links.py -k 'critical_top_level_links_follow_title_allowlist_and_scope_reset_suffix or dashboard_top_level_navigation_contract_by_uid'`).
- Ran the full `tests/integration/test_grafana_dashboard_links.py` suite which revealed 3 failing tests related to pre-existing Silver Reject Explorer panel-title expectations, unrelated to the link/title/tooltip changes introduced in this PR (3 failed, 37 passed).
- Recorded that the change set only touches docs, dashboard JSON metadata, and integration lint tests; further follow-up is recommended to resolve the Silver Reject Explorer panel-title contract drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f829120c1883248f7bbdc9015ba381)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->