### PR TITLE
Add optional scoped Loki contextual Explore links for critical dashboards

### DIFF
--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -19,6 +19,9 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 - Explore handoff для Loki/Tempo ведёт только через drilldown-приложения:
   - Logs: `/a/grafana-lokiexplore-app/explore?...`
   - Traces: `/a/grafana-exploretraces-app/?...`
+- Optional contextual Explore links (`options.dataLinks`) разрешены только для operator-critical panel surfaces в `bioetl-runtime`, `bioetl-dq-v2`, `bioetl-control-plane-v1`; baseline link `Open Logs (Loki, tracing profile)` MUST сохраняться.
+- Contextual Loki Explore link MUST содержать безопасный scope marker `scope_marker="dashboard_context"` и может использовать только `${pipeline:regex}` и `${run_type:regex}` как дополнительные фильтры после `{job="bioetl"} | json`.
+- Contextual Explore links MUST NOT передавать/использовать forensic переменные (`run_id`, `payload_hash`) или любые другие `var-*` вне разрешённого набора.
 
 
 ## Примеры URL (нормализованный формат)

--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -1,2779 +1,2791 @@
 {
-    "annotations": {
-        "list": [
-            {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-            }
-        ]
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Answers whether manifest, ledger, checkpoint, replay, and lineage state are trustworthy enough to allow replay/resume for the selected pipeline/run_type/time range. Primary question: Can we trust manifest/ledger/checkpoint/lineage state and safely replay/resume? GLOBAL read-path panels are not pipeline-scoped and must not use $pipeline or $run_type filtering.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 2,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Back to Overview",
+      "type": "link",
+      "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
     },
-    "description": "Answers whether manifest, ledger, checkpoint, replay, and lineage state are trustworthy enough to allow replay/resume for the selected pipeline/run_type/time range. Primary question: Can we trust manifest/ledger/checkpoint/lineage state and safely replay/resume? GLOBAL read-path panels are not pipeline-scoped and must not use $pipeline or $run_type filtering.",
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 1,
-    "id": null,
-    "iteration": 2,
-    "links": [
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Back to Overview",
-            "type": "link",
-            "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "2. Runtime",
-            "type": "link",
-            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "4. Data Quality",
-            "type": "link",
-            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-        },
-        {
-            "asDropdown": false,
-            "icon": "logs",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Explore Logs (Loki, tracing profile)",
-            "type": "link",
-            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
-        },
-        {
-            "asDropdown": false,
-            "icon": "share-alt",
-            "includeVars": false,
-            "keepTime": true,
-            "targetBlank": false,
-            "title": "Explore Traces (Tempo, tracing profile)",
-            "type": "link",
-            "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
-        },
-        {
-            "asDropdown": false,
-            "icon": "external link",
-            "includeVars": false,
-            "keepTime": false,
-            "targetBlank": true,
-            "title": "Observability Checklist (runbook)",
-            "type": "link",
-            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-        }
-    ],
-    "panels": [
-        {
-            "collapsed": false,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 0
-            },
-            "id": 900,
-            "panels": [],
-            "title": "Answer: Replay / Resume Safety",
-            "type": "row"
-        },
-        {
-            "collapsed": false,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 1
-            },
-            "id": 890,
-            "panels": [],
-            "title": "Trust Summary (Answer-First)",
-            "type": "row"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Replay safety state for selected pipeline/run_type. Zero means no blockers detected in selected range.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 0,
-                "y": 2
-            },
-            "id": 891,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)) + (sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
-                    "instant": true,
-                    "refId": "A"
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "2. Runtime",
+      "type": "link",
+      "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "4. Data Quality",
+      "type": "link",
+      "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "logs",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Explore Logs (Loki, tracing profile)",
+      "type": "link",
+      "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+    },
+    {
+      "asDropdown": false,
+      "icon": "share-alt",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Explore Traces (Tempo, tracing profile)",
+      "type": "link",
+      "url": "/a/grafana-exploretraces-app/?from=${__from}&to=${__to}&queryType=traceqlSearch&query=%7B%20span.%22bioetl.pipeline%22%20%3D~%20%22${pipeline:regex}%22%20%26%26%20span.%22bioetl.run_type%22%20%3D~%20%22${run_type:regex}%22%20%7D"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
+      "title": "Observability Checklist (runbook)",
+      "type": "link",
+      "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 900,
+      "panels": [],
+      "title": "Answer: Replay / Resume Safety",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 890,
+      "panels": [],
+      "title": "Trust Summary (Answer-First)",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Replay safety state for selected pipeline/run_type. Zero means no blockers detected in selected range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
                 }
-            ],
-            "title": "Replay Safety State",
-            "type": "stat"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Checkpoint freshness proxy for selected pipeline. Shows hours since most recent checkpoint operation event.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "yellow",
-                                "value": 6
-                            },
-                            {
-                                "color": "red",
-                                "value": 24
-                            }
-                        ]
-                    },
-                    "unit": "h",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 6,
-                "y": 2
-            },
-            "id": 892,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "clamp_min((time() - max(max_over_time(bioetl_checkpoint_operator_duration_seconds_count{pipeline=~\"$pipeline\"}[$__range]))) / 3600, 0)",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Checkpoint Freshness (hours since last op)",
-            "type": "stat"
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Ledger/manifest consistency proxy for selected pipeline/run_type. Non-zero means either manifest write or ledger append failures were observed.",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short",
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ]
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 12,
-                "y": 2
-            },
-            "id": 893,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)))",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Ledger / Manifest Consistency",
-            "type": "stat"
-        },
-        {
-            "id": 906,
-            "type": "text",
-            "title": "Next Drilldown: Replay Safety Diagnostics",
-            "gridPos": {
-                "h": 5,
-                "w": 6,
-                "x": 18,
-                "y": 2
-            },
-            "options": {
-                "content": "### Next step\nOpen Replay Safety diagnostics row for checkpoint/replay root-cause triage.",
-                "mode": "markdown"
-            },
-            "transparent": false,
-            "links": [
-                {
-                    "title": "Open Replay Safety diagnostics",
-                    "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?viewPanel=130&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
-                    "targetBlank": false
-                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
             ]
-        },
-        {
-            "datasource": "Prometheus",
-            "description": "Threshold semantics: replay/resume blockers are binary\u2014green at 0, red at >=1. Next action: stop replay/resume and investigate the first failing signal (manifest, ledger, checkpoint, replay drift, or lineage refs).",
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "links": [
-                        {
-                            "targetBlank": true,
-                            "title": "Open Replay & Resume Runbook",
-                            "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open Runtime Dependencies",
-                            "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        },
-                        {
-                            "targetBlank": true,
-                            "title": "Open DQ Dependencies",
-                            "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
-                        }
-                    ],
-                    "mappings": [
-                        {
-                            "type": "special",
-                            "options": {
-                                "match": "null",
-                                "result": {
-                                    "text": "UNKNOWN",
-                                    "color": "gray"
-                                }
-                            }
-                        }
-                    ],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "orange",
-                                "value": 1
-                            },
-                            {
-                                "color": "red",
-                                "value": 2
-                            }
-                        ]
-                    },
-                    "unit": "short"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 6,
-                "w": 4,
-                "x": 0,
-                "y": 15
-            },
-            "id": 130,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "9.5.0",
-            "targets": [
-                {
-                    "expr": "round(\n  (\n    sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)\n  )\n)",
-                    "instant": true,
-                    "refId": "A"
-                }
-            ],
-            "title": "Replay / Resume Blockers",
-            "type": "stat"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 31
-            },
-            "id": 902,
-            "panels": [
-                {
-                    "gridPos": {
-                        "h": 5,
-                        "w": 6,
-                        "x": 18,
-                        "y": 2
-                    },
-                    "id": 894,
-                    "options": {
-                        "content": "### Known blind spots\n- Checkpoint freshness by expected schedule/RPO is not instrumented yet.\n- Replay duplicate/overwrite risk signal is not instrumented yet.\n- Manifest-to-ledger referential integrity ratio is not instrumented yet.",
-                        "mode": "markdown"
-                    },
-                    "title": "Known Blind Spots",
-                    "type": "text"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range incompatible checkpoint compatibility decisions. Alert: BioETLCheckpointCompatibilityBlocked. Non-zero blocks resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short",
-                            "decimals": 0
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 4,
-                        "x": 10,
-                        "y": 8
-                    },
-                    "id": 3,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Incompatibilities",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range not_reconstructable replay observations. Alert: BioETLReplayNotReconstructable. Non-zero blocks replay.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 14,
-                        "y": 8
-                    },
-                    "id": 104,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Not Reconstructable",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range replay drift events. Alert: BioETLReplayDriftDetected. Non-zero means stop replay and inspect drift type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 17,
-                        "y": 8
-                    },
-                    "id": 120,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Drift",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range checkpoint load failures. Alert: BioETLCheckpointLoadFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 0,
-                        "y": 32
-                    },
-                    "id": 101,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_load_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Load Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range checkpoint save failures. Alert: BioETLCheckpointSaveFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 6,
-                        "y": 32
-                    },
-                    "id": 102,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_save_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Save Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "GLOBAL operator/admin checkpoint failures. Alert: BioETLCheckpointOperatorFailed. Not filtered by $pipeline or $run_type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 12,
-                        "y": 32
-                    },
-                    "id": 103,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_checkpoint_operator_operations_total{status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Checkpoint Operator Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Current replay lag seconds for selected pipeline/run_type. Alert: BioETLReplayLagHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 18,
-                        "y": 32
-                    },
-                    "id": 121,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "max(max_over_time(bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Lag Seconds",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Checkpoint compatibility outcomes grouped by disposition.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 0,
-                        "y": 38
-                    },
-                    "id": 5,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (disposition) (increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\"}[$__interval])) or label_replace(vector(0), \"disposition\", \"no_events\", \"\", \"\")",
-                            "legendFormat": "{{disposition}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Checkpoint Compatibility Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Replay drift trend by capability, drift type, and status. Alert: BioETLReplayDriftDetected.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 8,
-                        "y": 38
-                    },
-                    "id": 134,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (replay_capability, drift_type, status) (increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
-                            "legendFormat": "{{replay_capability}} / {{drift_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Drift by Type",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Replay lag trend by replay capability and status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 300
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 900
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 8,
-                        "x": 16,
-                        "y": 38
-                    },
-                    "id": 135,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "max by (replay_capability, status) (bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"})",
-                            "legendFormat": "{{replay_capability}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Replay Lag Trend",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Checkpoint save latency quantiles. No data means no latency samples, not zero latency. Alerts: BioETLCheckpointSaveLatencyHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 46
-                    },
-                    "id": 105,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p50 {{pipeline}} / {{operation}}",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p95 {{pipeline}} / {{operation}}",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
-                            "legendFormat": "p99 {{pipeline}} / {{operation}}",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Checkpoint Save Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "GLOBAL checkpoint operator/admin latency quantiles. Not filtered by $pipeline or $run_type. Alerts: BioETLCheckpointOperatorLatencyHigh.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Checkpoint Debugging",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 46
-                    },
-                    "id": 106,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50 {{operation}}",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95 {{operation}}",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99 {{operation}}",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "GLOBAL Checkpoint Operator Latency p50/p95/p99",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Replay Safety (Checkpoint / Replay)",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 15
-            },
-            "id": 901,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range manifest persistence failures. Alert: BioETLControlPlaneManifestWriteFailed. Action: inspect manifest persistence before replay/resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 4,
-                        "y": 8
-                    },
-                    "id": 1,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Write Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range run-ledger append failures. Alert: BioETLRunLedgerAppendFailed. Action: inspect run ledger before replay/resume.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 3,
-                        "x": 7,
-                        "y": 8
-                    },
-                    "id": 2,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Append Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Manifest write attempts grouped by status/run_type for the active pipeline/run_type scope.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 16
-                    },
-                    "id": 131,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (status, run_type) (increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
-                            "legendFormat": "{{run_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Writes by Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Run-ledger append attempts grouped by event type and status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 16
-                    },
-                    "id": 7,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (event_type, status) (increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[$__interval]))",
-                            "legendFormat": "{{event_type}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Appends by Event Type / Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "30m manifest write failure ratio. Alert: BioETLControlPlaneManifestWriteFailureRatioHigh. Ratio >0.10 is red.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 0,
-                        "y": 24
-                    },
-                    "id": 132,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Manifest Write Failure Ratio",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "30m ledger append failure ratio. Alert: BioETLRunLedgerAppendFailureRatioHigh. Ratio >0.10 is red.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Run Manifest Inspection",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 12,
-                        "y": 24
-                    },
-                    "id": 133,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Ledger Append Failure Ratio",
-                    "type": "stat"
-                }
-            ],
-            "title": "Incident Drilldown: Manifest / Ledger Integrity",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 55
-            },
-            "id": 903,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. Alert: BioETLControlPlaneReadFailureRate.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 0,
-                        "y": 56
-                    },
-                    "id": 4,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. 30m failure ratio by global read path. Alert: BioETLControlPlaneReadFailureRate.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "percentunit"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 6,
-                        "x": 6,
-                        "y": 56
-                    },
-                    "id": 136,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_reads_total[30m])) or vector(0)), 1)",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Failure Ratio",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 12,
-                        "x": 12,
-                        "y": 56
-                    },
-                    "id": 6,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (store, operation, status) (increase(bioetl_control_plane_reads_total[$__interval]))",
-                            "legendFormat": "{{store}} / {{operation}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Reads by Store / Operation / Status",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 24,
-                        "x": 0,
-                        "y": 62
-                    },
-                    "id": 111,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "GLOBAL Control-Plane Read Latency p50/p95/p99",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Global Control-Plane Store Reliability",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 71
-            },
-            "id": 904,
-            "panels": [
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range missing upstream lineage references. Alert: BioETLLineageRefsMissing. Missing lineage can make replay evidence incomplete.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short",
-                            "decimals": 0
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 4,
-                        "x": 20,
-                        "y": 8
-                    },
-                    "id": 122,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Refs Missing",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range lineage fragment persistence failures. Alert: BioETLLineageFragmentPersistenceFailed.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [
-                                {
-                                    "type": "special",
-                                    "options": {
-                                        "match": "null",
-                                        "result": {
-                                            "text": "UNKNOWN",
-                                            "color": "gray"
-                                        }
-                                    }
-                                }
-                            ],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "orange",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 2
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 0,
-                        "y": 88
-                    },
-                    "id": 137,
-                    "options": {
-                        "colorMode": "value",
-                        "graphMode": "area",
-                        "justifyMode": "auto",
-                        "orientation": "auto",
-                        "reduceOptions": {
-                            "calcs": [
-                                "lastNotNull"
-                            ],
-                            "fields": "",
-                            "values": false
-                        },
-                        "textMode": "auto"
-                    },
-                    "pluginVersion": "9.5.0",
-                    "targets": [
-                        {
-                            "expr": "round(sum(increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
-                            "instant": true,
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Fragment Persistence Failures",
-                    "type": "stat"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Selected-range missing lineage refs by layer/ref_type. Alert: BioETLLineageRefsMissing.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "thresholds"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 1
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 10
-                                    }
-                                ]
-                            },
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 16,
-                        "y": 88
-                    },
-                    "id": 138,
-                    "options": {
-                        "showHeader": true
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (layer, ref_type) (increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range]))",
-                            "instant": true,
-                            "legendFormat": "{{layer}} / {{ref_type}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Refs Missing by Layer / Ref Type",
-                    "type": "table"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit write outcomes by layer, operation, and status. Supporting evidence for replay safety, not answer-row decision.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 72
-                    },
-                    "id": 107,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "round(sum by (layer, operation, status) (increase(bioetl_audit_write_events_total[$__interval])) or vector(0))",
-                            "legendFormat": "{{layer}} / {{operation}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Audit Write Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit query outcomes by layer filter and status. Supporting evidence for replay safety, not answer-row decision.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 72
-                    },
-                    "id": 108,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "round(sum by (layer_filter, status) (increase(bioetl_audit_query_events_total[$__interval])) or vector(0))",
-                            "legendFormat": "{{layer_filter}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Audit Query Outcomes",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit write latency quantiles. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 0,
-                        "y": 80
-                    },
-                    "id": 109,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Audit Write Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Audit query latency quantiles. No data means no latency samples, not zero latency.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Observability Checklist",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "thresholds": {
-                                "mode": "absolute",
-                                "steps": [
-                                    {
-                                        "color": "green",
-                                        "value": null
-                                    },
-                                    {
-                                        "color": "yellow",
-                                        "value": 0.5
-                                    },
-                                    {
-                                        "color": "red",
-                                        "value": 1.0
-                                    }
-                                ]
-                            },
-                            "unit": "s"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 8,
-                        "w": 12,
-                        "x": 12,
-                        "y": 80
-                    },
-                    "id": 110,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p50",
-                            "refId": "A"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p95",
-                            "refId": "B"
-                        },
-                        {
-                            "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
-                            "legendFormat": "p99",
-                            "refId": "C"
-                        }
-                    ],
-                    "title": "Audit Query Latency p50/p95/p99",
-                    "type": "timeseries"
-                },
-                {
-                    "datasource": "Prometheus",
-                    "description": "Lineage fragment persistence outcomes by layer/status.",
-                    "fieldConfig": {
-                        "defaults": {
-                            "color": {
-                                "mode": "palette-classic"
-                            },
-                            "links": [
-                                {
-                                    "targetBlank": true,
-                                    "title": "Traceability Signal Ownership",
-                                    "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
-                                }
-                            ],
-                            "mappings": [],
-                            "unit": "short"
-                        },
-                        "overrides": []
-                    },
-                    "gridPos": {
-                        "h": 6,
-                        "w": 8,
-                        "x": 8,
-                        "y": 88
-                    },
-                    "id": 112,
-                    "options": {
-                        "legend": {
-                            "calcs": [],
-                            "displayMode": "list",
-                            "placement": "bottom"
-                        },
-                        "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                        }
-                    },
-                    "targets": [
-                        {
-                            "expr": "sum by (layer, status) (increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\"}[$__interval]))",
-                            "legendFormat": "{{layer}} / {{status}}",
-                            "refId": "A"
-                        }
-                    ],
-                    "title": "Lineage Fragment Outcomes",
-                    "type": "timeseries"
-                }
-            ],
-            "title": "Incident Drilldown: Audit / Lineage Completeness",
-            "type": "row"
-        },
-        {
-            "collapsed": true,
-            "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 95
-            },
-            "id": 905,
-            "panels": [
-                {
-                    "gridPos": {
-                        "h": 8,
-                        "w": 24,
-                        "x": 0,
-                        "y": 89
-                    },
-                    "id": 139,
-                    "options": {
-                        "content": "### Missing replay-safety signals\n\nThe dashboard cannot currently verify these invariants because no metric was found:\n\n- checkpoint_age <= recovery window / RPO\n- replay does not create unexplained duplicate records\n\nDo not add PromQL panels for these until metrics exist.\nOpen a separate instrumentation issue for:\n\n- bioetl_checkpoint_age_seconds\n- bioetl_replay_duplicate_records_total\n\n| Missing signal | Required future metric | Why it matters |\n| --- | --- | --- |\n| Checkpoint age vs recovery window | `bioetl_checkpoint_age_seconds` | Cannot visually prove checkpoint age is within RPO |\n| Replay duplicate records | `bioetl_replay_duplicate_records_total` | Cannot visually prove replay did not create unexplained duplicates |\n",
-                        "mode": "markdown"
-                    },
-                    "title": "Known Missing Replay-Safety Signals",
-                    "type": "text"
-                }
-            ],
-            "title": "Known missing replay-safety signals",
-            "type": "row"
-        }
-    ],
-    "refresh": "30s",
-    "schemaVersion": 30,
-    "style": "dark",
-    "tags": [
-        "control-plane",
-        "replay-safety",
-        "dashboard",
-        "traceability",
-        "observability"
-    ],
-    "templating": {
-        "list": [
+          },
+          "unit": "short",
+          "links": [
             {
-                "allValue": null,
-                "current": {},
-                "datasource": "Prometheus",
-                "definition": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Pipeline",
-                "multi": true,
-                "name": "pipeline",
-                "options": [],
-                "query": {
-                    "query": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false,
-                "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
             },
             {
-                "allValue": null,
-                "current": {},
-                "datasource": "Prometheus",
-                "definition": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
-                "hide": 0,
-                "includeAll": true,
-                "label": "Run Type",
-                "multi": true,
-                "name": "run_type",
-                "options": [],
-                "query": {
-                    "query": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 1,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false,
-                "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
             }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 2
+      },
+      "id": 891,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)) + (sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)) + (sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replay Safety State",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Checkpoint freshness proxy for selected pipeline. Shows hours since most recent checkpoint operation event.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 6
+              },
+              {
+                "color": "red",
+                "value": 24
+              }
+            ]
+          },
+          "unit": "h",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 2
+      },
+      "id": 892,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "clamp_min((time() - max(max_over_time(bioetl_checkpoint_operator_duration_seconds_count{pipeline=~\"$pipeline\"}[$__range]))) / 3600, 0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Checkpoint Freshness (hours since last op)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Ledger/manifest consistency proxy for selected pipeline/run_type. Non-zero means either manifest write or ledger append failures were observed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 2
+      },
+      "id": 893,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)) + (sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ledger / Manifest Consistency",
+      "type": "stat"
+    },
+    {
+      "id": 906,
+      "type": "text",
+      "title": "Next Drilldown: Replay Safety Diagnostics",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 2
+      },
+      "options": {
+        "content": "### Next step\nOpen Replay Safety diagnostics row for checkpoint/replay root-cause triage.",
+        "mode": "markdown"
+      },
+      "transparent": false,
+      "links": [
+        {
+          "title": "Open Replay Safety diagnostics",
+          "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?viewPanel=130&var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+          "targetBlank": false
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Threshold semantics: replay/resume blockers are binary—green at 0, red at >=1. Next action: stop replay/resume and investigate the first failing signal (manifest, ledger, checkpoint, replay drift, or lineage refs).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Open Replay & Resume Runbook",
+              "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/replay-resume.md?pipeline=${pipeline:queryparam}&run_type=${run_type:queryparam}&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open Runtime Dependencies",
+              "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            },
+            {
+              "targetBlank": true,
+              "title": "Open DQ Dependencies",
+              "url": "/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+            }
+          ],
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "UNKNOWN",
+                  "color": "gray"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 15
+      },
+      "id": 130,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "dataLinks": [
+          {
+            "title": "Open Logs (Loki, tracing profile)",
+            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D",
+            "targetBlank": true
+          },
+          {
+            "title": "Open Logs (Loki, contextual scope marker)",
+            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D%20%7C%20json%20%7C%20scope_marker%3D%22dashboard_context%22%20%7C%20pipeline%3D~%22${pipeline:regex}%22%20%7C%20run_type%3D~%22${run_type:regex}%22",
+            "targetBlank": true
+          }
         ]
+      },
+      "pluginVersion": "9.5.0",
+      "targets": [
+        {
+          "expr": "round(\n  (\n    sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)\n  )\n+\n  (\n    sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)\n  )\n)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replay / Resume Blockers",
+      "type": "stat"
     },
-    "time": {
-        "from": "now-12h",
-        "to": "now"
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 902,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 2
+          },
+          "id": 894,
+          "options": {
+            "content": "### Known blind spots\n- Checkpoint freshness by expected schedule/RPO is not instrumented yet.\n- Replay duplicate/overwrite risk signal is not instrumented yet.\n- Manifest-to-ledger referential integrity ratio is not instrumented yet.",
+            "mode": "markdown"
+          },
+          "title": "Known Blind Spots",
+          "type": "text"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range incompatible checkpoint compatibility decisions. Alert: BioETLCheckpointCompatibilityBlocked. Non-zero blocks resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 10,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\", disposition=~\".*_incompatible\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Incompatibilities",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range not_reconstructable replay observations. Alert: BioETLReplayNotReconstructable. Non-zero blocks replay.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 14,
+            "y": 8
+          },
+          "id": 104,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_replay_reconstructability_events_total{pipeline=~\"$pipeline\", status=\"not_reconstructable\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Not Reconstructable",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range replay drift events. Alert: BioETLReplayDriftDetected. Non-zero means stop replay and inspect drift type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 17,
+            "y": 8
+          },
+          "id": 120,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Drift",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range checkpoint load failures. Alert: BioETLCheckpointLoadFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 32
+          },
+          "id": 101,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_load_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Load Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range checkpoint save failures. Alert: BioETLCheckpointSaveFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 32
+          },
+          "id": 102,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_save_events_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Save Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "GLOBAL operator/admin checkpoint failures. Alert: BioETLCheckpointOperatorFailed. Not filtered by $pipeline or $run_type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 32
+          },
+          "id": 103,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_checkpoint_operator_operations_total{status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Checkpoint Operator Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Current replay lag seconds for selected pipeline/run_type. Alert: BioETLReplayLagHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 32
+          },
+          "id": 121,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "max(max_over_time(bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__range])) or vector(0)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Lag Seconds",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Checkpoint compatibility outcomes grouped by disposition.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 38
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (disposition) (increase(bioetl_checkpoint_compatibility_events_total{pipeline=~\"$pipeline\"}[$__interval])) or label_replace(vector(0), \"disposition\", \"no_events\", \"\", \"\")",
+              "legendFormat": "{{disposition}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Checkpoint Compatibility Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Replay drift trend by capability, drift type, and status. Alert: BioETLReplayDriftDetected.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 38
+          },
+          "id": 134,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (replay_capability, drift_type, status) (increase(bioetl_replay_drift_events_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
+              "legendFormat": "{{replay_capability}} / {{drift_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Drift by Type",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Replay lag trend by replay capability and status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 300
+                  },
+                  {
+                    "color": "red",
+                    "value": 900
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 38
+          },
+          "id": 135,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "max by (replay_capability, status) (bioetl_replay_lag_seconds{pipeline=~\"$pipeline\", run_type=~\"$run_type\"})",
+              "legendFormat": "{{replay_capability}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replay Lag Trend",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Checkpoint save latency quantiles. No data means no latency samples, not zero latency. Alerts: BioETLCheckpointSaveLatencyHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 105,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p50 {{pipeline}} / {{operation}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p95 {{pipeline}} / {{operation}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, pipeline, operation) (increase(bioetl_checkpoint_save_duration_seconds_bucket{pipeline=~\"$pipeline\"}[$__range])))",
+              "legendFormat": "p99 {{pipeline}} / {{operation}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Checkpoint Save Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "GLOBAL checkpoint operator/admin latency quantiles. Not filtered by $pipeline or $run_type. Alerts: BioETLCheckpointOperatorLatencyHigh.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Checkpoint Debugging",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/checkpoint-debugging.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50 {{operation}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95 {{operation}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, operation) (increase(bioetl_checkpoint_operator_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99 {{operation}}",
+              "refId": "C"
+            }
+          ],
+          "title": "GLOBAL Checkpoint Operator Latency p50/p95/p99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Replay Safety (Checkpoint / Replay)",
+      "type": "row"
     },
-    "timepicker": {
-        "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-        ]
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 901,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range manifest persistence failures. Alert: BioETLControlPlaneManifestWriteFailed. Action: inspect manifest persistence before replay/resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 4,
+            "y": 8
+          },
+          "id": 1,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Write Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range run-ledger append failures. Alert: BioETLRunLedgerAppendFailed. Action: inspect run ledger before replay/resume.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 7,
+            "y": 8
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Append Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Manifest write attempts grouped by status/run_type for the active pipeline/run_type scope.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 131,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (status, run_type) (increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[$__interval]))",
+              "legendFormat": "{{run_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Writes by Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Run-ledger append attempts grouped by event type and status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (event_type, status) (increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[$__interval]))",
+              "legendFormat": "{{event_type}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Appends by Event Type / Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "30m manifest write failure ratio. Alert: BioETLControlPlaneManifestWriteFailureRatioHigh. Ratio >0.10 is red.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 132,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\"}[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Manifest Write Failure Ratio",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "30m ledger append failure ratio. Alert: BioETLRunLedgerAppendFailureRatioHigh. Ratio >0.10 is red.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Run Manifest Inspection",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/run-manifest-inspection.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 133,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\", status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_ledger_appends_total{pipeline=~\"$pipeline\"}[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Ledger Append Failure Ratio",
+          "type": "stat"
+        }
+      ],
+      "title": "Incident Drilldown: Manifest / Ledger Integrity",
+      "type": "row"
     },
-    "timezone": "browser",
-    "title": "Control Plane / Replay Safety",
-    "uid": "bioetl-control-plane-v1",
-    "version": 2
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "id": 903,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. Alert: BioETLControlPlaneReadFailureRate.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 56
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. 30m failure ratio by global read path. Alert: BioETLControlPlaneReadFailureRate.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 56
+          },
+          "id": 136,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "(sum(increase(bioetl_control_plane_reads_total{status=\"failed\"}[30m])) or vector(0)) / clamp_min((sum(increase(bioetl_control_plane_reads_total[30m])) or vector(0)), 1)",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Failure Ratio",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 56
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (store, operation, status) (increase(bioetl_control_plane_reads_total[$__interval]))",
+              "legendFormat": "{{store}} / {{operation}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Reads by Store / Operation / Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Read-path metric is global by store/operation/status and is not filtered by $pipeline or $run_type. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 62
+          },
+          "id": 111,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_control_plane_read_duration_seconds_bucket{status!=\"failed\"}[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "GLOBAL Control-Plane Read Latency p50/p95/p99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Global Control-Plane Store Reliability",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 904,
+      "panels": [
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range missing upstream lineage references. Alert: BioETLLineageRefsMissing. Missing lineage can make replay evidence incomplete.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short",
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 8
+          },
+          "id": 122,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Refs Missing",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range lineage fragment persistence failures. Alert: BioETLLineageFragmentPersistenceFailed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "UNKNOWN",
+                      "color": "gray"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 2
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 88
+          },
+          "id": 137,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.0",
+          "targets": [
+            {
+              "expr": "round(sum(increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\", status=\"failed\"}[$__range])) or vector(0))",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Fragment Persistence Failures",
+          "type": "stat"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Selected-range missing lineage refs by layer/ref_type. Alert: BioETLLineageRefsMissing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 88
+          },
+          "id": 138,
+          "options": {
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "expr": "sum by (layer, ref_type) (increase(bioetl_lineage_refs_missing_total{pipeline=~\"$pipeline\"}[$__range]))",
+              "instant": true,
+              "legendFormat": "{{layer}} / {{ref_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Refs Missing by Layer / Ref Type",
+          "type": "table"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit write outcomes by layer, operation, and status. Supporting evidence for replay safety, not answer-row decision.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 72
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "round(sum by (layer, operation, status) (increase(bioetl_audit_write_events_total[$__interval])) or vector(0))",
+              "legendFormat": "{{layer}} / {{operation}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Audit Write Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit query outcomes by layer filter and status. Supporting evidence for replay safety, not answer-row decision.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 72
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "round(sum by (layer_filter, status) (increase(bioetl_audit_query_events_total[$__interval])) or vector(0))",
+              "legendFormat": "{{layer_filter}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Audit Query Outcomes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit write latency quantiles. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 80
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_write_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Audit Write Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Audit query latency quantiles. No data means no latency samples, not zero latency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Observability Checklist",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/observability-checklist.md"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "red",
+                    "value": 1.0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 80
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (increase(bioetl_audit_query_duration_seconds_bucket[$__range])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "title": "Audit Query Latency p50/p95/p99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Prometheus",
+          "description": "Lineage fragment persistence outcomes by layer/status.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "links": [
+                {
+                  "targetBlank": true,
+                  "title": "Traceability Signal Ownership",
+                  "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/traceability-signal-ownership.md"
+                }
+              ],
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 88
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (layer, status) (increase(bioetl_lineage_fragments_emitted_total{pipeline=~\"$pipeline\"}[$__interval]))",
+              "legendFormat": "{{layer}} / {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lineage Fragment Outcomes",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Incident Drilldown: Audit / Lineage Completeness",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 905,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 89
+          },
+          "id": 139,
+          "options": {
+            "content": "### Missing replay-safety signals\n\nThe dashboard cannot currently verify these invariants because no metric was found:\n\n- checkpoint_age <= recovery window / RPO\n- replay does not create unexplained duplicate records\n\nDo not add PromQL panels for these until metrics exist.\nOpen a separate instrumentation issue for:\n\n- bioetl_checkpoint_age_seconds\n- bioetl_replay_duplicate_records_total\n\n| Missing signal | Required future metric | Why it matters |\n| --- | --- | --- |\n| Checkpoint age vs recovery window | `bioetl_checkpoint_age_seconds` | Cannot visually prove checkpoint age is within RPO |\n| Replay duplicate records | `bioetl_replay_duplicate_records_total` | Cannot visually prove replay did not create unexplained duplicates |\n",
+            "mode": "markdown"
+          },
+          "title": "Known Missing Replay-Safety Signals",
+          "type": "text"
+        }
+      ],
+      "title": "Known missing replay-safety signals",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [
+    "control-plane",
+    "replay-safety",
+    "dashboard",
+    "traceability",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pipeline",
+        "multi": true,
+        "name": "pipeline",
+        "options": [],
+        "query": {
+          "query": "label_values(bioetl_control_plane_manifest_writes_total, pipeline)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "description": "Core scope: pipeline selector for pipeline-centric dashboards; fallback: All pipelines when not passed by source dashboard."
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus",
+        "definition": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Run Type",
+        "multi": true,
+        "name": "run_type",
+        "options": [],
+        "query": {
+          "query": "label_values(bioetl_control_plane_manifest_writes_total{pipeline=~\"$pipeline\"}, run_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false,
+        "description": "Core scope: run_type selector bounded by pipeline; fallback: All run types for selected pipeline."
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Control Plane / Replay Safety",
+  "uid": "bioetl-control-plane-v1",
+  "version": 2
 }

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -93,7 +93,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Operational gating/flow counters (Bronze\u2192Silver\u2192Gold and invariants). Separate from quality score trend.",
+      "description": "Operational gating/flow counters (Bronze→Silver→Gold and invariants). Separate from quality score trend.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -164,6 +164,11 @@
           {
             "title": "Open Control Plane v1 (replay/checkpoint)",
             "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+          },
+          {
+            "title": "Open Logs (Loki, contextual scope marker)",
+            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D%20%7C%20json%20%7C%20scope_marker%3D%22dashboard_context%22%20%7C%20pipeline%3D~%22${pipeline:regex}%22%20%7C%20run_type%3D~%22${run_type:regex}%22",
+            "targetBlank": true
           }
         ]
       },

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -276,6 +276,11 @@
           {
             "title": "Open Pipeline Failure Runbook",
             "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/pipeline-failure-critical.md"
+          },
+          {
+            "title": "Open Logs (Loki, contextual scope marker)",
+            "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D%20%7C%20json%20%7C%20scope_marker%3D%22dashboard_context%22%20%7C%20pipeline%3D~%22${pipeline:regex}%22%20%7C%20run_type%3D~%22${run_type:regex}%22",
+            "targetBlank": true
           }
         ]
       },

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -2356,3 +2356,53 @@ def test_provider_health_selected_provider_detail_row_is_collapsed() -> None:
     assert repeated_panel.get("gridPos", {}).get("y", 0) >= detail_row.get(
         "gridPos", {}
     ).get("y", 0)
+
+def test_runtime_dq_control_plane_expose_contextual_loki_explore_link() -> None:
+    """Critical runtime/dq/control-plane panels must keep at least one contextual Loki Explore link."""
+    dashboard_panels = {
+        "bioetl-runtime.json": "Failed Runs / 15m",
+        "bioetl-dq-v2.json": "Data Flow in Range: Bronze -> Silver -> Gold",
+        "bioetl-control-plane-v1.json": "Replay / Resume Blockers",
+    }
+
+    for dashboard_name, panel_title in dashboard_panels.items():
+        dashboard = load_dashboard(Path("grafana/dashboards") / dashboard_name)
+        panels = {
+            panel.get("title"): panel
+            for panel in get_dashboard_panels(dashboard)
+            if panel.get("title")
+        }
+        panel = panels.get(panel_title)
+        assert panel is not None, f"{dashboard_name} missing critical panel {panel_title!r}"
+
+        links = panel.get("options", {}).get("dataLinks", [])
+        assert links, f"{dashboard_name}:{panel_title} must include dataLinks"
+
+        baseline = [
+            link
+            for link in links
+            if isinstance(link, dict)
+            and str(link.get("title", "")).startswith("Open Logs (Loki")
+            and "query=%7Bjob%3D%22bioetl%22%7D" in str(link.get("url", ""))
+        ]
+        assert baseline, (
+            f"{dashboard_name}:{panel_title} must keep baseline Loki link with {{job=\"bioetl\"}}"
+        )
+
+        contextual = [
+            link
+            for link in links
+            if isinstance(link, dict)
+            and link.get("title") == "Open Logs (Loki, contextual scope marker)"
+            and "scope_marker%3D%22dashboard_context%22" in str(link.get("url", ""))
+        ]
+        assert contextual, (
+            f"{dashboard_name}:{panel_title} must include contextual Loki link with scope marker"
+        )
+
+        for link in contextual:
+            url = str(link.get("url", ""))
+            assert "${pipeline:regex}" in url
+            assert "${run_type:regex}" in url
+            assert "run_id" not in url
+            assert "payload_hash" not in url


### PR DESCRIPTION
### Motivation
- Provide operators an optional, safer Loki Explore handoff that preserves the existing baseline `{job="bioetl"}` link while enabling contextual pipeline/run_type scoping for critical runtime/DQ/control-plane panels.
- Codify where contextual Explore links are allowed and which variables/filters are permitted to prevent leaking forensic scope (e.g., `run_id`, `payload_hash`).
- Enforce the new contract with an automated test to ensure shipped dashboards include at least one contextual Loki Explore link on critical panels.

### Description
- Added contextual Loki `options.dataLinks` entries to critical panels in `grafana/dashboards/bioetl-runtime.json`, `grafana/dashboards/bioetl-dq-v2.json`, and `grafana/dashboards/bioetl-control-plane-v1.json` that include a safe `scope_marker="dashboard_context"` and only use `${pipeline:regex}` and `${run_type:regex}` as additional filters while preserving the baseline `{job="bioetl"}` link.
- Updated the navigation contract in `docs/03-guides/dashboards/navigation-contract.md` to document where contextual Explore links are allowed, the required baseline handoff, the safe scope marker requirement, and the prohibition on forensic variables.
- Added an integration test `test_runtime_dq_control_plane_expose_contextual_loki_explore_link` to `tests/integration/test_grafana_config.py` that asserts critical panels expose a baseline Loki link and at least one contextual Loki link with the scope marker and permitted variables.

### Testing
- Attempted the canonical memory pre-task command `python -m memory.tooling.workflow pre-task ...` but it failed due to missing `memory` module in the environment (`ModuleNotFoundError`).
- Validated JSON syntax with `uv run python -m json.tool` for `grafana/dashboards/bioetl-runtime.json`, `grafana/dashboards/bioetl-dq-v2.json`, and `grafana/dashboards/bioetl-control-plane-v1.json`, and all checks passed.
- Ran the targeted integration verification with `uv run python -m pytest -q tests/integration/test_grafana_config.py -k "contextual_loki_explore_link or critical_panels_expose_open_actionable_datalinks"` which completed successfully (`2 passed, 165 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8290958c08324a685c1678dd2b3d8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dashboard navigation with contextual Explore links for logs and diagnostics, including control plane replay/checkpoint access.
  * Added scope markers and refined query filtering for secure contextual log queries across dashboards.

* **Tests**
  * Expanded integration test coverage for dashboard validation, ensuring proper metric usage and link configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->