### PR TITLE
Add contract-driven checks for critical dashboard panel links

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -67,6 +67,38 @@ forbidden_dashboard_link_vars_by_target_uid:
   bioetl-workflow-overview: [run_id, payload_hash]
   bioetl-silver-reject-explorer: []
 
+required_panel_links_by_uid:
+  bioetl-overview-v2:
+    - panel_id: 208
+      target_uid: bioetl-runtime
+      link_titles: ["Open Runtime Drilldown", "Open Runtime status"]
+    - panel_id: 209
+      target_uid: bioetl-dq-v2
+      link_titles: ["Open Data Quality Drilldown", "Open Data Quality status"]
+    - panel_id: 210
+      target_uid: bioetl-control-plane-v1
+      link_titles: ["Open Control Plane Drilldown", "Open Control Plane status"]
+  bioetl-runtime:
+    - panel_id: 300
+      target_uid: bioetl-overview-v2
+      link_titles: ["Open Pipeline Conditions"]
+    - panel_id: 301
+      target_uid: bioetl-dq-v2
+      link_titles: ["Open DQ Conditions"]
+    - panel_id: 302
+      target_uid: bioetl-control-plane-v1
+      link_titles: ["Open Control Plane Conditions"]
+  bioetl-dq-v2:
+    - panel_id: 1
+      target_uid: bioetl-control-plane-v1
+      link_titles: ["Open Control Plane v1 (replay/checkpoint)"]
+    - panel_id: 116
+      target_uid: bioetl-control-plane-v1
+      link_titles: ["Open Control Plane v1 (lineage/traceability)"]
+    - panel_id: 151
+      target_uid: bioetl-control-plane-v1
+      link_titles: ["Open Control Plane v1 (gold hard-fail context)"]
+
 time_handoff_requirements:
   dashboard_links:
     required_tokens:

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -11,6 +11,7 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 ## Общие правила
 
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
+- Critical KPI панели **MUST** иметь first-hop action link (panel-level `dataLinks`) на целевой dashboard для первичного triage. Контракт хранится в `required_panel_links_by_uid` и валидирует `panel_id`, минимально допустимый `title`, `target_uid`, time handoff и allowlisted `var-*`.
 - Cross-dashboard handoff передаёт только target-scoped `var-*` параметры и **MUST** включать `${__url_time_range}` во всех dashboard URL (`/d/...`).
 - `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
   - dashboard links (`/d/<uid>/<slug>?...`): `${__url_time_range}`

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -37,6 +37,40 @@ def _load_navigation_links_contract() -> dict[str, object]:
             result[uid] = frozenset(str(v) for v in values)
         return result
 
+    raw_required_panel_links = raw_contract.get("required_panel_links_by_uid", {})
+    assert isinstance(
+        raw_required_panel_links, dict
+    ), "required_panel_links_by_uid must be a mapping"
+    required_panel_links_by_uid: dict[str, tuple[dict[str, object], ...]] = {}
+    for uid, entries in raw_required_panel_links.items():
+        assert isinstance(uid, str), "required_panel_links_by_uid keys must be strings"
+        assert isinstance(entries, list), f"required_panel_links_by_uid.{uid} must be a list"
+        normalized_entries: list[dict[str, object]] = []
+        for entry in entries:
+            assert isinstance(entry, dict), (
+                f"required_panel_links_by_uid.{uid} entries must be mappings"
+            )
+            panel_id = entry.get("panel_id")
+            target_uid = entry.get("target_uid")
+            link_titles = entry.get("link_titles", [])
+            assert isinstance(panel_id, int), (
+                f"required_panel_links_by_uid.{uid}.panel_id must be integer"
+            )
+            assert isinstance(target_uid, str), (
+                f"required_panel_links_by_uid.{uid}.target_uid must be string"
+            )
+            assert isinstance(link_titles, list), (
+                f"required_panel_links_by_uid.{uid}.link_titles must be a list"
+            )
+            normalized_entries.append(
+                {
+                    "panel_id": panel_id,
+                    "target_uid": target_uid,
+                    "link_titles": tuple(str(title) for title in link_titles),
+                }
+            )
+        required_panel_links_by_uid[uid] = tuple(normalized_entries)
+
     return {
         "allowed_dashboard_link_vars": _as_frozenset_map("allowed_dashboard_link_vars"),
         "forbidden_dashboard_link_vars_by_target_uid": _as_frozenset_map(
@@ -48,6 +82,7 @@ def _load_navigation_links_contract() -> dict[str, object]:
         "required_top_level_links_by_uid": _as_frozenset_map(
             "required_top_level_links_by_uid"
         ),
+        "required_panel_links_by_uid": required_panel_links_by_uid,
     }
 
 
@@ -60,6 +95,7 @@ _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT[
     "required_link_vars_by_target_uid"
 ]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
+_REQUIRED_PANEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_panel_links_by_uid"]
 
 
 def _extract_required_time_tokens(section: str) -> tuple[str, ...]:
@@ -306,6 +342,65 @@ def test_dashboard_top_level_navigation_contract_by_uid() -> None:
             f"{dashboard_path.name} ({uid}) is missing required top-level links: "
             f"{sorted(missing)}"
         )
+
+
+def test_required_critical_panel_links_by_uid_contract() -> None:
+    """Critical KPI panels must provide first-hop action links by contract."""
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        uid = dashboard.get("uid")
+        assert isinstance(uid, str), f"{dashboard_path.name} must declare string uid"
+        required_entries = _REQUIRED_PANEL_LINKS_BY_UID.get(uid, ())
+        if not required_entries:
+            continue
+
+        panels_by_id = {
+            panel.get("id"): panel
+            for panel in get_dashboard_panels(dashboard)
+            if isinstance(panel, dict) and isinstance(panel.get("id"), int)
+        }
+        for entry in required_entries:
+            panel_id = entry["panel_id"]
+            target_uid = entry["target_uid"]
+            expected_titles = set(entry["link_titles"])
+            panel = panels_by_id.get(panel_id)
+            assert isinstance(panel, dict), (
+                f"{dashboard_path.name} ({uid}) missing critical panel id={panel_id}"
+            )
+
+            data_links = _iter_panel_data_links(panel)
+            assert data_links, (
+                f"{dashboard_path.name} panel id={panel_id} must define dataLinks"
+            )
+
+            matching_links = []
+            for link in data_links:
+                title = str(link.get("title", ""))
+                url = str(link.get("url", ""))
+                if expected_titles and title not in expected_titles:
+                    continue
+                if url.startswith(f"/d/{target_uid}/"):
+                    matching_links.append(link)
+
+            assert matching_links, (
+                f"{dashboard_path.name} panel id={panel_id} must include at least one "
+                f"critical link to target_uid={target_uid} with title in "
+                f"{sorted(expected_titles)}"
+            )
+
+            allowed_vars = _ALLOWED_DASHBOARD_LINK_VARS[target_uid]
+            for link in matching_links:
+                url = str(link.get("url", ""))
+                _assert_required_time_tokens(
+                    url,
+                    tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+                    context=f"{dashboard_path.name} panel id={panel_id}",
+                )
+                passed_vars = _extract_link_vars(url)
+                assert passed_vars <= allowed_vars, (
+                    f"{dashboard_path.name} panel id={panel_id} link to {target_uid} "
+                    f"passes non-allowlisted vars: {sorted(passed_vars - allowed_vars)}"
+                )
 
 
 def test_dashboard_links_forbid_universal_handoff_patterns() -> None:


### PR DESCRIPTION
### Motivation
- Ensure critical KPI panels expose a first-hop actionable link for triage and that these links obey time-handoff and allowed `var-*` scoping.
- Encode panel-level requirements in the machine-readable navigation contract so tests can validate shipped Grafana dashboards against an explicit SSOT.

### Description
- Add new `required_panel_links_by_uid` section to the navigation contract at `docs/03-guides/dashboards/contracts/navigation-links.yaml` describing `dashboard UID -> panel_id -> target_uid -> link_titles` expectations.
- Extend `tests/integration/test_grafana_dashboard_links.py` to load and validate `required_panel_links_by_uid`, including type checks for `panel_id`, `target_uid`, and `link_titles`.
- Add `test_required_critical_panel_links_by_uid_contract` which asserts each contract-defined critical panel exists, exposes at least one `dataLink` to the expected target, includes the required time-handoff token, and passes only allowlisted `var-*` parameters.
- Update documentation `docs/03-guides/dashboards/navigation-contract.md` to formalize the rule that critical KPI panels MUST expose a first-hop action link governed by the contract.

### Testing
- Ran `python -m memory.tooling.workflow pre-task ...` as a pre-task smoke check but it failed due to missing runtime module: `ModuleNotFoundError: No module named 'memory'` (environment limitation).
- Attempted targeted test run `pytest -q tests/integration/test_grafana_dashboard_links.py -k required_critical_panel_links_by_uid_contract` but pytest aborted due to project `pytest.ini` addopts (`--timeout=300`) not supported in the current environment; then re-ran with `-o addopts=''` and collection failed due to missing dependency `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).
- Summary: tests and contract integration were added and exercised locally where possible, but automated test execution in this environment failed due to missing test runtime dependencies/plugins (`memory` module, `PyYAML`, and pytest timeout plugin).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f828e4abac8324a6ede30725c171b0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->