### PR TITLE
Add discoverable inbound dashboard path contract and validation

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -67,6 +67,35 @@ forbidden_dashboard_link_vars_by_target_uid:
   bioetl-workflow-overview: [run_id, payload_hash]
   bioetl-silver-reject-explorer: []
 
+
+required_discoverable_inbound_paths:
+  L1:
+    bioetl-runtime:
+      - source_uid: bioetl-overview-v2
+        source_panel_id: 208
+        source_panel_title: Runtime Status
+    bioetl-control-plane-v1:
+      - source_uid: bioetl-overview-v2
+        source_panel_id: 210
+        source_panel_title: Control Plane Status
+    bioetl-provider-health-v2:
+      - source_uid: bioetl-overview-v2
+        source_panel_id: 211
+        source_panel_title: Provider Status
+    bioetl-dq-v2:
+      - source_uid: bioetl-overview-v2
+        source_panel_id: 209
+        source_panel_title: Data Quality Status
+    bioetl-workflow-overview:
+      - source_uid: bioetl-overview-v2
+        source_panel_id: 212
+        source_panel_title: Workflow Status
+  L2:
+    bioetl-silver-reject-explorer:
+      - source_uid: bioetl-dq-v2
+        source_panel_id: 121
+        source_panel_title: Top Silver Reject Reasons (Pareto)
+
 time_handoff_requirements:
   dashboard_links:
     required_tokens:

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -30,6 +30,17 @@ Machine-readable navigation contract: `docs/03-guides/dashboards/contracts/navig
 | 5. Silver Reject Explorer | `bioetl-silver-reject-explorer` | Record-level explorer для `filtered_out`/`FILTERED_OUT_SILVER` записей (quarantine-backed) |
 | 6. Workflow Overview      | `bioetl-workflow-overview`      | Declarative workflow run/step outcomes and transform-step latency                          |
 
+## From where to enter each dashboard in 1 click
+
+| Target dashboard | 1-click entry source (dashboard -> panel id/title) |
+| --- | --- |
+| `bioetl-runtime` | `bioetl-overview-v2` -> `id=208` `Runtime Status` |
+| `bioetl-control-plane-v1` | `bioetl-overview-v2` -> `id=210` `Control Plane Status` |
+| `bioetl-provider-health-v2` | `bioetl-overview-v2` -> `id=211` `Provider Status` |
+| `bioetl-dq-v2` | `bioetl-overview-v2` -> `id=209` `Data Quality Status` |
+| `bioetl-workflow-overview` | `bioetl-overview-v2` -> `id=212` `Workflow Status` |
+| `bioetl-silver-reject-explorer` | `bioetl-dq-v2` -> `id=121` `Top Silver Reject Reasons (Pareto)` |
+
 ## Фильтрация
 
 - `bioetl-overview-v2`: `$pipeline`, `$run_type`

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -48,6 +48,9 @@ def _load_navigation_links_contract() -> dict[str, object]:
         "required_top_level_links_by_uid": _as_frozenset_map(
             "required_top_level_links_by_uid"
         ),
+        "required_discoverable_inbound_paths": raw_contract.get(
+            "required_discoverable_inbound_paths", {}
+        ),
     }
 
 
@@ -306,6 +309,76 @@ def test_dashboard_top_level_navigation_contract_by_uid() -> None:
             f"{dashboard_path.name} ({uid}) is missing required top-level links: "
             f"{sorted(missing)}"
         )
+
+
+def test_required_discoverable_inbound_paths_have_panel_level_links_and_policy() -> None:
+    """Contract inbound routes must exist via panel links and obey vars/time policy."""
+    inbound = _NAV_LINK_CONTRACT["required_discoverable_inbound_paths"]
+    assert isinstance(inbound, dict), "required_discoverable_inbound_paths must be a mapping"
+
+    dashboards = {load_dashboard(path).get("uid"): load_dashboard(path) for path in get_dashboard_files()}
+
+    for level_name, level_payload in inbound.items():
+        assert level_name in {"L1", "L2"}, f"Unexpected level in inbound contract: {level_name}"
+        assert isinstance(level_payload, dict), f"{level_name} payload must be mapping"
+
+        for target_uid, routes in level_payload.items():
+            assert isinstance(target_uid, str)
+            assert isinstance(routes, list) and routes, (
+                f"{level_name}.{target_uid} must declare at least one source panel route"
+            )
+
+            for route in routes:
+                assert isinstance(route, dict), f"{level_name}.{target_uid} route must be mapping"
+                source_uid = route.get("source_uid")
+                panel_id = route.get("source_panel_id")
+                panel_title = route.get("source_panel_title")
+                assert isinstance(source_uid, str)
+                assert isinstance(panel_id, int)
+                assert isinstance(panel_title, str) and panel_title
+
+                source_dashboard = dashboards.get(source_uid)
+                assert isinstance(source_dashboard, dict), (
+                    f"Source dashboard uid={source_uid} from inbound contract not found"
+                )
+                panel = next(
+                    (candidate for candidate in get_dashboard_panels(source_dashboard) if candidate.get("id") == panel_id),
+                    None,
+                )
+                assert isinstance(panel, dict), (
+                    f"Source panel id={panel_id} for {source_uid}->{target_uid} not found"
+                )
+                assert panel.get("title") == panel_title, (
+                    f"Source panel id={panel_id} title mismatch: expected {panel_title!r}, got {panel.get('title')!r}"
+                )
+
+                target_links = [
+                    link.get("url")
+                    for link in _iter_panel_data_links(panel)
+                    if isinstance(link.get("url"), str)
+                    and _extract_dashboard_uid(link["url"]) == target_uid
+                ]
+                assert target_links, (
+                    f"Panel id={panel_id} ({panel_title}) must contain data link to {target_uid}"
+                )
+
+                for url in target_links:
+                    passed_vars = _extract_link_vars(url)
+                    required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID[target_uid]
+                    forbidden_vars = _FORBIDDEN_DASHBOARD_LINK_VARS_BY_TARGET_UID[target_uid]
+                    assert required_vars <= passed_vars, (
+                        f"Inbound path {source_uid}:{panel_id}->{target_uid} missing vars "
+                        f"{sorted(required_vars - passed_vars)} via {url}"
+                    )
+                    assert not (passed_vars & forbidden_vars), (
+                        f"Inbound path {source_uid}:{panel_id}->{target_uid} leaks forbidden vars "
+                        f"{sorted(passed_vars & forbidden_vars)} via {url}"
+                    )
+                    _assert_required_time_tokens(
+                        url,
+                        tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
+                        context=f"Inbound path {source_uid}:{panel_id}->{target_uid}",
+                    )
 
 
 def test_dashboard_links_forbid_universal_handoff_patterns() -> None:


### PR DESCRIPTION
### Motivation

- Ensure each L1/L2 dashboard is discoverable from at least one explicit source panel so operators can reach the target in one click. 
- Make cross-dashboard inbound routes machine-declarable and enforce the existing variable/time handoff policies at panel-level links. 
- Provide a short operator-facing entry map in `dashboard-v2-usage.md` documenting the canonical one-click entry points.

### Description

- Added `required_discoverable_inbound_paths` section to `docs/03-guides/dashboards/contracts/navigation-links.yaml` declaring at least one source panel (`source_uid`, `source_panel_id`, `source_panel_title`) for L1 targets and the L2 `bioetl-silver-reject-explorer` entry. 
- Extended `tests/integration/test_grafana_dashboard_links.py` to include `_NAV_LINK_CONTRACT` mapping of `required_discoverable_inbound_paths` and added the test `test_required_discoverable_inbound_paths_have_panel_level_links_and_policy` which verifies source dashboard/panel existence, panel title match, presence of panel `dataLink` to the target, variable allowlist/forbid checks, and required dashboard time handoff tokens. 
- Updated `docs/03-guides/dashboards/dashboard-v2-usage.md` with a compact table “From where to enter each dashboard in 1 click” mapping targets to their preferred source panel entry points.

### Testing

- Ran targeted integration checks with `uv run pytest -q tests/integration/test_grafana_dashboard_links.py::test_required_discoverable_inbound_paths_have_panel_level_links_and_policy tests/integration/test_grafana_navigation_matrix.py` and the selected tests passed (4 passed). 
- A broader run of the full dashboard integration module (`uv run pytest -q tests/integration/test_grafana_dashboard_links.py tests/integration/test_grafana_navigation_matrix.py`) surfaced pre-existing unrelated failures in the environment (5 failed, 38 passed) which are not caused by the new contract/test additions and therefore the validation focused on the new contract behavior which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82901131c8324a1154cd512bbf726)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->