### PR TITLE
Add machine-readable KPI ownership contract and mirror canonical-link test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ ______________________________________________________________________
 - **Run Control Plane**: Immutable run manifests and append-only ledgers for provenance, replay analysis, and artifact linkage ([ADR-044](docs/02-architecture/decisions/ADR-044-run-manifest-ledger-control-plane.md)).
 - **Observability by Design**: Metrics, tracing, and logging ports ([ADR-017](docs/02-architecture/decisions/ADR-017-observability-architecture.md)).
 - **Operator Dashboards**: Unified L0/L1 Grafana default window `time.from=now-12h` (`time.to=now`, `refresh=30s`) including `bioetl-control-plane-v1`; `bioetl-silver-reject-explorer` is the explicit `time.from=now-24h` forensic exception (see `docs/03-guides/dashboards/variables-guide.md`).
+- **KPI Ownership Contract**: Canonical/mirror KPI ownership is machine-readable in `docs/03-guides/dashboards/contracts/navigation-links.yaml` (`kpi_ownership`), with integration tests enforcing mirror fallback links `Open canonical KPI view`.
 - **Unified HTTP Client**: Standardized rate limiting, retry, and telemetry ([ADR-032](docs/02-architecture/decisions/ADR-032-unified-http-client.md)).
 - **Strict Governance**: Comprehensive rules for schema evolution, data contracts, and operational procedures.
 

--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -124,3 +124,20 @@ navigation_transition_contract:
     - [bioetl-runtime, bioetl-control-plane-v1]
     - [bioetl-control-plane-v1, bioetl-dq-v2]
     - [bioetl-dq-v2, bioetl-silver-reject-explorer]
+
+kpi_ownership:
+  failed_runs_in_range:
+    canonical_uid: bioetl-overview-v2
+    mirror_panels:
+      - dashboard_uid: bioetl-runtime
+        panel_id: 205
+  worst_lag_stage:
+    canonical_uid: bioetl-overview-v2
+    mirror_panels:
+      - dashboard_uid: bioetl-runtime
+        panel_id: 237
+  worst_backlog_stage:
+    canonical_uid: bioetl-overview-v2
+    mirror_panels:
+      - dashboard_uid: bioetl-runtime
+        panel_id: 238

--- a/docs/03-guides/dashboards/panel-title-inventory.md
+++ b/docs/03-guides/dashboards/panel-title-inventory.md
@@ -2,6 +2,16 @@
 
 Generated from `grafana/dashboards/*.json`.
 
+## KPI ownership contract anchors
+
+Machine-readable SSOT: `docs/03-guides/dashboards/contracts/navigation-links.yaml` (`kpi_ownership`).
+
+| KPI key | Canonical UID | Mirror panel(s) |
+|---|---|---|
+| `failed_runs_in_range` | `bioetl-overview-v2` | `bioetl-runtime#205` |
+| `worst_lag_stage` | `bioetl-overview-v2` | `bioetl-runtime#237` |
+| `worst_backlog_stage` | `bioetl-overview-v2` | `bioetl-runtime#238` |
+
 | Dashboard | Panel ID | Title |
 |---|---:|---|
 | bioetl-control-plane-v1.json | 1 | Manifest Write Failures |

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -276,6 +276,11 @@
           {
             "title": "Open Pipeline Failure Runbook",
             "url": "https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/docs/05-operations/runbooks/pipeline-failure-critical.md"
+          },
+          {
+            "title": "Open canonical KPI view",
+            "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+            "targetBlank": false
           }
         ]
       },
@@ -440,6 +445,11 @@
           {
             "title": "Open Logs (Loki, tracing profile)",
             "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
+          },
+          {
+            "title": "Open canonical KPI view",
+            "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+            "targetBlank": false
           }
         ]
       },
@@ -656,6 +666,11 @@
               {
                 "title": "Open Control Plane v1 (checkpoint/replay)",
                 "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}"
+              },
+              {
+                "title": "Open canonical KPI view",
+                "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
+                "targetBlank": false
               }
             ]
           },

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -48,6 +48,7 @@ def _load_navigation_links_contract() -> dict[str, object]:
         "required_top_level_links_by_uid": _as_frozenset_map(
             "required_top_level_links_by_uid"
         ),
+        "kpi_ownership": raw_contract.get("kpi_ownership", {}),
     }
 
 
@@ -60,6 +61,7 @@ _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT[
     "required_link_vars_by_target_uid"
 ]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
+_KPI_OWNERSHIP = _NAV_LINK_CONTRACT["kpi_ownership"]
 
 
 def _extract_required_time_tokens(section: str) -> tuple[str, ...]:
@@ -162,6 +164,72 @@ def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
                 url,
                 tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
                 context=f"Overview status panel id={panel_id} link to {target_uid}",
+            )
+
+
+def test_kpi_mirror_panels_link_to_canonical_kpi_view() -> None:
+    """Mirror KPI panels must include canonical fallback data link."""
+    assert isinstance(_KPI_OWNERSHIP, dict), "kpi_ownership must be a mapping"
+
+    dashboards_by_uid: dict[str, dict[str, object]] = {}
+    for dashboard_path in get_dashboard_files():
+        dashboard = load_dashboard(dashboard_path)
+        uid = dashboard.get("uid")
+        assert isinstance(uid, str), f"{dashboard_path.name} must define string uid"
+        dashboards_by_uid[uid] = dashboard
+
+    for kpi_name, spec in _KPI_OWNERSHIP.items():
+        assert isinstance(spec, dict), f"kpi_ownership.{kpi_name} must be a mapping"
+        canonical_uid = spec.get("canonical_uid")
+        assert isinstance(canonical_uid, str), (
+            f"kpi_ownership.{kpi_name}.canonical_uid must be string"
+        )
+
+        mirror_panels = spec.get("mirror_panels", [])
+        assert isinstance(mirror_panels, list), (
+            f"kpi_ownership.{kpi_name}.mirror_panels must be a list"
+        )
+        for mirror in mirror_panels:
+            assert isinstance(mirror, dict), (
+                f"kpi_ownership.{kpi_name}.mirror_panels entries must be mappings"
+            )
+            dashboard_uid = mirror.get("dashboard_uid")
+            panel_id = mirror.get("panel_id")
+            assert isinstance(dashboard_uid, str), "mirror dashboard_uid must be string"
+            assert isinstance(panel_id, int), "mirror panel_id must be integer"
+
+            dashboard = dashboards_by_uid.get(dashboard_uid)
+            assert dashboard is not None, (
+                f"kpi_ownership.{kpi_name} references unknown dashboard {dashboard_uid}"
+            )
+            panel = next(
+                (
+                    panel
+                    for panel in get_dashboard_panels(dashboard)
+                    if panel.get("id") == panel_id
+                ),
+                None,
+            )
+            assert isinstance(panel, dict), (
+                f"kpi_ownership.{kpi_name} panel id={panel_id} not found in {dashboard_uid}"
+            )
+            links = _iter_panel_data_links(panel)
+            canonical_link = next(
+                (
+                    link
+                    for link in links
+                    if link.get("title") == "Open canonical KPI view"
+                ),
+                None,
+            )
+            assert isinstance(canonical_link, dict), (
+                f"{dashboard_uid} panel id={panel_id} must define data link "
+                "'Open canonical KPI view'"
+            )
+            url = canonical_link.get("url", "")
+            assert isinstance(url, str) and url.startswith(f"/d/{canonical_uid}/"), (
+                f"{dashboard_uid} panel id={panel_id} canonical link must target "
+                f"/d/{canonical_uid}/, got {url!r}"
             )
 
 


### PR DESCRIPTION
### Motivation
- Make KPI ownership explicit and machine-readable so mirror panels can be validated against a single-source-of-truth. 
- Enforce that secondary/mirror KPI cards include a canonical fallback link (`Open canonical KPI view`) to avoid ambiguity during triage. 
- Reduce manual drift between Grafana JSON, inventory, and docs by syncing canonical contract and human-facing inventory/README. 

### Description
- Added a `kpi_ownership` section to `docs/03-guides/dashboards/contracts/navigation-links.yaml` describing canonical dashboard UIDs and mirror panel references. 
- Extended `tests/integration/test_grafana_dashboard_links.py` with `test_kpi_mirror_panels_link_to_canonical_kpi_view` which reads the `kpi_ownership` contract and asserts mirror panels provide a `dataLink` titled `Open canonical KPI view` that targets the configured canonical UID. 
- Updated `grafana/dashboards/bioetl-runtime.json` to add the canonical fallback `dataLinks` for mirror panels `205`, `237`, and `238`. 
- Synchronized docs by updating `README.md` and `docs/03-guides/dashboards/panel-title-inventory.md` to reference the new machine-readable `kpi_ownership` contract. 

### Testing
- Ran the integration checks with `uv run python -m pytest tests/integration/test_grafana_dashboard_links.py::test_kpi_mirror_panels_link_to_canonical_kpi_view tests/integration/test_dashboard_navigation_contract_sync.py -q` and the suite passed (`3 passed`). 
- Attempted to run the canonical memory workflow pre/post commands (`python -m memory.tooling.workflow ...`) as part of post-change validation but the environment raised `ModuleNotFoundError: No module named 'memory'`, so those workflow invocations failed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f828f704608324beb1bba7d90fcd40)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->