### PR TITLE
Add top-level link priority metadata and enforce unique primary per target UID

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -42,6 +42,30 @@ required_top_level_links_by_uid:
     - Back to Overview
     - 2. Runtime
     - Control Plane v1
+top_level_link_priority_by_uid:
+  bioetl-overview-v2:
+    - title: 2. Runtime
+      target_uid: bioetl-runtime
+      priority: primary
+      semantics: scoped_runtime_handoff
+    - title: Control Plane v1
+      target_uid: bioetl-control-plane-v1
+      priority: secondary
+      semantics: scoped_control_plane_handoff
+    - title: 3. Provider Health
+      target_uid: bioetl-provider-health-v2
+      priority: contextual
+      semantics: provider_health_cross_scope
+  bioetl-provider-health-v2:
+    - title: 2. Runtime (Primary)
+      target_uid: bioetl-runtime
+      priority: primary
+      semantics: runtime_cross_scope_all_defaults
+    - title: "2. Runtime (Contextual: provider mapping)"
+      target_uid: bioetl-runtime
+      priority: contextual
+      semantics: runtime_provider_context_mapping
+
 required_link_vars_by_target_uid:
   bioetl-overview-v2: [pipeline, run_type]
   bioetl-control-plane-v1: [pipeline, run_type]

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -174,6 +174,7 @@ Variable handoff policy for dashboard links remains strict and bounded:
 - For overview/runtime/dq flows pass only `$pipeline/$run_type` unless destination needs another explicit scope.
 - For provider flow pass only `$provider/$adapter` (or explicit `All` defaults when opening non-provider dashboards).
 - Workflow-specific variables (`$workflow`, `$status`) and forensic IDs (`$run_id`, `$payload_hash`) MUST NOT be propagated into non-target dashboards.
+- Top-level links дополнительно маркируются приоритетом (`primary`, `secondary`, `contextual`) через contract block `top_level_link_priority_by_uid`; приоритет должен быть виден в `title`/`tooltip` для неоднозначных маршрутов.
 
 ## Default dashboard windows (L0/L1 baseline + L2 forensic exception)
 
@@ -223,7 +224,7 @@ Variable handoff policy for dashboard links remains strict and bounded:
   `bioetl_control_plane_reads_total` и
   `bioetl_control_plane_read_duration_seconds_bucket` глобальны по
   `store/operation/status`.
-- `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
+- `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime (Primary)`, `2. Runtime (Contextual: provider mapping)`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
 - `bioetl-dq-v2`: dashboard link `Back to Overview` плюс `5. Silver Reject Explorer`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают тот же переход для DQ incidents и freshness investigation. Handoff в Explorer передаёт только bounded `$pipeline/$run_type` scope, а не generic `includeVars` leakage. Panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`) дублирует Explore handoff через data links.
 - `bioetl-silver-reject-explorer`: dashboard links `Back to Overview`, `Back to Data Quality`, `Open Logs`, `Open Traces`; back-links возвращают только `$pipeline/$run_type`, не leaking `payload_hash` или other forensic filters. Main table поддерживает data links для self-drilldown по `payload_hash` и CLI handoff. Верхняя explanatory panel явно показывает banner `default 24h forensic window`, чтобы оператор не интерпретировал explorer как обычное `now-12h` окно.
 

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -11,6 +11,8 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 ## Общие правила
 
 - Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
+- Top-level dashboard links **MUST** иметь приоритет `primary | secondary | contextual`, заданный в `top_level_link_priority_by_uid` в `contracts/navigation-links.yaml`.
+- Для каждого source dashboard и каждого target UID допускается не более одной `primary` ссылки; `primary` ссылка **MUST** иметь однозначную `semantics` (непустой идентификатор смысла handoff).
 - Cross-dashboard handoff передаёт только target-scoped `var-*` параметры и **MUST** включать `${__url_time_range}` во всех dashboard URL (`/d/...`).
 - `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
   - dashboard links (`/d/<uid>/<slug>?...`): `${__url_time_range}`
@@ -44,3 +46,10 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 - `includeVars=true`
 - legacy Explore payload route: `/explore?left=`
 - перенос Explorer-only forensic scope (`var-run_id`, `var-payload_hash`) в non-explorer dashboards
+
+## Приоритет и semantics (пример)
+
+- `bioetl-provider-health-v2` содержит два перехода в Runtime:
+  - `2. Runtime (Primary)` — `priority: primary`, semantics `runtime_cross_scope_all_defaults`;
+  - `2. Runtime (Contextual: provider mapping)` — `priority: contextual`, semantics `runtime_provider_context_mapping`.
+- Priority должна быть отражена в `title` и/или `tooltip` ссылки в dashboard JSON.

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -37,8 +37,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer.",
+      "title": "2. Runtime (Primary)",
+      "tooltip": "Priority: primary. Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
     },
@@ -49,8 +49,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "2. Runtime (provider context)",
-      "tooltip": "Cross-scope handoff (provider-derived context mapping): provider/adapter map to runtime pipeline/run_type when mapping exists; fallback var-pipeline=All&var-run_type=All&var-stage=All.",
+      "title": "2. Runtime (Contextual: provider mapping)",
+      "tooltip": "Priority: contextual. Cross-scope handoff (provider-derived context mapping): provider/adapter map to runtime pipeline/run_type when mapping exists; fallback var-pipeline=All&var-run_type=All&var-stage=All.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=${provider:queryparam}&var-run_type=${adapter:queryparam}&var-stage=All&${__url_time_range}"
     },

--- a/tests/integration/test_grafana_navigation_matrix.py
+++ b/tests/integration/test_grafana_navigation_matrix.py
@@ -57,6 +57,24 @@ def _iter_top_level_uid_links() -> list[tuple[str, str, str]]:
     return rows
 
 
+def _iter_top_level_uid_links_with_title() -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    for path in _DASHBOARDS_DIR.glob("*.json"):
+        payload = load_dashboard(path)
+        source_uid = payload.get("uid")
+        assert isinstance(source_uid, str), f"{path.name} must define string uid"
+        for link in payload.get("links", []):
+            title = link.get("title")
+            url = link.get("url")
+            if not isinstance(title, str) or not isinstance(url, str):
+                continue
+            match = _DASHBOARD_UID_RE.match(url)
+            if match is None:
+                continue
+            rows.append((source_uid, title, match.group(1), url))
+    return rows
+
+
 def test_level_matrix_required_inbound_outbound_transitions_present() -> None:
     contract = _load_contract()["navigation_transition_contract"]
     assert isinstance(contract, dict)
@@ -139,3 +157,46 @@ def test_incident_critical_paths_are_reciprocal_and_non_terminal() -> None:
     assert not terminal_nodes, (
         f"Incident-critical dashboards must not be terminal nodes: {sorted(terminal_nodes)}"
     )
+
+
+def test_primary_priority_links_are_unique_per_target_uid_and_semantics() -> None:
+    contract = _load_contract()
+    priority_map = contract["top_level_link_priority_by_uid"]
+    assert isinstance(priority_map, dict)
+
+    links_by_source_and_title: dict[tuple[str, str], tuple[str, str]] = {}
+    for source_uid, title, target_uid, _url in _iter_top_level_uid_links_with_title():
+        links_by_source_and_title[(source_uid, title)] = (target_uid, title)
+
+    for source_uid, entries in priority_map.items():
+        assert isinstance(entries, list), f"{source_uid} priority entries must be list"
+        primary_by_target: dict[str, list[str]] = {}
+
+        for entry in entries:
+            assert isinstance(entry, dict), f"{source_uid} priority entry must be mapping"
+            title = entry["title"]
+            target_uid = entry["target_uid"]
+            priority = entry["priority"]
+            semantics = entry["semantics"]
+            assert isinstance(title, str)
+            assert isinstance(target_uid, str)
+            assert isinstance(priority, str)
+            assert isinstance(semantics, str) and semantics.strip(), (
+                f"{source_uid}:{title} must declare non-empty semantics"
+            )
+
+            assert (source_uid, title) in links_by_source_and_title, (
+                f"Missing top-level link in dashboard JSON for {source_uid}:{title}"
+            )
+            actual_target_uid, _ = links_by_source_and_title[(source_uid, title)]
+            assert actual_target_uid == target_uid, (
+                f"{source_uid}:{title} target mismatch: contract={target_uid}, dashboard={actual_target_uid}"
+            )
+
+            if priority == "primary":
+                primary_by_target.setdefault(target_uid, []).append(semantics)
+
+        for target_uid, semantics_list in primary_by_target.items():
+            assert len(semantics_list) <= 1, (
+                f"{source_uid}->{target_uid} has more than one primary link semantics: {semantics_list}"
+            )


### PR DESCRIPTION
### Motivation

- Introduce explicit priority for top-level dashboard links (`primary | secondary | contextual`) so navigation semantics are machine-readable and unambiguous. 
- Enforce that for any source dashboard → target UID there is at most one `primary` link and that a `primary` entry carries a single, non-empty `semantics` identifier. 
- Surface priority in the shipped dashboard JSON `title`/`tooltip` for ambiguous routes so operators see the chosen primary path in the UI.

### Description

- Added a new contract block `top_level_link_priority_by_uid` to `docs/03-guides/dashboards/contracts/navigation-links.yaml` containing per-source entries with `title`, `target_uid`, `priority` and `semantics`.
- Updated `grafana/dashboards/bioetl-provider-health-v2.json` to reflect priority in UI strings by renaming two Runtime links to `2. Runtime (Primary)` and `2. Runtime (Contextual: provider mapping)` and adding priority prefixes in their `tooltip` text.
- Extended integration tests by adding helper `_iter_top_level_uid_links_with_title()` and the test `test_primary_priority_links_are_unique_per_target_uid_and_semantics()` in `tests/integration/test_grafana_navigation_matrix.py` to verify contract entries map to real dashboard links, `target_uid` matches the dashboard URL, and that at most one `primary` semantics exists per `source_uid -> target_uid`.
- Updated documentation pages `docs/03-guides/dashboards/navigation-contract.md` and `docs/03-guides/dashboards/dashboard-v2-usage.md` to describe the priority model and require that priority be reflected in `title`/`tooltip` for ambiguous routes.
- Fixed YAML quoting for a title containing a colon to avoid parser errors when loading the contract.

### Testing

- Ran the integration test suite with `uv run python -m pytest -q tests/integration/test_grafana_navigation_matrix.py tests/integration/test_dashboard_navigation_contract_sync.py` and all tests passed: `6 passed`.
- During iteration a YAML syntax issue (unquoted title with `:`) was detected by the test runner, was corrected, and tests were re-run successfully.
- Attempts to run the `memory` workflow hooks (`python -m memory.tooling.workflow pre-task/post-task`) failed in this environment because the `memory` module is not available; this is an environment limitation and not a functional test failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82926f96483248534effa3f55cb53)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->