### PR TITLE
Standardize Provider→Runtime/Overview cross-scope reset/context markers

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -22,9 +22,10 @@ required_top_level_links_by_uid:
     - Explore Logs (Loki, tracing profile)
     - Explore Traces (Tempo, tracing profile)
   bioetl-provider-health-v2:
-    - Back to Overview
-    - 2. Runtime
-    - Control Plane v1
+    - Back to Overview (Reset scope)
+    - 2. Runtime (Reset scope)
+    - 2. Runtime (Context mapping)
+    - Control Plane v1 (Reset scope)
     - Explore Logs (Loki, tracing profile)
     - Explore Traces (Tempo, tracing profile)
   bioetl-dq-v2:
@@ -124,3 +125,16 @@ navigation_transition_contract:
     - [bioetl-runtime, bioetl-control-plane-v1]
     - [bioetl-control-plane-v1, bioetl-dq-v2]
     - [bioetl-dq-v2, bioetl-silver-reject-explorer]
+
+cross_scope_marker_contract:
+  required_markers:
+    reset_scope: "(Reset scope)"
+    context_mapping: "(Context mapping)"
+  required_titles_by_transition:
+    bioetl-provider-health-v2->bioetl-overview-v2: reset_scope
+    bioetl-provider-health-v2->bioetl-runtime: reset_scope
+    bioetl-provider-health-v2->bioetl-runtime#context: context_mapping
+    bioetl-provider-health-v2->bioetl-control-plane-v1: reset_scope
+  required_tooltip_tokens:
+    reset_scope: ["Reset scope"]
+    context_mapping: ["Context mapping"]

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -25,8 +25,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Back to Overview",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "title": "Back to Overview (Reset scope)",
+      "tooltip": "Reset scope: open Overview with var-pipeline=All and var-run_type=All. Context mapping is not applied for this link.",
       "type": "dashboards",
       "url": "/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },
@@ -37,8 +37,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "2. Runtime",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All, var-run_type=All, var-stage=All; provider/adapter do not transfer.",
+      "title": "2. Runtime (Reset scope)",
+      "tooltip": "Reset scope: open Runtime with var-pipeline=All, var-run_type=All, var-stage=All. Use contextual mapping via the dedicated secondary action.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=All&var-run_type=All&var-stage=All&${__url_time_range}"
     },
@@ -49,8 +49,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "2. Runtime (provider context)",
-      "tooltip": "Cross-scope handoff (provider-derived context mapping): provider/adapter map to runtime pipeline/run_type when mapping exists; fallback var-pipeline=All&var-run_type=All&var-stage=All.",
+      "title": "2. Runtime (Context mapping)",
+      "tooltip": "Context mapping: map provider/adapter into runtime var-pipeline/var-run_type when possible; fallback to All scope defaults and var-stage=All.",
       "type": "link",
       "url": "/d/bioetl-runtime/bioetl-runtime?var-pipeline=${provider:queryparam}&var-run_type=${adapter:queryparam}&var-stage=All&${__url_time_range}"
     },
@@ -72,8 +72,8 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Control Plane v1",
-      "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; provider/adapter do not transfer.",
+      "title": "Control Plane v1 (Reset scope)",
+      "tooltip": "Reset scope: open Control Plane with var-pipeline=All and var-run_type=All. Context mapping is not applied for this link.",
       "type": "link",
       "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=All&var-run_type=All&${__url_time_range}"
     },

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -48,6 +48,9 @@ def _load_navigation_links_contract() -> dict[str, object]:
         "required_top_level_links_by_uid": _as_frozenset_map(
             "required_top_level_links_by_uid"
         ),
+        "cross_scope_marker_contract": raw_contract.get(
+            "cross_scope_marker_contract", {}
+        ),
     }
 
 
@@ -60,6 +63,7 @@ _REQUIRED_LINK_VARS_BY_TARGET_UID = _NAV_LINK_CONTRACT[
     "required_link_vars_by_target_uid"
 ]
 _REQUIRED_TOP_LEVEL_LINKS_BY_UID = _NAV_LINK_CONTRACT["required_top_level_links_by_uid"]
+_CROSS_SCOPE_MARKER_CONTRACT = _NAV_LINK_CONTRACT["cross_scope_marker_contract"]
 
 
 def _extract_required_time_tokens(section: str) -> tuple[str, ...]:
@@ -306,6 +310,72 @@ def test_dashboard_top_level_navigation_contract_by_uid() -> None:
             f"{dashboard_path.name} ({uid}) is missing required top-level links: "
             f"{sorted(missing)}"
         )
+
+
+def test_cross_scope_links_use_explicit_reset_or_context_markers() -> None:
+    """Cross-scope links must expose explicit marker in title/tooltip."""
+    marker_contract = _CROSS_SCOPE_MARKER_CONTRACT
+    assert isinstance(marker_contract, dict), "cross_scope_marker_contract must be mapping"
+    required_markers = marker_contract.get("required_markers", {})
+    assert isinstance(required_markers, dict), "required_markers must be mapping"
+    required_titles_by_transition = marker_contract.get(
+        "required_titles_by_transition", {}
+    )
+    assert isinstance(
+        required_titles_by_transition, dict
+    ), "required_titles_by_transition must be mapping"
+    required_tooltip_tokens = marker_contract.get("required_tooltip_tokens", {})
+    assert isinstance(
+        required_tooltip_tokens, dict
+    ), "required_tooltip_tokens must be mapping"
+
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-provider-health-v2.json"))
+    links = [link for link in dashboard.get("links", []) if isinstance(link, dict)]
+
+    for transition, marker_key in required_titles_by_transition.items():
+        assert isinstance(marker_key, str), (
+            f"marker key for {transition} must be a string"
+        )
+        marker = required_markers.get(marker_key)
+        assert isinstance(marker, str) and marker, (
+            f"required marker '{marker_key}' must be declared for transition {transition}"
+        )
+        tooltip_tokens = required_tooltip_tokens.get(marker_key, [])
+        assert isinstance(tooltip_tokens, list), (
+            f"required_tooltip_tokens.{marker_key} must be list"
+        )
+
+        base_transition = transition.split("#", 1)[0]
+        from_uid, to_uid = base_transition.split("->", 1)
+        assert from_uid == "bioetl-provider-health-v2", (
+            f"this test currently validates provider-health transitions only, got {transition}"
+        )
+
+        matched_links = []
+        for link in links:
+            url = link.get("url", "")
+            if not isinstance(url, str):
+                continue
+            target_uid = _extract_dashboard_uid(url)
+            if target_uid != to_uid:
+                continue
+            title = str(link.get("title", ""))
+            if marker in title:
+                matched_links.append(link)
+
+        assert matched_links, (
+            f"Missing cross-scope link for {transition} with title marker '{marker}'"
+        )
+        for link in matched_links:
+            title = str(link.get("title", ""))
+            tooltip = str(link.get("tooltip", ""))
+            assert marker in title, (
+                f"Link title must include '{marker}' for transition {transition}: {title}"
+            )
+            for token in tooltip_tokens:
+                assert token in tooltip, (
+                    f"Link tooltip for transition {transition} must include '{token}': {tooltip}"
+                )
 
 
 def test_dashboard_links_forbid_universal_handoff_patterns() -> None:


### PR DESCRIPTION
### Motivation
- Provide one canonical pattern for Provider → Runtime/Overview cross-scope navigation so reset semantics and provider→runtime contextual mapping are unambiguous.
- Make dashboard navigation contract machine-verifiable by surfacing explicit title/tooltip markers for cross-scope links.
- Prevent accidental behavioral drift when dashboard links are edited by requiring a standardized marker footprint in the contract.

### Description
- Normalized top-level link titles and tooltips in `grafana/dashboards/bioetl-provider-health-v2.json` to explicitly mark primary actions as `Reset scope` and the provider→runtime handoff as `Context mapping`.
- Extended `docs/03-guides/dashboards/contracts/navigation-links.yaml` with a new `cross_scope_marker_contract` section that declares required title markers and tooltip token expectations for provider cross-scope transitions.
- Updated `tests/integration/test_grafana_dashboard_links.py` to load the new `cross_scope_marker_contract` and added `test_cross_scope_links_use_explicit_reset_or_context_markers` which enforces that Provider Health cross-scope links include the expected title marker and tooltip tokens.
- Files changed: `grafana/dashboards/bioetl-provider-health-v2.json`, `docs/03-guides/dashboards/contracts/navigation-links.yaml`, and `tests/integration/test_grafana_dashboard_links.py`.

### Testing
- Validated JSON syntax with `python -m json.tool grafana/dashboards/bioetl-provider-health-v2.json` which returned OK.
- Ran the focused integration tests with the project environment via `uv run pytest -q tests/integration/test_grafana_dashboard_links.py -k "top_level_navigation_contract_by_uid or cross_scope_links_use_explicit_reset_or_context_markers"` and observed `2 passed, 38 deselected`.
- Attempted to run the canonical pre-task memory command `python -m memory.tooling.workflow pre-task ...` but the base interpreter lacked the `memory` module (`ModuleNotFoundError`); this did not affect the dashboard contract tests which were executed inside the project environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f828e6ce888324a4bea57c52752288)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->