### PR TITLE
Add UID-class Grafana default time/refresh policy test and contract

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -67,6 +67,23 @@ forbidden_dashboard_link_vars_by_target_uid:
   bioetl-workflow-overview: [run_id, payload_hash]
   bioetl-silver-reject-explorer: []
 
+
+default_time_refresh_policy:
+  L0:
+    dashboards: [bioetl-overview-v2]
+    time_from: now-12h
+    refresh: 30s
+  L1:
+    dashboards: [bioetl-runtime, bioetl-control-plane-v1, bioetl-provider-health-v2, bioetl-dq-v2, bioetl-workflow-overview]
+    time_from: now-12h
+    refresh: 30s
+  L2:
+    dashboards: [bioetl-silver-reject-explorer]
+    time_from: now-24h
+    refresh: 1m
+
+default_time_refresh_policy_exceptions: {}
+
 time_handoff_requirements:
   dashboard_links:
     required_tokens:

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -183,6 +183,8 @@ Variable handoff policy for dashboard links remains strict and bounded:
   - `silver-reject-explorer` -> `time.from=now-24h`, `refresh=1m`.
   - Justification: forensic-поиск по reject payload обычно начинается с более широкого окна и не требует 30s polling; более медленный refresh снижает ненужные перезапросы при row-level drilldown.
 - Любое отклонение от baseline MUST сопровождаться явным обоснованием в документации и в PR (почему это не L0/L1 operator window).
+- Machine-readable contract source: `docs/03-guides/dashboards/contracts/navigation-links.yaml` -> `default_time_refresh_policy` + `default_time_refresh_policy_exceptions` (for explicit, justified deviations).
+
 
 ## Drilldown
 

--- a/docs/03-guides/dashboards/variables-guide.md
+++ b/docs/03-guides/dashboards/variables-guide.md
@@ -110,6 +110,8 @@ UX цель: убрать ложное ожидание, что source filters �
 - **Forensic L2 exception (must include explicit justification in docs/PR):**
   - `explorer` (`bioetl-silver-reject-explorer`): `time.from=now-24h`, `refresh=1m`
   - Justification: forensic/reject investigation требует больше стартового горизонта для редких инцидентов и сниженной частоты auto-refresh, чтобы уменьшить шум и нагрузку при row-level анализе.
+- Machine-readable contract source: `docs/03-guides/dashboards/contracts/navigation-links.yaml` -> `default_time_refresh_policy` + `default_time_refresh_policy_exceptions` (for explicit, justified deviations).
+
 - **Workflow dashboard class:**
   - `workflow-overview`: `time.from=now-12h`, `refresh=30s` (align with L0/L1 operator baseline for run-step triage).
 

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -34,6 +34,17 @@ GRAFANA_README_PATH = Path("grafana/README.md")
 _BIOETL_METRIC_TOKEN_RE = re.compile(r"\b(bioetl_[a-z0-9_]+)\b")
 
 
+NAVIGATION_CONTRACT_PATH = Path(
+    "docs/03-guides/dashboards/contracts/navigation-links.yaml"
+)
+
+
+def _load_navigation_contract() -> dict:
+    payload = yaml.safe_load(NAVIGATION_CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict), "navigation-links contract must deserialize into a mapping"
+    return payload
+
+
 def _load_recording_rule_names() -> set[str]:
     payload = yaml.safe_load(RULES_PATH.read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
@@ -2305,28 +2316,50 @@ def test_replay_panels_are_split_by_semantics(dashboard_file: str) -> None:
     assert lag.get("fieldConfig", {}).get("defaults", {}).get("unit") == "s"
 
 
-def test_dashboard_default_time_from_policy_by_uid() -> None:
-    """Shipped dashboards must keep canonical default time.from policy by UID."""
-    expected_time_from_by_uid = {
-        "bioetl-overview-v2": "now-12h",
-        "bioetl-runtime": "now-12h",
-        "bioetl-dq-v2": "now-12h",
-        "bioetl-provider-health-v2": "now-12h",
-        "bioetl-workflow-overview": "now-12h",
-        "bioetl-control-plane-v1": "now-12h",
-        "bioetl-silver-reject-explorer": "now-24h",
-    }
+def test_dashboard_default_time_and_refresh_policy_by_uid_class() -> None:
+    """Shipped dashboards must keep canonical time.from/refresh policy by UID class."""
+    contract = _load_navigation_contract()
+    policy = contract.get("default_time_refresh_policy", {})
+    exceptions = contract.get("default_time_refresh_policy_exceptions", {})
 
-    for uid, expected_time_from in expected_time_from_by_uid.items():
+    assert isinstance(policy, dict), "default_time_refresh_policy must be defined"
+    assert isinstance(exceptions, dict), "default_time_refresh_policy_exceptions must be a mapping"
+
+    l0_uids = policy.get("L0", {}).get("dashboards", [])
+    l1_uids = policy.get("L1", {}).get("dashboards", [])
+    l2_uids = policy.get("L2", {}).get("dashboards", [])
+
+    assert isinstance(l0_uids, list) and isinstance(l1_uids, list) and isinstance(l2_uids, list)
+
+    baseline = {"time_from": "now-12h", "refresh": "30s"}
+    explorer_baseline = {"time_from": "now-24h", "refresh": "1m"}
+
+    for uid in [*l0_uids, *l1_uids]:
+        expected = exceptions.get(uid, baseline)
         dashboard = load_dashboard(Path("grafana/dashboards") / f"{uid}.json")
-        actual_uid = dashboard.get("uid")
-        assert actual_uid == uid, f"Dashboard UID mismatch for {uid}.json"
+        assert dashboard.get("uid") == uid, f"Dashboard UID mismatch for {uid}.json"
 
         time_cfg = dashboard.get("time", {})
         assert isinstance(time_cfg, dict), f"{uid} time config must be an object"
-        assert time_cfg.get("from") == expected_time_from, (
-            f"{uid} must keep time.from={expected_time_from!r}, "
-            f"got {time_cfg.get('from')!r}"
+        assert time_cfg.get("from") == expected["time_from"], (
+            f"{uid} must keep time.from={expected['time_from']!r}, got {time_cfg.get('from')!r}"
+        )
+        assert dashboard.get("refresh") == expected["refresh"], (
+            f"{uid} must keep refresh={expected['refresh']!r}, got {dashboard.get('refresh')!r}"
+        )
+
+    for uid in l2_uids:
+        expected = exceptions.get(uid, explorer_baseline)
+        dashboard = load_dashboard(Path("grafana/dashboards") / f"{uid}.json")
+        assert dashboard.get("uid") == uid, f"Dashboard UID mismatch for {uid}.json"
+
+        time_cfg = dashboard.get("time", {})
+        assert isinstance(time_cfg, dict), f"{uid} time config must be an object"
+        assert time_cfg.get("from") == expected["time_from"], (
+            f"{uid} must keep time.from={expected['time_from']!r}, got {time_cfg.get('from')!r}"
+        )
+        assert dashboard.get("refresh") == expected["refresh"], (
+            f"{uid} must keep refresh={expected['refresh']!r}, got {dashboard.get('refresh')!r}"
         )
 
 


### PR DESCRIPTION
### Motivation

- Ensure shipped Grafana dashboards follow a canonical default time window and auto-refresh policy by dashboard class (L0/L1 baseline, L2 forensic exception). 
- Make policy machine-readable so tests can validate both `time.from` and `refresh` and allow documented, explicit exceptions.

### Description

- Replaced the previous `time.from`-only check with a new test `test_dashboard_default_time_and_refresh_policy_by_uid_class` in `tests/integration/test_grafana_config.py` that validates both `time.from` and `refresh` for L0/L1/L2 UID classes and honors explicit exceptions. 
- Added a navigation contract loader to the test (`_load_navigation_contract`) which reads `default_time_refresh_policy` and `default_time_refresh_policy_exceptions` from `docs/03-guides/dashboards/contracts/navigation-links.yaml`. 
- Extended `docs/03-guides/dashboards/contracts/navigation-links.yaml` with `default_time_refresh_policy` (L0/L1/L2 dashboards, baseline values) and an empty `default_time_refresh_policy_exceptions` mapping for justified deviations. 
- Updated `docs/03-guides/dashboards/variables-guide.md` and `docs/03-guides/dashboards/dashboard-v2-usage.md` to reference the new machine-readable contract keys as the source-of-truth for defaults and exceptions.

### Testing

- Ran the targeted integration test with `bash scripts/engineering/dev/run_pytest.sh tests/integration/test_grafana_config.py -k "time_and_refresh_policy_by_uid_class"`, which passed: `1 passed, 165 deselected`.
- Attempted to run the memory pre-task helper `python -m memory.tooling.workflow pre-task ...` but it failed due to missing `memory` module (`ModuleNotFoundError`), which is an environment limitation and did not affect the test run.
- No other automated tests were changed; this test will honor future entries added to `default_time_refresh_policy_exceptions` in the contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f828f0a7808324b47c4fece313ea9b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->