### PR TITLE
Define minimal L1 First Action templates and navigation targets

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -124,3 +124,43 @@ navigation_transition_contract:
     - [bioetl-runtime, bioetl-control-plane-v1]
     - [bioetl-control-plane-v1, bioetl-dq-v2]
     - [bioetl-dq-v2, bioetl-silver-reject-explorer]
+
+
+first_action_contract:
+  bioetl-control-plane-v1:
+    panel_id: 9001
+    min_cta: 3
+    max_cta: 4
+    ctas:
+      - title: Back to Overview
+        expected_target_uid: bioetl-overview-v2
+      - title: 2. Runtime
+        expected_target_uid: bioetl-runtime
+      - title: 4. Data Quality
+        expected_target_uid: bioetl-dq-v2
+      - title: Explore Logs (Loki, tracing profile)
+        expected_target_uid: grafana-lokiexplore-app
+  bioetl-provider-health-v2:
+    panel_id: 9002
+    min_cta: 3
+    max_cta: 4
+    ctas:
+      - title: Back to Overview
+        expected_target_uid: bioetl-overview-v2
+      - title: 2. Runtime
+        expected_target_uid: bioetl-runtime
+      - title: Control Plane v1
+        expected_target_uid: bioetl-control-plane-v1
+      - title: Explore Traces (Tempo, tracing profile)
+        expected_target_uid: grafana-exploretraces-app
+  bioetl-workflow-overview:
+    panel_id: 9003
+    min_cta: 3
+    max_cta: 4
+    ctas:
+      - title: Back to Overview
+        expected_target_uid: bioetl-overview-v2
+      - title: 2. Runtime
+        expected_target_uid: bioetl-runtime
+      - title: Control Plane v1
+        expected_target_uid: bioetl-control-plane-v1

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -212,7 +212,12 @@ Variable handoff policy for dashboard links remains strict and bounded:
   target-scoped variables; forensic IDs в runtime dashboard запрещены.
 - `bioetl-control-plane-v1`: Control Plane v1 отвечает на один
   primary question: can we trust manifest/ledger/checkpoint/lineage state and
-  safely replay/resume? На первом экране оставлены только Trust/Blocker KPI: `id=891..893` и `id=130`.
+  safely replay/resume? Минимальный `First Action` row шаблон: 3–4 CTA
+  (`Back to Overview`, `2. Runtime`, `4. Data Quality`, optional Explore).
+
+  **First 2 clicks (L1):**
+  1. Click #1: открыть `bioetl-control-plane-v1`, проверить `Replay Safety State` (`id=891`) и `Replay / Resume Blockers` (`id=130`).
+  2. Click #2: перейти через `First Action` CTA в `2. Runtime` (если есть активный blocker) или `4. Data Quality` (если blocker связан с downstream quality symptoms). На первом экране оставлены только Trust/Blocker KPI: `id=891..893` и `id=130`.
   Все остальные control-plane метрики перенесены в collapsed incident rows.
   Рекомендованный operator path: сначала проверить blocker cards, затем открыть
   ровно один collapsed diagnostic row под конкретный incident-pattern.
@@ -223,7 +228,11 @@ Variable handoff policy for dashboard links remains strict and bounded:
   `bioetl_control_plane_reads_total` и
   `bioetl_control_plane_read_duration_seconds_bucket` глобальны по
   `store/operation/status`.
-- `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
+- `bioetl-provider-health-v2`: dashboard links `Back to Overview`, `2. Runtime`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают быстрый переход из provider health surface в runtime/overview и correlation flow без ложного pipeline scope в target dashboards. Минимальный `First Action` row шаблон: 3–4 CTA (`Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore). 
+
+  **First 2 clicks (L1):**
+  1. Click #1: открыть `bioetl-provider-health-v2`, проверить `Current Provider Health Status` (`id=114`) и `Health Check Latency by Provider (p95)` (`id=1`).
+  2. Click #2: перейти в `2. Runtime` при active degradation/failure trend или в `Control Plane v1` при симптомах retry exhaustion/state inconsistency. Panel `id=114` (`Current Provider Health Status`) показывает явный enum mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY`, а panel `id=1` (`Health Check Latency by Provider (p95)`) дублирует Explore handoff через data links.
 - `bioetl-dq-v2`: dashboard link `Back to Overview` плюс `5. Silver Reject Explorer`, `Explore Logs (Loki, tracing profile)` и `Explore Traces (Tempo, tracing profile)` дают тот же переход для DQ incidents и freshness investigation. Handoff в Explorer передаёт только bounded `$pipeline/$run_type` scope, а не generic `includeVars` leakage. Panel `id=1` (`Data Flow in Range: Bronze -> Silver -> Gold`) дублирует Explore handoff через data links.
 - `bioetl-silver-reject-explorer`: dashboard links `Back to Overview`, `Back to Data Quality`, `Open Logs`, `Open Traces`; back-links возвращают только `$pipeline/$run_type`, не leaking `payload_hash` или other forensic filters. Main table поддерживает data links для self-drilldown по `payload_hash` и CLI handoff. Верхняя explanatory panel явно показывает banner `default 24h forensic window`, чтобы оператор не интерпретировал explorer как обычное `now-12h` окно.
 
@@ -241,7 +250,11 @@ Variable handoff policy for dashboard links remains strict and bounded:
 - Для очень редких инцидентов оператор MAY оставить 24h окно и уточнить
   контекст через `reason_code`, `field`, `run_id` и `payload_hash` перед
   action-операциями в CLI.
-- `bioetl-workflow-overview`: dashboard links `Back to Overview`, `2. Runtime`, `Control Plane v1`; cross-dashboard handoffs не leaking `$workflow/$status` into non-workflow targets. Prometheus panels use only bounded workflow labels (`workflow`, `status`, `step_kind`) and never require `run_id`/`step_id` labels.
+- `bioetl-workflow-overview`: dashboard links `Back to Overview`, `2. Runtime`, `Control Plane v1`; cross-dashboard handoffs не leaking `$workflow/$status` into non-workflow targets. Минимальный `First Action` row шаблон: 3–4 CTA (`Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore).
+
+  **First 2 clicks (L1):**
+  1. Click #1: открыть `bioetl-workflow-overview`, проверить `Failed Workflow Runs` (`id=2`) и `Step Outcomes by Kind` (`id=3`).
+  2. Click #2: перейти в `2. Runtime` для incident triage по pipeline impact или в `Control Plane v1` для replay/resume trust verification. Prometheus panels use only bounded workflow labels (`workflow`, `status`, `step_kind`) and never require `run_id`/`step_id` labels.
 - Loki drilldown использует безопасный low-cardinality entrypoint `{job="bioetl"}` без dashboard-variable interpolation внутри encoded Explore payload. Это сознательный baseline: Grafana надёжно не подставляет `$pipeline/$provider` в `left=...`, поэтому дополнительное сужение оператор делает уже в самом Explore. Tempo drilldown открывает trace search в том же временном окне; детальная correlation идёт через `trace_id` / `span_id`, а не через Prometheus labels.
 - Tempo drilldown теперь тоже открывается contextual: dashboards с `$pipeline/$run_type` предварительно фильтруют TraceQL по `span."bioetl.pipeline"` и `span."bioetl.run_type"`, а provider dashboard — по `span."bioetl.provider"`. Это не заменяет correlation по `trace_id` / `span_id`, но убирает пустой `{}` и делает handoff полезнее уже на первом клике.
 - `bioetl-runtime` row `Tracing-only Log Hygiene` теперь включает table panel `Alert-to-Action Map` как runbook-lite:

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -44,3 +44,12 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 - `includeVars=true`
 - legacy Explore payload route: `/explore?left=`
 - перенос Explorer-only forensic scope (`var-run_id`, `var-payload_hash`) в non-explorer dashboards
+
+
+## First Action row contract (L1 dashboards)
+
+| Dashboard UID | First Action panel ID | Minimal CTA template | Expected targets |
+| --- | ---: | --- | --- |
+| `bioetl-control-plane-v1` | `9001` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `4. Data Quality`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-dq-v2`, optional Explore app |
+| `bioetl-provider-health-v2` | `9002` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |
+| `bioetl-workflow-overview` | `9003` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |


### PR DESCRIPTION
### Motivation
- Standardize an operator-facing minimal `First Action` CTA row for key L1 dashboards so first-click handoffs are consistent and testable.
- Make navigation contracts machine-readable with explicit `panel_id` and `expected_target_uid` so tooling and reviews can validate cross-dashboard links.
- Provide concrete “first 2 clicks” operator scenarios in the usage docs to reduce ambiguity during incident triage.

### Description
- Added a `first_action_contract` block to `docs/03-guides/dashboards/contracts/navigation-links.yaml` that defines minimal 3–4 CTA templates and `panel_id` entries for `bioetl-control-plane-v1` (`panel_id: 9001`), `bioetl-provider-health-v2` (`panel_id: 9002`), and `bioetl-workflow-overview` (`panel_id: 9003`).
- Recorded expected CTA targets per dashboard in the YAML (`expected_target_uid` entries include `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-dq-v2`, `bioetl-control-plane-v1`, and optional Explore apps). 
- Extended `docs/03-guides/dashboards/dashboard-v2-usage.md` with explicit **"First 2 clicks (L1)"** scenarios for the three L1 dashboards describing the recommended first and second clicks and the primary panels to check (e.g., `id=891`, `id=130`, `id=114`, `id=1`, `id=2`, `id=3`).
- Added a human-readable table in `docs/03-guides/dashboards/navigation-contract.md` summarizing the First Action row contract, panel IDs, minimal CTA templates, and expected targets.

### Testing
- Ran repository search (`rg`) to verify inserted keys and references, which succeeded and confirmed the new `first_action_contract` and the inserted “First 2 clicks (L1)” text in the two docs. 
- Attempted YAML parse/validation via a small Python check, but it failed due to missing `PyYAML` in the execution environment (`ModuleNotFoundError: No module named 'yaml'`).
- Attempted `python -m memory.tooling.workflow pre-task` and `post-task` for post-change validation, but both failed due to the local environment missing the `memory` package (`ModuleNotFoundError: No module named 'memory'`).
- No runtime/dashboard JSON objects were modified and no unit/integration test suites were run as part of this change in this environment; commit was created and a PR was opened for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82919043083248cbba0c8f1b129ed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->