### PR TITLE
docs: centralize dashboard link/vars/time semantics in YAML SSOT and add CI consistency check

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -1,3 +1,12 @@
+normative_source:
+  scope: link_vars_time_semantics
+  authority: single_source_of_truth
+  narrative_minimal: |
+    This YAML is the only normative contract for dashboard link semantics,
+    allowed/required/forbidden var-* handoff, and time handoff policy.
+    Markdown guides are explanatory mirrors and MUST reference this file
+    instead of redefining normative rules.
+
 version: 1
 required_top_level_links_by_uid:
   bioetl-overview-v2:

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -8,23 +8,13 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 - `dashboard_links.required_tokens`: `${__url_time_range}`
 - `explore_links.required_tokens`: `from=${__from}`, `to=${__to}`
 
-## Общие правила
+## Нормативный источник
 
-- Каждый dashboard (кроме overview-hub) **MUST** иметь top-level ссылку `Back to Overview` на UID `bioetl-overview-v2`.
-- Top-level dashboard links **MUST** иметь приоритет `primary | secondary | contextual`, заданный в `top_level_link_priority_by_uid` в `contracts/navigation-links.yaml`.
-- Для каждого source dashboard и каждого target UID допускается не более одной `primary` ссылки; `primary` ссылка **MUST** иметь однозначную `semantics` (непустой идентификатор смысла handoff).
-- Critical KPI панели **MUST** иметь first-hop action link (panel-level `dataLinks`) на целевой dashboard для первичного triage. Контракт хранится в `required_panel_links_by_uid` и валидирует `panel_id`, минимально допустимый `title`, `target_uid`, time handoff и allowlisted `var-*`.
-- Cross-dashboard handoff передаёт только target-scoped `var-*` параметры и **MUST** включать `${__url_time_range}` во всех dashboard URL (`/d/...`).
-- `includeVars=true` и другие универсальные handoff-паттерны запрещены; используем только явные `var-*` и time-range по единому стандарту:
-  - dashboard links (`/d/<uid>/<slug>?...`): `${__url_time_range}`
-  - Explore links (`/explore` и `/a/grafana-*-explore-app/...`): `from=${__from}&to=${__to}`
-- Universal top-level link `Next Recommended Drilldown` is **optional**; when present, it MUST resolve to an existing shipped dashboard/Explore target and obey the same explicit `var-*` + time-range handoff rules.
-- Explore handoff для Loki/Tempo ведёт только через drilldown-приложения:
-  - Logs: `/a/grafana-lokiexplore-app/explore?...`
-  - Traces: `/a/grafana-exploretraces-app/?...`
-- Optional contextual Explore links (`options.dataLinks`) разрешены только для operator-critical panel surfaces в `bioetl-runtime`, `bioetl-dq-v2`, `bioetl-control-plane-v1`; baseline link `Open Logs (Loki, tracing profile)` MUST сохраняться.
-- Contextual Loki Explore link MUST содержать безопасный scope marker `scope_marker="dashboard_context"` и может использовать только `${pipeline:regex}` и `${run_type:regex}` как дополнительные фильтры после `{job="bioetl"} | json`.
-- Contextual Explore links MUST NOT передавать/использовать forensic переменные (`run_id`, `payload_hash`) или любые другие `var-*` вне разрешённого набора.
+Единственный нормативный источник link/vars/time semantics: `docs/03-guides/dashboards/contracts/navigation-links.yaml`.
+
+- Минимальный narrative закреплён в YAML: `normative_source.narrative_minimal`.
+- Нормативные ключи для проверок: `required_top_level_links_by_uid`, `required_link_vars_by_target_uid`, `allowed_dashboard_link_vars`, `forbidden_dashboard_link_vars_by_target_uid`, `time_handoff_requirements`, `default_time_refresh_policy`, `navigation_transition_contract`.
+- Этот Markdown — explanatory mirror: допускаются примеры и навигация, но не дублирование нормативных MUST-правил.
 
 ## Примеры URL (нормализованный формат)
 
@@ -32,35 +22,11 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 - Dashboard: `/d/bioetl-dq-v2/bioetl-dq-v2?var-pipeline=$pipeline&var-run_type=$run_type&var-stage=$stage&${__url_time_range}`
 - Dashboard: `/d/bioetl-overview-v2/bioetl-overview-v2?var-pipeline=All&var-run_type=All&${__url_time_range}`
 
-## Обязательные блоки по UID
+## Справка
 
-| Dashboard UID | Обязательные top-level links | Обязательные `var-*` в cross-links |
-|---|---|---|
-| `bioetl-overview-v2` | `2. Runtime`, `Control Plane v1`, `3. Provider Health`, `4. Data Quality`, `6. Workflow Overview`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Runtime/ControlPlane/DQ: `var-pipeline`, `var-run_type`; Provider/Workflow: без `var-*` |
-| `bioetl-runtime` | `Back to Overview`, `Control Plane v1`, `3. Provider Health`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/ControlPlane: `var-pipeline`, `var-run_type`; DQ: `var-pipeline`, `var-run_type`, `var-stage`; Provider: без `var-*` |
-| `bioetl-control-plane-v1` | `Back to Overview`, `2. Runtime`, `4. Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/Runtime/DQ: `var-pipeline`, `var-run_type` |
-| `bioetl-provider-health-v2` | `Back to Overview`, `2. Runtime (Primary)`, `2. Runtime (Contextual: provider mapping)`, `Control Plane v1`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | cross-dashboard `var-*` не передаются |
-| `bioetl-dq-v2` | `Back to Overview`, `Control Plane v1`, `5. Silver Reject Explorer`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/ControlPlane/Explorer: `var-pipeline`, `var-run_type` |
-| `bioetl-silver-reject-explorer` | `Back to Overview`, `Back to Data Quality`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)` | Overview/DQ: `var-pipeline`, `var-run_type` |
-| `bioetl-workflow-overview` | `Back to Overview`, `2. Runtime`, `Control Plane v1` | cross-dashboard `var-*` не передаются |
+Детальные обязательные блоки, forbidden patterns, priority/semantics и First Action contract поддерживаются только в YAML-контракте (`navigation-links.yaml`).
 
-## Запрещённые handoff-паттерны
 
-- `includeVars=true`
-- legacy Explore payload route: `/explore?left=`
-- перенос Explorer-only forensic scope (`var-run_id`, `var-payload_hash`) в non-explorer dashboards
 
-## Приоритет и semantics (пример)
 
-- `bioetl-provider-health-v2` содержит два перехода в Runtime:
-  - `2. Runtime (Primary)` — `priority: primary`, semantics `runtime_cross_scope_all_defaults`;
-  - `2. Runtime (Contextual: provider mapping)` — `priority: contextual`, semantics `runtime_provider_context_mapping`.
-- Priority должна быть отражена в `title` и/или `tooltip` ссылки в dashboard JSON.
 
-## First Action row contract (L1 dashboards)
-
-| Dashboard UID | First Action panel ID | Minimal CTA template | Expected targets |
-| --- | ---: | --- | --- |
-| `bioetl-control-plane-v1` | `9001` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `4. Data Quality`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-dq-v2`, optional Explore app |
-| `bioetl-provider-health-v2` | `9002` | 3–4 CTA: `Back to Overview`, `2. Runtime (Primary)`, `2. Runtime (Contextual: provider mapping)`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |
-| `bioetl-workflow-overview` | `9003` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |

--- a/docs/03-guides/dashboards/variables-guide.md
+++ b/docs/03-guides/dashboards/variables-guide.md
@@ -16,104 +16,18 @@ ______________________________________________________________________
 Дата сверки: **2026-05-03**  
 Источник истины: `grafana/dashboards/*.json`
 
-## Unified Variable Contract
+## Нормативный источник
 
-### Scope groups
+Единственный нормативный источник для переменных и time handoff: `docs/03-guides/dashboards/contracts/navigation-links.yaml`.
 
-- **Core scope**: `pipeline`, `run_type`, `stage` (где есть stage-level панели).
-- **Provider scope**: `provider`, `adapter` (только provider health dashboards).
-- **Forensic-only**: `run_id`, `payload_hash` (только `bioetl-silver-reject-explorer`).
+Используйте YAML-секции:
+- `required_link_vars_by_target_uid`
+- `allowed_dashboard_link_vars`
+- `forbidden_dashboard_link_vars_by_target_uid`
+- `time_handoff_requirements`
+- `default_time_refresh_policy` / `default_time_refresh_policy_exceptions`
 
-### Dashboard → scope contract
-
-| Dashboard UID | Contract |
-| --- | --- |
-| `bioetl-overview-v2` | Core: `pipeline`, `run_type` |
-| `bioetl-control-plane-v1` | Core: `pipeline`, `run_type` |
-| `bioetl-runtime` | Core: `pipeline`, `run_type`, `stage` |
-| `bioetl-dq-v2` | Core: `pipeline`, `run_type`, `stage` |
-| `bioetl-provider-health-v2` | Provider: `provider`, `adapter` |
-| `bioetl-silver-reject-explorer` | Core: `pipeline`, `run_type` + explorer fields `reason_code`, `field` + Forensic-only `run_id`, `payload_hash` |
-| `bioetl-workflow-overview` | Workflow-local: `workflow`, `status` |
-
-## Variable meanings and fallback semantics
-
-| Variable | Scope | Meaning | Fallback when source dashboard does not pass it |
-| --- | --- | --- | --- |
-| `pipeline` | Core | Pipeline selection baseline | Target dashboard uses default **All pipelines** |
-| `run_type` | Core | Run mode within selected pipeline | Target dashboard uses **All run types** |
-| `stage` | Core | Stage breakdown filter (`bronze/silver/gold`) | Target uses **All stages** |
-| `provider` | Provider | Provider selection for provider health panels | Target uses **All providers** |
-| `adapter` | Provider | Adapter selection for provider health panels | Target uses **All adapters** |
-| `run_id` | Forensic-only | Exact run narrowing in reject explorer | No run_id filter (all runs in selected pipeline/run_type scope) |
-| `payload_hash` | Forensic-only | Exact record lookup in reject explorer textbox | Empty textbox disables payload filter |
-
-## Cross-dashboard handoff rules (explicit)
-
-1. Передавать только `var-*`, которые входят в target contract.
-1. `includeVars=true` не используется для dashboard-to-dashboard ссылок.
-1. **Core → Core**: передавать `pipeline`, `run_type`; `stage` передаётся только если target поддерживает `stage`.
-1. **Core ↔ Provider**: provider dashboards не получают core variables; fallback через default provider/adapter selection.
-1. **Any → Forensic (Reject Explorer)**: допускаются только `pipeline`, `run_type`; forensic filters (`run_id`, `payload_hash`) всегда вводятся оператором вручную в explorer.
-1. **Forensic → Core**: передавать обратно только `pipeline`, `run_type`; не передавать `run_id`, `payload_hash`, `reason_code`, `field`.
-1. **Workflow dashboards** (`workflow`, `status`) изолированы; при переходах в runtime/control-plane действует fallback на defaults target dashboards.
-
-
-
-## Context reset UX
-
-Cross-scope links MUST явно предупреждать оператора, что filters не переносятся и target откроется с `All` scope.
-
-### Примеры link behavior
-
-- **Core → Provider** (`Overview/Runtime` → `Provider Health`): link title/tooltip содержит `opens with All provider scope`; URL принудительно задаёт `var-provider=All&var-adapter=All`.
-- **Provider → Core** (`Provider Health` → `Overview/Runtime`): link title/tooltip содержит `opens with All core scope`; URL задаёт `var-pipeline=All&var-run_type=All` (и `var-stage=All` для Runtime).
-- **Provider → Core (contextual fallback allowed)**: допустима дополнительная ссылка-variant (рядом с reset-to-All) с provider-derived mapping policy: `provider -> pipeline`, `adapter -> run_type`; при отсутствии/невалидности mapping target MUST fallback к `All` (`var-pipeline=All&var-run_type=All`, и `var-stage=All` для Runtime).
-- **Workflow → Core** (`Workflow Overview` → `Overview/Runtime`): link title/tooltip содержит `opens with All core scope`; workflow variables (`workflow`, `status`) не передаются.
-
-UX цель: убрать ложное ожидание, что source filters автоматически сохранятся при переходе между разными scope-контрактами.
-
-### Пример before/after (contract title preserved)
-
-```json
-// before
-{
-  "title": "3. Provider Health",
-  "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?${__url_time_range}"
-}
-```
-
-```json
-// after
-{
-  "title": "3. Provider Health",
-  "tooltip": "Cross-scope handoff (opens with All provider scope): var-provider=All and var-adapter=All; pipeline/run_type do not transfer.",
-  "url": "/d/bioetl-provider-health-v2/bioetl-provider-health-v2?var-provider=All&var-adapter=All&${__url_time_range}"
-}
-```
-
-Правило: каноническое `title` из navigation contract не меняем; пояснение о reset scope добавляем в `tooltip`.
-
-## Navigation time-range policy
-
-- Для всех `links[].url` с dashboard route (`/d/...`) используем единый time handoff: `${__url_time_range}`.
-- Для всех `links[].url` с Explore route (`/explore`, `/a/grafana-lokiexplore-app/explore`, `/a/grafana-exploretraces-app/`) используем `from=${__from}&to=${__to}`.
-- Смешанные/legacy варианты (`from=$__from`, отсутствие time-range, `includeVars=true`) не допускаются.
-
-## Default time window policy by dashboard class
-
-- **L0/L1 baseline (must be unified unless justified):**
-  - `overview`: `time.from=now-12h`, `refresh=30s`
-  - `runtime`: `time.from=now-12h`, `refresh=30s`
-  - `dq`: `time.from=now-12h`, `refresh=30s`
-  - `control-plane` (`uid=bioetl-control-plane-v1`): `time.from=now-12h`, `refresh=30s`
-- **Forensic L2 exception (must include explicit justification in docs/PR):**
-  - `explorer` (`bioetl-silver-reject-explorer`): `time.from=now-24h`, `refresh=1m`
-  - Justification: forensic/reject investigation требует больше стартового горизонта для редких инцидентов и сниженной частоты auto-refresh, чтобы уменьшить шум и нагрузку при row-level анализе.
-- Machine-readable contract source: `docs/03-guides/dashboards/contracts/navigation-links.yaml` -> `default_time_refresh_policy` + `default_time_refresh_policy_exceptions` (for explicit, justified deviations).
-
-- **Workflow dashboard class:**
-  - `workflow-overview`: `time.from=now-12h`, `refresh=30s` (align with L0/L1 operator baseline for run-step triage).
+Этот guide оставлен как explanatory reference (контекст и примеры), без повторного нормирования MUST/SHOULD правил.
 
 ## Test coverage expectations
 

--- a/tests/integration/ci/test_dashboard_docs_yaml_consistency.py
+++ b/tests/integration/ci/test_dashboard_docs_yaml_consistency.py
@@ -1,0 +1,53 @@
+"""CI guard: dashboard docs must mirror (not redefine) YAML navigation contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.integration
+
+_YAML_PATH = Path("docs/03-guides/dashboards/contracts/navigation-links.yaml")
+_NAV_PATH = Path("docs/03-guides/dashboards/navigation-contract.md")
+_VARS_PATH = Path("docs/03-guides/dashboards/variables-guide.md")
+
+
+@pytest.fixture(scope="module")
+def contract() -> dict[str, object]:
+    return yaml.safe_load(_YAML_PATH.read_text(encoding="utf-8"))
+
+
+def test_yaml_declares_single_normative_source(contract: dict[str, object]) -> None:
+    marker = contract.get("normative_source")
+    assert isinstance(marker, dict)
+    assert marker.get("scope") == "link_vars_time_semantics"
+    assert marker.get("authority") == "single_source_of_truth"
+    assert isinstance(marker.get("narrative_minimal"), str)
+
+
+def test_docs_reference_yaml_contract_keys(contract: dict[str, object]) -> None:
+    nav_text = _NAV_PATH.read_text(encoding="utf-8")
+    vars_text = _VARS_PATH.read_text(encoding="utf-8")
+
+    required_keys = [
+        "required_link_vars_by_target_uid",
+        "allowed_dashboard_link_vars",
+        "forbidden_dashboard_link_vars_by_target_uid",
+        "time_handoff_requirements",
+        "default_time_refresh_policy",
+    ]
+
+    assert "navigation-links.yaml" in nav_text
+    assert "navigation-links.yaml" in vars_text
+
+    for key in required_keys:
+        assert key in vars_text or key in nav_text
+        assert key in contract
+
+
+def test_docs_do_not_redefine_normative_tables() -> None:
+    nav_text = _NAV_PATH.read_text(encoding="utf-8")
+    assert "| Dashboard UID | Обязательные top-level links" not in nav_text
+    assert "| Dashboard UID | First Action panel ID" not in nav_text


### PR DESCRIPTION
### Motivation
- Establish a single normative source of truth for dashboard link/variable/time semantics to avoid duplicated normative rules across Markdown and YAML. 
- Reduce documentation drift by making Markdown files explanatory mirrors that reference machine-readable contract keys. 
- Prevent future regressions by adding a CI guard that enforces docs ↔ YAML consistency for the navigation contract.

### Description
- Added a `normative_source` block to `docs/03-guides/dashboards/contracts/navigation-links.yaml` declaring the YAML as the single SSOT and providing a minimal narrative. 
- Simplified `docs/03-guides/dashboards/navigation-contract.md` to remove duplicated normative tables and instead reference the YAML contract keys. 
- Simplified `docs/03-guides/dashboards/variables-guide.md` to point to the YAML sections for variable/time semantics rather than restating normative rules. 
- Added a CI integration test `tests/integration/ci/test_dashboard_docs_yaml_consistency.py` that validates the `normative_source` marker exists, required YAML keys are present and referenced by the docs, and that the removed normative tables are not reintroduced in `navigation-contract.md`.

### Testing
- Attempted a pre-task memory workflow with `python -m memory.tooling.workflow pre-task ...` which failed in this environment due to `ModuleNotFoundError: No module named 'memory'`. 
- Ran `pytest -q tests/integration/ci/test_dashboard_docs_yaml_consistency.py tests/integration/test_dashboard_navigation_contract_sync.py` which failed due to project `pytest.ini` addopts requiring plugins not available in this environment. 
- Re-ran `pytest -q -o addopts='' tests/integration/ci/test_dashboard_docs_yaml_consistency.py tests/integration/test_dashboard_navigation_contract_sync.py` which failed during collection with `ModuleNotFoundError: No module named 'yaml'` (PyYAML missing in the sandbox). 
- The new CI test file was created and committed (`tests/integration/ci/test_dashboard_docs_yaml_consistency.py`) and should pass in CI where the repository test environment provides `pytest` plugins and `PyYAML`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a03220d48324a59b767ccfc9dd38)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Centralized dashboard navigation and variable rules into a single authoritative source file
  * Markdown guides updated to reference the consolidated rules instead of duplicating them

* **Tests**
  * Added integration tests to enforce documentation consistency and alignment across guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->