### PR TITLE
Align overview inbound CTA contract with actual first-screen 'Next Action' panel

### DIFF
--- a/docs/03-guides/dashboards/contracts/navigation-links.yaml
+++ b/docs/03-guides/dashboards/contracts/navigation-links.yaml
@@ -96,24 +96,29 @@ required_discoverable_inbound_paths:
   L1:
     bioetl-runtime:
       - source_uid: bioetl-overview-v2
-        source_panel_id: 208
-        source_panel_title: Runtime Status
+        source_panel_id: 215
+        source_panel_title: Next Action
+        source_status_row_panel_title_matcher: "^L0 Overview Scope$"
     bioetl-control-plane-v1:
       - source_uid: bioetl-overview-v2
-        source_panel_id: 210
-        source_panel_title: Control Plane Status
+        source_panel_id: 215
+        source_panel_title: Next Action
+        source_status_row_panel_title_matcher: "^L0 Overview Scope$"
     bioetl-provider-health-v2:
       - source_uid: bioetl-overview-v2
-        source_panel_id: 211
-        source_panel_title: Provider Status
+        source_panel_id: 215
+        source_panel_title: Next Action
+        source_status_row_panel_title_matcher: "^L0 Overview Scope$"
     bioetl-dq-v2:
       - source_uid: bioetl-overview-v2
-        source_panel_id: 209
-        source_panel_title: Data Quality Status
+        source_panel_id: 215
+        source_panel_title: Next Action
+        source_status_row_panel_title_matcher: "^L0 Overview Scope$"
     bioetl-workflow-overview:
       - source_uid: bioetl-overview-v2
-        source_panel_id: 212
-        source_panel_title: Workflow Status
+        source_panel_id: 215
+        source_panel_title: Next Action
+        source_status_row_panel_title_matcher: "^L0 Overview Scope$"
   L2:
     bioetl-silver-reject-explorer:
       - source_uid: bioetl-dq-v2

--- a/docs/03-guides/dashboards/navigation-contract.md
+++ b/docs/03-guides/dashboards/navigation-contract.md
@@ -64,3 +64,15 @@ YAML также фиксирует time handoff policy в `time_handoff_requirem
 | `bioetl-control-plane-v1` | `9001` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `4. Data Quality`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-dq-v2`, optional Explore app |
 | `bioetl-provider-health-v2` | `9002` | 3–4 CTA: `Back to Overview`, `2. Runtime (Primary)`, `2. Runtime (Contextual: provider mapping)`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |
 | `bioetl-workflow-overview` | `9003` | 3–4 CTA: `Back to Overview`, `2. Runtime`, `Control Plane v1`, optional Explore | `bioetl-overview-v2`, `bioetl-runtime`, `bioetl-control-plane-v1`, optional Explore app |
+
+## Required inbound paths (discoverable first-screen CTA)
+
+L1-target dashboards MUST be discoverable from first-screen status/KPI area on `bioetl-overview-v2` via panel `Next Action` (id `215`), located on the first screen status row after the scope header panel matched by regex `^L0 Overview Scope$`.
+
+| Target UID | Source UID | Source panel id | Source panel title | First-screen row matcher |
+| --- | --- | ---: | --- | --- |
+| `bioetl-runtime` | `bioetl-overview-v2` | `215` | `Next Action` | `^L0 Overview Scope$` |
+| `bioetl-control-plane-v1` | `bioetl-overview-v2` | `215` | `Next Action` | `^L0 Overview Scope$` |
+| `bioetl-provider-health-v2` | `bioetl-overview-v2` | `215` | `Next Action` | `^L0 Overview Scope$` |
+| `bioetl-dq-v2` | `bioetl-overview-v2` | `215` | `Next Action` | `^L0 Overview Scope$` |
+| `bioetl-workflow-overview` | `bioetl-overview-v2` | `215` | `Next Action` | `^L0 Overview Scope$` |

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -163,23 +163,29 @@ def _is_traces_drilldown_url(url: str) -> bool:
     return "/a/grafana-exploretraces-app/" in url
 
 
-_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: dict[int, str] = {
-    208: "bioetl-runtime",
-    209: "bioetl-dq-v2",
-    210: "bioetl-control-plane-v1",
-    211: "bioetl-provider-health-v2",
-    212: "bioetl-workflow-overview",
-}
+_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: tuple[tuple[int, str], ...] = (
+    (215, "bioetl-runtime"),
+    (215, "bioetl-dq-v2"),
+    (215, "bioetl-control-plane-v1"),
+    (215, "bioetl-provider-health-v2"),
+    (215, "bioetl-workflow-overview"),
+)
 
 
 def _iter_panel_data_links(panel: dict[str, object]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
     options = panel.get("options")
-    if not isinstance(options, dict):
-        return []
-    links = options.get("dataLinks", [])
-    if not isinstance(links, list):
-        return []
-    return [link for link in links if isinstance(link, dict)]
+    if isinstance(options, dict):
+        links = options.get("dataLinks", [])
+        if isinstance(links, list):
+            result.extend(link for link in links if isinstance(link, dict))
+
+    defaults = panel.get("fieldConfig", {}).get("defaults", {})
+    if isinstance(defaults, dict):
+        field_links = defaults.get("links", [])
+        if isinstance(field_links, list):
+            result.extend(link for link in field_links if isinstance(link, dict))
+    return result
 
 
 def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
@@ -191,32 +197,30 @@ def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
         if isinstance(panel.get("id"), int)
     }
 
-    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID.items():
+    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID:
         panel = panels.get(panel_id)
         assert isinstance(panel, dict), f"Missing overview status panel id={panel_id}"
 
         data_links = _iter_panel_data_links(panel)
         assert data_links, f"Panel id={panel_id} must expose at least one data link"
 
-        for link in data_links:
-            url = link.get("url", "")
-            assert isinstance(url, str), (
-                f"Panel id={panel_id} data link URL must be string"
-            )
-            assert url.startswith(f"/d/{target_uid}/"), (
-                f"Panel id={panel_id} must point to /d/{target_uid}/: {url}"
-            )
-            assert "?" in url, (
-                f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
-            )
-
+        matched_urls = [
+            str(link.get("url"))
+            for link in data_links
+            if isinstance(link.get("url"), str)
+            and str(link.get("url")).startswith(f"/d/{target_uid}/")
+        ]
+        assert matched_urls, (
+            f"Panel id={panel_id} must include at least one link to /d/{target_uid}/"
+        )
+        for url in matched_urls:
+            assert "?" in url, f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
             passed_vars = _extract_link_vars(url)
             required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID[target_uid]
             assert required_vars <= passed_vars, (
                 f"Panel id={panel_id} link to {target_uid} missing required vars "
                 f"{sorted(required_vars - passed_vars)} via {url}"
             )
-
             _assert_required_time_tokens(
                 url,
                 tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,
@@ -466,9 +470,17 @@ def test_required_discoverable_inbound_paths_have_panel_level_links_and_policy()
                 source_uid = route.get("source_uid")
                 panel_id = route.get("source_panel_id")
                 panel_title = route.get("source_panel_title")
+                status_row_title_matcher = route.get(
+                    "source_status_row_panel_title_matcher"
+                )
                 assert isinstance(source_uid, str)
                 assert isinstance(panel_id, int)
                 assert isinstance(panel_title, str) and panel_title
+                if level_name == "L1":
+                    assert (
+                        isinstance(status_row_title_matcher, str)
+                        and status_row_title_matcher
+                    )
 
                 source_dashboard = dashboards.get(source_uid)
                 assert isinstance(source_dashboard, dict), (
@@ -488,6 +500,28 @@ def test_required_discoverable_inbound_paths_have_panel_level_links_and_policy()
                 assert panel.get("title") == panel_title, (
                     f"Source panel id={panel_id} title mismatch: expected {panel_title!r}, got {panel.get('title')!r}"
                 )
+                if level_name == "L1":
+                    row_re = re.compile(status_row_title_matcher)
+                    status_header_panel = next(
+                        (
+                            candidate
+                            for candidate in get_dashboard_panels(source_dashboard)
+                            if isinstance(candidate.get("title"), str)
+                            and row_re.search(candidate["title"]) is not None
+                        ),
+                        None,
+                    )
+                    assert isinstance(status_header_panel, dict), (
+                        f"{source_uid}:{panel_id}->{target_uid} must resolve status-row matcher {status_row_title_matcher!r}"
+                    )
+                    row_y = status_header_panel.get("gridPos", {}).get("y")
+                    panel_y = panel.get("gridPos", {}).get("y")
+                    assert isinstance(row_y, int) and isinstance(panel_y, int), (
+                        f"{source_uid}:{panel_id}->{target_uid} row/panel y gridPos must be integers"
+                    )
+                    assert panel_y > row_y, (
+                        f"{source_uid}:{panel_id}->{target_uid} panel must be on first-screen status row below matched header panel {status_header_panel.get('title')!r}"
+                    )
 
                 target_links = [
                     link.get("url")
@@ -753,23 +787,28 @@ def _is_traces_drilldown_url(url: str) -> bool:
     return "/a/grafana-exploretraces-app/" in url
 
 
-_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: dict[int, str] = {
-    208: "bioetl-runtime",
-    209: "bioetl-dq-v2",
-    210: "bioetl-control-plane-v1",
-    211: "bioetl-provider-health-v2",
-    212: "bioetl-workflow-overview",
-}
+_OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID: tuple[tuple[int, str], ...] = (
+    (215, "bioetl-runtime"),
+    (215, "bioetl-dq-v2"),
+    (215, "bioetl-control-plane-v1"),
+    (215, "bioetl-provider-health-v2"),
+    (215, "bioetl-workflow-overview"),
+)
 
 
 def _iter_panel_data_links(panel: dict[str, object]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
     options = panel.get("options")
-    if not isinstance(options, dict):
-        return []
-    links = options.get("dataLinks", [])
-    if not isinstance(links, list):
-        return []
-    return [link for link in links if isinstance(link, dict)]
+    if isinstance(options, dict):
+        links = options.get("dataLinks", [])
+        if isinstance(links, list):
+            result.extend(link for link in links if isinstance(link, dict))
+    defaults = panel.get("fieldConfig", {}).get("defaults", {})
+    if isinstance(defaults, dict):
+        field_links = defaults.get("links", [])
+        if isinstance(field_links, list):
+            result.extend(link for link in field_links if isinstance(link, dict))
+    return result
 
 
 def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
@@ -781,32 +820,29 @@ def test_overview_status_cards_use_scoped_drilldown_urls() -> None:
         if isinstance(panel.get("id"), int)
     }
 
-    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID.items():
+    for panel_id, target_uid in _OVERVIEW_STATUS_PANEL_IDS_BY_TARGET_UID:
         panel = panels.get(panel_id)
         assert isinstance(panel, dict), f"Missing overview status panel id={panel_id}"
 
         data_links = _iter_panel_data_links(panel)
         assert data_links, f"Panel id={panel_id} must expose at least one data link"
-
-        for link in data_links:
-            url = link.get("url", "")
-            assert isinstance(url, str), (
-                f"Panel id={panel_id} data link URL must be string"
-            )
-            assert url.startswith(f"/d/{target_uid}/"), (
-                f"Panel id={panel_id} must point to /d/{target_uid}/: {url}"
-            )
-            assert "?" in url, (
-                f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
-            )
-
+        matched_urls = [
+            str(link.get("url"))
+            for link in data_links
+            if isinstance(link.get("url"), str)
+            and str(link.get("url")).startswith(f"/d/{target_uid}/")
+        ]
+        assert matched_urls, (
+            f"Panel id={panel_id} must include at least one link to /d/{target_uid}/"
+        )
+        for url in matched_urls:
+            assert "?" in url, f"Panel id={panel_id} must not use bare /d/<uid> URL: {url}"
             passed_vars = _extract_link_vars(url)
             required_vars = _REQUIRED_LINK_VARS_BY_TARGET_UID[target_uid]
             assert required_vars <= passed_vars, (
                 f"Panel id={panel_id} link to {target_uid} missing required vars "
                 f"{sorted(required_vars - passed_vars)} via {url}"
             )
-
             _assert_required_time_tokens(
                 url,
                 tokens=_DASHBOARD_TIME_HANDOFF_TOKENS,


### PR DESCRIPTION
### Motivation
- The Overview dashboard first-screen CTA panel moved to a single consolidated `Next Action` stat (panel id `215`), so the navigation contract and tests must reference the real discoverable CTA instead of legacy panel ids `208..212`.
- Tests must validate not only presence of links but that they originate from the actual first-screen status/KPI area (to ensure discoverability and correct operator handoff semantics).

### Description
- Updated `docs/03-guides/dashboards/contracts/navigation-links.yaml` to map L1 inbound discoverable routes to `source_panel_id: 215`, `source_panel_title: Next Action`, and added `source_status_row_panel_title_matcher` to require the first-screen status row header match `^L0 Overview Scope$`.
- Extended `docs/03-guides/dashboards/navigation-contract.md` with a short human-readable table and text documenting the required inbound-first-screen CTA mapping and the status-row matcher semantics.
- Strengthened `tests/integration/test_grafana_dashboard_links.py` by extracting panel-level CTA links from both `options.dataLinks` and `fieldConfig.defaults.links`, updating the overview status-card assertions to require per-target matching links, and adding verification that L1 inbound routes are discoverable from the first-screen status row using the configured title matcher plus `gridPos.y` checks.

### Testing
- Ran the focused integration selection via the repository test runner with `uv run pytest -q tests/integration/test_grafana_dashboard_links.py -k 'inbound_paths or overview_status_cards'`, which completed successfully with `2 passed, 42 deselected`.
- A direct `pytest` invocation in this environment initially errored due to test-runner/pytest.ini plugin/timeout settings and missing runtime `yaml` dependency, so the canonical `uv run` runner was used for validation and passed.
- All modified integration assertions exercised the updated contract and first-screen matcher logic and succeeded in the `uv run` execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a01270e083248e2f6360708793b7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->