### PR TITLE
Align root hygiene registry states for absent local-only root dirs

### DIFF
--- a/configs/quality/root_hygiene_review_registry.yaml
+++ b/configs/quality/root_hygiene_review_registry.yaml
@@ -51,7 +51,7 @@ review_lanes:
       - .venv/bin/python scripts/engineering/repo/audit_root_cleanliness.py --strict-untracked
     candidates:
       - path: .ai
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_reclassify_through_explicit_structure_governance
       - path: .claude
@@ -84,7 +84,7 @@ review_lanes:
       - rg -n "\\.agent-work/|\\.agentbridge/|\\.cache/" .gitignore docs scripts .github tests configs
     candidates:
       - path: .agent-work
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_reclassify_through_explicit_structure_governance
       - path: .agentbridge
@@ -92,7 +92,7 @@ review_lanes:
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_reclassify_through_explicit_structure_governance
       - path: .cache
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_scope_to_a_documented_cache_surface
 
@@ -105,15 +105,15 @@ review_lanes:
       - rg -n "\\.junie/|\\.sonarlint/|\\.windsurf/" .gitignore docs scripts .github tests configs
     candidates:
       - path: .junie
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_move_curated_shared_content_to_an_approved_root_surface
       - path: .sonarlint
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_reclassify_through_explicit_owner_review
       - path: .windsurf
-        current_live_state: present_local_only_root_surface
+        current_live_state: absent_from_root_baseline
         canonical_path: null
         action_if_reintroduced: keep_untracked_or_move_curated_shared_content_to_an_approved_root_surface
 


### PR DESCRIPTION
### Motivation
- The root hygiene registry marked several local-only root surfaces as present while those paths are missing, causing `check-root-review-registry` validation to fail in CI.

### Description
- Updated `configs/quality/root_hygiene_review_registry.yaml` to set `current_live_state: absent_from_root_baseline` for `.ai`, `.agent-work`, `.cache`, `.junie`, `.sonarlint`, and `.windsurf` so the registry reflects the actual repository root state.

### Testing
- Ran `uv run python -m scripts.engineering.repo check-root-review-registry`, which initially reproduced the reported failure and after the change returned `[OK] Root hygiene review registry is valid`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92df9a8bc83249ddf53070155eb43)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->