### PR TITLE
Skip binary cassettes and normalize paths when backfilling VCR sidecars

### DIFF
--- a/scripts/ops/migrations/active/backfill_vcr_metadata_sidecars.py
+++ b/scripts/ops/migrations/active/backfill_vcr_metadata_sidecars.py
@@ -69,9 +69,17 @@ def _selected_cassettes(vcr_root: Path, provider: str) -> list[Path]:
     )
 
 
+def _is_binary_file(path: Path) -> bool:
+    """Best-effort binary-file detection for cassette candidates."""
+    chunk = path.read_bytes()[:1024]
+    return b"\x00" in chunk
+
+
 def _build_sidecar_payload(
     vcr_root: Path, cassette_path: Path, *, recorded_at: str
 ) -> dict[str, object]:
+    cassette_path = cassette_path.resolve()
+    vcr_root = vcr_root.resolve()
     provider = cassette_path.relative_to(vcr_root).parts[0]
     cassette_bytes = cassette_path.read_bytes()
     cassette_rel_path = cassette_path.relative_to(ROOT).as_posix()
@@ -89,7 +97,7 @@ def _build_sidecar_payload(
 
 def main() -> int:
     args = _parse_args()
-    vcr_root = Path(args.vcr_root)
+    vcr_root = Path(args.vcr_root).resolve()
     cassettes = _selected_cassettes(vcr_root, args.provider)
     if args.limit > 0:
         cassettes = cassettes[: args.limit]
@@ -111,6 +119,8 @@ def main() -> int:
 
     written = 0
     for cassette_path in cassettes:
+        if _is_binary_file(cassette_path):
+            continue
         metadata_path = _metadata_path_for(cassette_path)
         if metadata_path.exists() and not args.rewrite_existing:
             continue


### PR DESCRIPTION
### Motivation
- Prevent creation of YAML sidecars for non-text/binary cassette files and avoid generating invalid metadata for such files.
- Ensure consistent path handling and SHA256 calculation by resolving `vcr_root` and `cassette_path` to absolute paths.
- Keep existing `--check` and `--rewrite-existing` behaviors intact while making the backfill more robust.

### Description
- Add `_is_binary_file(path: Path) -> bool` to perform a best-effort binary detection by checking for a NUL byte in the first 1024 bytes.
- Skip any cassette files detected as binary in the main processing loop before attempting to build or write sidecars.
- Resolve `cassette_path` and `vcr_root` to absolute paths in `_build_sidecar_payload` and resolve `vcr_root` in `main` to ensure consistent relative path computation and checksum calculation.
- Preserve existing sidecar filename logic and `--check`/`--rewrite-existing` command-line behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f933f5b76483248c5f96f9c30b2a7d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->