### PR TITLE
Align provider-health enum descriptions and add mapping consistency regressions

### DIFF
--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -236,7 +236,7 @@
       ],
       "title": "Health Check Latency by Provider (p95)",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -325,7 +325,7 @@
       ],
       "title": "Current Provider Health Status",
       "type": "table",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -396,7 +396,7 @@
       ],
       "title": "Healthy Checks",
       "type": "stat",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -476,7 +476,7 @@
       ],
       "title": "Provider Failure Rate",
       "type": "gauge",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -549,7 +549,7 @@
       ],
       "title": "Health Checks Total",
       "type": "stat",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -622,7 +622,7 @@
       ],
       "title": "Degraded Checks",
       "type": "stat",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -705,7 +705,7 @@
       ],
       "title": "Track Failure and Degraded Trend by Provider",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -767,7 +767,7 @@
       ],
       "title": "Track Provider Failure Share (Selected Range)",
       "type": "bargauge",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -830,7 +830,7 @@
       ],
       "title": "Track Retries Exhausted by Provider/Operation",
       "type": "table",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -909,7 +909,7 @@
       ],
       "title": "Track Retries Exhausted Trend by Provider/Operation",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "collapsed": true,
@@ -999,7 +999,7 @@
       ],
       "title": "Provider Health Check Latency (p95) - $provider",
       "type": "gauge",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1060,7 +1060,7 @@
       ],
       "title": "Adapter Request Latency by Endpoint (p95)",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1139,7 +1139,7 @@
       ],
       "title": "HTTP Errors by Method / Error Type",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1218,7 +1218,7 @@
       ],
       "title": "Rate Limiter Wait by Provider (p95)",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1278,7 +1278,7 @@
       ],
       "title": "Minimum Rate Limiter Tokens Available",
       "type": "bargauge",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1350,7 +1350,7 @@
       ],
       "title": "Circuit Breaker State (max)",
       "type": "stat",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     },
     {
       "datasource": "Prometheus",
@@ -1422,7 +1422,7 @@
       ],
       "title": "Circuit Breaker Trips by Provider",
       "type": "timeseries",
-      "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
+      "description": "Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN."
     }
   ],
   "refresh": "30s",

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -951,6 +951,67 @@ def test_provider_dashboard_surfaces_current_health_status_panel() -> None:
     )
 
 
+def test_provider_health_panel_114_description_disallows_zero_as_healthy() -> None:
+    """Panel 114 description must keep provider enum semantics for 0 state."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-provider-health-v2.json"))
+    panel = next(
+        (item for item in get_dashboard_panels(dashboard) if item.get("id") == 114),
+        None,
+    )
+    assert panel is not None, "Panel id=114 not found"
+
+    description = str(panel.get("description", ""))
+    assert "0=UNHEALTHY" in description, (
+        "Panel id=114 must explicitly document 0 as UNHEALTHY"
+    )
+    description_upper = description.upper()
+    assert "0=HEALTHY" not in description_upper
+    assert "0=OK" not in description_upper
+
+
+def test_provider_health_status_mappings_match_description_enum() -> None:
+    """Provider status panels must keep mapping texts and enum descriptions aligned."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-provider-health-v2.json"))
+    expected_pairs = {"0": "UNHEALTHY", "1": "DEGRADED", "2": "HEALTHY"}
+    expected_null = "UNKNOWN"
+
+    for panel in get_dashboard_panels(dashboard):
+        mappings = panel.get("fieldConfig", {}).get("defaults", {}).get("mappings", [])
+        value_mapping = next(
+            (
+                mapping
+                for mapping in mappings
+                if mapping.get("type") == "value"
+                and isinstance(mapping.get("options"), dict)
+            ),
+            None,
+        )
+        if value_mapping is None:
+            continue
+
+        options = value_mapping.get("options", {})
+        if not all(key in options for key in (*expected_pairs.keys(), "null")):
+            continue
+
+        description = str(panel.get("description", ""))
+        for status_code, label in expected_pairs.items():
+            text = str(options[status_code].get("text", "")).upper()
+            assert text == label, (
+                f"Panel id={panel.get('id')} status {status_code} text must be {label}"
+            )
+            assert f"{status_code}={label}" in description, (
+                f"Panel id={panel.get('id')} description must include {status_code}={label}"
+            )
+
+        null_text = str(options["null"].get("text", "")).upper()
+        assert null_text == expected_null, (
+            f"Panel id={panel.get('id')} null mapping must be {expected_null}"
+        )
+        assert f"null={expected_null}" in description, (
+            f"Panel id={panel.get('id')} description must include null={expected_null}"
+        )
+
+
 def test_runtime_provider_alert_conditions_do_not_filter_on_missing_pipeline_labels():
     """Provider runtime alert summaries are fleet-wide and must not filter on pipeline."""
     dashboard = load_dashboard(Path("grafana/dashboards/bioetl-runtime.json"))


### PR DESCRIPTION
### Motivation
- Replace generic status wording in provider-health panels with explicit provider-specific enum semantics so operator-facing text and panel mappings are unambiguous.
- Add regression checks to prevent future regressions where `0` could be misdocumented or misinterpreted as healthy/ok and to ensure mapping consistency between `fieldConfig` mappings and panel descriptions.

### Description
- Updated `grafana/dashboards/bioetl-provider-health-v2.json` to replace the generic description `Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data.` with `Provider status enum: 0=UNHEALTHY, 1=DEGRADED, 2=HEALTHY; null=UNKNOWN.` across provider-status panels (including panel `id=114`).
- Added `test_provider_health_panel_114_description_disallows_zero_as_healthy` to `tests/integration/test_grafana_config.py` which asserts panel `id=114` documents `0=UNHEALTHY` and does not describe `0` as `HEALTHY`/`OK`.
- Added `test_provider_health_status_mappings_match_description_enum` to `tests/integration/test_grafana_config.py` which verifies `fieldConfig.defaults.mappings` for provider-status panels contain value mappings for `0/1/2/null` that match the description enum texts (`UNHEALTHY/DEGRADED/HEALTHY/UNKNOWN`).

### Testing
- Verified JSON validity with `python -m json.tool grafana/dashboards/bioetl-provider-health-v2.json`, which succeeded.
- Attempted to run the new integration tests with `pytest -q tests/integration/test_grafana_config.py -k 'provider_health_panel_114_description_disallows_zero_as_healthy or provider_health_status_mappings_match_description_enum'`, but the run failed in the current environment due to pytest addopts expecting a timeout plugin (`--timeout`) that is not available in the environment.
- Re-ran pytest with addopts cleared via `pytest -q -o addopts='' tests/integration/test_grafana_config.py -k 'provider_health_panel_114_description_disallows_zero_as_healthy or provider_health_status_mappings_match_description_enum'`, and collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).
- Note: a pre-task memory workflow command `python -m memory.tooling.workflow pre-task ...` was attempted and failed due to missing `memory` tooling in the execution environment; these environment limitations prevented full automated test execution here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9375a901083248f305cf39f9ae658)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->