### PR TITLE
Fix Workflow→Control Plane handoff scope and validate dashboard link variables

### DIFF
--- a/grafana/dashboards/bioetl-workflow-overview.json
+++ b/grafana/dashboards/bioetl-workflow-overview.json
@@ -121,8 +121,8 @@
           "targetBlank": false,
           "title": "Control Plane v1",
           "type": "link",
-          "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=$pipeline&var-run_type=$run_type&${__url_time_range}",
-          "tooltip": "Cross-scope handoff with explicit core scope: var-pipeline=$pipeline and var-run_type=$run_type. Reset scope: target dashboard opens with explicit All/default scope; source-specific filters are not transferred."
+          "url": "/d/bioetl-control-plane-v1/bioetl-control-plane-v1?var-pipeline=All&var-run_type=All&${__url_time_range}",
+          "tooltip": "Cross-scope handoff (opens with All core scope): var-pipeline=All and var-run_type=All; workflow/status do not transfer. Scope reset: target dashboard opens with explicit All/default scope; source-specific filters are not transferred."
         },
         {
           "asDropdown": false,

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -32,6 +32,7 @@ GRAFANA_DASHBOARD_PROVISIONING_PATH = Path(
 )
 GRAFANA_README_PATH = Path("grafana/README.md")
 _BIOETL_METRIC_TOKEN_RE = re.compile(r"\b(bioetl_[a-z0-9_]+)\b")
+_GRAFANA_VAR_TOKEN_RE = re.compile(r"\$(\{)?([a-zA-Z_][a-zA-Z0-9_]*)(?(1)\})")
 
 
 NAVIGATION_CONTRACT_PATH = Path(
@@ -191,6 +192,56 @@ def test_no_duplicate_variable_names(dashboard_path):
     duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
     assert not duplicates, (
         f"Dashboard {dashboard_path.name} has duplicate variables: {duplicates}"
+    )
+
+
+@pytest.mark.parametrize("dashboard_path", get_dashboard_files(), ids=lambda p: p.name)
+def test_dashboard_links_only_reference_declared_variables(dashboard_path: Path) -> None:
+    """All $var tokens in dashboard links must be present in templating.list."""
+    dashboard = load_dashboard(dashboard_path)
+    declared_variables = {
+        str(variable.get("name"))
+        for variable in dashboard.get("templating", {}).get("list", [])
+        if variable.get("name")
+    }
+
+    violations: list[str] = []
+
+    for panel in get_dashboard_panels(dashboard):
+        links = panel.get("links", [])
+        if not isinstance(links, list):
+            continue
+        for link in links:
+            if not isinstance(link, dict):
+                continue
+            url = str(link.get("url", ""))
+            for _, variable_name in _GRAFANA_VAR_TOKEN_RE.findall(url):
+                if variable_name.startswith("__"):
+                    continue
+                if variable_name not in declared_variables:
+                    violations.append(
+                        f"panel={panel.get('title', '<untitled>')} link={link.get('title', '<untitled>')} "
+                        f"uses ${variable_name} not declared in templating.list"
+                    )
+
+    dashboard_links = dashboard.get("links", [])
+    if isinstance(dashboard_links, list):
+        for link in dashboard_links:
+            if not isinstance(link, dict):
+                continue
+            url = str(link.get("url", ""))
+            for _, variable_name in _GRAFANA_VAR_TOKEN_RE.findall(url):
+                if variable_name.startswith("__"):
+                    continue
+                if variable_name not in declared_variables:
+                    violations.append(
+                        f"dashboard_link={link.get('title', '<untitled>')} "
+                        f"uses ${variable_name} not declared in templating.list"
+                    )
+
+    assert not violations, (
+        f"Dashboard {dashboard_path.name} has links with undeclared variables:\n"
+        + "\n".join(violations)
     )
 
 


### PR DESCRIPTION
### Motivation
- Prevent dashboard links from referencing variables that are not declared in the dashboard and avoid unexpected cross-scope filtering when navigating from Workflow to Control Plane. 
- Enforce a UX contract where cross-dashboard handoffs explicitly reset scope to `All` (no implicit transfer of source-specific `$pipeline/$run_type`).

### Description
- Updated `grafana/dashboards/bioetl-workflow-overview.json` (panel `id=9003` / `Control Plane v1`) to use an explicit scope reset in the URL: `?var-pipeline=All&var-run_type=All&${__url_time_range}` and aligned the link `tooltip` to document the cross-scope handoff. 
- Added a regular expression `_GRAFANA_VAR_TOKEN_RE` and new integration test `test_dashboard_links_only_reference_declared_variables` in `tests/integration/test_grafana_config.py` to assert that every `$var` used in `panel.links` and `dashboard.links` is present in `templating.list`, while ignoring Grafana internal `__*` variables. 
- Minor commit containing the two-file change and updated test assertions to enforce the navigation/templating contract.

### Testing
- Attempted `python -m memory.tooling.workflow pre-task ...` which failed due to the `memory.tooling.workflow` module not being available in this environment. 
- Ran `uv run python -m pytest -q tests/integration/test_grafana_config.py -k 'workflow_overview or links_only_reference_declared_variables'` and the targeted suite passed (`7 passed, 140 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93768293c8324bcc573b6ef6cb6c1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->