### PR TITLE
Unify DQ panel no-data semantics and blocked-share percent policy

### DIFF
--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -255,7 +255,7 @@
       },
       "targets": [
         {
-          "expr": "((sum((bioetl_dq_validation_score{pipeline=~\"$pipeline\"} * bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"})) or vector(0)) / clamp_min((sum(bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}) or vector(0)), 1))",
+          "expr": "((sum((bioetl_dq_validation_score{pipeline=~\"$pipeline\"} * bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}))) / clamp_min(sum(bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}), 1))",
           "legendFormat": "Quality",
           "refId": "A"
         }
@@ -705,7 +705,7 @@
             "mode": "thresholds"
           },
           "decimals": 2,
-          "max": 100,
+          "max": 1,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -716,15 +716,15 @@
               },
               {
                 "color": "orange",
-                "value": 1
+                "value": 0.05
               },
               {
                 "color": "red",
-                "value": 2
+                "value": 0.2
               }
             ]
           },
-          "unit": "percent",
+          "unit": "percentunit",
           "mappings": [
             {
               "type": "special",
@@ -771,8 +771,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "100 * ((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__range])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__range])) or vector(0)), 1))",
-          "legendFormat": "blocked %",
+          "expr": "((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__range])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__range])) or vector(0)), 1))",
+          "legendFormat": "blocked share",
           "range": true,
           "refId": "A"
         }
@@ -1709,7 +1709,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "((sum((bioetl_dq_validation_score{pipeline=~\"$pipeline\"} * bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"})) or vector(0)) / clamp_min((sum(bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}) or vector(0)), 1))",
+              "expr": "((sum((bioetl_dq_validation_score{pipeline=~\"$pipeline\"} * bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}))) / clamp_min(sum(bioetl_dq_validation_record_count{pipeline=~\"$pipeline\"}), 1))",
               "legendFormat": "DQ score",
               "range": true,
               "refId": "A"
@@ -1727,7 +1727,7 @@
                 "mode": "thresholds"
               },
               "decimals": 2,
-              "max": 100,
+              "max": 1,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",
@@ -1738,15 +1738,15 @@
                   },
                   {
                     "color": "orange",
-                    "value": 1
+                    "value": 0.05
                   },
                   {
                     "color": "red",
-                    "value": 2
+                    "value": 0.2
                   }
                 ]
               },
-              "unit": "percent",
+              "unit": "percentunit",
               "mappings": [
                 {
                   "type": "special",
@@ -1787,8 +1787,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "100 * ((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__interval])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__interval])) or vector(0)), 1))",
-              "legendFormat": "blocked %",
+              "expr": "((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=\"filtered_out\"}[$__interval])) or vector(0)) / clamp_min((sum(increase(bioetl_records_processed_total{pipeline=~\"$pipeline\", run_type=~\"$run_type\", stage=~\"raw|validated|enriched|filtered_out|deduplicated|final\"}[$__interval])) or vector(0)), 1))",
+              "legendFormat": "blocked share",
               "range": true,
               "refId": "A"
             }

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -486,8 +486,9 @@ def test_dq_score_uses_validation_metric(dashboard_file, panel_title):
         f"Panel '{panel_title}' in {dashboard_file} must use "
         "bioetl_dq_validation_record_count for volume-aware weighting"
     )
-    assert any("or vector(0)" in expr for expr in expressions), (
-        f"Panel '{panel_title}' in {dashboard_file} must stay zero-safe"
+    assert all("or vector(0)" not in expr for expr in expressions), (
+        f"Panel '{panel_title}' in {dashboard_file} must preserve no-data state "
+        "instead of coercing missing telemetry to zero"
     )
 
 
@@ -509,6 +510,41 @@ def test_worst_entity_dq_score_preserves_no_data_state() -> None:
     assert all("or vector(0)" not in expr for expr in expressions), (
         "Worst-Entity DQ Score must preserve no-data rather than rendering score 0"
     )
+
+
+def test_dq_blocked_share_panels_use_percentunit_domain_and_policy_thresholds() -> None:
+    """Blocked-share panels must share the same 0..1/percentunit DQ policy semantics."""
+    dashboard = load_dashboard(Path("grafana/dashboards/bioetl-dq-v2.json"))
+    expected_panels = {
+        "DQ Impact on Deliverability (Blocked Share)",
+        "DQ Impact on Deliverability Trend (Blocked Share %)",
+    }
+    expected_threshold_steps = [
+        {"color": "green", "value": None},
+        {"color": "orange", "value": 0.05},
+        {"color": "red", "value": 0.2},
+    ]
+
+    panels = {
+        panel.get("title"): panel
+        for panel in get_dashboard_panels(dashboard)
+        if panel.get("title") in expected_panels
+    }
+    assert set(panels) == expected_panels, (
+        "DQ dashboard must expose both blocked-share summary and trend panels"
+    )
+
+    for panel_title, panel in panels.items():
+        defaults = panel.get("fieldConfig", {}).get("defaults", {})
+        assert defaults.get("unit") == "percentunit", (
+            f"Panel '{panel_title}' must use percentunit for ratio semantics"
+        )
+        assert defaults.get("min") == 0, f"Panel '{panel_title}' must use min=0"
+        assert defaults.get("max") == 1, f"Panel '{panel_title}' must use max=1"
+        assert defaults.get("thresholds", {}).get("steps") == expected_threshold_steps, (
+            f"Panel '{panel_title}' must use DQ policy thresholds "
+            "(warn=0.05, crit=0.20)"
+        )
 
 
 def test_dashboards_do_not_use_prometheus_created_timestamps() -> None:


### PR DESCRIPTION
### Motivation
- Prevent missing DQ telemetry from being coerced to zero by removing the `or vector(0)` fallback so Grafana preserves `no-data/UNKNOWN` semantics for DQ score panels.
- Standardize blocked-share panels to a single ratio domain and unit so percent/ratio visualization and alert interpretation are consistent across summary and trend views.
- Align visual thresholds with the project DQ policy (warning/hard-fail) to ensure consistent operator interpretation across panels.

### Description
- Updated `grafana/dashboards/bioetl-dq-v2.json` to remove the `or vector(0)` fallback from the DQ score expressions for both the current-value gauge and the trend timeseries to preserve no-data state instead of coercing to `0`.
- Normalized blocked-share panels (`DQ Impact on Deliverability (Blocked Share)` and `DQ Impact on Deliverability Trend (Blocked Share %`) to ratio semantics by removing `* 100`, setting `unit` to `percentunit`, `min=0`, `max=1`, unifying `legendFormat` to `blocked share`, and applying policy thresholds `warn=0.05` and `crit=0.20` in the `thresholds.steps`.
- Added/updated integration checks in `tests/integration/test_grafana_config.py` to assert absence of `or vector(0)` on the volume-weighted DQ score, and to validate blocked-share panels use `percentunit`, `min=0`, `max=1`, and the DQ policy threshold steps (`0.05` / `0.20`).

### Testing
- Ran the targeted integration subset with `uv run pytest -q tests/integration/test_grafana_config.py -k 'dq_score_uses_validation_metric or worst_entity_dq_score_preserves_no_data_state or blocked_share_panels_use_percentunit_domain_and_policy_thresholds'` which passed (`3 passed, 138 deselected`).
- Attempted `python -m memory.tooling.workflow pre-task --help` and observed `ModuleNotFoundError` in the current environment (`No module named 'memory'`), noted as an environment limitation not required for this change.
- No additional CI failures observed for the touched integration checks after modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f937739f588324aed6e86b88565cf8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->