### PR TITLE
Fix provider dashboard duplicate JSON keys and enforce panel title / aggregation vocabulary

### DIFF
--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -80,11 +80,6 @@
     },
     {
       "asDropdown": false,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
       "icon": "bolt",
       "includeVars": false,
       "keepTime": true,
@@ -1420,7 +1415,7 @@
           "refId": "A"
         }
       ],
-      "title": "Circuit Breaker Trips by Provider",
+      "title": "Circuit Breaker Trips by Adapter",
       "type": "timeseries",
       "description": "Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data."
     }

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -39,6 +39,26 @@ NAVIGATION_CONTRACT_PATH = Path(
 )
 
 
+def _json_load_without_duplicate_keys(path: Path) -> dict:
+    """Load JSON and fail fast when duplicate keys are present."""
+
+    def _reject_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        payload: dict[str, object] = {}
+        seen: set[str] = set()
+        for key, value in pairs:
+            if key in seen:
+                raise AssertionError(f"Duplicate JSON key '{key}' in {path}")
+            seen.add(key)
+            payload[key] = value
+        return payload
+
+    with path.open(encoding="utf-8") as source:
+        data = json.load(source, object_pairs_hook=_reject_duplicates)
+
+    assert isinstance(data, dict), "Dashboard JSON root must be an object"
+    return data
+
+
 def _load_navigation_contract() -> dict:
     payload = yaml.safe_load(NAVIGATION_CONTRACT_PATH.read_text(encoding="utf-8"))
     assert isinstance(payload, dict), (
@@ -61,9 +81,38 @@ def _load_recording_rule_names() -> set[str]:
 @pytest.mark.parametrize("dashboard_path", get_dashboard_files(), ids=lambda p: p.name)
 def test_dashboard_is_valid_json(dashboard_path):
     """L1: Verify that the dashboard file is a valid JSON."""
-    data = load_dashboard(dashboard_path)
+    data = _json_load_without_duplicate_keys(dashboard_path)
     assert isinstance(data, dict)
     assert "title" in data
+
+
+@pytest.mark.parametrize("dashboard_path", get_dashboard_files(), ids=lambda p: p.name)
+def test_panel_title_vocabulary_matches_group_by_vocabulary(dashboard_path: Path) -> None:
+    """Panel titles should describe aggregation vocabulary in PromQL group-by labels."""
+    dashboard = load_dashboard(dashboard_path)
+    errors: list[str] = []
+
+    for panel in get_dashboard_panels(dashboard):
+        title = panel.get("title", "")
+        if not isinstance(title, str):
+            continue
+
+        expressions = get_panel_expressions(panel)
+        grouped_by_provider = any("by (provider" in expr for expr in expressions)
+        grouped_by_adapter = any("by (adapter" in expr for expr in expressions)
+
+        if grouped_by_provider and "by Provider" not in title:
+            errors.append(
+                f"{dashboard_path.name}: panel '{title}' groups by provider but title "
+                "does not contain 'by Provider'"
+            )
+        if grouped_by_adapter and "by Adapter" not in title:
+            errors.append(
+                f"{dashboard_path.name}: panel '{title}' groups by adapter but title "
+                "does not contain 'by Adapter'"
+            )
+
+    assert not errors, "Panel title vocabulary drift detected:\n" + "\n".join(errors)
 
 
 @pytest.mark.parametrize("dashboard_path", get_dashboard_files(), ids=lambda p: p.name)


### PR DESCRIPTION
### Motivation
- Ensure Grafana dashboard JSONs are canonical (no duplicate keys) and surface-level navigation/link objects do not contain repeated fields that can hide bugs or cause downstream tooling to misparse files. 
- Make panel titles accurately describe the PromQL aggregation semantics so human readers and incident playbooks are not misled by mismatched vocabulary (e.g., `provider` vs `adapter`).
- Add automated detection for duplicate JSON keys to prevent regressions from recurring in dashboard sources.

### Description
- Updated `grafana/dashboards/bioetl-provider-health-v2.json` to rename the panel with a `sum by (adapter)` query from `"Circuit Breaker Trips by Provider"` to `"Circuit Breaker Trips by Adapter"`. 
- Rewrote the provider dashboard top-level `links` entry for the `Explore Traces` item to remove duplicated JSON keys and keep a single canonical set of fields (`icon`, `includeVars`, `keepTime`, `tags`, `targetBlank`).
- Added `_json_load_without_duplicate_keys` to `tests/integration/test_grafana_config.py` which uses `json.load(..., object_pairs_hook=...)` to fail fast on duplicate keys when loading dashboard JSON files. 
- Added `test_panel_title_vocabulary_matches_group_by_vocabulary` to `tests/integration/test_grafana_config.py` which asserts panel titles contain the expected vocabulary (`"by Provider"` or `"by Adapter"`) when the panel PromQL expressions group by the corresponding label.

### Testing
- Ran a targeted pytest invocation: `python -m pytest tests/integration/test_grafana_config.py -k 'valid_json or panel_title_vocabulary'` but the environment rejected `--timeout=...` from `pytest.ini`, so an adjusted run was attempted. 
- Re-ran with no extra addopts: `python -m pytest -o addopts='' tests/integration/test_grafana_config.py -k 'valid_json or panel_title_vocabulary'` which failed during test collection due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`), preventing full execution of the integration checks in this environment. 
- The new JSON-load check will raise an `AssertionError` for duplicate keys (detectable locally by running the affected tests with `PyYAML` installed), and the new title-vocabulary test will fail if a panel groups by `provider`/`adapter` but its title does not include the corresponding `by Provider`/`by Adapter` phrase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9377625148324aa8031f3fe9f14a1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->