### PR TITLE
Replace invalid checkpoint freshness expression with placeholder panel and add guard test

### DIFF
--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -258,7 +258,6 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
       "description": "Checkpoint freshness proxy for selected pipeline. Shows hours since most recent checkpoint operation event.",
       "fieldConfig": {
         "defaults": {
@@ -323,29 +322,13 @@
       },
       "id": 892,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
+        "content": "Checkpoint age not instrumented",
+        "mode": "markdown"
       },
       "pluginVersion": "9.5.0",
-      "targets": [
-        {
-          "expr": "clamp_min((time() - max(max_over_time(bioetl_checkpoint_operator_duration_seconds_count[$__range]))) / 3600, 0)",
-          "instant": true,
-          "refId": "A"
-        }
-      ],
       "title": "Checkpoint Freshness (hours since last op)",
-      "type": "stat"
+      "type": "text",
+      "transparent": false
     },
     {
       "datasource": "Prometheus",

--- a/tests/integration/test_grafana_config.py
+++ b/tests/integration/test_grafana_config.py
@@ -617,6 +617,29 @@ def test_dq_freshness_panel_uses_age_from_timestamp_metric() -> None:
     ), "Freshness lag must not collapse scope to the freshest entity"
 
 
+def test_freshness_panels_do_not_compute_age_from_counter_suffix_metrics() -> None:
+    """Freshness panels must never derive age from *_count metrics."""
+    dashboard_dir = Path("grafana/dashboards")
+    disallowed_pattern = re.compile(r"time\(\)\s*-\s*.*_count")
+
+    violations: list[str] = []
+    for dashboard_path in dashboard_dir.glob("*.json"):
+        dashboard = load_dashboard(dashboard_path)
+        for panel in get_dashboard_panels(dashboard):
+            panel_title = str(panel.get("title", ""))
+            if "freshness" not in panel_title.lower():
+                continue
+
+            for target in panel.get("targets", []):
+                expr = target.get("expr", "")
+                if isinstance(expr, str) and disallowed_pattern.search(expr):
+                    violations.append(
+                        f"{dashboard_path.name}::{panel_title} uses forbidden expr: {expr}"
+                    )
+
+    assert not violations, "\n".join(violations)
+
+
 @pytest.mark.parametrize(
     ("dashboard_file", "panel_title"),
     [


### PR DESCRIPTION
### Motivation
- The control-plane dashboard used a PromQL expression that computed age from a counter metric (`..._count`), which is incorrect for freshness; this removes the unsafe expression to prevent misleading visuals.
- Add an automated guard to prevent regressions where freshness panels derive age from counter-suffixed metrics.

### Description
- Replaced panel `id=892` in `grafana/dashboards/bioetl-control-plane-v1.json` with a text/stat placeholder by removing the `targets`/expr and switching the panel to a `text` panel with content `Checkpoint age not instrumented`.
- Added `test_freshness_panels_do_not_compute_age_from_counter_suffix_metrics` in `tests/integration/test_grafana_config.py` which scans all dashboard JSONs and fails if any freshness panel contains a `time() - .*_count` pattern.
- Changes touch `grafana/dashboards/bioetl-control-plane-v1.json` and `tests/integration/test_grafana_config.py` only, leaving room for a follow-up PR to add a proper bounded metric (`bioetl_checkpoint_age_seconds`) and reintroduce a numeric freshness panel.

### Testing
- Ran `uv run python -m pytest -q tests/integration/test_grafana_config.py -k 'test_freshness_panels_do_not_compute_age_from_counter_suffix_metrics or test_dq_freshness_panel_uses_age_from_timestamp_metric'` and both tests passed.
- A broader run `uv run python -m pytest -q tests/integration/test_grafana_config.py -k 'freshness or control_plane_l1_triage_row_has_3_to_5_kpis_and_one_next_step'` surfaced an existing unrelated failure in `test_control_plane_l1_triage_row_has_3_to_5_kpis_and_one_next_step` but the newly added guard test passed in targeted runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93760504c8324831a502fe509115e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->