### PR TITLE
Add explicit empty-state and backend-error copy to Silver Reject Explorer table

### DIFF
--- a/grafana/dashboards/bioetl-silver-reject-explorer.json
+++ b/grafana/dashboards/bioetl-silver-reject-explorer.json
@@ -410,7 +410,8 @@
               "title": "Open Logs",
               "url": "/a/grafana-lokiexplore-app/explore?from=${__from}&to=${__to}&query=%7Bjob%3D%22bioetl%22%7D"
             }
-          ]
+          ],
+          "noValue": "No rejected records for current filters."
         },
         "overrides": []
       },
@@ -446,7 +447,7 @@
           "expr": ""
         }
       ],
-      "description": "Shows latest 100 records for selected scope, sorted by ingestion_ts descending. Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data.",
+      "description": "Shows latest 100 records for selected scope, sorted by ingestion_ts descending. Empty-state copy: No rejected records for current filters. Backend/query failure copy: If data source query fails, treat this as an error state and inspect Grafana query error details. Status mapping: 0 = healthy/ok, 1 = warning/degraded, >=2 = critical/failing, null = no data.",
       "title": "Filtered Records Table",
       "type": "table"
     },
@@ -643,7 +644,7 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false,
-        "description": "Forensic-only: exact run identifier for reject explorer; fallback: no run_id filter (all runs in current scope)."
+        "description": "Forensic-only: exact run identifier for reject explorer; explore filter only (not a Prometheus label); fallback: no run_id filter (all runs in current scope)."
       },
       {
         "current": {
@@ -658,7 +659,7 @@
         "query": "",
         "skipUrlSync": false,
         "type": "textbox",
-        "description": "Forensic-only: exact payload hash textbox for reject explorer; fallback: empty value disables record details filter."
+        "description": "Forensic-only: exact payload hash textbox for reject explorer; explore filter only (not a Prometheus label); fallback: empty value disables record details filter."
       }
     ]
   },

--- a/tests/unit/grafana/test_silver_reject_explorer_copy.py
+++ b/tests/unit/grafana/test_silver_reject_explorer_copy.py
@@ -1,0 +1,24 @@
+"""Copy/assert checks for Silver Reject Explorer dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_filtered_records_table_has_explicit_empty_and_failure_copy() -> None:
+    dashboard = json.loads(
+        Path("grafana/dashboards/bioetl-silver-reject-explorer.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    panel = next(
+        p for p in dashboard["panels"] if p.get("title") == "Filtered Records Table"
+    )
+
+    assert (
+        panel["fieldConfig"]["defaults"]["noValue"]
+        == "No rejected records for current filters."
+    )
+    assert "Backend/query failure copy:" in panel["description"]


### PR DESCRIPTION
### Motivation
- Make the Silver Reject Explorer table show an explicit empty-state message and a separate backend/query-failure guidance so operators can distinguish "no results" vs data-source errors. 
- Keep the explorer fail-closed forensic scope semantics clear and avoid accidental promotion of forensic filters to Prometheus labels. 
- Codify in-dashboard copy that `run_id` and `payload_hash` are explore-only filters to prevent misuse in Prometheus-based summary dashboards.

### Description
- Updated `grafana/dashboards/bioetl-silver-reject-explorer.json` to add `fieldConfig.defaults.noValue` with the text `No rejected records for current filters.` for the `Filtered Records Table` panel and extended that panel `description` with a dedicated backend/query-failure message. 
- Updated template variable descriptions for `run_id` and `payload_hash` to explicitly state they are forensic/explore-only filters (not Prometheus labels). 
- Added a lightweight unit test `tests/unit/grafana/test_silver_reject_explorer_copy.py` that asserts the table has explicit `noValue` copy and that the description contains the backend/query-failure copy.

### Testing
- Ran the dashboard unit checks with `python -m pytest -o addopts='' tests/unit/grafana/test_silver_reject_explorer_copy.py tests/unit/grafana/test_workflow_dashboard_json_valid.py -q`, and both tests passed (`2 passed`).
- A plain `pytest` run failed initially due to repository `pytest.ini` addopts referencing a timeout plugin in this environment, so the `-o addopts=''` override was used to validate the changes.
- Pre/post memory workflow hooks from the repo guidance (`memory.tooling.workflow pre-task` / `post-task`) were attempted but skipped because `memory.tooling.workflow` is unavailable in the current environment (`ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93bc22eb88324b5865a5a19856a1e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->