### PR TITLE
Gate Sonar baseline steps on SONAR_TOKEN availability

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -61,16 +61,24 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build Sonar baseline report
+        if: steps.sonar-token.outputs.available == 'true'
         env:
           SONARQUBE_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           python3 scripts/ai/sonar_issue_processor.py --write
 
       - name: Upload Sonar baseline artifact
+        if: steps.sonar-token.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: sonar-baseline-report
           path: reports/quality/sonar_baseline_report.json
+
+
+      - name: Note Sonar baseline intentionally skipped
+        if: steps.sonar-token.outputs.available == 'false'
+        run: |
+          echo "Sonar baseline report was intentionally skipped because SONAR_TOKEN is unavailable." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Enforce Sonar baseline ratchet
         if: steps.sonar-token.outputs.available == 'true'


### PR DESCRIPTION
### Motivation
- Prevent the workflow from failing or waiting for artifacts when `SONAR_TOKEN` is not configured by gating baseline-related steps on token availability.
- Avoid attempting to upload a non-existent baseline artifact when the baseline build is skipped.
- Provide a clear, non-blocking summary note when the Sonar baseline is intentionally skipped so CI output is informative.

### Description
- Added `if: steps.sonar-token.outputs.available == 'true'` to the `Build Sonar baseline report` step in `.github/workflows/sonarcloud.yml` so the baseline is only generated when the token is present.
- Added the same `if: steps.sonar-token.outputs.available == 'true'` guard to the `Upload Sonar baseline artifact` step to avoid uploading a missing file.
- Added a non-blocking fallback step `Note Sonar baseline intentionally skipped` that runs when `steps.sonar-token.outputs.available == 'false'` and appends an explanatory message to `$GITHUB_STEP_SUMMARY`.
- Ensured all Sonar execution/enforcement steps are consistently gated on the same `steps.sonar-token.outputs.available == 'true'` condition.

### Testing
- Inspected the edited file with `sed -n '1,260p' .github/workflows/sonarcloud.yml` to verify the conditional guards were placed as intended and that the fallback step exists, and this inspection succeeded.
- Verified the exact diff with `git diff -- .github/workflows/sonarcloud.yml` to confirm only the intended workflow changes were introduced, and the diff output matched expectations.
- Reviewed the file with `nl -ba .github/workflows/sonarcloud.yml | sed -n '35,130p'` and committed the change with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f93de74d248324bba84c959d47a7bd)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->