### PR TITLE
ci(governance): enforce pinned SHA for GitHub Actions policy and preflight gate

### DIFF
--- a/.github/actions/setup-mermaid/action.yml
+++ b/.github/actions/setup-mermaid/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: "20"
 

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -33,15 +33,15 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
     - name: Cache uv and virtualenv
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ~/.cache/uv
@@ -78,7 +78,7 @@ runs:
 
     - name: Cache pytest and hypothesis
       if: inputs.enable-pytest-cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           .pytest_cache

--- a/.github/workflows/architecture-docs-nightly.yml
+++ b/.github/workflows/architecture-docs-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -38,7 +38,7 @@ jobs:
           cat /tmp/architecture-docs-summary.txt >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload architecture docs artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: architecture-dependency-map-nightly
           path: |

--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            -   uses: actions/checkout@v6
+            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -54,7 +54,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
-            -   uses: actions/checkout@v6
+            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -83,7 +83,7 @@ jobs:
         runs-on: windows-latest
         timeout-minutes: 15
         steps:
-            -   uses: actions/checkout@v6
+            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/compiled-artifacts-block.yml
+++ b/.github/workflows/compiled-artifacts-block.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/contract-governance-fast-check.yml
+++ b/.github/workflows/contract-governance-fast-check.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: contract-governance-diagnostics
           path: |

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -76,7 +76,7 @@ jobs:
           uv run pytest $PYTEST_ARGS --junit-xml=reports/junit/contract-results.xml || echo "TESTS_FAILED=true" >> $GITHUB_OUTPUT
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: contract-test-results
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: steps.contract_tests.outputs.TESTS_FAILED == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];

--- a/.github/workflows/diagram-nightly.yml
+++ b/.github/workflows/diagram-nightly.yml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -86,7 +86,7 @@ jobs:
             --markdown-out reports/diagrams/diagram-quality-budget-nightly.md
 
       - name: Upload nightly reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagrams-nightly-reports
           path: |
@@ -129,10 +129,10 @@ jobs:
     continue-on-error: ${{ matrix.allow_failure }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload canary report artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagrams-canary-${{ matrix.label }}
           path: |

--- a/.github/workflows/docs-kpi-weekly.yml
+++ b/.github/workflows/docs-kpi-weekly.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -34,7 +34,7 @@ jobs:
             --fail-on-breach
 
       - name: Upload docs KPI artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-kpi-weekly
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -106,7 +106,7 @@ jobs:
         run: uv run python -m scripts.docs check-links --links --specs --configs --report-json docs/reports/docs-link-check-report.json
 
       - name: Upload docs link-check report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-link-check-report
           path: docs/reports/docs-link-check-report.json
@@ -141,7 +141,7 @@ jobs:
       diagrams_changed: ${{ steps.filter.outputs.diagrams_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Mermaid CLI
         uses: ./.github/actions/setup-mermaid
@@ -192,7 +192,7 @@ jobs:
           python3 scripts/diagrams/summarize_diagram_lint.py /tmp/diagram-lint.json
 
       - name: Upload diagram lint report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagram-lint-report
           path: /tmp/diagram-lint.json
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Mermaid CLI
         uses: ./.github/actions/setup-mermaid
@@ -246,21 +246,21 @@ jobs:
             --markdown-out reports/diagrams/diagram-quality-report.md
 
       - name: Upload SVG artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagrams-svg
           path: |
             docs/**/svg/*.svg
 
       - name: Upload PNG artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagrams-png
           path: |
             docs/**/png/*.png
 
       - name: Upload diagram quality report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: diagrams-quality-report
           path: |
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check for source-vs-rendered drift
         run: |

--- a/.github/workflows/duplication-complexity.yml
+++ b/.github/workflows/duplication-complexity.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -178,7 +178,7 @@ jobs:
           PY
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: duplication-complexity-reports
           path: reports
@@ -202,10 +202,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -221,10 +221,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/e2e-matrix-health.yml
+++ b/.github/workflows/e2e-matrix-health.yml
@@ -41,7 +41,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
                 with:
                     lfs: true
 
@@ -83,7 +83,7 @@ jobs:
                       --markdown-out reports/e2e/matrix-rerun-stability.md
 
             -   name: Upload E2E matrix health artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: always()
                 with:
                     name: e2e-matrix-health-blocking
@@ -109,7 +109,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -154,7 +154,7 @@ jobs:
                     exit 0
 
             -   name: Upload E2E nightly artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: always()
                 with:
                     name: e2e-matrix-health-nightly-live

--- a/.github/workflows/import-linter.yml
+++ b/.github/workflows/import-linter.yml
@@ -30,7 +30,7 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
                 with:
                     fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -147,7 +147,7 @@ jobs:
 
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v5
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -45,7 +45,7 @@ jobs:
           uv-extras: "dev"
 
       - name: Cache mutmut
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .mutmut-cache
           key: ${{ runner.os }}-mutmut-${{ hashFiles('src/bioetl/domain/**', 'src/bioetl/application/**') }}
@@ -113,7 +113,7 @@ jobs:
           PY
 
       - name: Upload mutation reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: mutation-reports

--- a/.github/workflows/performance-nightly.yml
+++ b/.github/workflows/performance-nightly.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Upload performance artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: performance-nightly-${{ github.run_number }}

--- a/.github/workflows/port-contracts.yml
+++ b/.github/workflows/port-contracts.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -70,7 +70,7 @@ jobs:
             --junit-xml=reports/junit/port-contracts-results.xml
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: port-contracts-results
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -110,7 +110,7 @@ jobs:
           HYPOTHESIS_PROFILE: ci
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: hypothesis-contracts-results

--- a/.github/workflows/provider-contract-drift.yml
+++ b/.github/workflows/provider-contract-drift.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload provider drift artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: provider-contract-drift-report
           path: reports/quality/provider-contract-drift-report.json

--- a/.github/workflows/quality-debt-weekly.yml
+++ b/.github/workflows/quality-debt-weekly.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -39,7 +39,7 @@ jobs:
           uv run python -m scripts.schema analyze-gaps
 
       - name: Upload weekly debt artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-debt-weekly
           path: |

--- a/.github/workflows/reusable-mermaid-setup.yml
+++ b/.github/workflows/reusable-mermaid-setup.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 

--- a/.github/workflows/root-hygiene.yml
+++ b/.github/workflows/root-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -43,7 +43,7 @@ jobs:
           --report-json reports/quality/root-hygiene-cleanup-classification.json
 
       - name: Upload cleanup classification evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: root-hygiene-cleanup-classification
           path: reports/quality/root-hygiene-cleanup-classification.json

--- a/.github/workflows/schema-governance.yml
+++ b/.github/workflows/schema-governance.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload Silver schema drift telemetry
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: silver-schema-drift-results
           path: reports/schema-governance/silver-schema-drift.xml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,9 +27,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install detect-secrets
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/skills-consistency.yml
+++ b/.github/workflows/skills-consistency.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify docs/00-project/ai/skills/local mirror
         run: bash scripts/ai/codex/check_skills_mirror.sh --check

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run SonarCloud scan
         if: steps.sonar-token.outputs.available == 'true'
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # pinned
         with:
           args: >
             -Dsonar.sources=src/bioetl
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload Sonar baseline artifact
         if: steps.sonar-token.outputs.available == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sonar-baseline-report
           path: reports/quality/sonar_baseline_report.json

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/stale@v9
+      uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           stale-pr-message: >
             This PR has been inactive for 14 days and is now marked as stale.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Install uv + cache + dependencies
                 uses: ./.github/actions/setup-python-uv
@@ -88,7 +88,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -105,7 +105,7 @@ jobs:
                       --junitxml=reports/e2e/control-plane-completeness.xml
 
             -   name: Upload control-plane completeness artifacts
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: always()
                 with:
                     name: control-plane-completeness
@@ -125,7 +125,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -146,7 +146,7 @@ jobs:
 
             -   name: Upload contract confidence telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-telemetry-contract-confidence
                     path: reports/test-telemetry/junit-contract-confidence.xml
@@ -161,7 +161,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -190,6 +190,9 @@ jobs:
 
             -   name: Validate scripts catalog governance policy
                 run: uv run python -m scripts.engineering.repo check-catalog --catalog scripts/engineering/repo/catalog.yaml
+
+            -   name: Validate GitHub Actions pinning policy
+                run: uv run python -m scripts.engineering.repo check-gh-actions-pins
 
             -   name: Validate deterministic Neo4j memory ontology invariants
                 run: uv run python -m scripts.engineering.ci neo4j-memory
@@ -254,7 +257,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -290,7 +293,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -349,7 +352,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -366,7 +369,7 @@ jobs:
 
             -   name: Upload Track D telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-telemetry-track-d
                     path: reports/test-telemetry/junit-track-d.xml
@@ -382,7 +385,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -401,7 +404,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -416,7 +419,7 @@ jobs:
 
             -   name: Upload quality metrics artifact
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: ci-quality-metrics
                     path: reports/quality/ci-quality-metrics.json
@@ -431,7 +434,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -454,7 +457,7 @@ jobs:
 
             -   name: Upload fast test telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-telemetry-fast
                     path: reports/test-telemetry/junit-fast.xml
@@ -494,7 +497,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -525,7 +528,7 @@ jobs:
 
             -   name: Upload coverage shard (${{ matrix.test-group.name }} on Python 3.12)
                 if: always() && matrix.python-version == '3.12'
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: coverage-data-${{ matrix.test-group.name }}
                     path: reports/coverage/.coverage.${{ matrix.test-group.name }}
@@ -534,7 +537,7 @@ jobs:
 
             -   name: Upload test telemetry (${{ matrix.test-group.name }} on Python 3.12)
                 if: always() && matrix.python-version == '3.12'
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-telemetry-${{ matrix.test-group.name }}
                     path: reports/test-telemetry/junit.${{ matrix.test-group.name }}.xml
@@ -550,7 +553,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -569,7 +572,7 @@ jobs:
 
             -   name: Upload memory test telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-telemetry-memory
                     path: reports/test-telemetry/junit-memory.xml
@@ -585,7 +588,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -640,7 +643,7 @@ jobs:
                     fi
 
             -   name: Upload performance budget report
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: always()
                 with:
                     name: performance-hotspot-budgets
@@ -666,7 +669,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -676,7 +679,7 @@ jobs:
                     pytest-cache-fingerprint: ${{ hashFiles('tests/**/*.py', 'tests/conftest.py', 'pyproject.toml') }}
 
             -   name: Download coverage shards
-                uses: actions/download-artifact@v4
+                uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
                 with:
                     pattern: coverage-data-*
                     path: reports/coverage
@@ -701,7 +704,7 @@ jobs:
                     uv run python -m coverage xml -o reports/coverage/coverage.xml
 
             -   name: Upload Coverage Report
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: always()
                 with:
                     name: coverage-report
@@ -721,7 +724,7 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Setup Python + uv
                 uses: ./.github/actions/setup-python-uv
@@ -729,7 +732,7 @@ jobs:
                     python-version: "3.12"
 
             -   name: Download JUnit telemetry shards
-                uses: actions/download-artifact@v4
+                uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
                 continue-on-error: true
                 with:
                     pattern: test-telemetry-*
@@ -892,7 +895,7 @@ jobs:
 
             -   name: Upload slow-test telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-duration-telemetry
                     path: |
@@ -903,7 +906,7 @@ jobs:
 
             -   name: Upload test-health telemetry
                 if: always()
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 with:
                     name: test-health-telemetry
                     path: reports/quality/test-runs/

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv
@@ -165,7 +165,7 @@ jobs:
           PY
 
       - name: Upload type checking reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: type-checking-reports

--- a/.github/workflows/vacuum.yml
+++ b/.github/workflows/vacuum.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python + uv
         uses: ./.github/actions/setup-python-uv

--- a/.github/workflows/validate-mermaid.yml
+++ b/.github/workflows/validate-mermaid.yml
@@ -22,7 +22,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v6
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
             -   name: Run mermaid check (warn, don't fail)
                 run: |

--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,18 +1,19 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-05-04T15:19:19.690001+00:00",
+  "generated_at": "2026-05-05T01:28:53.052000+00:00",
   "summary": {
-    "total_scripts": 360,
+    "total_scripts": 355,
     "status_counts": {
-      "active": 333,
-      "supporting": 27
+      "active": 330,
+      "orphan": 2,
+      "supporting": 23
     },
     "reference_group_coverage": {
       "agents": 4,
       "build": 2,
       "ci": 50,
-      "docs": 121,
-      "scripts": 304,
+      "docs": 120,
+      "scripts": 301,
       "skills": 8,
       "tests": 143
     }
@@ -84,7 +85,7 @@
       "references": [
         {
           "path": ".github/workflows/sonarcloud.yml",
-          "line": 80,
+          "line": 88,
           "source_group": "ci",
           "text": "python3 scripts/ai/check_sonar_issues.py \\"
         },
@@ -1509,7 +1510,7 @@
       "references": [
         {
           "path": "tests/architecture/test_dev_setup_copilot_codex_mcp_consolidation.py",
-          "line": 157,
+          "line": 139,
           "source_group": "tests",
           "text": "ps_content = (root / \"scripts/ai/mcp/github-mcp-wrapper.ps1\").read_text("
         }
@@ -1520,16 +1521,10 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 4,
+      "reference_count": 3,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
-          "line": 61,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/github-mcp-wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
           "line": 61,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/github-mcp-wrapper.sh\""
@@ -1542,9 +1537,32 @@
         },
         {
           "path": "tests/architecture/test_dev_setup_copilot_codex_mcp_consolidation.py",
-          "line": 154,
+          "line": 136,
           "source_group": "tests",
           "text": "sh_content = (root / \"scripts/ai/mcp/github-mcp-wrapper.sh\").read_text("
+        }
+      ]
+    },
+    {
+      "path": "scripts/ai/mcp/mcp_ast_grep_wrapper.ps1",
+      "type": "ps1",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
+    },
+    {
+      "path": "scripts/ai/mcp/mcp_ast_grep_wrapper.sh",
+      "type": "sh",
+      "status": "active",
+      "agent_usage": [],
+      "reference_count": 1,
+      "references": [
+        {
+          "path": "scripts/ai/mcp/check.sh",
+          "line": 11,
+          "source_group": "scripts",
+          "text": "EXPECTED_AST_GREP_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_ast_grep_wrapper.sh\""
         }
       ]
     },
@@ -1561,7 +1579,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
@@ -1570,14 +1588,8 @@
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_brave_search_wrapper.sh\""
         },
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 112,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_brave_search_wrapper.sh\""
-        },
-        {
           "path": "scripts/ai/mcp/check.sh",
-          "line": 16,
+          "line": 15,
           "source_group": "scripts",
           "text": "EXPECTED_BRAVE_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_brave_search_wrapper.sh\""
         }
@@ -1596,19 +1608,36 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 2,
+      "reference_count": 1,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
           "line": 142,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_chembl_wrapper.sh\""
-        },
+        }
+      ]
+    },
+    {
+      "path": "scripts/ai/mcp/mcp_code_interpreter_wrapper.ps1",
+      "type": "ps1",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
+    },
+    {
+      "path": "scripts/ai/mcp/mcp_code_interpreter_wrapper.sh",
+      "type": "sh",
+      "status": "active",
+      "agent_usage": [],
+      "reference_count": 1,
+      "references": [
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 142,
+          "path": "scripts/ai/mcp/check.sh",
+          "line": 12,
           "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_chembl_wrapper.sh\""
+          "text": "EXPECTED_CODE_INTERPRETER_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_code_interpreter_wrapper.sh\""
         }
       ]
     },
@@ -1625,60 +1654,19 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
           "line": 82,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_context7_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 82,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_context7_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/mcp/check.sh",
-          "line": 11,
-          "source_group": "scripts",
-          "text": "EXPECTED_CONTEXT7_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_context7_wrapper.sh\""
-        }
-      ]
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_docker_docs_wrapper.ps1",
-      "type": "ps1",
-      "status": "supporting",
-      "agent_usage": [],
-      "reference_count": 0,
-      "references": []
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_docker_docs_wrapper.sh",
-      "type": "sh",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 3,
-      "references": [
-        {
-          "path": "scripts/ai/.mcp.json",
-          "line": 76,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_docker_docs_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 76,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_docker_docs_wrapper.sh\""
         },
         {
           "path": "scripts/ai/mcp/check.sh",
           "line": 10,
           "source_group": "scripts",
-          "text": "EXPECTED_DOCKER_DOCS_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_docker_docs_wrapper.sh\""
+          "text": "EXPECTED_CONTEXT7_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_context7_wrapper.sh\""
         }
       ]
     },
@@ -1695,16 +1683,10 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
-          "line": 70,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_docker_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
           "line": 70,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_docker_wrapper.sh\""
@@ -1714,41 +1696,6 @@
           "line": 9,
           "source_group": "scripts",
           "text": "EXPECTED_DOCKER_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_docker_wrapper.sh\""
-        }
-      ]
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_dockerhub_wrapper.ps1",
-      "type": "ps1",
-      "status": "supporting",
-      "agent_usage": [],
-      "reference_count": 0,
-      "references": []
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_dockerhub_wrapper.sh",
-      "type": "sh",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 3,
-      "references": [
-        {
-          "path": "scripts/ai/.mcp.json",
-          "line": 94,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_dockerhub_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 94,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_dockerhub_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/mcp/check.sh",
-          "line": 13,
-          "source_group": "scripts",
-          "text": "EXPECTED_DOCKERHUB_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_dockerhub_wrapper.sh\""
         }
       ]
     },
@@ -1765,7 +1712,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
@@ -1774,14 +1721,8 @@
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_grafana_wrapper.sh\""
         },
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 106,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_grafana_wrapper.sh\""
-        },
-        {
           "path": "scripts/ai/mcp/check.sh",
-          "line": 15,
+          "line": 14,
           "source_group": "scripts",
           "text": "EXPECTED_GRAFANA_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_grafana_wrapper.sh\""
         }
@@ -1800,54 +1741,13 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 2,
+      "reference_count": 1,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
           "line": 160,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_mermaid_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 160,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_mermaid_wrapper.sh\""
-        }
-      ]
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_needle_wrapper.ps1",
-      "type": "ps1",
-      "status": "supporting",
-      "agent_usage": [],
-      "reference_count": 0,
-      "references": []
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_needle_wrapper.sh",
-      "type": "sh",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 3,
-      "references": [
-        {
-          "path": "scripts/ai/.mcp.json",
-          "line": 136,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_needle_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 136,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_needle_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/mcp/check.sh",
-          "line": 20,
-          "source_group": "scripts",
-          "text": "EXPECTED_NEEDLE_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_needle_wrapper.sh\""
         }
       ]
     },
@@ -1864,7 +1764,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
@@ -1873,14 +1773,8 @@
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_neo4j_cypher_wrapper.sh\""
         },
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 124,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_neo4j_cypher_wrapper.sh\""
-        },
-        {
           "path": "scripts/ai/mcp/check.sh",
-          "line": 18,
+          "line": 17,
           "source_group": "scripts",
           "text": "EXPECTED_NEO4J_CYPHER_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_neo4j_cypher_wrapper.sh\""
         }
@@ -1899,7 +1793,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 23,
+      "reference_count": 22,
       "references": [
         {
           "path": "docs/00-project/ai/memory/neo4j-project-memory-seed.json",
@@ -1952,41 +1846,6 @@
       ]
     },
     {
-      "path": "scripts/ai/mcp/mcp_paper_search_wrapper.ps1",
-      "type": "ps1",
-      "status": "supporting",
-      "agent_usage": [],
-      "reference_count": 0,
-      "references": []
-    },
-    {
-      "path": "scripts/ai/mcp/mcp_paper_search_wrapper.sh",
-      "type": "sh",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 3,
-      "references": [
-        {
-          "path": "scripts/ai/.mcp.json",
-          "line": 88,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_paper_search_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 88,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_paper_search_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/mcp/check.sh",
-          "line": 12,
-          "source_group": "scripts",
-          "text": "EXPECTED_PAPER_SEARCH_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_paper_search_wrapper.sh\""
-        }
-      ]
-    },
-    {
       "path": "scripts/ai/mcp/mcp_prometheus_wrapper.ps1",
       "type": "ps1",
       "status": "supporting",
@@ -1999,7 +1858,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 3,
+      "reference_count": 2,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
@@ -2008,14 +1867,8 @@
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_prometheus_wrapper.sh\""
         },
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 100,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_prometheus_wrapper.sh\""
-        },
-        {
           "path": "scripts/ai/mcp/check.sh",
-          "line": 14,
+          "line": 13,
           "source_group": "scripts",
           "text": "EXPECTED_PROMETHEUS_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_prometheus_wrapper.sh\""
         }
@@ -2034,16 +1887,10 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 2,
+      "reference_count": 1,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
-          "line": 148,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_pubchem_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
           "line": 148,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_pubchem_wrapper.sh\""
@@ -2063,16 +1910,10 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 2,
+      "reference_count": 1,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
-          "line": 154,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_pubmed_wrapper.sh\""
-        },
-        {
-          "path": "scripts/ai/.vscode/mcp.json",
           "line": 154,
           "source_group": "scripts",
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_pubmed_wrapper.sh\""
@@ -2092,7 +1933,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 4,
+      "reference_count": 3,
       "references": [
         {
           "path": "scripts/ai/.mcp.json",
@@ -2101,14 +1942,8 @@
           "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_sonarqube_wrapper.sh\""
         },
         {
-          "path": "scripts/ai/.vscode/mcp.json",
-          "line": 118,
-          "source_group": "scripts",
-          "text": "\"/mnt/wsl/docker-desktop-bind-mounts/Ubuntu/ccd98afae0adb4ee090bbfed89f354b31936eafe0874d43825bf3cb903f3bd1d/scripts/ai/mcp/mcp_sonarqube_wrapper.sh\""
-        },
-        {
           "path": "scripts/ai/mcp/check.sh",
-          "line": 17,
+          "line": 16,
           "source_group": "scripts",
           "text": "EXPECTED_SONARQUBE_WRAPPER_PATH=\"${REPO_ROOT}/scripts/ai/mcp/mcp_sonarqube_wrapper.sh\""
         },
@@ -2227,7 +2062,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 26,
+      "reference_count": 20,
       "references": [
         {
           "path": "scripts/ai/mcp/mcp_brave_search_wrapper.sh",
@@ -2266,13 +2101,13 @@
           "text": "source \"${script_dir}/support/docker_cli_resolver.sh\""
         },
         {
-          "path": "scripts/ai/mcp/mcp_docker_docs_wrapper.sh",
+          "path": "scripts/ai/mcp/mcp_docker_wrapper.sh",
           "line": 5,
           "source_group": "scripts",
           "text": "# shellcheck source=./support/docker_cli_resolver.sh"
         },
         {
-          "path": "scripts/ai/mcp/mcp_docker_docs_wrapper.sh",
+          "path": "scripts/ai/mcp/mcp_docker_wrapper.sh",
           "line": 6,
           "source_group": "scripts",
           "text": "source \"${script_dir}/support/docker_cli_resolver.sh\""
@@ -2284,7 +2119,7 @@
       "type": "ps1",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 11,
+      "reference_count": 9,
       "references": [
         {
           "path": "docs/05-operations/tooling/scripts-ops/WSL_SETUP_SUMMARY.md",
@@ -2305,19 +2140,7 @@
           "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
         },
         {
-          "path": "scripts/ai/mcp/mcp_dockerhub_wrapper.ps1",
-          "line": 6,
-          "source_group": "scripts",
-          "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
-        },
-        {
           "path": "scripts/ai/mcp/mcp_grafana_wrapper.ps1",
-          "line": 6,
-          "source_group": "scripts",
-          "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
-        },
-        {
-          "path": "scripts/ai/mcp/mcp_needle_wrapper.ps1",
           "line": 6,
           "source_group": "scripts",
           "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
@@ -2330,6 +2153,18 @@
         },
         {
           "path": "scripts/ai/mcp/mcp_neo4j_memory_wrapper.ps1",
+          "line": 6,
+          "source_group": "scripts",
+          "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
+        },
+        {
+          "path": "scripts/ai/mcp/mcp_prometheus_wrapper.ps1",
+          "line": 6,
+          "source_group": "scripts",
+          "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
+        },
+        {
+          "path": "scripts/ai/mcp/mcp_sonarqube_wrapper.ps1",
           "line": 6,
           "source_group": "scripts",
           "text": ". (Join-Path $PSScriptRoot \"support/load_repo_env.ps1\")"
@@ -2801,7 +2636,7 @@
       "references": [
         {
           "path": ".github/workflows/sonarcloud.yml",
-          "line": 67,
+          "line": 68,
           "source_group": "ci",
           "text": "python3 scripts/ai/sonar_issue_processor.py --write"
         },
@@ -4492,13 +4327,13 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 313,
+          "line": 316,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.docs export-matrix-structural-contract --check"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 322,
+          "line": 325,
           "source_group": "ci",
           "text": "uv run python -m scripts.docs sync-matrix-structural-policy --check --input \"$workbook\" --output \"$workbook\""
         },
@@ -4523,21 +4358,6 @@
       "agent_usage": [],
       "reference_count": 0,
       "references": []
-    },
-    {
-      "path": "scripts/docs/build/mkdocs_build.py",
-      "type": "py",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 1,
-      "references": [
-        {
-          "path": "scripts/docs/README.md",
-          "line": 42,
-          "source_group": "scripts",
-          "text": "| `build-site`                             | `scripts/docs/build/mkdocs_build.py`                            | Build the MkDocs site through the packaged Python entrypoint                             "
-        }
-      ]
     },
     {
       "path": "scripts/docs/build_docs_site.sh",
@@ -5410,7 +5230,7 @@
       "references": [
         {
           "path": "scripts/ops/neo4j_memory_sync.py",
-          "line": 475,
+          "line": 527,
           "source_group": "scripts",
           "text": "\"script_path\": \"scripts/docs/verify_docs.py\","
         },
@@ -5569,13 +5389,13 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 195,
+          "line": 198,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.engineering.ci neo4j-memory"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 279,
+          "line": 282,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.engineering.ci neo4j-memory-live"
         },
@@ -5911,7 +5731,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 690,
+          "line": 693,
           "source_group": "ci",
           "text": "scripts/engineering/ci/run_pytest_resilient.py \\"
         },
@@ -6112,63 +5932,6 @@
       "agent_usage": [],
       "reference_count": 0,
       "references": []
-    },
-    {
-      "path": "scripts/engineering/dev/.setup_wsl_codex.sh",
-      "type": "sh",
-      "status": "active",
-      "agent_usage": [],
-      "reference_count": 12,
-      "references": [
-        {
-          "path": "docs/03-guides/development/codex-wsl2-setup.md",
-          "line": 68,
-          "source_group": "docs",
-          "text": "| `.setup_wsl_codex.sh`  | `scripts/engineering/dev/` | DNS resolver (dig + PowerShell fallback) |"
-        },
-        {
-          "path": "docs/03-guides/development/codex-wsl2-setup.md",
-          "line": 228,
-          "source_group": "docs",
-          "text": "**Layer 1: DNS** (`scripts/engineering/dev/.setup_wsl_codex.sh`)"
-        },
-        {
-          "path": "docs/03-guides/development/codex-wsl2-setup.md",
-          "line": 241,
-          "source_group": "docs",
-          "text": "bash \"$BIOETL_DIR/scripts/engineering/dev/.setup_wsl_codex.sh\""
-        },
-        {
-          "path": "docs/03-guides/development/codex-wsl2-setup.md",
-          "line": 267,
-          "source_group": "docs",
-          "text": "bash \"$BIOETL_DIR/scripts/engineering/dev/.setup_wsl_codex.sh\" 2>/dev/null"
-        },
-        {
-          "path": "docs/03-guides/development/codex-wsl2-setup.md",
-          "line": 323,
-          "source_group": "docs",
-          "text": "bash \"$BIOETL_DIR/scripts/engineering/dev/.setup_wsl_codex.sh\""
-        },
-        {
-          "path": "docs/05-operations/tooling/scripts-ops/CODEX_QUICK_REF.md",
-          "line": 7,
-          "source_group": "docs",
-          "text": ".\\scripts\\engineering\\dev\\.setup_wsl_codex.sh"
-        },
-        {
-          "path": "docs/05-operations/tooling/scripts-ops/CODEX_QUICK_REF.md",
-          "line": 71,
-          "source_group": "docs",
-          "text": "| `OpenAI timeout`    | Run setup: `.\\scripts\\engineering\\dev\\.setup_wsl_codex.sh`                               |"
-        },
-        {
-          "path": "docs/05-operations/tooling/scripts-ops/CODEX_SETUP.md",
-          "line": 23,
-          "source_group": "docs",
-          "text": ".\\scripts\\engineering\\dev\\.setup_wsl_codex.sh"
-        }
-      ]
     },
     {
       "path": "scripts/engineering/dev/.wsl-vpn-fix.ps1",
@@ -7576,7 +7339,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 204,
+          "line": 207,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.engineering.qa check-naming-pkg --check"
         },
@@ -7756,7 +7519,7 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 328,
+          "line": 331,
           "source_group": "ci",
           "text": "run: uv run python scripts/engineering/qa/generate_architecture_dependency_map.py --check"
         },
@@ -7852,7 +7615,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 610,
+          "line": 613,
           "source_group": "ci",
           "text": "uv run python scripts/engineering/qa/generate_hotspot_degradation_report.py \\"
         },
@@ -8590,7 +8353,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 47,
+      "reference_count": 49,
       "references": [
         {
           "path": ".github/workflows/compiled-artifacts-block.yml",
@@ -8722,7 +8485,7 @@
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 76,
+          "line": 78,
           "source_group": "scripts",
           "text": "| `check_cleanup_governance.py`  | Guard active docs/scripts against broad cleanup guidance  |"
         },
@@ -8731,6 +8494,27 @@
           "line": 44,
           "source_group": "scripts",
           "text": "\"check-cleanup-governance\": \"check_cleanup_governance.py\","
+        }
+      ]
+    },
+    {
+      "path": "scripts/engineering/repo/check_github_action_pins.py",
+      "type": "py",
+      "status": "active",
+      "agent_usage": [],
+      "reference_count": 2,
+      "references": [
+        {
+          "path": "scripts/engineering/repo/README.md",
+          "line": 24,
+          "source_group": "scripts",
+          "text": "| `check-gh-actions-pins` | `check_github_action_pins.py` | Enforce pinned SHA + version comment policy in GitHub Actions files |"
+        },
+        {
+          "path": "scripts/engineering/repo/__main__.py",
+          "line": 46,
+          "source_group": "scripts",
+          "text": "\"check-gh-actions-pins\": \"check_github_action_pins.py\","
         }
       ]
     },
@@ -8899,37 +8683,37 @@
       "references": [
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 36,
+          "line": 37,
           "source_group": "scripts",
           "text": "bash scripts/engineering/repo/cleanup_branch_candidates.sh"
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 37,
+          "line": 38,
           "source_group": "scripts",
           "text": "bash scripts/engineering/repo/cleanup_branch_candidates.sh --apply"
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 38,
+          "line": 39,
           "source_group": "scripts",
           "text": "bash scripts/engineering/repo/cleanup_branch_candidates.sh --apply --with-remote"
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 51,
+          "line": 52,
           "source_group": "scripts",
           "text": "`cleanup_branch_candidates.sh` when you want the same workflow through a"
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 78,
+          "line": 80,
           "source_group": "scripts",
           "text": "| `cleanup_branch_candidates.sh` | Dry-run/apply cleanup for the curated branch deletion set |"
         },
         {
           "path": "scripts/engineering/repo/__main__.py",
-          "line": 49,
+          "line": 50,
           "source_group": "scripts",
           "text": "\"cleanup-branch-candidates\": \"cleanup_branch_candidates.sh\","
         },
@@ -8983,19 +8767,19 @@
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 24,
+          "line": 25,
           "source_group": "scripts",
           "text": "| `preflight-cleanup`     | `preflight_cleanup.sh`           | Preview/apply the bounded release-preflight cleanup set               |"
         },
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 77,
+          "line": 79,
           "source_group": "scripts",
           "text": "| `preflight_cleanup.sh`         | Bounded release-preflight cleanup helper                  |"
         },
         {
           "path": "scripts/engineering/repo/__main__.py",
-          "line": 46,
+          "line": 47,
           "source_group": "scripts",
           "text": "\"preflight-cleanup\": \"preflight_cleanup.sh\","
         }
@@ -9010,13 +8794,13 @@
       "references": [
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 25,
+          "line": 26,
           "source_group": "scripts",
           "text": "| `split-testing-roadmap` | `split_testing_roadmap_issue.py` | Preview or create child issues for testing roadmap issue `#2511`      |"
         },
         {
           "path": "scripts/engineering/repo/__main__.py",
-          "line": 47,
+          "line": 48,
           "source_group": "scripts",
           "text": "\"split-testing-roadmap\": \"split_testing_roadmap_issue.py\","
         }
@@ -9031,13 +8815,13 @@
       "references": [
         {
           "path": "scripts/engineering/repo/README.md",
-          "line": 26,
+          "line": 27,
           "source_group": "scripts",
           "text": "| `sync-docs-issues`      | `sync_docs_issues.py`            | Preview or apply labels, milestone, and comments for docs-sync issues |"
         },
         {
           "path": "scripts/engineering/repo/__main__.py",
-          "line": 48,
+          "line": 49,
           "source_group": "scripts",
           "text": "\"sync-docs-issues\": \"sync_docs_issues.py\","
         }
@@ -9393,19 +9177,19 @@
         },
         {
           "path": "scripts/ops/neo4j_memory_sync.py",
-          "line": 496,
+          "line": 548,
           "source_group": "scripts",
           "text": "\"entrypoint_path\": \"scripts/diagrams/__main__.py\","
         },
         {
           "path": "scripts/ops/neo4j_memory_sync.py",
-          "line": 521,
+          "line": 573,
           "source_group": "scripts",
           "text": "\"entrypoint_path\": \"scripts/docs/__main__.py\","
         },
         {
           "path": "scripts/ops/neo4j_memory_sync.py",
-          "line": 546,
+          "line": 598,
           "source_group": "scripts",
           "text": "\"entrypoint_path\": \"scripts/schema/__main__.py\","
         }
@@ -9878,7 +9662,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 16,
+      "reference_count": 14,
       "references": [
         {
           "path": "Makefile",
@@ -9899,18 +9683,6 @@
           "text": "`scripts/ops/launchers/codex/setup_plugins.sh --pytest-only` перед запуском pytest."
         },
         {
-          "path": "makefile",
-          "line": 32,
-          "source_group": "build",
-          "text": "bash scripts/ops/launchers/codex/setup_plugins.sh --pytest-only"
-        },
-        {
-          "path": "makefile",
-          "line": 35,
-          "source_group": "build",
-          "text": "bash scripts/ops/launchers/codex/setup_plugins.sh"
-        },
-        {
           "path": "scripts/engineering/dev/README.md",
           "line": 90,
           "source_group": "scripts",
@@ -9927,6 +9699,18 @@
           "line": 459,
           "source_group": "scripts",
           "text": "bash scripts/ops/launchers/codex/setup_plugins.sh --pytest-only"
+        },
+        {
+          "path": "scripts/engineering/dev/run_pytest.sh",
+          "line": 463,
+          "source_group": "scripts",
+          "text": "# setup_plugins.sh may provision a temporary pytest runtime under /tmp when"
+        },
+        {
+          "path": "scripts/engineering/repo/generate_scripts_wrapper_caller_matrix.py",
+          "line": 107,
+          "source_group": "scripts",
+          "text": "Candidate(\"scripts/ops/launchers/codex/setup_plugins.sh\", BOOTSTRAP_HELPER_ROLE),"
         }
       ]
     },
@@ -10776,31 +10560,31 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 301,
+          "line": 304,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.schema validate-configs"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 304,
+          "line": 307,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.schema check-invariants"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 307,
+          "line": 310,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.schema check-required-fields --verbose"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 310,
+          "line": 313,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.schema audit-optionality --check"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 325,
+          "line": 328,
           "source_group": "ci",
           "text": "run: uv run python -m scripts.schema generate-pipeline --check"
         },

--- a/docs/03-guides/github-local-workflow.md
+++ b/docs/03-guides/github-local-workflow.md
@@ -224,3 +224,24 @@ git push origin --delete <branch-name>
 - For branch consolidation, prefer selective cherry-pick over merging noisy automation branches.
 - In mixed Windows + WSL work, do not share the same `.venv`; use `.venv-win`
   in PowerShell and `${BIOETL_WSL_VENV_DIR:-$HOME/.venvs/bioetl}` in WSL.
+
+
+## GitHub Actions pinning standard
+
+All `uses:` references in `.github/workflows/*.yml` and `.github/actions/*/action.yml` must use:
+
+- full 40-char pinned commit SHA;
+- inline version comment (e.g. `# v6.0.2` or `# release/v1`).
+
+Disallowed patterns:
+
+- major or tag refs without SHA (`@v4`, `@v5`, `@main`, `@master`);
+- deprecated major aliases from denylist (e.g., `v0`..`v9`) instead of explicit pinned commit refs.
+
+Local validation command:
+
+```bash
+uv run python -m scripts.engineering.repo check-gh-actions-pins
+```
+
+This validation is also part of the CI `governance-preflight` lane.

--- a/scripts/engineering/repo/README.md
+++ b/scripts/engineering/repo/README.md
@@ -21,6 +21,7 @@ python -m scripts.engineering.repo cleanup-branch-candidates --help
 | `check-cleanliness`     | `audit_root_cleanliness.py`      | Audit repository root layout allowlist                                |
 | `check-cleanup-governance` | `check_cleanup_governance.py` | Block unsafe broad cleanup guidance outside allowlisted examples       |
 | `check-root-review-registry` | `check_root_hygiene_review_registry.py` | Validate review-required and blocked cleanup lanes              |
+| `check-gh-actions-pins` | `check_github_action_pins.py` | Enforce pinned SHA + version comment policy in GitHub Actions files |
 | `preflight-cleanup`     | `preflight_cleanup.sh`           | Preview/apply the bounded release-preflight cleanup set               |
 | `split-testing-roadmap` | `split_testing_roadmap_issue.py` | Preview or create child issues for testing roadmap issue `#2511`      |
 | `sync-docs-issues`      | `sync_docs_issues.py`            | Preview or apply labels, milestone, and comments for docs-sync issues |
@@ -63,6 +64,7 @@ the risky local branches.
 | `check-cleanliness`         | After adding files to repository root                                                    | Pre-commit hook              |
 | `check-cleanup-governance`  | After changing cleanup docs, runbooks, or repo maintenance scripts                       | Root-hygiene workflow        |
 | `check-root-review-registry` | After updating review-required or blocked cleanup lanes                                 | Root-hygiene workflow        |
+| `check-gh-actions-pins` | After editing `.github/workflows/*` or `.github/actions/*`                              | Governance preflight gate    |
 | `preflight-cleanup`         | Before release or before expensive local verification waves                              | Manual / `make clean-preflight` |
 | `split-testing-roadmap`     | When converting a roadmap issue into executable GitHub child issues                      | Manual maintenance workflow  |
 | `sync-docs-issues`          | When applying the documentation-sync issue package metadata and execution-order comments | Manual maintenance workflow  |

--- a/scripts/engineering/repo/__main__.py
+++ b/scripts/engineering/repo/__main__.py
@@ -43,6 +43,7 @@ COMMANDS = {
     "check-cleanliness": "audit_root_cleanliness.py",
     "check-cleanup-governance": "check_cleanup_governance.py",
     "check-root-review-registry": "check_root_hygiene_review_registry.py",
+    "check-gh-actions-pins": "check_github_action_pins.py",
     "preflight-cleanup": "preflight_cleanup.sh",
     "split-testing-roadmap": "split_testing_roadmap_issue.py",
     "sync-docs-issues": "sync_docs_issues.py",

--- a/scripts/engineering/repo/check_github_action_pins.py
+++ b/scripts/engineering/repo/check_github_action_pins.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import re
+from pathlib import Path
+
+TARGETS=[Path('.github/workflows'),Path('.github/actions')]
+USE_RE=re.compile(r'^(?P<i>\s*)uses:\s*(?P<a>[\w.-]+/[\w.-]+)@(?P<r>[^\s#]+)(?P<c>\s*#.*)?\s*$')
+SHA_RE=re.compile(r'^[0-9a-f]{40}$')
+
+def iter_files():
+    for root in TARGETS:
+        if root.exists():
+            for p in root.rglob('*'):
+                if p.suffix in {'.yml','.yaml'}:
+                    yield p
+
+def main()->int:
+    errs=[]
+    for fp in sorted(iter_files()):
+        for n,line in enumerate(fp.read_text().splitlines(),1):
+            m=USE_RE.match(line)
+            if not m: continue
+            ref=m.group('r'); comment=(m.group('c') or '').strip()
+            if not SHA_RE.fullmatch(ref):
+                errs.append(f"{fp}:{n} uses non-pinned ref '{ref}'")
+                continue
+            if not comment:
+                errs.append(f"{fp}:{n} pinned SHA missing version comment")
+    if errs:
+        print('GitHub Action pin policy violations:')
+        print('\n'.join(f'- {e}' for e in errs))
+        return 1
+    print('OK: all GitHub action uses are pinned to SHA with version comments.')
+    return 0
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/scripts/engineering/repo/check_github_action_pins.py
+++ b/scripts/engineering/repo/check_github_action_pins.py
@@ -1,37 +1,47 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import re
 from pathlib import Path
 
-TARGETS=[Path('.github/workflows'),Path('.github/actions')]
-USE_RE=re.compile(r'^(?P<i>\s*)uses:\s*(?P<a>[\w.-]+/[\w.-]+)@(?P<r>[^\s#]+)(?P<c>\s*#.*)?\s*$')
-SHA_RE=re.compile(r'^[0-9a-f]{40}$')
+TARGETS = [Path('.github/workflows'), Path('.github/actions')]
+USE_RE = re.compile(
+    r'^(?P<i>\s*)uses:\s*(?P<a>[\w.-]+/[\w.-]+)@(?P<r>[^\s#]+)(?P<c>\s*#.*)?\s*$'
+)
+SHA_RE = re.compile(r'^[0-9a-f]{40}$')
 
-def iter_files():
+
+def iter_files() -> list[Path]:
+    files: list[Path] = []
     for root in TARGETS:
         if root.exists():
-            for p in root.rglob('*'):
-                if p.suffix in {'.yml','.yaml'}:
-                    yield p
+            for path in root.rglob('*'):
+                if path.suffix in {'.yml', '.yaml'}:
+                    files.append(path)
+    return files
 
-def main()->int:
-    errs=[]
-    for fp in sorted(iter_files()):
-        for n,line in enumerate(fp.read_text().splitlines(),1):
-            m=USE_RE.match(line)
-            if not m: continue
-            ref=m.group('r'); comment=(m.group('c') or '').strip()
+
+def main() -> int:
+    errs: list[str] = []
+    for filepath in sorted(iter_files()):
+        for line_no, line in enumerate(filepath.read_text().splitlines(), 1):
+            match = USE_RE.match(line)
+            if not match:
+                continue
+            ref = match.group('r')
+            comment = (match.group('c') or '').strip()
             if not SHA_RE.fullmatch(ref):
-                errs.append(f"{fp}:{n} uses non-pinned ref '{ref}'")
+                errs.append(f"{filepath}:{line_no} uses non-pinned ref '{ref}'")
                 continue
             if not comment:
-                errs.append(f"{fp}:{n} pinned SHA missing version comment")
+                errs.append(f'{filepath}:{line_no} pinned SHA missing version comment')
     if errs:
         print('GitHub Action pin policy violations:')
-        print('\n'.join(f'- {e}' for e in errs))
+        print('\n'.join(f'- {err}' for err in errs))
         return 1
     print('OK: all GitHub action uses are pinned to SHA with version comments.')
     return 0
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Enforce a single repository standard for GitHub Action `uses:` references to avoid tag/branch drift and improve reproducibility by requiring pinned 40-char commit SHAs with an inline version comment. 
- Fail fast on drift of Action versions during preflight so expensive test/lint lanes do not run on PRs with unpinned or malformed Action refs. 

### Description

- Added a new repo check script `scripts/engineering/repo/check_github_action_pins.py` which validates `.github/workflows/*.yml` and `.github/actions/*/action.yml` for pinned 40-character SHAs and presence of an inline version comment. 
- Normalized `uses:` entries across `.github/workflows/*` and `.github/actions/*/action.yml` to use pinned SHAs (with inline version comments) and updated many workflow/action files to the pinned form. 
- Wired the new check into the repo CLI as `check-gh-actions-pins` by updating `scripts/engineering/repo/__main__.py` and documented the command in `scripts/engineering/repo/README.md`. 
- Documented the standard in `docs/03-guides/github-local-workflow.md` and added the check into the CI `governance-preflight` lane in `.github/workflows/tests.yml` so drift is detected before expensive lanes.

### Testing

- Ran the local pre-task memory workflow attempt `python -m memory.tooling.workflow pre-task ...` but it failed due to the environment missing the `memory` module (skipped as environment limitation). 
- Executed `uv run python -m scripts.engineering.repo check-gh-actions-pins` and iterated fixes until the script reported success (final output: `OK: all GitHub action uses are pinned to SHA with version comments.`). 
- Performed an ad-hoc regex verification (`python -c '...';` reported `bad 0`) to confirm no remaining non-SHA `uses:` refs under `.github/workflows` and `.github/actions`. 
- The new check is now invoked from the CI `governance-preflight` lane so subsequent PRs will fail preflight if violations are introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9442c7d508324bea8a7ec46f116b0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->