### PR TITLE
ci: add dependency-preflight gating and diagnostics

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,6 +116,12 @@ them:
 These checks still reduce the risk of merging failing tests, lint errors, or
 secret leaks.
 
+
+### Dependency Preflight Triage
+
+If many jobs fail quickly, inspect `dependency-preflight` first.
+Download and review `reports/ci/dependency-preflight.log` from its artifact and summary before debugging downstream jobs.
+
 ### Triage rule for `checks-complete`
 
 - If `checks-complete` fails, **always** open job logs in this order first:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,3 +51,5 @@
 - [ ] Tests added/updated for new code (TEST-002)
 - [ ] If `checks-complete` fails, I first triage `lint` → `c901-governance` →
       `arch-tests` and do not debug `checks-complete` separately
+
+- [ ] If many jobs fail quickly, I inspected `dependency-preflight` first (`reports/ci/dependency-preflight.log`)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,52 @@ env:
     QUALITY_EXEMPTIONS_SCORECARD: configs/quality/debt_scorecard.yaml
 
 jobs:
+
+    dependency-preflight:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: read
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            -   name: Setup Python + uv
+                uses: ./.github/actions/setup-python-uv
+                with:
+                    python-version: "3.12"
+
+            -   name: Check uv lock drift
+                run: |
+                    mkdir -p reports/ci
+                    set -o pipefail
+                    {
+                      echo "Dependency preflight diagnostics"
+                      echo "Timestamp (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+                      echo
+                      echo "Running: uv lock --check"
+                      uv lock --check
+                    } 2>&1 | tee reports/ci/dependency-preflight.log
+
+            -   name: Upload dependency preflight diagnostics
+                if: always()
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+                with:
+                    name: dependency-preflight
+                    path: reports/ci/dependency-preflight.log
+                    if-no-files-found: error
+                    retention-days: 14
+
+            -   name: Publish dependency preflight summary
+                if: always()
+                run: |
+                    {
+                      echo "## Dependency preflight"
+                      echo "Diagnostic artifact: dependency-preflight/reports/ci/dependency-preflight.log"
+                    } >> "$GITHUB_STEP_SUMMARY"
     # Minimal dependency smoke: keep test lanes unblocked by unrelated governance checks
     smoke-check:
+        needs: dependency-preflight
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
@@ -154,6 +198,7 @@ jobs:
                     retention-days: 14
 
     governance-preflight:
+        needs: dependency-preflight
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -23,7 +23,48 @@ on:
   workflow_dispatch:
 
 jobs:
+
+  dependency-preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python + uv
+        uses: ./.github/actions/setup-python-uv
+
+      - name: Check uv lock drift
+        run: |
+          mkdir -p reports/ci
+          set -o pipefail
+          {
+            echo "Dependency preflight diagnostics"
+            echo "Timestamp (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            echo
+            echo "Running: uv lock --check"
+            uv lock --check
+          } 2>&1 | tee reports/ci/dependency-preflight.log
+
+      - name: Upload dependency preflight diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: type-checking-dependency-preflight
+          path: reports/ci/dependency-preflight.log
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish dependency preflight summary
+        if: always()
+        run: |
+          {
+            echo "## Dependency preflight"
+            echo "Diagnostic artifact: type-checking-dependency-preflight/reports/ci/dependency-preflight.log"
+          } >> "$GITHUB_STEP_SUMMARY"
   type-check:
+    needs: dependency-preflight
     runs-on: ubuntu-latest
     timeout-minutes: 40
 


### PR DESCRIPTION
### Motivation

- Prevent large cascades of downstream CI failures by failing early on dependency lock drift and surface a single diagnostic cause. 
- Give contributors an immediate artifact and summary to triage dependency issues before inspecting many unrelated job logs.

### Description

- Added a `dependency-preflight` job to `.github/workflows/tests.yml` that performs `actions/checkout`, runs `./.github/actions/setup-python-uv` with `python-version: "3.12"`, runs `uv lock --check`, writes diagnostics to `reports/ci/dependency-preflight.log`, uploads it as an artifact, and appends a short link into `GITHUB_STEP_SUMMARY`; the job is declared at `jobs.dependency-preflight` in `tests.yml`.
- Added an equivalent `dependency-preflight` job to `.github/workflows/type-checking.yml` and gated the `type-check` job with `needs: dependency-preflight`.
- Wired key jobs in `tests.yml` (at minimum `smoke-check` and `governance-preflight`) to depend on `dependency-preflight` via `needs: dependency-preflight` so they stop early when dependency checks fail.
- Updated contributor guidance in `.github/CONTRIBUTING.md` and the PR checklist in `.github/pull_request_template.md` with a short triage note instructing reviewers to inspect `dependency-preflight` (`reports/ci/dependency-preflight.log`) first when many jobs fail quickly.

### Testing

- Confirmed presence of the new gates and checks with repository scans (`rg -n "dependency-preflight|uv lock --check|needs:" .github/workflows/...`) which returned the expected insertions. 
- Verified the workflow diffs and staged changes with `git diff` / `git status` and committed the changes successfully (commit message: `ci: add dependency preflight gates for test and type workflows`).
- Attempted to run the repository memory workflow hooks (`python -m memory.tooling.workflow pre-task` and `post-task`) as automated validation steps but both failed in this environment with `ModuleNotFoundError: No module named 'memory'`, which is an environment limitation rather than a workflow change failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9518a9c348324bcb64480d8bd47ad)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/3685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->