### PR TITLE
🔒 [security fix: remove hardcoded neo4j fallback passwords]

### DIFF
--- a/src/memory/graph/sync.py
+++ b/src/memory/graph/sync.py
@@ -3859,7 +3859,11 @@ def resolve_neo4j_connection(
         )
         auth_username, auth_password = _parse_auth_pair(env.get("NEO4J_AUDIT_AUTH"))
         username = username or auth_username or "neo4j"
-        password = password or auth_password or "audit_secure_password"
+        password = password or auth_password
+        if not password:
+            raise RuntimeError(
+                "Neo4j audit password not found in NEO4J_AUDIT_PASSWORD or NEO4J_AUDIT_AUTH"
+            )
         http_uri = (
             explicit_http_uri
             or env.get("NEO4J_AUDIT_HTTP_URI")
@@ -3872,7 +3876,11 @@ def resolve_neo4j_connection(
         database = env.get("NEO4J_DATABASE", "neo4j")
         auth_username, auth_password = _parse_auth_pair(env.get("NEO4J_AUTH"))
         username = username or auth_username or "neo4j"
-        password = password or auth_password or "bioetl_secure_password"
+        password = password or auth_password
+        if not password:
+            raise RuntimeError(
+                "Neo4j password not found in NEO4J_PASSWORD, NEO4J_AUTH_PASSWORD, or NEO4J_AUTH"
+            )
         http_uri = (
             explicit_http_uri or env.get("NEO4J_HTTP_URI") or derive_http_uri(bolt_uri)
         )

--- a/src/tools/neo4j_audit.py
+++ b/src/tools/neo4j_audit.py
@@ -34,13 +34,22 @@ def get_neo4j_auth() -> tuple[str, str]:
 
     Returns:
         Tuple of (username, password)
+
+    Raises:
+        RuntimeError: If password is not set in environment.
     """
     if os.getenv("LIVE_AUDIT_MODE"):
         # Audit instance has separate credentials
-        return ("neo4j", "audit_secure_password")
+        password = os.getenv("NEO4J_AUDIT_PASSWORD")
+        if not password:
+            raise RuntimeError("NEO4J_AUDIT_PASSWORD environment variable is not set")
+        return ("neo4j", password)
     else:
         # MCP instance
-        return ("neo4j", os.getenv("NEO4J_PASSWORD", "bioetl_secure_password"))
+        password = os.getenv("NEO4J_PASSWORD")
+        if not password:
+            raise RuntimeError("NEO4J_PASSWORD environment variable is not set")
+        return ("neo4j", password)
 
 
 def is_audit_mode() -> bool:


### PR DESCRIPTION
🎯 **What**: Removal of hardcoded Neo4j passwords in `src/tools/neo4j_audit.py` and `src/memory/graph/sync.py`.
⚠️ **Risk**: Unauthorized access if default passwords are used in production-like environments where environment variables might be accidentally omitted.
🛡️ **Solution**: Forcing the use of environment variables and failing early with a `RuntimeError` if credentials are not provided.

---
*PR created automatically by Jules for task [2845814033682854815](https://jules.google.com/task/2845814033682854815) started by @SatoryKono*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes / Security**
  * Neo4j connection configuration now requires explicit credentials via environment variables instead of falling back to hard-coded defaults. Users must configure appropriate Neo4j credentials; missing credentials will raise clear error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SatoryKono/BioactivityDataAcquisition/pull/4082)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->