### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N^2) list deduplication with O(N) dict.fromkeys

### DIFF
--- a/src/bioetl/application/composite/aggregator.py
+++ b/src/bioetl/application/composite/aggregator.py
@@ -30,12 +30,7 @@ _ORDER_SENSITIVE_FUNCTIONS = frozenset(
 
 def _deduplicate_columns(columns: list[str]) -> list[str]:
     """Return columns in first-seen order with duplicates removed."""
-    deduped: list[str] = []
-    for column in columns:
-        if column in deduped:
-            continue
-        deduped.append(column)
-    return deduped
+    return list(dict.fromkeys(columns))
 
 
 class EnricherAggregator:


### PR DESCRIPTION
**What:**
Replaced the pure-Python loop `_deduplicate_columns` which had O(N^2) time complexity with `list(dict.fromkeys(columns))`.

**Why:**
To improve performance. The original code performs a membership check (`if column in deduped:`) against a list on each iteration, leading to O(N^2) runtime for deduplication. Python 3's `dict` maintains insertion order and gives O(1) lookup for keys, making `list(dict.fromkeys(...))` an elegant and O(N) solution.

**Impact:**
Decreases algorithmic complexity of column deduplication from O(N^2) to O(N) and decreases Python interpreter loop overhead by moving execution to C-level loops.

**Measurement:**
Look for faster aggregation times when parsing data containing many columns during composite joins.

---
*PR created automatically by Jules for task [9066108671930857351](https://jules.google.com/task/9066108671930857351) started by @SatoryKono*