### PR TITLE
docs: align onboarding runtime baseline to Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BioETL: Bioactivity Data Acquisition Pipeline
 
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code Style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -120,7 +120,7 @@ repo-wide reorganization wave.
 
 ### Prerequisites
 
-- **Python**: Version 3.11 or higher.
+- **Python**: Version 3.12 (baseline).
 - **Make**: For running automation commands.
 - **uv**: Recommended package manager ([install](https://docs.astral.sh/uv/getting-started/installation/)).
 - **Docker**: Optional, only for `docker-compose` extras such as Neo4j and monitoring; not required for the Local-Only runtime.
@@ -128,6 +128,12 @@ repo-wide reorganization wave.
 
 The supported dependency/bootstrap path is uv-first. `pip` remains a manual
 fallback when `uv` is unavailable.
+
+### Runtime compatibility policy
+
+- **Python runtime baseline: 3.12** for local development, onboarding, and CI defaults.
+- The **source of truth** for Python runtime compatibility is `pyproject.toml` (`requires-python` and classifiers).
+- Any docs or scripts mentioning older Python versions (3.10/3.11) should be treated as deprecated and updated before use.
 
 ### Installation
 
@@ -204,7 +210,7 @@ uv sync --extra dev --extra tracing
    uv sync --extra dev --extra tracing --extra docs
 
    # Fallback without uv
-   python3 -m venv .venv
+   python3.12 -m venv .venv
    . .venv/bin/activate
    pip install -e ".[dev,tracing,docs]"
 ```

--- a/docs/03-guides/getting-started.md
+++ b/docs/03-guides/getting-started.md
@@ -28,7 +28,7 @@ and be able to execute data pipelines.
 
 Ensure you have the following tools installed on your machine:
 
-- **Python 3.11** or higher: [Download](https://www.python.org/downloads/)
+- **Python 3.12** (baseline): [Download](https://www.python.org/downloads/)
 - **uv** (recommended): Python package/environment manager used by the maintained install path.
 - **Git**: Version control.
 - **Make** (optional): Build automation tool. On Windows, use Chocolatey or WSL, or run commands manually.
@@ -37,6 +37,12 @@ Ensure you have the following tools installed on your machine:
 
 - Docker Desktop
 - Redis, MinIO, Postgres
+
+## Runtime compatibility policy
+
+- **Python runtime baseline: 3.12** for onboarding and local execution.
+- **Source of truth**: `pyproject.toml` (`requires-python`, Trove classifiers).
+- Any references to Python 3.10/3.11 are deprecated documentation drift and should be ignored.
 
 ## 1. Clone the Repository
 
@@ -107,7 +113,7 @@ uv sync --extra dev --extra tracing --extra docs
 On Windows without `make` or `uv`:
 
 ```powershell
-python -m venv .venv
+python3.12 -m venv .venv
 .venv\Scripts\activate
 pip install -e .[dev,tracing,docs]
 ```

--- a/docs/03-guides/quick-start.md
+++ b/docs/03-guides/quick-start.md
@@ -22,6 +22,12 @@ TL;DR for setting up and running BioETL locally.
 > onboarding walkthrough, environment/config details, and broader first-time
 > troubleshooting, use [Getting Started](getting-started.md).
 
+## Runtime compatibility policy
+
+- **Python runtime baseline: 3.12**.
+- **Source of truth**: `pyproject.toml` (`requires-python`, classifiers).
+- Treat any Python 3.10/3.11 snippets as deprecated and update to 3.12 commands.
+
 ## Setup (3 minutes)
 
 ### Option A: Supported Local Bootstrap (Recommended)
@@ -78,7 +84,7 @@ cd BioactivityDataAcquisition
 uv sync --extra dev --extra tracing
 
 # Fallback without uv
-python3 -m venv .venv
+python3.12 -m venv .venv
 . .venv/bin/activate
 pip install -e ".[dev,tracing]"
 ```


### PR DESCRIPTION
### Motivation
- Унифицировать baseline Python runtime на `3.12` в ключевых onboarding-точках (README / Getting Started / Quick Start).
- Обновить примеры команд создания venv и установки зависимостей под явный `python3.12` для уменьшения дрейфа инструкций.
- Добавить краткую политику совместимости рантайма с явной ссылкой на источник истины (`pyproject.toml`).

### Description
- Обновлён бейдж версии Python в `README.md` на `Python 3.12` и заменены соответствующие строки в разделе prerequisites. (`README.md`)
- Добавлен блок `Runtime compatibility policy` в `README.md`, `docs/03-guides/getting-started.md` и `docs/03-guides/quick-start.md` с указанием `pyproject.toml` как source-of-truth. (`README.md`, `docs/03-guides/getting-started.md`, `docs/03-guides/quick-start.md`)
- Обновлены примеры создания виртуального окружения в onboarding-руководствах с `python3 -m venv .venv` на `python3.12 -m venv .venv` и аналогичные ручные примеры для Windows/WSL. (`README.md`, `docs/03-guides/getting-started.md`, `docs/03-guides/quick-start.md`)
- Явно помечены упоминания `3.10/3.11` в этих onboarding surfaces как deprecated/documentation drift (policy-блоки). (`README.md`, `docs/03-guides/getting-started.md`, `docs/03-guides/quick-start.md`)

### Testing
- Запущен поиск по документации для проверок ссылок на версии Python с помощью `rg` и подтверждена корректная замена целевых строк — успешно.
- Просмотрен `pyproject.toml` и подтверждён `requires-python = ">=3.12"` как source-of-truth — успешно.
- Попытка выполнить `python -m memory.tooling.workflow pre-task --task-id ...` завершилась с `ModuleNotFoundError` из-за отсутствующего модуля `memory` в окружении, поэтому автоматизированный memory pre-task не был выполнен (skipped / failed due to environment).
- Проверен diff изменений с `git diff` и внесён коммит; изменённые файлы: `README.md`, `docs/03-guides/getting-started.md`, `docs/03-guides/quick-start.md` — подтверждение изменений выполнено.
- Примечание по post-change validation: затронуты только документационные onboarding surfaces; зеркалирование/синхронизация опубликованных docs (mkdocs/site) не выполнялось в этой сессии (mirror-sync: not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c8b3de6083248a5273c2f3f72467)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/4719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->