### PR TITLE
🧹 [code health] Remove unused get_resource_name method

### DIFF
--- a/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
+++ b/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
@@ -182,22 +182,6 @@ class ChemblEntityMapper:
         return has_entity_composite_key(entity_type)
 
     @staticmethod
-    def get_resource_name(entity_type: str) -> str | None:
-        """Get the ChEMBL resource name for entity type.
-
-        Args:
-            entity_type: Entity type (e.g., 'activity', 'publication').
-
-        Returns:
-            Resource name or None if unknown.
-
-        Example:
-            >>> ChemblEntityMapper.get_resource_name("publication")
-            'document'
-        """
-        return resolve_resource_name(entity_type)
-
-    @staticmethod
     def is_known_entity(entity_type: str) -> bool:
         """Check if entity type is known (publication or non-publication).
 


### PR DESCRIPTION
🎯 What: Removed the dead code `get_resource_name` method from `ChemblEntityMapper`.
💡 Why: The method was completely unused in the codebase (as verified by a global search). Removing unused dead code improves readability and maintainability.
✅ Verification: Ran pytest for tests/unit/infrastructure/adapters/chembl/, ran ruff formatter, and ruff linter on the modified file to ensure no functionality is broken.
✨ Result: Cleaner mapper utility with only the actually used methods.

---
*PR created automatically by Jules for task [10073976247236922223](https://jules.google.com/task/10073976247236922223) started by @SatoryKono*