### PR TITLE
🧹 Remove unused imports in test_health_server.py

### DIFF
--- a/tests/unit/interfaces/http/test_health_server.py
+++ b/tests/unit/interfaces/http/test_health_server.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncGenerator
-from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
 
 import pytest
 import pytest_asyncio
 
-from bioetl.domain.types import HealthStatus, RunType
+from bioetl.domain.types import HealthStatus
 from bioetl.interfaces.http.health_server import HealthServer
 from bioetl.interfaces.http.types import HealthResponse
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`datetime.UTC`, `datetime`, `timedelta`, `uuid.uuid4`, and `RunType`) in `tests/unit/interfaces/http/test_health_server.py`.
💡 **Why:** To improve code maintainability, cleanliness, and readability by eliminating dead code and satisfying linter warnings.
✅ **Verification:** Ran formatting, linting (`ruff`), and the full `tests/unit/interfaces/http/` test suite to confirm the changes did not break any functionality.
✨ **Result:** The code is cleaner, linter warnings are resolved, and existing behavior is fully preserved.

---
*PR created automatically by Jules for task [13765935383322656675](https://jules.google.com/task/13765935383322656675) started by @SatoryKono*