### PR TITLE
⚡ Bolt: Optimize Polars DataFrame masking and iteration

### DIFF
--- a/src/bioetl/application/composite/merger_metrics_mixin.py
+++ b/src/bioetl/application/composite/merger_metrics_mixin.py
@@ -146,7 +146,8 @@ class MergeMetricsRecorderMixin:
         any_enriched = pl.any_horizontal(
             [pl.col(col).is_not_null() for col in enricher_cols]
         )
-        return len(df.filter(any_enriched))
+        # ⚡ Bolt: avoid memory allocation from materializing a filtered DataFrame by using sum()
+        return df.select(any_enriched.sum()).item()
 
     def _count_fully_enriched(
         self,
@@ -180,13 +181,17 @@ class MergeMetricsRecorderMixin:
         if len(df) == 0:
             return {}
 
-        coverage: dict[str, float] = {}
-        for col in df.columns:
-            if not col.startswith("_"):
-                non_null = len(df.filter(df[col].is_not_null()))
-                coverage[col] = non_null / len(df)
+        cols_to_check = [col for col in df.columns if not col.startswith("_")]
+        if not cols_to_check:
+            return {}
 
-        return coverage
+        # ⚡ Bolt: evaluate all expressions simultaneously in C to avoid Python loop overhead,
+        # and use sum() instead of filter() to prevent materializing intermediate DataFrames
+        exprs = [pl.col(col).is_not_null().sum().alias(col) for col in cols_to_check]
+        non_null_counts = df.select(exprs).row(0, named=True)
+        total_rows = len(df)
+
+        return {col: count / total_rows for col, count in non_null_counts.items()}
 
 
 __all__ = ["MergeMetricsRecorderMixin"]


### PR DESCRIPTION
💡 What: Replaced pure-Python loops executing individual .filter() queries with a list of Polars expressions evaluated simultaneously via .select(). Also replaced len(df.filter(expr)) with df.select(expr.sum()).item().\n🎯 Why: Iterating over columns in Python incurs loop overhead, and using filter() just to count matches materializes unneeded intermediate DataFrames in memory.\n📊 Impact: Eliminates Python loop overhead for field coverage calculations and significantly reduces memory usage and execution time by evaluating counts concurrently in C without intermediate materializations.\n🔬 Measurement: Run the test suite (uv run python -m pytest tests/unit/application/composite/). Profiling the execution time and memory usage of _count_enriched_records and _calculate_field_coverage on large DataFrames will show the improvement.

---
*PR created automatically by Jules for task [4877564212703090533](https://jules.google.com/task/4877564212703090533) started by @SatoryKono*