### PR TITLE
⚡ Bolt: Optimize merger metrics Polars calculations

### DIFF
--- a/src/bioetl/application/composite/merger_metrics_mixin.py
+++ b/src/bioetl/application/composite/merger_metrics_mixin.py
@@ -146,7 +146,9 @@ class MergeMetricsRecorderMixin:
         any_enriched = pl.any_horizontal(
             [pl.col(col).is_not_null() for col in enricher_cols]
         )
-        return len(df.filter(any_enriched))
+        # ⚡ Bolt: Using select().item() instead of len(filter()) avoids
+        # materializing a new intermediate DataFrame, saving memory and time.
+        return df.select(any_enriched.sum()).item()
 
     def _count_fully_enriched(
         self,
@@ -180,13 +182,17 @@ class MergeMetricsRecorderMixin:
         if len(df) == 0:
             return {}
 
-        coverage: dict[str, float] = {}
-        for col in df.columns:
-            if not col.startswith("_"):
-                non_null = len(df.filter(df[col].is_not_null()))
-                coverage[col] = non_null / len(df)
+        target_cols = [col for col in df.columns if not col.startswith("_")]
+        if not target_cols:
+            return {}
 
-        return coverage
+        # ⚡ Bolt: Build a list of Polars expressions and evaluate them simultaneously
+        # to eliminate Python loop overhead and avoid materializing filtered DataFrames.
+        exprs = [
+            (pl.col(col).is_not_null().sum() / pl.len()).alias(col)
+            for col in target_cols
+        ]
+        return df.select(exprs).row(0, named=True)
 
 
 __all__ = ["MergeMetricsRecorderMixin"]


### PR DESCRIPTION
💡 What: Optimized Polars operations in `merger_metrics_mixin.py` by replacing `len(df.filter(...))` with `.select(...sum()).item()` and batching coverage calculations.
🎯 Why: To eliminate Python loop overhead and avoid materializing intermediate DataFrames in memory during metrics calculation.
📊 Impact: Reduces memory usage and improves execution speed for metric calculations on large DataFrames.
🔬 Measurement: Run metrics calculation benchmarks; observe reduced memory spikes and faster execution times for `_count_enriched_records` and `_calculate_field_coverage`.

---
*PR created automatically by Jules for task [12766459557031402223](https://jules.google.com/task/12766459557031402223) started by @SatoryKono*