### PR TITLE
docs: reconcile Qodo governance guidance and policy pack

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,15 +75,20 @@ For the full local GitHub workflow, including worktrees, sync/rebase, PR creatio
 | **application**    | ✅     | ✅          | ❌          | ❌             | ❌         |
 | **composition**    | ✅     | ✅          | ✅          | ✅             | ❌         |
 | **infrastructure** | ✅     | ❌          | ❌          | ✅             | ❌         |
-| **interfaces**     | ✅     | ✅          | ✅          | ✅             | ✅         |
+| **interfaces**     | ✅     | ✅          | ✅          | ❌             | ✅         |
 
 ### Key Rules
 
 - **Dependency Injection**: Dependencies via constructor, not created inside classes
 - **Composition Root**: `src/bioetl/composition/bootstrap/` is the only place for wiring
-- **Async I/O**: Use `httpx` for HTTP, `run_in_executor` for blocking operations
+- **Adapter HTTP**: Provider/runtime HTTP goes through `UnifiedHTTPClient`; do not bypass it with direct client usage in adapters
+- **Blocking I/O**: Use `run_in_executor` for blocking operations
 - **Logging**: Use `structlog` with `run_id`, never `print()`
 - **Secrets**: Environment variables only (`BIOETL_{PROVIDER}_{KEY}`)
+
+Direct `interfaces -> infrastructure` imports are forbidden. If an interface
+needs concrete runtime behavior, route it through composition-owned entrypoints
+instead of importing infrastructure modules directly.
 
 ## Testing Requirements
 

--- a/.github/root-allowlist.txt
+++ b/.github/root-allowlist.txt
@@ -16,10 +16,12 @@
 .secrets.baseline
 .wsl_proxy_env.sh
 AGENTS.md
+best_practices.md
 CHANGELOG.md
 GEMINI.md
 LICENSE
 Makefile
+pr_compliance_checklist.yaml
 README.md
 commitlint.config.mjs
 docker-compose.monitoring.yml

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,0 +1,75 @@
+# BioETL Qodo Best Practices
+
+These guidelines are repo-specific review patterns for Qodo. Keep feedback
+aligned with `AGENTS.md`, `docs/00-project/RULES.md`, accepted ADRs, executable
+tests, and committed governance/config surfaces.
+
+## Architecture Boundaries
+
+Prefer:
+
+- Keep dependency direction inward: `interfaces -> application -> domain`,
+  `infrastructure -> domain`, `composition -> application + infrastructure`.
+- Route concrete runtime wiring through composition-owned entrypoints.
+- Treat `src/bioetl/composition/**` as the only place for concrete DI.
+
+Avoid:
+
+- Direct `interfaces -> infrastructure` imports.
+- Domain imports from application, infrastructure, composition, or interfaces.
+- Application imports of concrete infrastructure implementations.
+
+## Domain Purity
+
+Prefer:
+
+- Pure domain logic with deterministic state transitions and explicit
+  invariants.
+- Aggregate behavior centered on `Batch`, `PipelineRun`, and
+  `QuarantineEntry`.
+
+Avoid:
+
+- HTTP, filesystem access, pandas, or concrete adapters in `src/bioetl/domain/**`.
+- Business logic hidden inside infrastructure adapters.
+
+## HTTP and I/O
+
+Prefer:
+
+- `UnifiedHTTPClient` for provider/runtime HTTP behavior.
+- Async-safe patterns and repository-approved abstractions.
+
+Avoid:
+
+- Direct HTTP client usage in adapters when the unified client already covers
+  the use case.
+- New bespoke networking wrappers that bypass the sanctioned HTTP surface.
+
+## Medallion and Validation
+
+Prefer:
+
+- Bronze as immutable append-only JSONL without normalization.
+- Silver normalization plus mandatory Pandera validation before write.
+- Gold writes behind strict Pandera schema validation with fail-closed behavior.
+- Deterministic merges by primary key and idempotent reruns.
+
+Avoid:
+
+- Writing Silver or Gold outputs without their required validation step.
+- Duplicate-producing reruns or merge behavior that ignores primary keys.
+
+## Governance and Change Discipline
+
+Prefer:
+
+- Small, reversible patches with targeted validation evidence.
+- Updating contributor/governance docs when repo-facing behavior or guidance changes.
+- Explicitly calling out manual-inspection-required items for portal or GitHub UI state.
+
+Avoid:
+
+- Increasing technical-debt budgets, exemptions, or governance thresholds.
+- Editing `.env` files without explicit user approval.
+- Inventing undocumented Qodo keys or unsupported repo-level schemas.

--- a/docs/00-project/governance/qodo/README.md
+++ b/docs/00-project/governance/qodo/README.md
@@ -1,0 +1,56 @@
+# Qodo Governance Mirror
+
+This directory is a human-readable mirror for BioETL's repo-level Qodo review
+surfaces. It must not redefine runtime or governance behavior on its own.
+
+## Authoritative Sources
+
+Use these sources in the listed order when Qodo-related instructions appear to
+conflict:
+
+1. `AGENTS.md`
+2. `docs/00-project/RULES.md`
+3. Accepted ADRs in `docs/02-architecture/decisions/`
+4. Executable governance and architecture surfaces:
+   - `.importlinter`
+   - `tests/architecture/**`
+   - `.github/workflows/**`
+5. Repo-level Qodo artifacts:
+   - `.pr_agent.toml`
+   - `best_practices.md`
+   - `pr_compliance_checklist.yaml`
+
+## Repo-Level Qodo Surfaces
+
+- `.pr_agent.toml`: repository-level Qodo configuration for GitHub review
+  behavior and extra review instructions.
+- `best_practices.md`: project-specific best-practice guidance consumed by Qodo
+  rule enforcement paths.
+- `pr_compliance_checklist.yaml`: PR compliance checklist using the vendor
+  `pr_compliances` schema.
+
+## Important Local Distinctions
+
+- `.qodo/mcp.json` is a local MCP runtime configuration surface. It is not the
+  repository's Qodo review-policy source of truth.
+- Path-local supported files may be added later for narrower scope, but root
+  files apply repository-wide by default.
+
+## Manual Inspection Required
+
+The following items are not proven by repository files alone and require manual
+verification in Qodo Portal or GitHub UI:
+
+- GitHub App installation and permissions
+- organization-level or portal-level Qodo settings
+- live branch protection / ruleset enforcement state
+
+## Vendor Validation Notes
+
+- `.pr_agent.toml` keys in this repository were validated against current Qodo
+  configuration docs.
+- `best_practices.md` is a documented supported file name in Qodo rule
+  enforcement docs.
+- `pr_compliance_checklist.yaml` is a documented supported file name in Qodo
+  Review Standards docs, and the local schema mirrors the vendor template from
+  `The-PR-Agent/pr-agent`.

--- a/docs/03-guides/cleanup-policy.md
+++ b/docs/03-guides/cleanup-policy.md
@@ -289,8 +289,11 @@ Enforcement:
 - CI **MUST** run cleanup governance checks that block broad cleanup guidance
   from active docs/scripts and export deterministic cleanup classification
   evidence for review.
-- GitHub branch protection for `main` **MUST** require the `root-hygiene`
-  status check.
+- Target state: GitHub branch protection for `main` **SHOULD** require the
+  `root-hygiene` status check when repository rulesets are enabled.
+- Current-state enforcement is tracked in
+  `docs/00-project/governance/05-github-policy.md`; do not treat this cleanup
+  guide as live branch-protection evidence on its own.
 - Any intentional new root-level tracked file **MUST** be added to `.github/root-allowlist.txt` in the same PR with justification.
 
 ### 7.4. Scheduled Jobs (SHOULD)

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -1,0 +1,36 @@
+pr_compliances:
+  - title: "Hexagonal dependency boundaries remain intact"
+    compliance_label: false
+    objective: "Repository-facing changes must preserve the inward dependency flow and composition-owned runtime wiring"
+    success_criteria: "No direct interfaces-to-infrastructure imports are introduced; domain and application boundaries still match the executable architecture policy"
+    failure_criteria: "A pull request introduces forbidden layer imports, bypasses composition-owned entrypoints, or weakens documented architecture boundaries"
+
+  - title: "Domain stays pure and infrastructure stays implementation-only"
+    compliance_label: false
+    objective: "Business rules stay in domain/application while infrastructure remains an adapter layer"
+    success_criteria: "Domain code contains no I/O or concrete adapter usage, and infrastructure changes do not add business logic that belongs in domain or application"
+    failure_criteria: "Domain gains HTTP/filesystem/pandas/concrete adapter behavior, or infrastructure embeds business rules and orchestration logic"
+
+  - title: "HTTP uses the sanctioned unified client"
+    compliance_label: false
+    objective: "Provider and runtime HTTP behavior must go through the repository-approved unified client surface"
+    success_criteria: "HTTP-capable adapters and related runtime paths continue to use UnifiedHTTPClient or composition-managed wrappers around it"
+    failure_criteria: "A pull request introduces direct adapter HTTP usage that bypasses UnifiedHTTPClient without an accepted repository exception"
+
+  - title: "Medallion writes preserve validation and idempotency"
+    compliance_label: false
+    objective: "Bronze, Silver, and Gold behavior must remain deterministic, validated, and rerun-safe"
+    success_criteria: "Bronze remains append-only, Silver validates before write, Gold enforces strict schema validation, and reruns remain primary-key idempotent"
+    failure_criteria: "Validation is skipped, schema violations are tolerated, or reruns can create duplicates or non-deterministic merges"
+
+  - title: "Governance docs do not contradict executable policy"
+    compliance_label: false
+    objective: "Repo-facing instructions consumed by contributors and review bots must agree with tests, configs, and accepted governance sources"
+    success_criteria: "Updated docs match `.importlinter`, active workflows, `AGENTS.md`, and current governance policy surfaces"
+    failure_criteria: "A pull request leaves stale or conflicting guidance about architecture, branch protection, validation, or sanctioned tooling"
+
+  - title: "Technical-debt budgets and secret-bearing guardrails are preserved"
+    compliance_label: false
+    objective: "Governance changes must not widen debt budgets or weaken secret-handling rules"
+    success_criteria: "No debt threshold or exemption limit increases are introduced, and `.env`/secret-bearing surfaces remain protected"
+    failure_criteria: "A pull request raises technical-debt budgets, broadens exemptions, or relaxes the repository's `.env` handling guardrails"


### PR DESCRIPTION
## Summary
- reconcile contributor guidance with `.importlinter` by forbidding direct `interfaces -> infrastructure` imports in `CONTRIBUTING`
- clarify branch-protection wording so cleanup guidance points to current-state governance docs instead of asserting live enforcement
- add vendor-validated Qodo repo surfaces: `best_practices.md`, `pr_compliance_checklist.yaml`, and a governance mirror README
- allow the new root-level Qodo files in `.github/root-allowlist.txt`

## Validation
- `bash scripts/engineering/dev/run_pytest.sh --skip-preflight tests/architecture/test_docs_root_surface_governance_alignment.py tests/architecture/test_docs_version_sync.py tests/architecture/test_integration_vcr_policy.py --timeout=120 -n 1`
- `python3 -m scripts.docs check-links --links --specs --configs`
- `python3 -m scripts.docs check-drift --runtime-mirrors --freshness`

## Notes
- no production code, public API, pipeline orchestration, or storage semantics changed
- manual inspection is still required for live Qodo Portal settings, GitHub App permissions, and branch-protection UI state

Fixes #5607
Fixes #5608
Fixes #5610

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/5617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new repository guidance and compliance checklists for contribution and review workflows.
  * Clarified architecture and dependency rules, including stricter separation between layers and approved ways to handle HTTP, I/O, logging, and secrets.
  * Added a human-readable governance reference that points to the authoritative policy sources.
  * Updated cleanup guidance to reflect current branch-protection expectations and where enforcement is tracked.
  * Expanded the tracked-root file list to include the new governance documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->