### PR TITLE
⚡ Bolt: Optimize Polars operations in merger metrics

### DIFF
--- a/src/bioetl/application/composite/merger_metrics_mixin.py
+++ b/src/bioetl/application/composite/merger_metrics_mixin.py
@@ -146,7 +146,8 @@ class MergeMetricsRecorderMixin:
         any_enriched = pl.any_horizontal(
             [pl.col(col).is_not_null() for col in enricher_cols]
         )
-        return len(df.filter(any_enriched))
+        # Compute sum directly to avoid materializing a new filtered DataFrame
+        return df.select(any_enriched.sum()).item()
 
     def _count_fully_enriched(
         self,
@@ -180,13 +181,18 @@ class MergeMetricsRecorderMixin:
         if len(df) == 0:
             return {}
 
-        coverage: dict[str, float] = {}
-        for col in df.columns:
-            if not col.startswith("_"):
-                non_null = len(df.filter(df[col].is_not_null()))
-                coverage[col] = non_null / len(df)
+        exprs = [
+            pl.col(col).is_not_null().sum().alias(col)
+            for col in df.columns
+            if not col.startswith("_")
+        ]
+        if not exprs:
+            return {}
 
-        return coverage
+        # Evaluate all null checks simultaneously to avoid Python loop overhead
+        counts = df.select(exprs).row(0, named=True)
+        total_rows = len(df)
+        return {col: count / total_rows for col, count in counts.items()}
 
 
 __all__ = ["MergeMetricsRecorderMixin"]


### PR DESCRIPTION
💡 What
Optimized Polars metrics calculations in `MergeMetricsRecorderMixin`. Replaced a Python for-loop that executed individual `.filter()` calls per column with a single `.select()` operation evaluating all expressions simultaneously. Also replaced a `len(df.filter(...))` call with `df.select(...sum()).item()`.

🎯 Why
Running multiple `.filter()` operations inside a Python loop incurs overhead from context switching and materializes multiple intermediate DataFrames. Evaluating all expressions at once lets Polars parallelize execution natively in Rust and avoids materializing a filtered DataFrame just to calculate a row count.

📊 Impact
Reduces the memory and execution overhead in the merge metrics pipeline, improving execution speed significantly when processing DataFrames with a large number of columns.

🔬 Measurement
The test suite verifies that the exact coverage and enrichment values are maintained. Running `uv run pytest tests/unit/application/composite/ -n auto` passes successfully with the optimizations in place.

---
*PR created automatically by Jules for task [7583565822371623805](https://jules.google.com/task/7583565822371623805) started by @SatoryKono*