### PR TITLE
⚡ Bolt: Optimize Polars filtering with single-pass selection in MergerMetricsMixin

### DIFF
--- a/src/bioetl/application/composite/merger_metrics_mixin.py
+++ b/src/bioetl/application/composite/merger_metrics_mixin.py
@@ -146,7 +146,8 @@ class MergeMetricsRecorderMixin:
         any_enriched = pl.any_horizontal(
             [pl.col(col).is_not_null() for col in enricher_cols]
         )
-        return len(df.filter(any_enriched))
+        # Calculate boolean mask sum directly without materializing a filtered dataframe
+        return df.select(any_enriched.sum()).item()
 
     def _count_fully_enriched(
         self,
@@ -180,13 +181,13 @@ class MergeMetricsRecorderMixin:
         if len(df) == 0:
             return {}
 
-        coverage: dict[str, float] = {}
-        for col in df.columns:
-            if not col.startswith("_"):
-                non_null = len(df.filter(df[col].is_not_null()))
-                coverage[col] = non_null / len(df)
+        cols = [col for col in df.columns if not col.startswith("_")]
+        if not cols:
+            return {}
 
-        return coverage
+        # Build list of expressions to evaluate in a single pass instead of looping with individual filters
+        exprs = [(pl.col(col).is_not_null().sum() / len(df)).alias(col) for col in cols]
+        return df.select(exprs).row(0, named=True)
 
 
 __all__ = ["MergeMetricsRecorderMixin"]


### PR DESCRIPTION
💡 What: Optimized Polars operations in `MergerMetricsMixin._calculate_field_coverage` and `_count_enriched_records`. Replaced Python loops executing individual `.filter()` operations with a single `.select()` query evaluating multiple expressions simultaneously. Also replaced `.filter().len()` with `.select(expr.sum()).item()`.
🎯 Why: Iterating over DataFrame columns in Python to run individual `.filter()` operations causes significant performance overhead and prevents Polars' query engine from parallelizing the workload. Materializing an entire filtered DataFrame just to compute its length is also unnecessarily expensive.
📊 Impact: Expected to significantly reduce Python overhead and speed up execution, as all column nullability checks and sums are now executed in a single vectorized pass without materializing intermediate filtered DataFrames.
🔬 Measurement: Run the test suite using `uv run pytest tests/unit/application/composite/ -n auto` to ensure functionality remains correct and performance has improved.

---
*PR created automatically by Jules for task [18304071604588056087](https://jules.google.com/task/18304071604588056087) started by @SatoryKono*