### PR TITLE
test: close architecture governance issues 6220-6229

### DIFF
--- a/configs/quality/domain_aggregate_classification.yaml
+++ b/configs/quality/domain_aggregate_classification.yaml
@@ -1,0 +1,112 @@
+schema_version: 1
+policy_scope: domain_aggregate_classification
+linked_issue: "#6225"
+reviewed_on: "2026-07-12"
+review_by: "2026-10-31"
+owner: "@bioetl-domain"
+new_surface_policy: fail_fast_unclassified_domain_aggregate_surface
+rationale: >-
+  Domain aggregate roots are limited to the reviewed aggregate package and must
+  stay backed by invariant evidence. Other top-level domain packages and root
+  modules are classified as support surfaces so new aggregate-like clusters
+  cannot appear without an explicit owner review.
+aggregate_package:
+  name: aggregates
+  path: src/bioetl/domain/aggregates
+  classification: aggregate_root_package
+  owner: "@bioetl-domain"
+  invariant_registry: reports/quality/domain-aggregate-invariant-registry.json
+true_aggregates:
+  - aggregate: Batch
+    root_module: src/bioetl/domain/aggregates/batch.py
+    implementation_modules:
+      - src/bioetl/domain/aggregates/_batch_aggregate.py
+      - src/bioetl/domain/aggregates/_batch_lifecycle.py
+      - src/bioetl/domain/aggregates/_batch_mixins.py
+      - src/bioetl/domain/aggregates/_batch_record.py
+      - src/bioetl/domain/aggregates/_batch_status.py
+    invariant_tests:
+      - tests/unit/domain/aggregates/test_batch.py
+      - tests/unit/domain/aggregates/test_batch_determinism.py
+      - tests/unit/domain/aggregates/test_batch_internal_modules.py
+      - tests/unit/domain/aggregates/test_batch_invariant_properties.py
+  - aggregate: PipelineRun
+    root_module: src/bioetl/domain/aggregates/pipeline_run.py
+    implementation_modules:
+      - src/bioetl/domain/aggregates/pipeline_run.py
+      - src/bioetl/domain/aggregates/pipeline_run_stage_result.py
+      - src/bioetl/domain/aggregates/_pipeline_run_mixins.py
+    invariant_tests:
+      - tests/unit/domain/aggregates/test_pipeline_run.py
+      - tests/unit/domain/aggregates/test_pipeline_run_events.py
+      - tests/unit/domain/aggregates/test_pipeline_run_internal_mixins.py
+      - tests/unit/domain/aggregates/test_pipeline_run_invariant_properties.py
+  - aggregate: QuarantineEntry
+    root_module: src/bioetl/domain/aggregates/quarantine_entry.py
+    implementation_modules:
+      - src/bioetl/domain/aggregates/_quarantine_aggregate.py
+      - src/bioetl/domain/aggregates/_quarantine_entry_properties_mixin.py
+      - src/bioetl/domain/aggregates/_quarantine_entry_transitions_mixin.py
+      - src/bioetl/domain/aggregates/_quarantine_value_objects.py
+    invariant_tests:
+      - tests/unit/domain/aggregates/test_quarantine_entry.py
+      - tests/unit/domain/aggregates/test_quarantine_entry_internal_mixins.py
+      - tests/unit/domain/aggregates/test_quarantine_entry_invariant_properties.py
+      - tests/unit/domain/aggregates/test_deterministic_identity.py
+row_templates:
+  support_cluster: &support_cluster
+    classification: domain_support_cluster
+    owner: "@bioetl-domain"
+    rationale: "Not an aggregate root; package owns domain support types, policies, or contracts."
+  support_module: &support_module
+    classification: domain_support_module
+    owner: "@bioetl-domain"
+    rationale: "Not an aggregate root; module owns domain support types, policies, or contracts."
+non_aggregate_clusters:
+  - {name: behavior, path: src/bioetl/domain/behavior, <<: *support_cluster}
+  - {name: composite, path: src/bioetl/domain/composite, <<: *support_cluster}
+  - {name: config, path: src/bioetl/domain/config, <<: *support_cluster}
+  - {name: contracts, path: src/bioetl/domain/contracts, <<: *support_cluster}
+  - {name: control_plane, path: src/bioetl/domain/control_plane, <<: *support_cluster}
+  - {name: entities, path: src/bioetl/domain/entities, <<: *support_cluster}
+  - {name: exceptions, path: src/bioetl/domain/exceptions, <<: *support_cluster}
+  - {name: filtering, path: src/bioetl/domain/filtering, <<: *support_cluster}
+  - {name: lineage, path: src/bioetl/domain/lineage, <<: *support_cluster}
+  - {name: mapping, path: src/bioetl/domain/mapping, <<: *support_cluster}
+  - {name: models, path: src/bioetl/domain/models, <<: *support_cluster}
+  - {name: normalization, path: src/bioetl/domain/normalization, <<: *support_cluster}
+  - {name: ports, path: src/bioetl/domain/ports, <<: *support_cluster}
+  - {name: registry, path: src/bioetl/domain/registry, <<: *support_cluster}
+  - {name: schemas, path: src/bioetl/domain/schemas, <<: *support_cluster}
+  - {name: services, path: src/bioetl/domain/services, <<: *support_cluster}
+  - {name: transformations, path: src/bioetl/domain/transformations, <<: *support_cluster}
+  - {name: types, path: src/bioetl/domain/types, <<: *support_cluster}
+  - {name: validation, path: src/bioetl/domain/validation, <<: *support_cluster}
+  - {name: value_objects, path: src/bioetl/domain/value_objects, <<: *support_cluster}
+  - {name: workflow, path: src/bioetl/domain/workflow, <<: *support_cluster}
+non_aggregate_root_modules:
+  - {module: bioetl.domain._observability_contract_core, path: src/bioetl/domain/_observability_contract_core.py, <<: *support_module}
+  - {module: bioetl.domain._observability_contract_primitives, path: src/bioetl/domain/_observability_contract_primitives.py, <<: *support_module}
+  - {module: bioetl.domain.constants, path: src/bioetl/domain/constants.py, <<: *support_module}
+  - {module: bioetl.domain.context, path: src/bioetl/domain/context.py, <<: *support_module}
+  - {module: bioetl.domain.context_cached_bronze, path: src/bioetl/domain/context_cached_bronze.py, <<: *support_module}
+  - {module: bioetl.domain.context_correlation, path: src/bioetl/domain/context_correlation.py, <<: *support_module}
+  - {module: bioetl.domain.context_filtering, path: src/bioetl/domain/context_filtering.py, <<: *support_module}
+  - {module: bioetl.domain.context_run, path: src/bioetl/domain/context_run.py, <<: *support_module}
+  - {module: bioetl.domain.context_time, path: src/bioetl/domain/context_time.py, <<: *support_module}
+  - {module: bioetl.domain.context_validation, path: src/bioetl/domain/context_validation.py, <<: *support_module}
+  - {module: bioetl.domain.deterministic_identity, path: src/bioetl/domain/deterministic_identity.py, <<: *support_module}
+  - {module: bioetl.domain.error_classifier, path: src/bioetl/domain/error_classifier.py, <<: *support_module}
+  - {module: bioetl.domain.error_types, path: src/bioetl/domain/error_types.py, <<: *support_module}
+  - {module: bioetl.domain.events, path: src/bioetl/domain/events.py, <<: *support_module}
+  - {module: bioetl.domain.locking, path: src/bioetl/domain/locking.py, <<: *support_module}
+  - {module: bioetl.domain.medallion, path: src/bioetl/domain/medallion.py, <<: *support_module}
+  - {module: bioetl.domain.observability_contract, path: src/bioetl/domain/observability_contract.py, <<: *support_module}
+  - {module: bioetl.domain.observability_event_mapping, path: src/bioetl/domain/observability_event_mapping.py, <<: *support_module}
+  - {module: bioetl.domain.observability_metric_names, path: src/bioetl/domain/observability_metric_names.py, <<: *support_module}
+  - {module: bioetl.domain.pubchem_standardization_catalog, path: src/bioetl/domain/pubchem_standardization_catalog.py, <<: *support_module}
+  - {module: bioetl.domain.resilience, path: src/bioetl/domain/resilience.py, <<: *support_module}
+  - {module: bioetl.domain.runtime_observability_publication_contract, path: src/bioetl/domain/runtime_observability_publication_contract.py, <<: *support_module}
+  - {module: bioetl.domain.serialization, path: src/bioetl/domain/serialization.py, <<: *support_module}
+  - {module: bioetl.domain.types_config_validation, path: src/bioetl/domain/types_config_validation.py, <<: *support_module}
+  - {module: bioetl.domain.version, path: src/bioetl/domain/version.py, <<: *support_module}

--- a/configs/quality/public_lazy_facade_inventory.yaml
+++ b/configs/quality/public_lazy_facade_inventory.yaml
@@ -1,0 +1,143 @@
+schema_version: 1
+policy_scope: public_lazy_facades
+linked_issue: "#6220"
+reviewed_on: "2026-07-12"
+review_by: "2026-10-31"
+owner: "@bioetl-architecture"
+new_surface_policy: fail_fast_unclassified_lazy_public_facade
+row_count: 51
+rationale: >-
+  Lazy public facades are intentional only when the owning package declares the
+  owner, allowed importer class, classification, and exit criteria. New
+  __getattr__, _PUBLIC_EXPORTS, or _PUBLIC_SYMBOL_TARGETS surfaces under
+  src/bioetl must be added here before merge.
+allowed_classifications:
+  - external_public_api
+  - owner_package_root
+  - compatibility_debt
+  - internal_lazy_import_optimization
+row_templates:
+  composition_external: &composition_external
+    classification: external_public_api
+    owner: "@bioetl-composition"
+    allowed_importers: [external_consumers, tests]
+    exit_criteria: "Retain until reviewed public-API migration or breaking-change ADR removes the facade."
+  composition_package: &composition_package
+    classification: owner_package_root
+    owner: "@bioetl-composition"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+  composition_internal: &composition_internal
+    classification: internal_lazy_import_optimization
+    owner: "@bioetl-composition"
+    allowed_importers: [owning_module_family, tests]
+    exit_criteria: "Retain while it prevents import cycles or expensive eager imports."
+  domain_package: &domain_package
+    classification: owner_package_root
+    owner: "@bioetl-domain"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+  cli_package: &cli_package
+    classification: owner_package_root
+    owner: "@bioetl-interfaces-cli"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the CLI package root is the reviewed owner import surface."
+  config_compatibility: &config_compatibility
+    classification: compatibility_debt
+    owner: "@bioetl-config"
+    allowed_importers: [external_compatibility_consumers, tests]
+    exit_criteria: >-
+      Collapse after first-party callers remain at zero and the compatibility
+      owner approves an external sunset or replacement import path.
+  infrastructure_package: &infrastructure_package
+    classification: owner_package_root
+    owner: "@bioetl-infrastructure"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+  observability_package: &observability_package
+    classification: owner_package_root
+    owner: "@bioetl-observability"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+  storage_internal: &storage_internal
+    classification: internal_lazy_import_optimization
+    owner: "@bioetl-infrastructure-storage"
+    allowed_importers: [owning_module_family, tests]
+    exit_criteria: "Retain while it prevents import cycles or expensive eager imports."
+  adapter_internal: &adapter_internal
+    classification: internal_lazy_import_optimization
+    owner: "@bioetl-infrastructure-adapters"
+    allowed_importers: [owning_module_family, tests]
+    exit_criteria: "Retain while it prevents import cycles or expensive eager imports."
+  application_external: &application_external
+    classification: external_public_api
+    owner: "@bioetl-application"
+    allowed_importers: [external_consumers, tests]
+    exit_criteria: "Retain until reviewed public-API migration or breaking-change ADR removes the facade."
+  application_package: &application_package
+    classification: owner_package_root
+    owner: "@bioetl-application"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+  application_internal: &application_internal
+    classification: internal_lazy_import_optimization
+    owner: "@bioetl-application"
+    allowed_importers: [owning_module_family, tests]
+    exit_criteria: "Retain while it prevents import cycles or expensive eager imports."
+  control_plane_package: &control_plane_package
+    classification: owner_package_root
+    owner: "@bioetl-application-control-plane"
+    allowed_importers: [owning_package, tests]
+    exit_criteria: "Retain while the package root is the reviewed owner import surface."
+facades:
+  - {path: src/bioetl/composition/control_plane_api.py, module: bioetl.composition.control_plane_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/composition/entrypoints.py, module: bioetl.composition.entrypoints, markers: [_PUBLIC_SYMBOL_TARGETS], <<: *composition_external}
+  - {path: src/bioetl/composition/execution_api.py, module: bioetl.composition.execution_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/composition/health_api.py, module: bioetl.composition.health_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/composition/maintenance_api.py, module: bioetl.composition.maintenance_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/composition/registry_api.py, module: bioetl.composition.registry_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/composition/resources_api.py, module: bioetl.composition.resources_api, markers: [_PUBLIC_EXPORTS], <<: *composition_external}
+  - {path: src/bioetl/domain/__init__.py, module: bioetl.domain, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/interfaces/cli/commands/__init__.py, module: bioetl.interfaces.cli.commands, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/composite/__init__.py, module: bioetl.interfaces.cli.commands.domains.composite, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/diagnostics/__init__.py, module: bioetl.interfaces.cli.commands.domains.diagnostics, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/health/__init__.py, module: bioetl.interfaces.cli.commands.domains.health, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/maintenance/__init__.py, module: bioetl.interfaces.cli.commands.domains.maintenance, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/quarantine/__init__.py, module: bioetl.interfaces.cli.commands.domains.quarantine, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/interfaces/cli/commands/domains/run_all/__init__.py, module: bioetl.interfaces.cli.commands.domains.run_all, markers: [__getattr__], <<: *cli_package}
+  - {path: src/bioetl/infrastructure/config/__init__.py, module: bioetl.infrastructure.config, markers: [__getattr__], <<: *config_compatibility}
+  - {path: src/bioetl/infrastructure/control_plane/__init__.py, module: bioetl.infrastructure.control_plane, markers: [__getattr__], <<: *infrastructure_package}
+  - {path: src/bioetl/infrastructure/export/__init__.py, module: bioetl.infrastructure.export, markers: [__getattr__], <<: *infrastructure_package}
+  - {path: src/bioetl/infrastructure/observability/__init__.py, module: bioetl.infrastructure.observability, markers: [__getattr__], <<: *observability_package}
+  - {path: src/bioetl/infrastructure/storage/support/atomic_ops.py, module: bioetl.infrastructure.storage.support.atomic_ops, markers: [__getattr__], <<: *storage_internal}
+  - {path: src/bioetl/infrastructure/adapters/http/health_monitor.py, module: bioetl.infrastructure.adapters.http.health_monitor, markers: [__getattr__], <<: *adapter_internal}
+  - {path: src/bioetl/domain/behavior/__init__.py, module: bioetl.domain.behavior, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *domain_package}
+  - {path: src/bioetl/domain/config/__init__.py, module: bioetl.domain.config, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/entities/__init__.py, module: bioetl.domain.entities, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/exceptions/__init__.py, module: bioetl.domain.exceptions, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/filtering/__init__.py, module: bioetl.domain.filtering, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/ports/__init__.py, module: bioetl.domain.ports, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/types/__init__.py, module: bioetl.domain.types, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/value_objects/__init__.py, module: bioetl.domain.value_objects, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/domain/normalization/profiles/__init__.py, module: bioetl.domain.normalization.profiles, markers: [__getattr__], <<: *domain_package}
+  - {path: src/bioetl/composition/bootstrap/__init__.py, module: bioetl.composition.bootstrap, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *composition_package}
+  - {path: src/bioetl/composition/factories/__init__.py, module: bioetl.composition.factories, markers: [__getattr__], <<: *composition_package}
+  - {path: src/bioetl/composition/providers/__init__.py, module: bioetl.composition.providers, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *composition_package}
+  - {path: src/bioetl/composition/runtime_builders/inputs_resolver.py, module: bioetl.composition.runtime_builders.inputs_resolver, markers: [__getattr__], <<: *composition_external}
+  - {path: src/bioetl/composition/runtime_builders/_run_manifest_data_roots.py, module: bioetl.composition.runtime_builders._run_manifest_data_roots, markers: [__getattr__], <<: *composition_internal}
+  - {path: src/bioetl/composition/runtime_builders/_run_manifest_refs.py, module: bioetl.composition.runtime_builders._run_manifest_refs, markers: [__getattr__], <<: *composition_internal}
+  - {path: src/bioetl/composition/factories/dq/__init__.py, module: bioetl.composition.factories.dq, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *composition_package}
+  - {path: src/bioetl/composition/factories/pipeline/registry.py, module: bioetl.composition.factories.pipeline.registry, markers: [__getattr__], <<: *composition_internal}
+  - {path: src/bioetl/composition/factories/pipeline/__init__.py, module: bioetl.composition.factories.pipeline, markers: [__getattr__], <<: *composition_package}
+  - {path: src/bioetl/composition/factories/services/factory.py, module: bioetl.composition.factories.services.factory, markers: [__getattr__], <<: *composition_internal}
+  - {path: src/bioetl/composition/factories/services/__init__.py, module: bioetl.composition.factories.services, markers: [__getattr__], <<: *composition_package}
+  - {path: src/bioetl/composition/bootstrap/cli/__init__.py, module: bioetl.composition.bootstrap.cli, markers: [__getattr__], <<: *composition_package}
+  - {path: src/bioetl/composition/bootstrap/runtime/composite.py, module: bioetl.composition.bootstrap.runtime.composite, markers: [__getattr__], <<: *composition_internal}
+  - {path: src/bioetl/composition/bootstrap/runtime/__init__.py, module: bioetl.composition.bootstrap.runtime, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *composition_package}
+  - {path: src/bioetl/application/services/control_plane/replay/__init__.py, module: bioetl.application.services.control_plane.replay, markers: [__getattr__, _PUBLIC_EXPORTS], <<: *control_plane_package}
+  - {path: src/bioetl/application/pipelines/common/blocks.py, module: bioetl.application.pipelines.common.blocks, markers: [__getattr__], <<: *application_internal}
+  - {path: src/bioetl/application/pipelines/crossref/__init__.py, module: bioetl.application.pipelines.crossref, markers: [__getattr__], <<: *application_package}
+  - {path: src/bioetl/application/core/wiring/factory.py, module: bioetl.application.core.wiring.factory, markers: [_PUBLIC_EXPORTS], <<: *application_external}
+  - {path: src/bioetl/application/core/wiring/registry.py, module: bioetl.application.core.wiring.registry, markers: [_PUBLIC_EXPORTS], <<: *application_external}
+  - {path: src/bioetl/application/core/wiring/transformer.py, module: bioetl.application.core.wiring.transformer, markers: [_PUBLIC_EXPORTS], <<: *application_external}
+  - {path: src/bioetl/application/core/wiring/__init__.py, module: bioetl.application.core.wiring, markers: [__getattr__], <<: *application_package}

--- a/reports/quality/tech-debt-issues-6220-6229-closeout.json
+++ b/reports/quality/tech-debt-issues-6220-6229-closeout.json
@@ -1,0 +1,228 @@
+{
+  "schema_version": "tech-debt-issues-6220-6229-closeout-v1",
+  "generated_on": "2026-07-12",
+  "generated_by": "codex",
+  "debt_budget_policy": "flat_or_decreasing_only",
+  "debt_budget_outcome": "reduced_or_unchanged",
+  "issue_batch": {
+    "issues": [6220, 6221, 6222, 6224, 6225, 6226, 6227, 6229],
+    "theme": "architecture_ownership_governance_drift_closeout"
+  },
+  "issues": [
+    {
+      "number": 6220,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/public_lazy_facade_inventory.yaml",
+        "tests/architecture/test_public_lazy_facade_inventory.py",
+        "reports/quality/compatibility-importer-census.json"
+      ]
+    },
+    {
+      "number": 6221,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/internal_compatibility_shim_inventory.yaml",
+        "reports/quality/compatibility-importer-census.json",
+        "tests/architecture/test_public_surface_importer_census_governance.py"
+      ]
+    },
+    {
+      "number": 6222,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/composition_bootstrap_owner_map.yaml",
+        "configs/quality/control_plane_facade_import_policy.yaml",
+        "tests/architecture/test_bootstrap_layer_boundaries.py",
+        "reports/quality/architecture-quality-scorecard.json"
+      ]
+    },
+    {
+      "number": 6224,
+      "status": "closed-ready",
+      "evidence": [
+        "reports/quality/dead-code-inventory.json",
+        "reports/quality/dead-code-inventory.md",
+        "tests/architecture/test_retirement_candidate_triage.py"
+      ]
+    },
+    {
+      "number": 6225,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/domain_aggregate_classification.yaml",
+        "reports/quality/domain-aggregate-invariant-registry.json",
+        "tests/architecture/test_domain_aggregate_classification.py",
+        "tests/architecture/test_domain_aggregate_invariant_registry.py"
+      ]
+    },
+    {
+      "number": 6226,
+      "status": "closed-ready",
+      "evidence": [
+        "reports/quality/pipeline-config-contract-ownership-map.json",
+        "reports/quality/pipeline-config-contract-ownership-map.md",
+        "reports/quality/contract-registry-dq-diagnostics.json",
+        "reports/quality/config-discrepancy-baseline.json",
+        "tests/architecture/test_pipeline_config_contract_ownership_map_integrity.py",
+        "tests/architecture/test_pipeline_config_contract_ownership_map_drift.py"
+      ]
+    },
+    {
+      "number": 6227,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/runtime_uuid_seams.yaml",
+        "configs/quality/determinism_identity_policy.yaml",
+        "reports/observability/runtime_cardinality_inventory.json",
+        "reports/observability/runtime_cardinality_review.json",
+        "configs/base/bronze_fixture_gaps.yaml",
+        "reports/quality/vcr-metadata-catalog.json",
+        "tests/architecture/test_runtime_uuid_seam_inventory.py",
+        "tests/architecture/test_determinism_identity_policy.py",
+        "tests/architecture/test_observability_metric_governance.py",
+        "tests/architecture/test_vcr_metadata_catalog_drift.py",
+        "tests/architecture/test_bronze_fixture_replay_baseline.py"
+      ]
+    },
+    {
+      "number": 6229,
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/test_matrix.yaml",
+        "configs/quality/pytest_shards.yaml",
+        "configs/quality/test_telemetry_baseline.yaml",
+        "reports/test-telemetry/slowest-tests.json",
+        "reports/test-telemetry/slowest-tests.md",
+        "tests/architecture/test_test_matrix_lane_policy.py",
+        "tests/architecture/test_test_telemetry_governance.py"
+      ]
+    }
+  ],
+  "outcomes": {
+    "6220": {
+      "status": "closeable",
+      "summary": "All lazy __getattr__, _PUBLIC_EXPORTS, and _PUBLIC_SYMBOL_TARGETS surfaces under src/bioetl are inventoried with owner, importer class, classification, markers, and exit criteria."
+    },
+    "6221": {
+      "status": "closeable",
+      "summary": "Infrastructure config compatibility shims remain bounded at zero first-party src importers with owner tests and exit criteria."
+    },
+    "6222": {
+      "status": "closeable",
+      "summary": "Bootstrap runtime, CLI service assembly, and composite runner ownership are mapped to reviewed owner graphs, and architecture scorecard layer violations remain zero."
+    },
+    "6224": {
+      "status": "closeable",
+      "summary": "Dead-code inventory has zero untriaged zero-import candidates and retained candidates are owner-test anchored."
+    },
+    "6225": {
+      "status": "closeable",
+      "summary": "True aggregate roots stay aligned with invariant registry evidence, while non-aggregate domain clusters and root modules are explicitly classified."
+    },
+    "6226": {
+      "status": "closeable",
+      "summary": "Pipeline config-contract ownership map covers all 27 rows; contract diagnostics and config discrepancy baselines have zero blocking/inconsistent findings."
+    },
+    "6227": {
+      "status": "closeable",
+      "summary": "Runtime UUID seams, runtime cardinality review requirements, bronze fixture gaps, and VCR ownership gaps are all at zero."
+    },
+    "6229": {
+      "status": "closeable",
+      "summary": "S7 architecture scan hotspots are documented in telemetry, slow-governance cache evidence is captured, and fast/slow architecture lanes remain split."
+    }
+  },
+  "ratchets": {
+    "public_lazy_facade_rows": {
+      "current": 51,
+      "max": 51,
+      "opening": 51,
+      "source": "configs/quality/public_lazy_facade_inventory.yaml"
+    },
+    "unclassified_public_lazy_facades": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "configs/quality/public_lazy_facade_inventory.yaml"
+    },
+    "retained_public_export_facades": {
+      "current": 4,
+      "max": 4,
+      "opening": 4,
+      "source": "reports/quality/compatibility-importer-census.json"
+    },
+    "config_root_src_importers": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/compatibility-importer-census.json"
+    },
+    "layer_violations": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/architecture-quality-scorecard.json"
+    },
+    "repo_wide_untriaged_zero_import_candidates": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/dead-code-inventory.json"
+    },
+    "aggregate_registry_missing_source_paths": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/domain-aggregate-invariant-registry.json"
+    },
+    "pipeline_config_contract_rows": {
+      "current": 27,
+      "max": 27,
+      "opening": 27,
+      "source": "reports/quality/pipeline-config-contract-ownership-map.json"
+    },
+    "contract_registry_dq_blocking_issues": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/contract-registry-dq-diagnostics.json"
+    },
+    "config_discrepancy_inconsistent_parameters": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/config-discrepancy-baseline.json"
+    },
+    "runtime_uuid4_seams": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "configs/quality/runtime_uuid_seams.yaml"
+    },
+    "runtime_cardinality_review_required": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/observability/runtime_cardinality_inventory.json"
+    },
+    "runtime_cardinality_threshold_violations": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/observability/runtime_cardinality_inventory.json"
+    },
+    "bronze_fixture_gaps": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "configs/base/bronze_fixture_gaps.yaml"
+    },
+    "vcr_unowned_cassettes": {
+      "current": 0,
+      "max": 0,
+      "opening": 0,
+      "source": "reports/quality/vcr-metadata-catalog.json"
+    }
+  }
+}

--- a/tests/architecture/test_domain_aggregate_classification.py
+++ b/tests/architecture/test_domain_aggregate_classification.py
@@ -1,0 +1,122 @@
+"""Governance checks for domain aggregate classification coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+DOMAIN_ROOT = ROOT / "src/bioetl/domain"
+CLASSIFICATION_PATH = ROOT / "configs/quality/domain_aggregate_classification.yaml"
+REGISTRY_PATH = ROOT / "reports/quality/domain-aggregate-invariant-registry.json"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _top_level_domain_package_paths() -> set[str]:
+    return {
+        path.relative_to(ROOT).as_posix()
+        for path in DOMAIN_ROOT.iterdir()
+        if path.is_dir() and path.name != "__pycache__"
+    }
+
+
+def _top_level_domain_module_paths() -> set[str]:
+    return {
+        path.relative_to(ROOT).as_posix()
+        for path in DOMAIN_ROOT.iterdir()
+        if path.is_file() and path.suffix == ".py" and path.name != "__init__.py"
+    }
+
+
+def test_domain_aggregate_classification_has_expected_policy_shape() -> None:
+    payload = _load_yaml(CLASSIFICATION_PATH)
+
+    assert payload["schema_version"] == 1
+    assert payload["policy_scope"] == "domain_aggregate_classification"
+    assert payload["linked_issue"] == "#6225"
+    assert payload["new_surface_policy"] == (
+        "fail_fast_unclassified_domain_aggregate_surface"
+    )
+    assert payload["aggregate_package"]["path"] == "src/bioetl/domain/aggregates"
+    assert payload["true_aggregates"]
+    assert payload["non_aggregate_clusters"]
+    assert payload["non_aggregate_root_modules"]
+
+
+def test_domain_top_level_packages_are_exactly_classified() -> None:
+    payload = _load_yaml(CLASSIFICATION_PATH)
+    aggregate_package = payload["aggregate_package"]
+    assert isinstance(aggregate_package, dict)
+
+    classified = {str(aggregate_package["path"])}
+    classified.update(str(row["path"]) for row in payload["non_aggregate_clusters"])
+
+    assert classified == _top_level_domain_package_paths()
+
+
+def test_domain_top_level_root_modules_are_exactly_classified() -> None:
+    payload = _load_yaml(CLASSIFICATION_PATH)
+    classified = {str(row["path"]) for row in payload["non_aggregate_root_modules"]}
+
+    assert classified == _top_level_domain_module_paths()
+
+
+def test_true_aggregates_match_invariant_registry() -> None:
+    classification = _load_yaml(CLASSIFICATION_PATH)
+    registry = _load_json(REGISTRY_PATH)
+
+    true_rows = {
+        str(row["aggregate"]): row for row in classification["true_aggregates"]
+    }
+    registry_rows = {str(row["aggregate"]): row for row in registry["aggregates"]}
+
+    assert set(true_rows) == set(registry_rows)
+    assert registry["aggregate_root_count"] == len(true_rows)
+
+    for aggregate_name, true_row in true_rows.items():
+        registry_row = registry_rows[aggregate_name]
+        assert true_row["root_module"] == registry_row["root_module"]
+        assert set(true_row["implementation_modules"]) == set(
+            registry_row["implementation_modules"]
+        )
+        assert set(true_row["invariant_tests"]) == set(registry_row["test_paths"])
+
+        evidence_paths = [
+            true_row["root_module"],
+            *true_row["implementation_modules"],
+            *true_row["invariant_tests"],
+        ]
+        missing = [path for path in evidence_paths if not (ROOT / path).exists()]
+        assert missing == []
+
+
+def test_non_aggregate_classifications_do_not_overlap_aggregate_package() -> None:
+    payload = _load_yaml(CLASSIFICATION_PATH)
+    non_aggregate_paths = [
+        *(str(row["path"]) for row in payload["non_aggregate_clusters"]),
+        *(str(row["path"]) for row in payload["non_aggregate_root_modules"]),
+    ]
+
+    assert not [
+        path
+        for path in non_aggregate_paths
+        if path.startswith("src/bioetl/domain/aggregates")
+    ]
+    assert len(non_aggregate_paths) == len(set(non_aggregate_paths))

--- a/tests/architecture/test_public_lazy_facade_inventory.py
+++ b/tests/architecture/test_public_lazy_facade_inventory.py
@@ -1,0 +1,142 @@
+"""Governance checks for public lazy facade classification."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = ROOT / "configs/quality/public_lazy_facade_inventory.yaml"
+PUBLIC_MARKERS = frozenset({"__getattr__", "_PUBLIC_EXPORTS", "_PUBLIC_SYMBOL_TARGETS"})
+
+
+def _load_inventory() -> dict[str, Any]:
+    payload = yaml.safe_load(INVENTORY_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _target_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    if isinstance(target, ast.Tuple | ast.List):
+        names: set[str] = set()
+        for element in target.elts:
+            names.update(_target_names(element))
+        return names
+    return set()
+
+
+def _assignment_names(node: ast.stmt) -> set[str]:
+    if isinstance(node, ast.Assign):
+        names: set[str] = set()
+        for target in node.targets:
+            names.update(_target_names(target))
+        return names
+    if isinstance(node, ast.AnnAssign):
+        return _target_names(node.target)
+    return set()
+
+
+def _public_lazy_markers(tree: ast.Module) -> frozenset[str]:
+    markers: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "__getattr__":
+            markers.add("__getattr__")
+            continue
+        markers.update(_assignment_names(node).intersection(PUBLIC_MARKERS))
+    return frozenset(markers)
+
+
+def _discover_public_lazy_markers(
+    source_ast_cache: dict[Path, ast.Module],
+) -> dict[str, frozenset[str]]:
+    discovered: dict[str, frozenset[str]] = {}
+    for path, tree in source_ast_cache.items():
+        try:
+            relative_path = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            continue
+        if not relative_path.startswith("src/bioetl/"):
+            continue
+        markers = _public_lazy_markers(tree)
+        if markers:
+            discovered[relative_path] = markers
+    return discovered
+
+
+def _inventory_by_path() -> dict[str, dict[str, Any]]:
+    payload = _load_inventory()
+    return {str(row["path"]): row for row in payload["facades"]}
+
+
+def test_public_lazy_facade_inventory_has_policy_shape() -> None:
+    payload = _load_inventory()
+    facades = payload["facades"]
+
+    assert payload["schema_version"] == 1
+    assert payload["policy_scope"] == "public_lazy_facades"
+    assert payload["linked_issue"] == "#6220"
+    assert payload["new_surface_policy"] == (
+        "fail_fast_unclassified_lazy_public_facade"
+    )
+    assert payload["row_count"] == len(facades) == 51
+    assert set(payload["allowed_classifications"]) == {
+        "external_public_api",
+        "owner_package_root",
+        "compatibility_debt",
+        "internal_lazy_import_optimization",
+    }
+    assert len({row["path"] for row in facades}) == len(facades)
+
+
+def test_public_lazy_facade_inventory_matches_source_ast(
+    source_ast_cache: dict[Path, ast.Module],
+) -> None:
+    inventory_markers = {
+        path: frozenset(str(marker) for marker in row["markers"])
+        for path, row in _inventory_by_path().items()
+    }
+
+    assert _discover_public_lazy_markers(source_ast_cache) == inventory_markers
+
+
+def test_public_lazy_facade_rows_have_owner_importer_and_exit_metadata() -> None:
+    payload = _load_inventory()
+    allowed = set(payload["allowed_classifications"])
+
+    violations: list[str] = []
+    for row in payload["facades"]:
+        path = str(row["path"])
+        if row["classification"] not in allowed:
+            violations.append(f"{path}: unknown classification {row['classification']}")
+        if not str(row["owner"]).startswith("@"):
+            violations.append(f"{path}: owner must be a team handle")
+        if not row["allowed_importers"]:
+            violations.append(f"{path}: allowed_importers must be populated")
+        if not str(row["exit_criteria"]).strip():
+            violations.append(f"{path}: exit_criteria must be populated")
+        if not (ROOT / path).is_file():
+            violations.append(f"{path}: missing source file")
+
+    assert violations == []
+
+
+def test_infrastructure_config_root_facade_remains_bounded_compatibility_debt() -> None:
+    row = _inventory_by_path()["src/bioetl/infrastructure/config/__init__.py"]
+
+    assert row["classification"] == "compatibility_debt"
+    assert row["owner"] == "@bioetl-config"
+    assert row["allowed_importers"] == [
+        "external_compatibility_consumers",
+        "tests",
+    ]
+    assert "Collapse after first-party callers remain at zero" in row["exit_criteria"]

--- a/tests/architecture/test_tech_debt_issues_6220_6229_closeout.py
+++ b/tests/architecture/test_tech_debt_issues_6220_6229_closeout.py
@@ -1,0 +1,217 @@
+"""Architecture closeout guards for issues #6220 through #6229."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+CLOSEOUT = ROOT / "reports/quality/tech-debt-issues-6220-6229-closeout.json"
+EXPECTED_ISSUES = {6220, 6221, 6222, 6224, 6225, 6226, 6227, 6229}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_issue_pack_6220_6229_closeout_artifact_is_complete_and_budget_safe() -> None:
+    closeout = _load_json(CLOSEOUT)
+
+    assert {
+        "schema_version": closeout["schema_version"],
+        "debt_budget_policy": closeout["debt_budget_policy"],
+        "debt_budget_outcome": closeout["debt_budget_outcome"],
+    } == {
+        "schema_version": "tech-debt-issues-6220-6229-closeout-v1",
+        "debt_budget_policy": "flat_or_decreasing_only",
+        "debt_budget_outcome": "reduced_or_unchanged",
+    }
+
+    issue_status_by_number = {
+        int(issue["number"]): issue["status"] for issue in closeout["issues"]
+    }
+    assert issue_status_by_number == dict.fromkeys(EXPECTED_ISSUES, "closed-ready")
+
+    outcome_status_by_number = {
+        int(issue): outcome["status"] for issue, outcome in closeout["outcomes"].items()
+    }
+    assert outcome_status_by_number == dict.fromkeys(EXPECTED_ISSUES, "closeable")
+
+    missing_evidence = [
+        relative_path
+        for issue in closeout["issues"]
+        for relative_path in issue["evidence"]
+        if not (ROOT / relative_path).exists()
+    ]
+    assert missing_evidence == []
+
+    ratchet_violations = {
+        metric_name: ratchet
+        for metric_name, ratchet in closeout["ratchets"].items()
+        if ratchet["current"] > ratchet["max"]
+        or ratchet["current"] > ratchet["opening"]
+        or not (ROOT / ratchet["source"]).exists()
+    }
+    assert ratchet_violations == {}
+
+
+def test_issue_6220_public_lazy_facades_are_fully_classified() -> None:
+    closeout = _load_json(CLOSEOUT)
+    inventory = _load_yaml(ROOT / "configs/quality/public_lazy_facade_inventory.yaml")
+    facades = inventory["facades"]
+
+    assert (
+        inventory["row_count"]
+        == closeout["ratchets"]["public_lazy_facade_rows"]["current"]
+    )
+    assert len(facades) == 51
+    assert not [
+        row for row in facades if not row.get("classification") or not row.get("owner")
+    ]
+    assert closeout["ratchets"]["unclassified_public_lazy_facades"]["current"] == 0
+
+
+def test_issue_6221_config_compatibility_facade_has_zero_first_party_importers() -> (
+    None
+):
+    closeout = _load_json(CLOSEOUT)
+    census = _load_json(ROOT / "reports/quality/compatibility-importer-census.json")
+    summary = census["summary"]
+
+    assert (
+        summary["config_root_src_importer_count"]
+        == closeout["ratchets"]["config_root_src_importers"]["current"]
+    )
+    assert summary["config_root_src_importer_count"] == 0
+    for symbol in census["config_root_facade"]["symbols"]:
+        assert symbol["current_src_importer_count"] == 0
+        assert symbol["max_src_importers"] == 0
+
+
+def test_issue_6222_bootstrap_and_control_plane_ownership_are_violation_free() -> None:
+    closeout = _load_json(CLOSEOUT)
+    scorecard = _load_json(ROOT / "reports/quality/architecture-quality-scorecard.json")
+    bootstrap_map = _load_yaml(
+        ROOT / "configs/quality/composition_bootstrap_owner_map.yaml"
+    )
+    control_plane_policy = _load_yaml(
+        ROOT / "configs/quality/control_plane_facade_import_policy.yaml"
+    )
+
+    assert (
+        scorecard["metrics"]["layer_violations"]
+        == closeout["ratchets"]["layer_violations"]["current"]
+    )
+    assert scorecard["metrics"]["layer_violations"] == 0
+    assert bootstrap_map["policy_scope"] == "composition_bootstrap_owner_map"
+    assert bootstrap_map["owner_graphs"]
+    assert control_plane_policy["policy_scope"] == "control_plane_facade_import_policy"
+    assert control_plane_policy["facades"]
+
+
+def test_issue_6224_dead_code_review_has_no_untriaged_zero_import_candidates() -> None:
+    closeout = _load_json(CLOSEOUT)
+    inventory = _load_json(ROOT / "reports/quality/dead-code-inventory.json")
+    summary = inventory["summary"]
+
+    assert (
+        summary["repo_wide_untriaged_zero_import_candidate_count"]
+        == closeout["ratchets"]["repo_wide_untriaged_zero_import_candidates"]["current"]
+    )
+    assert summary["repo_wide_untriaged_zero_import_candidate_count"] == 0
+    assert summary["repo_wide_candidates_without_owner_tests_count"] == 0
+    assert summary["triaged_retained_without_owner_tests_count"] == 0
+
+
+def test_issue_6225_aggregate_registry_and_classification_are_aligned() -> None:
+    closeout = _load_json(CLOSEOUT)
+    registry = _load_json(
+        ROOT / "reports/quality/domain-aggregate-invariant-registry.json"
+    )
+    classification = _load_yaml(
+        ROOT / "configs/quality/domain_aggregate_classification.yaml"
+    )
+
+    assert registry["summary"]["missing_source_paths"] == []
+    assert registry["summary"]["missing_test_paths"] == []
+    assert (
+        closeout["ratchets"]["aggregate_registry_missing_source_paths"]["current"] == 0
+    )
+    assert {row["aggregate"] for row in classification["true_aggregates"]} == {
+        row["aggregate"] for row in registry["aggregates"]
+    }
+
+
+def test_issue_6226_pipeline_config_contract_gates_are_blocker_free() -> None:
+    closeout = _load_json(CLOSEOUT)
+    ownership = _load_json(
+        ROOT / "reports/quality/pipeline-config-contract-ownership-map.json"
+    )
+    dq = _load_json(ROOT / "reports/quality/contract-registry-dq-diagnostics.json")
+    discrepancy = _load_json(ROOT / "reports/quality/config-discrepancy-baseline.json")
+
+    assert (
+        ownership["row_count"]
+        == closeout["ratchets"]["pipeline_config_contract_rows"]["current"]
+    )
+    assert ownership["row_count"] == 27
+    assert (
+        dq["blocking_issue_count"]
+        == closeout["ratchets"]["contract_registry_dq_blocking_issues"]["current"]
+    )
+    assert dq["blocking_issue_count"] == 0
+    assert (
+        discrepancy["metrics"]["inconsistent_parameter_count"]
+        == closeout["ratchets"]["config_discrepancy_inconsistent_parameters"]["current"]
+    )
+    assert discrepancy["metrics"]["inconsistent_parameter_count"] == 0
+
+
+def test_issue_6227_replay_identity_and_observability_drift_gates_are_zero() -> None:
+    closeout = _load_json(CLOSEOUT)
+    uuid_seams = _load_yaml(ROOT / "configs/quality/runtime_uuid_seams.yaml")
+    cardinality = _load_json(
+        ROOT / "reports/observability/runtime_cardinality_inventory.json"
+    )
+    bronze = _load_yaml(ROOT / "configs/base/bronze_fixture_gaps.yaml")
+    vcr = _load_json(ROOT / "reports/quality/vcr-metadata-catalog.json")
+
+    assert uuid_seams["seams"] == []
+    assert closeout["ratchets"]["runtime_uuid4_seams"]["current"] == 0
+    assert cardinality["runtime_cardinality_review_required"] == []
+    assert cardinality["runtime_cardinality_threshold_violations"] == []
+    assert cardinality["dashboarded_without_declaration"] == []
+    assert cardinality["documented_without_registry"] == []
+    assert bronze["gaps"] == {}
+    assert vcr["totals"]["unowned_cassette_count"] == 0
+
+
+def test_issue_6229_architecture_scan_hotspots_are_split_and_cache_backed() -> None:
+    test_matrix = _load_yaml(ROOT / "configs/quality/test_matrix.yaml")
+    shards = _load_yaml(ROOT / "configs/quality/pytest_shards.yaml")
+    telemetry = _load_yaml(ROOT / "configs/quality/test_telemetry_baseline.yaml")
+    slowest = _load_json(ROOT / "reports/test-telemetry/slowest-tests.json")
+
+    probe = telemetry["slow_governance_cache_probe"]
+    report_probe = probe["probes"][0]
+    assert probe["lane_isolation"]["isolated"] is True
+    assert float(report_probe["improvement_factor"]) > 1.0
+    assert slowest["total_cases"] == telemetry["duration_telemetry"]["total_cases"]
+    assert "architecture-fast-boundary" in str(test_matrix)
+    assert "architecture-slow-governance" in str(test_matrix)
+    assert "architecture-fast-boundary" in str(shards)
+    assert "architecture-slow-governance" in str(shards)


### PR DESCRIPTION
Closed as redundant: `main` already contains `29a0e4bf72363360c30451a5f7e74f8366998c94` (`Merge branch 'close-issues-6220-6229'`) with the closeout evidence for #6220, #6221, #6222, #6224, #6225, #6226, #6227, and #6229.

Local validation performed before the remote closeout:
- `./.venv/bin/ruff check tests/architecture/test_public_lazy_facade_inventory.py tests/architecture/test_domain_aggregate_classification.py tests/architecture/test_tech_debt_issues_6220_6229_closeout.py`
- `./.venv/bin/python -m pytest tests/architecture/test_public_lazy_facade_inventory.py tests/architecture/test_domain_aggregate_classification.py tests/architecture/test_tech_debt_issues_6220_6229_closeout.py -q`
- related architecture pytest suite: 40 passed
- `./.venv/bin/python -m scripts.schema check-invariants --verbose`
- `./.venv/bin/python -m scripts.schema validate-configs`
- `./.venv/bin/python -m scripts.engineering.qa report-compatibility-importer-census --check`
- `./.venv/bin/python -m scripts.engineering.qa.report_observability_metric_inventory --repo-root . --check --write-evidence reports/observability/runtime_cardinality_inventory.json`