### PR TITLE
docs: close documentation audit findings

### DIFF
--- a/docs/02-architecture/01-domain-layer.md
+++ b/docs/02-architecture/01-domain-layer.md
@@ -532,12 +532,17 @@ domain surface. Runtime execution остаётся на `PipelineRunContext` и
 - `aggregation.py` - агрегация composite configs
 - `config.py` - composite domain config
 - `config_*.py` - специализированные composite configs
+- `config_cross_validation.py` - immutable cross-enricher config и пороговые инварианты
 - `cross_validation.py` - cross-validation logic
 - `field_groups.py` - field groups
 - `lineage.py` - lineage для composite
 - `result.py` - composite results
 
-**Зависимости:** Связан с ADR-008 (Composite Pattern).
+**Зависимости:** Связан с
+[ADR-026](decisions/ADR-026-composite-pipeline-pattern.md).
+
+**Историческая граница:** ADR-008 описывает superseded graceful-shutdown
+strategy и не является решением для этого слоя.
 
 #### 2.8.2. `contracts/`
 

--- a/docs/02-architecture/domain-composite.md
+++ b/docs/02-architecture/domain-composite.md
@@ -4,7 +4,7 @@
 
 Composite Domain Layer реализует паттерн Composite для оркестрации составных пайплайнов обогащения данных. Этот слой управляет конфигурацией, выполнением и слиянием данных из multiple enrichment pipelines в единую результирующую структуру.
 
-**Связанный ADR:** ADR-008 (Composite Pattern), ADR-026 (Composite Pipeline Architecture)
+**Связанный ADR:** ADR-026 (Composite Pipeline Pattern).
 
 ## Архитектура
 
@@ -16,6 +16,7 @@ src/bioetl/domain/composite/
 ├── config.py                         # Публичный API конфигурации
 ├── config_composite_serialization.py # Сериализация/десериализация
 ├── config_composite_validation.py    # Валидация конфигурации
+├── config_cross_validation.py        # Immutable cross-enricher config и пороговые инварианты
 ├── config_dq.py                      # DQ конфигурация
 ├── config_merge.py                   # Конфигурация слияния
 ├── config_models.py                  # Базовые модели конфигурации
@@ -256,8 +257,9 @@ src/bioetl/domain/composite/
 
 ## Связанные ADR
 
-- **ADR-008:** Composite Pattern - архитектурное решение для composite pattern
-- **ADR-026:** Composite Pipeline Architecture - детальная архитектура composite пайплайнов
+- **ADR-026:** принятое архитектурное решение для этого слоя.
+- **ADR-008:** Graceful Shutdown Strategy — исторический superseded ADR;
+  он не определяет архитектуру этого слоя.
 
 ## Зависимости
 

--- a/docs/05-operations/runbooks/codex-wsl-docker-sandbox-troubleshooting.md
+++ b/docs/05-operations/runbooks/codex-wsl-docker-sandbox-troubleshooting.md
@@ -1,3 +1,18 @@
+______________________________________________________________________
+
+Version: 1.0.0
+Status: active
+Class: internal-published
+Owner: BioETL Team
+Reviewers:
+
+- BioETL Team
+  Priority: P2
+  Runtime profile: Local-Only single-instance (ADR-010); Docker/MCP are optional adjunct tooling.
+  Last verified: '2026-07-13'
+
+______________________________________________________________________
+
 # Codex WSL Docker Sandbox Troubleshooting
 
 This runbook replaces the former root-level
@@ -5,23 +20,39 @@ This runbook replaces the former root-level
 
 ## Trigger
 
-Use this runbook when Codex setup or Docker sandbox startup fails on Windows /
-WSL with Docker Desktop virtualization errors such as:
+Use this runbook when Codex setup or the optional Docker sandbox fails on
+Windows / WSL with Docker Desktop virtualization errors such as:
 
 ```text
 panic: whp error, failed to set extended vm exits: The parameter is incorrect
 ```
 
-## Primary Response Order
+## Impact
 
-1. Restart Docker Desktop completely.
-1. Verify Hyper-V / CPU virtualization is enabled.
-1. Confirm the WSL distro is running as WSL 2.
-1. Re-check Docker Desktop WSL integration and memory allocation.
-1. Fall back to the non-sandboxed Codex launcher path if the sandbox VM stays
-   broken.
+- Priority: P2.
+- The failure blocks optional Codex sandbox tooling; it does not alter the
+  local-only BioETL runtime, pipeline data, or control-plane artifacts.
+- An unsafe container fallback can expose a token or let an unsandboxed process
+  act on a mounted workspace, so it is never the default recovery path.
 
-## 1. Restart Docker Desktop
+## Preconditions
+
+- Confirm that the target symptom is a Docker Desktop / WSL sandbox failure,
+  rather than a BioETL pipeline failure.
+- Have local administrator access before changing Hyper-V or WSL settings.
+- Keep Docker/MCP optional under ADR-010; use the canonical WSL launcher for
+  normal Codex work.
+- Do not create, edit, rename, move, or delete any `.env` file while following
+  this runbook.
+- An optional container fallback requires explicit task-owner approval, a
+  reviewed isolated workspace, and a token supplied only through the local
+  process environment. Never paste a token into a command, issue, log, or doc.
+
+## Procedure
+
+### 1. Triage and restart Docker Desktop
+
+Restart Docker Desktop completely, then check that its daemon responds:
 
 ```powershell
 taskkill /IM "Docker Desktop.exe" /F
@@ -32,43 +63,34 @@ Start-Sleep -Seconds 30
 docker ps
 ```
 
-## 2. Verify Hyper-V and CPU Virtualization
+### 2. Verify virtualization and WSL prerequisites
+
+Check Hyper-V and the target WSL distribution:
 
 ```powershell
 Get-WindowsOptionalFeature -Online -FeatureName Hyper-V
+wsl --list --verbose
 ```
 
-If Hyper-V is disabled, enable it and reboot:
+If Hyper-V is disabled, enable it and reboot. If the target distribution is
+WSL 1, upgrade the named distribution to WSL 2. Also verify BIOS virtualization
+(`VT-x` / `AMD-V`).
 
 ```powershell
 Enable-WindowsOptionalFeature -Online -FeatureName Hyper-V -All
+wsl --set-version <distribution-name> 2
 ```
 
-Also confirm BIOS virtualization is enabled (`VT-x` / `AMD-V`).
+### 3. Check Docker Desktop settings
 
-## 3. Confirm WSL 2
-
-```powershell
-wsl --list -v
-```
-
-If the target distro is WSL 1, upgrade it:
-
-```powershell
-wsl --set-version Ubuntu 2
-```
-
-## 4. Check Docker Desktop Settings
-
-- `Settings > General`: verify container runtime options are healthy.
+- `Settings > General`: verify that the container runtime is healthy.
 - `Settings > Resources`: allocate at least 8 GB memory for Codex-heavy runs.
-- `Settings > Resources > WSL Integration`: ensure the active distro is
-  enabled.
+- `Settings > Resources > WSL Integration`: enable the active distribution.
 
-## 5. Fall Back to the Canonical WSL Launchers
+### 4. Recover with the canonical WSL launchers
 
-If Docker sandbox VMs remain unstable, prefer the canonical Codex launchers
-that run the CLI in WSL and keep Docker/MCP as optional adjunct tooling:
+If Docker sandbox VMs remain unstable, use the supported WSL launchers. They
+keep Docker/MCP as optional adjunct tooling:
 
 ```powershell
 .\scripts\ai\codex\run-codex.ps1
@@ -76,32 +98,59 @@ that run the CLI in WSL and keep Docker/MCP as optional adjunct tooling:
 .\scripts\ai\codex\run-codex.ps1 check
 ```
 
-Related setup docs:
+### 5. Escalate an exceptional container fallback
 
-- `docs/05-operations/tooling/scripts-ops/CODEX_SETUP.md`
-- `docs/05-operations/tooling/scripts-ops/CODEX_WSL_SETUP.md`
-- `scripts/ai/codex/QUICKSTART_WSL.md`
+Do not use `--dangerously-bypass-approvals-and-sandbox` as a normal recovery
+step. If diagnostic access to a Docker sandbox image is indispensable, stop
+here and obtain explicit task-owner approval for a bounded, isolated diagnostic
+session. Record the approved image, workspace scope, token-handling method,
+operator, and exit criterion in the incident or issue. Do not mount a workspace
+containing secret-bearing files and do not use the fallback to perform writes.
 
-## Optional Container Fallback
+## Verification
 
-Only use this when you explicitly need the Docker sandbox image path for
-diagnosis:
-
-```powershell
-docker pull docker/sandbox-templates:codex
-docker run -it --rm `
-  -e OPENAI_API_KEY=$env:OPENAI_API_KEY `
-  -v "$PWD:/workspace" `
-  docker/sandbox-templates:codex `
-  codex --dangerously-bypass-approvals-and-sandbox "/workspace"
-```
-
-## Validation
-
-After remediation, verify:
+After remediation, verify the supported path:
 
 ```powershell
 docker ps
 wsl --list --verbose
 .\scripts\ai\codex\run-codex.ps1 check
 ```
+
+Record the observed Docker/WSL status and launcher result in the incident or
+issue before declaring the problem resolved.
+
+## Rollback
+
+- If a Hyper-V or WSL change worsens the host, stop the procedure and restore
+  the previous Windows feature or distribution setting through the approved
+  local administrator process.
+- If Docker remains unhealthy, do not retry an unbounded container fallback;
+  return to the canonical WSL launcher path and escalate the host issue.
+- No BioETL runtime configuration, pipeline data, or `.env` file is changed by
+  this runbook, so no data rollback is expected.
+
+## Post-incident
+
+- Record the error signature, host/WSL version, commands run, and verification
+  result.
+- Link the incident or issue to any Docker Desktop, WSL, launcher, or
+  documentation follow-up.
+- Update this runbook only when a supported launcher or safety boundary changes.
+
+## Compliance
+
+| Control | Requirement | Status | Evidence |
+| --- | --- | --- | --- |
+| Runtime posture | Docker/MCP remain optional under ADR-010 | pass | Preconditions and Procedure |
+| Safety | Bypass fallback requires explicit approval and isolated scope | pass | Procedure step 5 |
+| Secret handling | No secret values or `.env` mutation | pass | Preconditions |
+| Verification | Supported launcher health check is reproducible | pass | Verification |
+| Ownership | Incident/issue records operator and outcome | pass | Post-incident |
+
+## References
+
+- [ADR-010: Local-Only Deployment Strategy](../../02-architecture/decisions/ADR-010-local-only-deployment.md)
+- [Codex Setup](../tooling/scripts-ops/CODEX_SETUP.md)
+- [Codex WSL Setup](../tooling/scripts-ops/CODEX_WSL_SETUP.md)
+- [`scripts/ai/codex/QUICKSTART_WSL.md`](../../../scripts/ai/codex/QUICKSTART_WSL.md)

--- a/docs/05-operations/runbooks/index.md
+++ b/docs/05-operations/runbooks/index.md
@@ -63,6 +63,7 @@ ______________________________________________________________________
 | Runbook                                                                     | Description                                                          | Priority |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------- |
 | [Checkpoint Debugging](checkpoint-debugging.md)                             | Debugging checkpoint issues                                          | P2       |
+| [Codex WSL/Docker Sandbox Troubleshooting](codex-wsl-docker-sandbox-troubleshooting.md) | Optional Codex sandbox failure triage with a guarded WSL recovery path | P2       |
 | [Neo4j Backend Recovery Quick Start](neo4j-backend-recovery-quick-start.md) | Short recovery checklist for local Neo4j backend incidents           | P2       |
 | [Neo4j Complete Recovery Guide](neo4j-complete-recovery-guide.md)           | Compatibility pointer to canonical Neo4j quick-start runbook         | P2       |
 | [Stale Lock](stale-lock.md)                                                 | Handling stale lock situations                                       | P1       |

--- a/docs/reports/evidence/project-test-health/metadata.yaml
+++ b/docs/reports/evidence/project-test-health/metadata.yaml
@@ -2,8 +2,15 @@ version: 1
 policy_scope: non_canonical_evidence_summary
 summary_path: docs/reports/evidence/project-test-health/SUMMARY.md
 owner: "@bioetl-quality"
-last_verified: "2026-04-30"
+last_verified: "2026-07-13"
 freshness_window_days: 30
+verification_scope: tracked_test_module_inventory
+source_ref: c9d639733928a2b699be2cc5031a38c4b3a3707e
+test_module_inventory:
+  command: "git ls-files 'tests/**/test_*.py' | wc -l"
+  count: 1988
+  counted_on: "2026-07-13"
+  full_evidence_snapshot_date: "2026-03-23"
 allowed_interpretation: backlog_signal_only
 canonical_sources:
   - configs/quality/test_matrix.yaml

--- a/docs/reports/evidence/project-test-health/shard_registry.yaml
+++ b/docs/reports/evidence/project-test-health/shard_registry.yaml
@@ -2,6 +2,9 @@ version: 1
 policy_scope: project_test_health_evidence_shards
 owner: "@bioetl-quality"
 last_reviewed: "2026-04-30"
+last_inventory_rebaseline: "2026-07-13"
+inventory_source_ref: c9d639733928a2b699be2cc5031a38c4b3a3707e
+inventory_scope: tracked_test_module_inventory
 summary_path: docs/reports/evidence/project-test-health/SUMMARY.md
 shards:
   - id: failure-stability

--- a/tests/architecture/test_governance_freshness_protocol.py
+++ b/tests/architecture/test_governance_freshness_protocol.py
@@ -101,7 +101,7 @@ def test_project_test_health_summary_declares_machine_readable_freshness_metadat
     metadata = yaml.safe_load(metadata_text)
 
     assert metadata["status"] == "active-non-canonical"
-    assert metadata["last_verified"] == "2026-04-30"
+    assert metadata["last_verified"].startswith("2026-")
     assert metadata["freshness_window_days"] > 0
     assert metadata["owner"] == "quality"
     assert set(metadata["canonical_sources"]) >= {
@@ -132,8 +132,19 @@ def test_project_test_health_summary_has_machine_readable_metadata() -> None:
     assert metadata["last_verified"].startswith("2026-")
     assert metadata["allowed_interpretation"] == "backlog_signal_only"
     assert metadata["canonical_sources"]
+    assert metadata["verification_scope"] == "tracked_test_module_inventory"
+    assert metadata["source_ref"] == "c9d639733928a2b699be2cc5031a38c4b3a3707e"
+    assert metadata["test_module_inventory"] == {
+        "command": "git ls-files 'tests/**/test_*.py' | wc -l",
+        "count": 1988,
+        "counted_on": "2026-07-13",
+        "full_evidence_snapshot_date": "2026-03-23",
+    }
     assert shard_registry["policy_scope"] == "project_test_health_evidence_shards"
     assert shard_registry["owner"]
+    assert shard_registry["last_inventory_rebaseline"] == "2026-07-13"
+    assert shard_registry["inventory_source_ref"] == metadata["source_ref"]
+    assert shard_registry["inventory_scope"] == metadata["verification_scope"]
     assert shard_registry["shards"]
 
     resolved_shards = {


### PR DESCRIPTION
## Summary

- aligns Composite domain documentation with ADR-026 and the actual `config_cross_validation.py` module;
- replaces the unsafe Codex/WSL/Docker troubleshooting recipe with a governed, local-only runbook and adds it to the runbook index;
- rebaselines the tracked test-module inventory and protects its freshness/provenance with an architecture test.

Fixes #6234
Fixes #6235
Fixes #6236

## Validation

- `.venv/bin/python -m scripts.docs check-links --doc-governance`
- `.venv/bin/python -m scripts.docs check-drift --ports --classes --modules --json`
- `.venv/bin/python -m scripts.docs check-drift --runtime-mirrors --freshness`
- `.venv/bin/python -m pytest -q tests/architecture/test_governance_freshness_protocol.py tests/unit/domain/composite/test_config_cross_validation.py tests/architecture/test_check_doc_links_guardrails.py tests/architecture/test_documentation_sync.py tests/unit/scripts/test_documentation_governance_check.py`

## Scope

Documentation and a documentation-governance test only. No runtime configuration, secrets, `.env` files, or technical-debt budgets were changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified composite-domain architecture guidance and updated references to the current ADR.
  * Added documentation for cross-validation configuration and its threshold requirements.
  * Expanded the Codex WSL/Docker troubleshooting runbook with structured recovery, verification, rollback, and compliance guidance.
  * Added the troubleshooting runbook to the operations index.

* **Tests**
  * Improved validation of test-health evidence freshness, provenance, inventory, and shard metadata.

* **Chores**
  * Refreshed test-health inventory metadata and verification timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->