### PR TITLE
fix(observability): use canonical audit compose path

### DIFF
--- a/tests/integration/test_grafana_datasource_provisioning.py
+++ b/tests/integration/test_grafana_datasource_provisioning.py
@@ -22,7 +22,7 @@ def _load_monitoring_compose() -> dict[str, object]:
 
 
 def _load_monitoring_audit_override() -> dict[str, object]:
-    compose_path = Path("docker-compose.monitoring.audit.yml")
+    compose_path = Path("scripts/ops/observability/docker-compose.monitoring.audit.yml")
     return yaml.safe_load(compose_path.read_text(encoding="utf-8"))
 
 


### PR DESCRIPTION
## Summary

Point the Grafana datasource integration helper at the canonical audit override:
` scripts/ops/observability/docker-compose.monitoring.audit.yml`.

The post-merge Docker isolation removed the forbidden root duplicate while the test helper retained the obsolete root path. This one-line change restores ownership consistency without reintroducing a root artifact.

## Validation

- 22 focused observability tests passed
- `python -m scripts.engineering.repo check-cleanliness --strict-untracked --check-local-forbidden-outputs`
- `python -m scripts.engineering.repo check-root-review-registry --check`

Follow-up to merged #6301.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->