### PR TITLE
⚡ Bolt: Use .select() and .sum() instead of .filter() to count boolean masks

### DIFF
--- a/src/bioetl/application/services/dq/silver_statistics.py
+++ b/src/bioetl/application/services/dq/silver_statistics.py
@@ -235,8 +235,10 @@ class SilverStatisticsCalculator:
         hash_collision_count: int | None = None
         if "_content_hash" in df.columns:
             hash_counts = df["_content_hash"].value_counts()
-            duplicates = hash_counts.filter(pl.col("count") > 1)
-            hash_collision_count = len(duplicates)
+            # Avoid overhead of materializing a new DataFrame via .filter() by calculating sum directly
+            hash_collision_count = int(
+                hash_counts.select((pl.col("count") > 1).sum()).item()
+            )
         return _check_content_hash_integrity_stats(len(df), hash_collision_count)
 
     def distribution_to_dict(


### PR DESCRIPTION
**What:** Replaced `len(df.filter(expr))` with `int(df.select(expr.sum()).item())` in `src/bioetl/application/services/dq/silver_statistics.py`.
**Why:** Polars performance is impacted by the overhead of instantiating and holding new DataFrames in memory when calling `.filter()`. If we only need a count from a mask condition, we can avoid `.filter()` entirely and compute the aggregation directly over the columns using Polars expressions. The `int()` cast ensures compliance with strict `mypy` typing.
**Impact:** Decreases memory overhead and execution time when checking content hash integrity.
**Measurement:** Run data quality check tests (`uv run pytest tests/unit/application/services/dq/ -n auto`) to ensure no performance degradations or functionality breakage occurs. 

---
*PR created automatically by Jules for task [955247713724688528](https://jules.google.com/task/955247713724688528) started by @SatoryKono*