### PR TITLE
Fix/remediation f0adc0df 5c0cd8 (#6371)

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -70,15 +70,13 @@ services:
     restart: unless-stopped
     healthcheck:
       test:
-        - "CMD"
-        - "/usr/bin/loki"
-        - "-config.file=/etc/loki/config.yml"
-        - "-verify-config=true"
-      interval: 20s
+        - "CMD-SHELL"
+        - "wget --quiet --tries=1 --timeout=2 -O /dev/null http://localhost:3100/ready"
+      interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 15s
-    mem_limit: 7680m
+      retries: 6
+      start_period: 60s
+    mem_limit: 768m
     mem_reservation: 384m
     cpus: 7.5
     pids_limit: 2560

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -3219,7 +3219,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "description": "Pipeline-scoped structured warning logs for the selected pipeline over the bounded 1h window (last hour). Columns are parsed JSON fields (not a single flattened line). Empty state is neutral; warning visual weight is reserved for returned warning rows. Terminal-state contract: successful empty=VALID EMPTY; datasource/query failures=ERROR; blank/loading is forbidden.",
+          "description": "Pipeline-scoped structured warning logs for the selected pipeline over the bounded last hour. Columns are parsed JSON fields (not a single flattened line). Empty state is neutral; warning visual weight is reserved for returned warning rows. Terminal-state contract: successful empty=VALID EMPTY; datasource/query failures=ERROR; blank/loading is forbidden.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3364,7 +3364,7 @@
           "type": "table"
         },
         {
-          "description": "GLOBAL log events that failed JSON parsing over the bounded 1h window (last hour). Only the bounded parser error is rendered; the raw source line is intentionally excluded because it may contain secret-bearing payloads. Not pipeline-scoped runtime evidence; compare with pipeline-scoped warning logs. Terminal-state contract: successful empty=VALID EMPTY; datasource/query failures=ERROR; blank/loading is forbidden.",
+          "description": "GLOBAL log events that failed JSON parsing over the bounded last hour. Only the bounded parser error is rendered; the raw source line is intentionally excluded because it may contain secret-bearing payloads. Not pipeline-scoped runtime evidence; compare with pipeline-scoped warning logs. Terminal-state contract: successful empty=VALID EMPTY; datasource/query failures=ERROR; blank/loading is forbidden.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/scripts/ops/observability/grafana/audit_live_grafana_panels.py
+++ b/scripts/ops/observability/grafana/audit_live_grafana_panels.py
@@ -10,7 +10,7 @@ import os
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from time import monotonic
+from time import monotonic, sleep
 from typing import Any, Literal, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
@@ -1419,36 +1419,45 @@ def _audit_loki_panel(
         query_params
     )
     started_at = monotonic()
+    readiness = ""
+    readiness_error: Exception | None = None
     try:
-        readiness = _fetch_text(
-            f"{config.loki_base_url}/ready",
-            timeout_seconds=config.request_timeout_seconds,
-        )
-        if readiness.strip().lower() != "ready":
-            raise ValueError(f"unexpected /ready response: {readiness[:80]!r}")
-        elapsed_after_ready = monotonic() - started_at
-        remaining_timeout = config.request_timeout_seconds - elapsed_after_ready
+        while True:
+            elapsed = monotonic() - started_at
+            remaining_timeout = config.request_timeout_seconds - elapsed
+            if remaining_timeout <= 0:
+                return AuditResult(
+                    dashboard_uid=spec.dashboard_uid,
+                    panel_id=spec.panel_id,
+                    title=spec.title,
+                    source_kind=spec.source_kind,
+                    semantic_kind=spec.semantic_kind,
+                    status="error" if spec.required else "ok",
+                    classification="timeout_budget_exceeded",
+                    detail=(
+                        "Loki readiness probe exhausted the governed request budget; "
+                        f"latency_seconds={elapsed:.3f}; "
+                        f"budget_seconds={config.request_timeout_seconds:.3f}"
+                    ),
+                    query_preview=rendered_expr[:400],
+                    target_ref_id=spec.target_ref_id,
+                )
+            try:
+                readiness = _fetch_text(
+                    f"{config.loki_base_url}/ready",
+                    timeout_seconds=remaining_timeout,
+                )
+                readiness_error = None
+            except (HTTPError, URLError, OSError) as exc:
+                readiness_error = exc
+            if readiness_error is None and readiness.strip().lower() == "ready":
+                break
+            sleep(min(0.5, max(0.0, config.request_timeout_seconds - (monotonic() - started_at))))
+
+        remaining_timeout = config.request_timeout_seconds - (monotonic() - started_at)
         if remaining_timeout <= 0:
-            return AuditResult(
-                dashboard_uid=spec.dashboard_uid,
-                panel_id=spec.panel_id,
-                title=spec.title,
-                source_kind=spec.source_kind,
-                semantic_kind=spec.semantic_kind,
-                status="error" if spec.required else "ok",
-                classification="timeout_budget_exceeded",
-                detail=(
-                    "Loki readiness probe exhausted the governed request budget; "
-                    f"latency_seconds={elapsed_after_ready:.3f}; "
-                    f"budget_seconds={config.request_timeout_seconds:.3f}"
-                ),
-                query_preview=rendered_expr[:400],
-                target_ref_id=spec.target_ref_id,
-            )
-        payload = _fetch_json(
-            query_url,
-            timeout_seconds=remaining_timeout,
-        )
+            raise TimeoutError("Loki readiness probe exhausted the governed request budget")
+        payload = _fetch_json(query_url, timeout_seconds=remaining_timeout)
     except (HTTPError, URLError, OSError, ValueError, json.JSONDecodeError) as exc:
         return AuditResult(
             dashboard_uid=spec.dashboard_uid,
@@ -1457,7 +1466,11 @@ def _audit_loki_panel(
             source_kind=spec.source_kind,
             semantic_kind=spec.semantic_kind,
             status="error" if spec.required else "ok",
-            classification="blocked_unavailable",
+            classification=(
+                "timeout_budget_exceeded"
+                if isinstance(exc, TimeoutError)
+                else "blocked_unavailable"
+            ),
             detail=f"Loki readiness/query could not be executed: {exc}",
             query_preview=rendered_expr[:400],
             target_ref_id=spec.target_ref_id,

--- a/tests/unit/scripts/ops/observability/test_grafana_dashboard_audit_cycle.py
+++ b/tests/unit/scripts/ops/observability/test_grafana_dashboard_audit_cycle.py
@@ -751,6 +751,39 @@ def test_grafana_gate_rejects_cross_occurrence_source_artifacts(
     assert payload["release_passed"] is False
 
 
+def test_grafana_gate_rejects_render_source_without_panel_scope(
+    tmp_path: Path,
+) -> None:
+    config = cycle_subject._parse_args(
+        [
+            "--screenshot-dir",
+            str(tmp_path / "screenshots"),
+            "--gate-output",
+            str(tmp_path / "dashboard-release-gates.json"),
+        ]
+    )
+    _write_gate_sources(config, semantic_status="pass", render_status="pass")
+    manifest_path = config.screenshot_dir / "render-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["dashboards"][0].pop("terminalStateValidation")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    cycle_subject._write_gate_report(
+        config,
+        semantic_status="pass",
+        render_status="pass",
+        semantic_detail="Semantic source passed.",
+        render_detail="Render source claimed pass.",
+    )
+
+    payload = json.loads(config.gate_output_path.read_text(encoding="utf-8"))
+    render_source = payload["dashboard_render_gate"]["source_artifact"]
+    assert payload["dashboard_render_gate"]["status"] == "fail"
+    assert render_source["terminal_status"] == "fail"
+    assert render_source["dashboard_scope"] == []
+    assert render_source["validated"] is False
+
+
 def test_grafana_audit_cycle_router_exposes_command() -> None:
     assert_router_python_command(
         ops_router,


### PR DESCRIPTION
This pull request introduces several important improvements to the Grafana dashboard audit and observability pipeline, focusing on increased security, improved reliability, and clearer documentation. The changes enforce stricter time bounds on log queries, prevent accidental exposure of sensitive log data, and enhance CI/CD workflows for dashboard validation and artifact routing.

**Dashboard and Log Query Security:**

* Updated all relevant Grafana dashboard panels and queries to strictly bound log queries to the last one hour (`[1h]` or `timeFrom: "1h"`), replacing previous reliance on the Grafana UI range. This ensures consistent, reproducible evidence and prevents unbounded queries. [[1]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebL3222-R3222) [[2]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebR3362-R3367) [[3]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebL3407-R3412) [[4]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebL3419-R3421) [[5]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebL3475-R3482)
* Modified unstructured log error panels and contract inventory to render only the parsed `.__error__` field, explicitly excluding the raw source log line to avoid accidental exposure of secret-bearing payloads. [[1]](diffhunk://#diff-3885f2d693653a48b8fe7994b7787c33e2ef53de38d7670c9e5133b03480f4aeL4819-R4823) [[2]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebR3362-R3367) [[3]](diffhunk://#diff-e322fe58100f697931c0d8e534a3746a514c10bace351b64cadd048ef62a19ebL3407-R3412)

**CI/CD Workflow and Artifact Improvements:**

* Moved the observability metric inventory drift check and artifact upload into the dashboard semantic release policy gate, ensuring all dashboard evidence is validated and uploaded together. The CI workflow now also includes additional dashboard contract and drift tests and uploads both the semantic policy and runtime cardinality review artifacts.
[[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL298-L305) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR320-R336) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL341-R347)
* Added a new artifact routing entry for the dashboard release gate report, clarifying its generation and upload policy.

**Infrastructure and Reliability Enhancements:**

* Improved Loki service health checks in `docker-compose.monitoring.yml` to use an explicit `/ready` probe, ensuring dependent services only start when Loki is actually ready. Increased the wait time for Grafana datasource bootstrapping to accommodate Loki's startup behavior. [[1]](diffhunk://#diff-972a05e8310f6ab22c30abd73869f953cdb0a78f3cf415753bb28eb8a40a797dL72-R78) [[2]](diffhunk://#diff-972a05e8310f6ab22c30abd73869f953cdb0a78f3cf415753bb28eb8a40a797dL92-R98) [[3]](diffhunk://#diff-134c061e5db1a918d48b6a95aa730880e0562c85533d34386530b50cf19db9f2L9-R10)
* Updated Promtail configuration to use the correct Loki service URL and added retry/backoff logic for more robust log shipping.

**Documentation Updates:**

* Expanded and clarified documentation in both English and Russian to reflect the new bounded query behavior, stricter evidence requirements, and fail-closed policy for unknown semantic classifications. [[1]](diffhunk://#diff-6c93a4e8550573becb36b7c41957413d93fce298172aa5df2fa9621b8547ed65L10-R16) [[2]](diffhunk://#diff-6c93a4e8550573becb36b7c41957413d93fce298172aa5df2fa9621b8547ed65L50-R51) [[3]](diffhunk://#diff-6c93a4e8550573becb36b7c41957413d93fce298172aa5df2fa9621b8547ed65L81-R104) [[4]](diffhunk://#diff-5384f4b092e0ef3e8746c1b78609b1d88e9fd040bf8384ff1b389cb80fa59e44L114-R119) [[5]](diffhunk://#diff-5384f4b092e0ef3e8746c1b78609b1d88e9fd040bf8384ff1b389cb80fa59e44L144-R162)

**Other Minor Changes:**

* Incremented the dashboard version to reflect these contract and evidence changes.
* Added missing imports to support monotonic timing in live audit scripts.## Summary

<!-- Brief description of changes (1-3 sentences) -->

## Changes

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Config / pipeline change
- [ ] Documentation
- [ ] CI / infrastructure

## Affected layers

- [ ] Domain
- [ ] Application
- [ ] Infrastructure
- [ ] Composition
- [ ] Interfaces
- [ ] Configs

## Test plan

- [ ] Unit tests pass (`pytest tests/unit/`)
- [ ] Architecture tests pass (`pytest tests/architecture/`)
- [ ] Type check passes (`mypy --strict src/bioetl/`)
- [ ] Manual verification (describe below if applicable)

## Architecture verification evidence

<!-- Required for architecture/debt/gate/refactor changes. -->

<!-- Record concrete before/after values and the exact gates you ran. -->

- Before metrics:
- After metrics:
- Gates / verification:
- Outcome: `improved` / `unchanged` / `worsened`
- Justification (required for `unchanged` or `worsened`):

## Checklist

- [ ] No new import boundary violations (ARCH-001)
- [ ] No hardcoded secrets (AP-005)
- [ ] Type annotations on all public functions (TYPE-001)
- [ ] Tests added/updated for new code (TEST-002)
- [ ] If `checks-complete` fails, I first triage `lint` → `c901-governance` →
      `arch-tests` and do not debug `checks-complete` separately

- [ ] If many jobs fail quickly, I inspected `dependency-preflight` first (`reports/ci/dependency-preflight.log`)

<!-- devin-review-badge-begin -->

---

<a
href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6371" target="_blank">
  <picture>
<source media="(prefers-color-scheme: dark)"
srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1"> <img
src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---------

## Summary

<!-- Brief description of changes (1-3 sentences) -->

## Changes

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Config / pipeline change
- [ ] Documentation
- [ ] CI / infrastructure

## Affected layers

- [ ] Domain
- [ ] Application
- [ ] Infrastructure
- [ ] Composition
- [ ] Interfaces
- [ ] Configs

## Test plan

- [ ] Unit tests pass (`pytest tests/unit/`)
- [ ] Architecture tests pass (`pytest tests/architecture/`)
- [ ] Type check passes (`mypy --strict src/bioetl/`)
- [ ] Manual verification (describe below if applicable)

## Architecture verification evidence

<!-- Required for architecture/debt/gate/refactor changes. -->

<!-- Record concrete before/after values and the exact gates you ran. -->

- Before metrics:
- After metrics:
- Gates / verification:
- Outcome: `improved` / `unchanged` / `worsened`
- Justification (required for `unchanged` or `worsened`):

## Checklist

- [ ] No new import boundary violations (ARCH-001)
- [ ] No hardcoded secrets (AP-005)
- [ ] Type annotations on all public functions (TYPE-001)
- [ ] Tests added/updated for new code (TEST-002)
- [ ] If `checks-complete` fails, I first triage `lint` → `c901-governance` →
      `arch-tests` and do not debug `checks-complete` separately

- [ ] If many jobs fail quickly, I inspected `dependency-preflight` first (`reports/ci/dependency-preflight.log`)
