### PR TITLE
fix(scripts): add type annotations for mypy --strict (#6383)

### DIFF
--- a/scripts/engineering/qa/report_observability_metric_inventory.py
+++ b/scripts/engineering/qa/report_observability_metric_inventory.py
@@ -21,10 +21,11 @@ import os
 import re
 import subprocess
 import sys
+import types
 from collections import defaultdict
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Final, cast
+from typing import Final, Protocol, TypedDict
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -52,6 +53,12 @@ from bioetl.infrastructure.observability.prometheus_metric_registries import (  
     GAUGES,
     HISTOGRAMS,
 )
+
+
+class _StartupInfoLike(Protocol):
+    dwFlags: int
+    wShowWindow: int
+
 
 _CANONICAL_METRIC_RE = re.compile(r"\bbioetl_[a-z0-9_]+\b")
 _PROMETHEUS_METRIC_NAME_RE = re.compile(r"^[A-Za-z_:][A-Za-z0-9_:]*$")
@@ -85,8 +92,9 @@ _RUNTIME_EXCLUDE_PARTS = (
     "src/bioetl/domain",
 )
 _TEXT_SUFFIXES = {".py", ".md", ".json", ".yml", ".yaml"}
+MetricInventoryReport = dict[str, list[str] | dict[str, list[str]]]
 _TEXT_FILE_DISCOVERY_CACHE: dict[str, tuple[Path, ...]] = {}
-_METRIC_INVENTORY_CACHE: dict[str, dict[str, object]] = {}
+_METRIC_INVENTORY_CACHE: dict[str, MetricInventoryReport] = {}
 _SOURCE_TEXT_CACHE: dict[str, str | None] = {}
 _RUNTIME_CANDIDATE_TEXT_CACHE: dict[str, str | None] = {}
 _RUNTIME_CANDIDATE_PATH_CACHE: dict[str, tuple[Path, ...]] = {}
@@ -334,7 +342,7 @@ def _run_text_discovery_command(
     timeout: float,
 ) -> tuple[subprocess.CompletedProcess[str], str]:
     """Capture small discovery output through a bounded subprocess call."""
-    result = subprocess.run(  # type: ignore[arg-type]
+    result = subprocess.run(
         command,
         capture_output=True,
         text=True,
@@ -347,15 +355,20 @@ def _run_text_discovery_command(
     return result, result.stdout or ""
 
 
+class _WindowsSubprocessKwargs(TypedDict, total=False):
+    creationflags: int
+    startupinfo: _StartupInfoLike
+
+
 def _hidden_windows_subprocess_kwargs(
     *,
     os_name: str = os.name,
-    subprocess_module: object = subprocess,
-) -> dict[str, int]:
+    subprocess_module: types.ModuleType = subprocess,
+) -> _WindowsSubprocessKwargs:
     if os_name != "nt":
         return {}
 
-    kwargs: dict[str, int] = {}
+    kwargs: _WindowsSubprocessKwargs = {}
     create_no_window = int(getattr(subprocess_module, "CREATE_NO_WINDOW", 0))
     if create_no_window:
         kwargs["creationflags"] = create_no_window
@@ -469,7 +482,7 @@ def _scan_canonical_metric_mentions_with_git_grep(
     for index in range(0, len(relative_paths), _METRIC_MENTION_GREP_CHUNK_SIZE):
         chunk = relative_paths[index : index + _METRIC_MENTION_GREP_CHUNK_SIZE]
         try:
-            result = subprocess.run(  # type: ignore[arg-type]
+            result = subprocess.run(
                 [
                     "git",
                     "-C",
@@ -544,7 +557,7 @@ def _scan_canonical_metric_mentions_with_rg(
                 check=False,
                 timeout=_METRIC_MENTION_GREP_TIMEOUT_SECONDS,
                 **_hidden_windows_subprocess_kwargs(),
-            )  # type: ignore[arg-type]
+            )
         except OSError:
             return None
         except subprocess.TimeoutExpired:
@@ -1513,9 +1526,23 @@ def _load_declared_metric_definitions(repo_root: Path) -> dict[str, set[str]]:
     return definitions
 
 
+def _coerce_int(value: object, *, default: int = -1) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
 def _iter_dashboard_panels(payload: dict[str, object]) -> list[dict[str, object]]:
     panels: list[dict[str, object]] = []
-    for raw_panel in payload.get("panels", []):
+    raw_panels = payload.get("panels", [])
+    if not isinstance(raw_panels, list):
+        return panels
+    for raw_panel in raw_panels:
         if not isinstance(raw_panel, dict):
             continue
         panels.append(raw_panel)
@@ -1526,7 +1553,8 @@ def _iter_dashboard_panels(payload: dict[str, object]) -> list[dict[str, object]
 def _panel_runbook_urls(panel: dict[str, object]) -> list[str]:
     """Return deterministic runbook links from panel and field data links."""
     urls: set[str] = set()
-    candidates: list[object] = list(panel.get("links", []))
+    raw_links = panel.get("links", [])
+    candidates: list[object] = list(raw_links) if isinstance(raw_links, list) else []
     field_config = panel.get("fieldConfig", {})
     if isinstance(field_config, dict):
         defaults = field_config.get("defaults", {})
@@ -1600,7 +1628,7 @@ def _panel_contract(
     datasource_type: str,
 ) -> dict[str, object]:
     """Build one complete, deterministic dashboard target documentation row."""
-    panel_id = int(panel.get("id", -1))
+    panel_id = _coerce_int(panel.get("id", -1))
     kind = _target_kind(datasource_type=datasource_type, target=target)
     query = str(target.get("url") or target.get("expr") or target.get("query") or "")
     description = str(panel.get("description", ""))
@@ -1774,14 +1802,17 @@ def collect_typed_observability_inventory(repo_root: Path) -> dict[str, object]:
         payload = json.loads(dashboard_path.read_text(encoding="utf-8"))
         dashboard_uid = str(payload.get("uid", dashboard_path.stem))
         for panel in _iter_dashboard_panels(payload):
-            panel_id = int(panel.get("id", -1))
+            panel_id = _coerce_int(panel.get("id", -1))
             panel_datasource = panel.get("datasource", {})
             panel_datasource_type = (
                 str(panel_datasource.get("type", ""))
                 if isinstance(panel_datasource, dict)
                 else str(panel_datasource)
             )
-            for target in panel.get("targets", []):
+            raw_targets = panel.get("targets", [])
+            if not isinstance(raw_targets, list):
+                continue
+            for target in raw_targets:
                 if not isinstance(target, dict):
                     continue
                 expr = str(target.get("expr", ""))
@@ -1841,7 +1872,7 @@ def collect_typed_observability_inventory(repo_root: Path) -> dict[str, object]:
     typed_targets.sort(
         key=lambda row: (
             str(row["dashboard_uid"]),
-            int(row["panel_id"]),
+            _coerce_int(row.get("panel_id", -1)),
             str(row["ref_id"]),
             str(row["kind"]),
         )
@@ -1868,7 +1899,7 @@ def collect_typed_observability_inventory(repo_root: Path) -> dict[str, object]:
             http_targets,
             key=lambda row: (
                 str(row["dashboard_uid"]),
-                int(row["panel_id"]),
+                _coerce_int(row.get("panel_id", -1)),
                 str(row["ref_id"]),
                 str(row["url"]),
             ),
@@ -2483,12 +2514,12 @@ def _build_runtime_cardinality_review_summary(
 
 def collect_metric_inventory(
     repo_root: Path,
-) -> dict[str, list[str] | dict[str, list[str]]]:
+) -> MetricInventoryReport:
     repo_root = repo_root.resolve()
     cache_key = repo_root.as_posix()
     cached = _METRIC_INVENTORY_CACHE.get(cache_key)
     if cached is not None:
-        return cached  # type: ignore[return-value]
+        return cached
     declared_metric_definitions = _load_declared_metric_definitions(repo_root)
     declared_rule_metrics = declared_metric_definitions["recording_rule_metrics"]
     declared_policy_aliases = declared_metric_definitions["policy_alias_metrics"]
@@ -2588,10 +2619,10 @@ def collect_metric_inventory(
         for metric_name in helper_runtime_set
         if f"{metric_name}_total" in runtime_registered_set
     }
-    registry_only_metrics = runtime_registered_set - canonical_runtime_set
-    runtime_without_registry = runtime_set - registered_set - runtime_counter_bases
-    dead_metrics = registry_only_metrics - docs_set - rules_set
-    ruled_without_runtime = (rules_set & runtime_registered_set) - canonical_runtime_set
+    registry_only_metric_set = runtime_registered_set - canonical_runtime_set
+    runtime_without_registry_set = runtime_set - registered_set - runtime_counter_bases
+    dead_metrics = registry_only_metric_set - docs_set - rules_set
+    ruled_without_runtime_set = (rules_set & runtime_registered_set) - canonical_runtime_set
     combined_emitters = _combine_metric_emitters(
         runtime_mentions, helper_backed_mentions
     )
@@ -2611,13 +2642,13 @@ def collect_metric_inventory(
         "unused_declared_metrics", set()
     )
     registry_only_metrics = sorted(
-        set(registry_only_metrics) - reviewed_unused_declared_metrics
+        registry_only_metric_set - reviewed_unused_declared_metrics
     )
     reviewed_runtime_without_registry = drift_allowlist.get(
         "runtime_without_registry", set()
     )
     runtime_without_registry = sorted(
-        set(runtime_without_registry) - reviewed_runtime_without_registry
+        runtime_without_registry_set - reviewed_runtime_without_registry
     )
     reviewed_unused_declared_observability_events = drift_allowlist.get(
         "unused_declared_observability_events", set()
@@ -2630,7 +2661,7 @@ def collect_metric_inventory(
         "alerted_without_emission", set()
     )
     ruled_without_runtime = sorted(
-        set(ruled_without_runtime) - reviewed_alerted_without_emission
+        ruled_without_runtime_set - reviewed_alerted_without_emission
     )
     reviewed_runtime_cardinality = drift_allowlist.get(
         "runtime_cardinality_review_required", set()
@@ -2684,7 +2715,7 @@ def collect_metric_inventory(
         and metric_name not in contract_bounded_risky_labels
     ]
 
-    report: dict[str, list[str] | dict[str, list[str]]] = {
+    report: MetricInventoryReport = {
         "declared_metrics": registered,
         "emitted_metrics": sorted(registered_set & canonical_runtime_set),
         "declared_observability_events": declared_observability_events,
@@ -3008,9 +3039,6 @@ def _render_text(report: dict[str, list[str] | dict[str, list[str]]]) -> str:
     return "\n".join(lines)
 
 
-MetricInventoryReport = dict[str, list[str] | dict[str, list[str]]]
-
-
 def _write_evidence_report(
     report: MetricInventoryReport, *, repo_root: Path, evidence_path: Path | None
 ) -> None:
@@ -3090,14 +3118,24 @@ def _write_runtime_cardinality_review_summary(
 def _render_runtime_cardinality_review_summary(
     summary: RuntimeCardinalityReviewSummary,
 ) -> str:
+    reviewed_metrics = summary.get("reviewed_metrics", [])
+    review_required_metrics = summary.get("review_required_metrics", [])
+    reviewed_count = (
+        len(reviewed_metrics) if isinstance(reviewed_metrics, list) else 0
+    )
+    review_required_count = (
+        len(review_required_metrics)
+        if isinstance(review_required_metrics, list)
+        else 0
+    )
     lines = [
         "## Observability Runtime Cardinality Review",
         "",
         f"- Status: `{summary['status']}`",
         f"- Mode: `{summary['mode']}`",
         f"- Prometheus source: `{summary['prometheus_base_url_source']}`",
-        f"- Reviewed metrics: `{len(summary['reviewed_metrics'])}`",
-        f"- Review-required metrics: `{len(summary['review_required_metrics'])}`",
+        f"- Reviewed metrics: `{reviewed_count}`",
+        f"- Review-required metrics: `{review_required_count}`",
     ]
 
     degraded_reasons = summary.get("degraded_reasons", [])
@@ -3139,29 +3177,35 @@ def _append_runtime_cardinality_review_summary(
         handle.write(prefix + _render_runtime_cardinality_review_summary(summary))
 
 
+def _typed_inventory_violations(typed_report: dict[str, object]) -> dict[str, list[str]]:
+    violations: dict[str, list[str]] = {}
+    for key in (
+        "recording_outputs_without_declaration",
+        "recording_declarations_without_output",
+        "policy_aliases_overlapping_outputs",
+        "policy_aliases_overlapping_runtime_metrics",
+        "policy_aliases_without_catalog",
+        "catalog_aliases_without_declaration",
+        "http_semantics_violations",
+        "panel_contract_drift",
+        "prometheus_run_id_selector_violations",
+    ):
+        value = typed_report.get(key)
+        if isinstance(value, list) and value:
+            violations[key] = [item for item in value if isinstance(item, str)]
+    return violations
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    violations: dict[str, list[str]]
     if args.typed_observability_views:
         typed_report = collect_typed_observability_inventory(args.repo_root)
         if args.update_panel_contracts:
             write_panel_contract_inventory(args.repo_root, typed_report)
             typed_report["panel_contract_drift"] = []
-        violations = {
-            key: typed_report[key]
-            for key in (
-                "recording_outputs_without_declaration",
-                "recording_declarations_without_output",
-                "policy_aliases_overlapping_outputs",
-                "policy_aliases_overlapping_runtime_metrics",
-                "policy_aliases_without_catalog",
-                "catalog_aliases_without_declaration",
-                "http_semantics_violations",
-                "panel_contract_drift",
-                "prometheus_run_id_selector_violations",
-            )
-            if typed_report[key]
-        }
+        violations = _typed_inventory_violations(typed_report)
         if args.json:
             json.dump(typed_report, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")

--- a/scripts/generate_adr_registry.py
+++ b/scripts/generate_adr_registry.py
@@ -12,8 +12,40 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import TypedDict
 
 import yaml
+
+
+class ADRJsonRegistryEntry(TypedDict):
+    adr_number: str
+    title: str
+    file_path: str
+    status: str
+    source_status: str | None
+    category: str
+    owner: str
+    decision_date: str | None
+    last_reviewed: str | None
+    context: str
+    decision: str
+    consequences: str
+    supersedes: list[str]
+    superseded_by: list[str]
+    related: list[str]
+    tags: list[str]
+
+
+class ADRJsonRegistryStats(TypedDict):
+    by_status: dict[str, int]
+    by_category: dict[str, int]
+
+
+class ADRJsonRegistry(TypedDict):
+    generated: str
+    total_adrs: int
+    adrs: list[ADRJsonRegistryEntry]
+    stats: ADRJsonRegistryStats
 
 
 @dataclass
@@ -52,13 +84,13 @@ class ADRMetadata:
 class ADRRegistryGenerator:
     """Generates ADR registry with metadata."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.adr_dir = Path("docs/02-architecture/decisions")
         self.output_dir = Path("docs/02-architecture/adr-registry")
         self.navigator_registry_file = Path("docs/02-architecture/adr-registry.md")
         self.adr_index_file = self.adr_dir / "README.md"
         self.adr_index_metadata = self._load_adr_index_metadata()
-        self.adrs = []
+        self.adrs: list[ADRMetadata] = []
 
     def _load_adr_index_metadata(self) -> dict[str, dict[str, str]]:
         """Load title/category/date/status metadata from the live ADR index table."""
@@ -106,17 +138,19 @@ class ADRRegistryGenerator:
             return match.group(1)
         return None
 
-    def parse_adr_front_matter(self, content: str) -> dict:
+    def parse_adr_front_matter(self, content: str) -> dict[str, object]:
         """Parse YAML front matter from ADR content."""
 
-        metadata = {}
+        metadata: dict[str, object] = {}
 
         if content.startswith("---"):
             front_matter_end = content.find("\n---", 1)
             if front_matter_end != -1:
                 front_matter = content[3:front_matter_end].strip()
                 try:
-                    metadata = yaml.safe_load(front_matter) or {}
+                    loaded = yaml.safe_load(front_matter)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
                 except Exception as e:
                     print(f"⚠️  Error parsing front matter: {e}")
 
@@ -172,8 +206,25 @@ class ADRRegistryGenerator:
             return None
         return normalized
 
+    @staticmethod
+    def _metadata_str_value(value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        return str(value)
+
+    @staticmethod
+    def _metadata_tags(value: object) -> list[str]:
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, str)]
+        return []
+
     def _extract_decision_date(
-        self, content: str, front_matter: dict, index_metadata: dict
+        self,
+        content: str,
+        front_matter: dict[str, object],
+        index_metadata: dict[str, str],
     ) -> str | None:
         candidates = (
             front_matter.get("date"),
@@ -181,7 +232,9 @@ class ADRRegistryGenerator:
             index_metadata.get("decision_date"),
         )
         for candidate in candidates:
-            normalized = self._normalize_metadata_value(candidate)
+            normalized = self._normalize_metadata_value(
+                candidate if isinstance(candidate, str) else None
+            )
             if normalized is not None:
                 return normalized
 
@@ -265,7 +318,7 @@ class ADRRegistryGenerator:
     def determine_adr_status(
         self,
         content: str,
-        metadata: dict,
+        metadata: dict[str, object],
         *,
         relationships: dict[str, list[str]] | None = None,
     ) -> str:
@@ -333,7 +386,7 @@ class ADRRegistryGenerator:
                 index_metadata,
             )
             last_reviewed = self._normalize_metadata_value(
-                front_matter.get("last_reviewed")
+                self._metadata_str_value(front_matter.get("last_reviewed"))
             ) or self._normalize_metadata_value(
                 self._extract_inline_metadata_value(
                     content,
@@ -341,7 +394,7 @@ class ADRRegistryGenerator:
                 )
             )
             owner = self._normalize_metadata_value(
-                front_matter.get("owner")
+                self._metadata_str_value(front_matter.get("owner"))
             ) or self._normalize_metadata_value(
                 self._extract_inline_metadata_value(
                     content,
@@ -357,7 +410,9 @@ class ADRRegistryGenerator:
 
             # Determine status
             source_status = (
-                self._normalize_metadata_value(front_matter.get("status"))
+                self._normalize_metadata_value(
+                    self._metadata_str_value(front_matter.get("status"))
+                )
                 or self._normalize_metadata_value(
                     self._extract_inline_metadata_value(content, labels=("Status",))
                 )
@@ -372,11 +427,19 @@ class ADRRegistryGenerator:
                 relationships=relationships,
             )
 
+            resolved_title = (
+                self._metadata_str_value(front_matter.get("title"))
+                or index_metadata.get("title")
+            )
+            resolved_category = (
+                self._metadata_str_value(front_matter.get("category"))
+                or index_metadata.get("category")
+            )
+
             # Create metadata object
             adr_metadata = ADRMetadata(
                 adr_number=adr_number,
-                title=front_matter.get("title")
-                or index_metadata.get("title")
+                title=resolved_title
                 or file_path.stem.replace(f"ADR-{adr_number}-", "").replace("-", " "),
                 file_path=str(file_path.relative_to(self.adr_dir)),
                 status=status,
@@ -389,9 +452,8 @@ class ADRRegistryGenerator:
                 supersedes=relationships.get("supersedes", []),
                 superseded_by=relationships.get("superseded_by", []),
                 related=relationships.get("related", []),
-                category=front_matter.get("category")
-                or index_metadata.get("category", "architecture"),
-                tags=front_matter.get("tags", []),
+                category=resolved_category or "architecture",
+                tags=self._metadata_tags(front_matter.get("tags", [])),
                 owner=owner or "BioETL Team",
             )
 
@@ -589,12 +651,12 @@ class ADRRegistryGenerator:
             return "# ADR Status Dashboard\n\nNo ADRs found."
 
         # Count by status
-        status_counts = {}
+        status_counts: dict[str, int] = {}
         for adr in self.adrs:
             status_counts[adr.status] = status_counts.get(adr.status, 0) + 1
 
         # Count by category
-        category_counts = {}
+        category_counts: dict[str, int] = {}
         for adr in self.adrs:
             category_counts[adr.category] = category_counts.get(adr.category, 0) + 1
 
@@ -674,23 +736,15 @@ class ADRRegistryGenerator:
 
         return "\n".join(lines)
 
-    def generate_json_registry(self) -> dict:
+    def generate_json_registry(self) -> ADRJsonRegistry:
         """Generate JSON registry for programmatic access."""
 
-        registry = {
-            "generated": datetime.now().isoformat(),
-            "total_adrs": len(self.adrs),
-            "adrs": [],
-            "stats": {"by_status": {}, "by_category": {}},
-        }
-
-        # Count stats
-        status_counts = {}
-        category_counts = {}
+        adrs: list[ADRJsonRegistryEntry] = []
+        status_counts: dict[str, int] = {}
+        category_counts: dict[str, int] = {}
 
         for adr in self.adrs:
-            # Convert to dict
-            adr_dict = {
+            adr_dict: ADRJsonRegistryEntry = {
                 "adr_number": adr.adr_number,
                 "title": adr.title,
                 "file_path": adr.file_path,
@@ -709,18 +763,22 @@ class ADRRegistryGenerator:
                 "tags": adr.tags,
             }
 
-            registry["adrs"].append(adr_dict)
+            adrs.append(adr_dict)
 
-            # Update stats
             status_counts[adr.status] = status_counts.get(adr.status, 0) + 1
             category_counts[adr.category] = category_counts.get(adr.category, 0) + 1
 
-        registry["stats"]["by_status"] = status_counts
-        registry["stats"]["by_category"] = category_counts
+        return {
+            "generated": datetime.now().isoformat(),
+            "total_adrs": len(self.adrs),
+            "adrs": adrs,
+            "stats": {
+                "by_status": status_counts,
+                "by_category": category_counts,
+            },
+        }
 
-        return registry
-
-    def write_output_files(self):
+    def write_output_files(self) -> None:
         """Write all output files to the registry directory."""
 
         # Create output directory
@@ -883,7 +941,7 @@ The ADR registry integrates with:
 """
 
 
-def main():
+def main() -> None:
     """Main entry point."""
 
     print("🚀 Generating ADR Registry...")


### PR DESCRIPTION
## Summary

- Close #6383 by typing `scripts/generate_adr_registry.py` and `scripts/engineering/qa/report_observability_metric_inventory.py` for `mypy --strict`
- Refactor ADR registry metadata/JSON shapes with TypedDict + explicit return annotations; type subprocess discovery helpers without `# type: ignore`

## Changes

- `ADRMetadata` / JSON registry TypedDicts and helper normalizers in `generate_adr_registry.py`
- Typed `_run_text_discovery_command` / Windows subprocess kwargs; tighten inventory report dict types
- Removed existing `# type: ignore` on subprocess calls in the inventory script

## Test plan

- [x] `python -m mypy scripts/generate_adr_registry.py --strict` → Success (0 errors)
- [x] `python -m mypy scripts/engineering/qa/report_observability_metric_inventory.py --strict` → Success (0 errors)
- [ ] `make lint` / `make test` / architecture suite — skipped (scripts-only typing; no `src/bioetl` behavior change)

## Checklist

- [x] No new `# type: ignore` / `Any` escape hatches
- [x] No secrets
- [x] Conventional Commits title
- [x] Closes #6383


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->