### PR TITLE
chore(audit): pin post-merge memory evidence

### DIFF
--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,7 +4,7 @@ audits:
   - id: total-tech-debt-main-2026-07-19
     status: current
     report_path: reports/quality/total-tech-debt-audit-main-current.md
-    audited_commit_sha: 4d29a26545e41807fd616413203a37cfd6ca5f25
+    audited_commit_sha: 2d46c3a69e75bf9a79094c071ec84a758f9e0289
     evidence_surface_sha256: '1560030f714988449af60641dfc368af6ccc6f66ee1349c01db1793864d098c9'
     evidence_paths:
       - configs/quality/compatibility_facade_inventory.yaml

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,7 +8,7 @@ Audited repository: `SatoryKono/BioactivityDataAcquisition`
 
 Audited branch: `main`
 
-Audited commit SHA: `4d29a26545e41807fd616413203a37cfd6ca5f25`
+Audited commit SHA: `2d46c3a69e75bf9a79094c071ec84a758f9e0289`
 
 Evidence surface SHA-256: `1560030f714988449af60641dfc368af6ccc6f66ee1349c01db1793864d098c9`
 


### PR DESCRIPTION
## Summary

- re-pin the current technical-debt audit registry to the exact post-merge `main` snapshot from #6389 (`2d46c3a69e75bf9a79094c071ec84a758f9e0289`)
- refresh the human-readable audit report to the same audited commit
- preserve the evidence-surface SHA-256 (`1560030f714988449af60641dfc368af6ccc6f66ee1349c01db1793864d098c9`)

## Validation

- technical-debt audit validator: passed
- focused audit tests: 5 passed
- docs verification (`--skip-build`): links, navigation, specs, configs, drift, docstrings, and cleanup inventory passed
- `git diff --check`: passed

This is a two-file post-merge evidence re-pin. It changes no runtime behavior, quality gate, exclusion, allowlist, or technical-debt budget.

Refs #6355