### PR TITLE
fix(tooling): close MCP and CI hardening gaps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1110,10 +1110,10 @@ jobs:
                     raw_dir = Path("reports/test-telemetry/raw")
                     rows: list[dict[str, object]] = []
                     junit_paths = sorted(raw_dir.rglob("*.xml"))
-                    lane_wall_time_s: dict[str, float] = {}
+                    junit_testcase_duration_sum_s: dict[str, float] = {}
                     for junit_path in junit_paths:
                         root = ET.parse(junit_path).getroot()
-                        lane_wall_time_s[junit_path.name] = round(
+                        junit_testcase_duration_sum_s[junit_path.name] = round(
                             sum(
                                 float(case.attrib.get("time", "0") or 0.0)
                                 for case in root.iter("testcase")
@@ -1181,7 +1181,9 @@ jobs:
                                 "mixed: xdist unit/integration; serial "
                                 "contracts/repo-backed/memory"
                             ),
-                            "lane_wall_time_s": lane_wall_time_s,
+                            "junit_testcase_duration_sum_s": (
+                                junit_testcase_duration_sum_s
+                            ),
                             "explicit_exclusions": [
                                 {
                                     "lane": "live-provider-contracts",

--- a/docs/00-project/ai/mcp-governance.md
+++ b/docs/00-project/ai/mcp-governance.md
@@ -38,6 +38,15 @@ starting token-bearing servers. Use `BIOETL_MCP_VALIDATE_ONLY=1` for safe
 preflight checks that validate configuration without launching long-lived stdio
 servers.
 
+OpenAI and OpenRouter credentials are provider-specific and must remain
+separate. The environment loaders do not alias `OPENAI_API_KEY` to
+`OPENROUTER_API_KEY`.
+
+MCP uv/uvx wrappers preserve configured proxy egress by default. Operators may
+set `BIOETL_UVX_DIRECT_NETWORK=1` only as an explicit, host-local workaround
+for broken proxy configuration. This opt-in permits direct package-resolution
+traffic and must not be enabled as a shared default.
+
 ## Активные MCP
 memory, filesystem, fetch, github, context7, ast-grep, mcp-code-interpreter,
 prometheus, grafana, mermaid,

--- a/docs/00-project/ai/mcp-token-configuration.md
+++ b/docs/00-project/ai/mcp-token-configuration.md
@@ -45,6 +45,11 @@ Supported aliases:
 | `DOCKERHUB_USERNAME` | `DOCKER_USERNAME` |
 | `NEO4J_USERNAME` / `NEO4J_PASSWORD` | `NEO4J_AUTH`, `NEO4J_AUTH_USERNAME`, `NEO4J_AUTH_PASSWORD` |
 
+Provider credentials are intentionally isolated. `OPENAI_API_KEY` and
+`OPENROUTER_API_KEY` identify different providers and MUST be configured separately;
+the repository environment loaders never project one into the
+other.
+
 Run a non-secret status check:
 
 ```bash
@@ -60,6 +65,7 @@ The script reports `SET` / `NOT SET` only and must not print secret values.
 | GitHub | `GITHUB_PERSONAL_ACCESS_TOKEN` | Yes for GitHub MCP | GitHub fine-grained PAT or classic PAT | Repository read access needed for the task | 90 days |
 | Brave Search | `BRAVE_API_KEY` | Yes for Brave MCP | Brave Search API console | Web Search API quota | 90 days |
 | Ref Tools | `REF_TOOL_API_KEY` or OAuth | No when OAuth is used | Ref Tools key console or interactive OAuth | Documentation search only | 90 days |
+| OpenRouter | `OPENROUTER_API_KEY` | Only for OpenRouter-backed tooling | OpenRouter key console | Models explicitly selected by the local tool | 90 days |
 | Prometheus | `PROMETHEUS_TOKEN` or username/password | No | Local protected Prometheus endpoint | Read/query only | 90 days for shared service accounts |
 | Grafana | `GRAFANA_SERVICE_ACCOUNT_TOKEN` or username/password | No | Grafana service account preferred | Viewer/read-only dashboard and datasource access | 90 days |
 | Neo4j Cypher | `NEO4J_*` | No for local defaults | Local Neo4j memory instance | Local memory database only | Rotate default before shared-host use |
@@ -107,6 +113,7 @@ bash scripts/ai/mcp/check.sh
 | Grafana MCP starts but queries fail | Set `GRAFANA_SERVICE_ACCOUNT_TOKEN` or local username/password; confirm `GRAFANA_URL`. |
 | Prometheus MCP cannot query | Confirm `PROMETHEUS_URL`; add token or username/password only if the endpoint is protected. |
 | Neo4j MCP authentication fails | Confirm `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD`, or `NEO4J_AUTH`. Rotate the documented local default before shared-host use. |
+| OpenRouter authentication fails | Set a dedicated `OPENROUTER_API_KEY`; never reuse or alias `OPENAI_API_KEY`. |
 | Docker-backed MCP cannot start | Confirm Docker is installed and available through the wrapper resolver. |
 
 ## CI/CD Stance

--- a/scripts/ai/mcp/_patch_grok_mcp_tokens.py
+++ b/scripts/ai/mcp/_patch_grok_mcp_tokens.py
@@ -36,7 +36,7 @@ def bump_timeouts(text: str) -> str:
 
 
 def wire_ref(text: str) -> str:
-    if 'x-ref-api-key' in text and "REF_TOOL_API_KEY" in text:
+    if "x-ref-api-key" in text and "REF_TOOL_API_KEY" in text:
         return text
     pattern = re.compile(
         r"(\[mcp_servers\.ref\]\s*\n"
@@ -82,8 +82,6 @@ def main() -> None:
             print("updated", path)
         else:
             print("unchanged", path)
-        idx = updated.find("[mcp_servers.ref]")
-        print(updated[idx : idx + 250] if idx >= 0 else "no ref section")
 
 
 if __name__ == "__main__":

--- a/scripts/ai/mcp/support/load_repo_env.ps1
+++ b/scripts/ai/mcp/support/load_repo_env.ps1
@@ -47,11 +47,6 @@ function Normalize-BioetlRepoEnvAliases {
         }
     }
 
-    # ADR analysis uses OpenRouter; many local envs only set OPENAI_API_KEY.
-    if (-not $env:OPENROUTER_API_KEY -and $env:OPENAI_API_KEY) {
-        $env:OPENROUTER_API_KEY = $env:OPENAI_API_KEY
-    }
-
     # Context7 optional key aliases
     if (-not $env:CONTEXT7_API_KEY) {
         if ($env:CONTEXT7_API_TOKEN) {

--- a/scripts/engineering/ci/update_test_telemetry_baseline.py
+++ b/scripts/engineering/ci/update_test_telemetry_baseline.py
@@ -191,7 +191,7 @@ def _derive_slowest_summary_from_junit_paths(
             "junit_sources": [path.name for path in junit_paths if path.exists()],
             "executed_count": len(rows),
             "worker_mode": "caller-declared; see source run metadata",
-            "lane_wall_time_s": {},
+            "junit_testcase_duration_sum_s": {},
             "explicit_exclusions": [],
         },
     }

--- a/scripts/ops/support/load_repo_env.sh
+++ b/scripts/ops/support/load_repo_env.sh
@@ -210,10 +210,6 @@ normalize_repo_env_aliases() {
     export GITHUB_PERSONAL_ACCESS_TOKEN="${GITHUB_ANY_PERSONAL_ADjCCESS_TOKEN}"
   fi
 
-  if [[ -z "${OPENROUTER_API_KEY:-}" && -n "${OPENAI_API_KEY:-}" ]]; then
-    export OPENROUTER_API_KEY="${OPENAI_API_KEY}"
-  fi
-
   if [[ -z "${CONTEXT7_API_KEY:-}" ]]; then
     if [[ -n "${CONTEXT7_API_TOKEN:-}" ]]; then
       export CONTEXT7_API_KEY="${CONTEXT7_API_TOKEN}"

--- a/tests/architecture/test_ci_test_strategy.py
+++ b/tests/architecture/test_ci_test_strategy.py
@@ -109,6 +109,12 @@ def test_tests_workflow_publishes_duration_telemetry_artifact() -> None:
     assert "slowest-tests.md" in workflow and "slowest-tests.json" in workflow, (
         "duration telemetry output should include both markdown and JSON summaries"
     )
+    assert "junit_testcase_duration_sum_s" in workflow, (
+        "summed testcase durations must use an aggregate-duration label"
+    )
+    assert "lane_wall_time_s" not in workflow, (
+        "summed xdist testcase durations must not be labeled as lane wall time"
+    )
 
 
 def test_tests_workflow_publishes_test_health_telemetry_artifact() -> None:

--- a/tests/architecture/test_mcp_token_configuration.py
+++ b/tests/architecture/test_mcp_token_configuration.py
@@ -29,6 +29,9 @@ def test_repo_env_loaders_preserve_mcp_token_aliases() -> None:
         assert "GRAFANA_SERVICE_ACCOUNT_TOKEN" in text
         assert "HUB_PAT_TOKEN" in text
 
+    assert 'export OPENROUTER_API_KEY="${OPENAI_API_KEY}"' not in shell_loader
+    assert "$env:OPENROUTER_API_KEY = $env:OPENAI_API_KEY" not in powershell_loader
+
 
 def test_token_validation_helpers_are_used_by_token_bearing_wrappers() -> None:
     assert (ROOT / "scripts/ai/mcp/support/token_validation.sh").exists()
@@ -87,6 +90,9 @@ def test_mcp_token_docs_cover_sources_rotation_validation_and_ci_stance() -> Non
         "CI/CD Stance",
         "GITHUB_PERSONAL_ACCESS_TOKEN",
         "BRAVE_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "configured separately",
         "90 days",
         "historical `.env` / `.env.local` path entries",
         "treated as exposed and rotated before use",
@@ -95,6 +101,7 @@ def test_mcp_token_docs_cover_sources_rotation_validation_and_ci_stance() -> Non
 
     assert "mcp-token-configuration.md" in governance
     assert "BIOETL_MCP_VALIDATE_ONLY=1" in governance
+    assert "BIOETL_UVX_DIRECT_NETWORK=1" in governance
     assert "token_validation.sh" in runtime_config
     assert "CI must not require personal MCP tokens" in runtime_config
     assert "third-party service tokens" in runtime_config

--- a/tests/architecture/test_test_telemetry_governance.py
+++ b/tests/architecture/test_test_telemetry_governance.py
@@ -45,7 +45,7 @@ def test_committed_test_telemetry_baseline_is_populated() -> None:
     assert context["executed_count"] == payload["duration_telemetry"]["total_cases"]
     assert context["junit_source_count"] == len(context["junit_sources"])
     assert context["worker_mode"]
-    assert context["lane_wall_time_s"]
+    assert context["junit_testcase_duration_sum_s"]
     assert context["explicit_exclusions"]
 
 

--- a/tests/integration/test_grafana_dashboard_links.py
+++ b/tests/integration/test_grafana_dashboard_links.py
@@ -715,7 +715,13 @@ def _assert_cross_dashboard_link_policy(
             url=url,
             passed_vars=passed_vars,
         )
-    if isinstance(dashboard_links, list) and link in dashboard_links:
+    required_top_level_titles = _REQUIRED_TOP_LEVEL_LINKS_BY_UID.get(
+        current_uid, frozenset()
+    )
+    is_required_top_level_link = link.get("title") in required_top_level_titles
+    if is_required_top_level_link or (
+        isinstance(dashboard_links, list) and link in dashboard_links
+    ):
         _assert_top_level_cross_dashboard_handoff(
             dashboard_name=dashboard_name,
             current_uid=current_uid,
@@ -750,20 +756,21 @@ def _assert_cross_scope_matched_links(
 
 
 def test_top_level_handoff_fails_closed_when_required_link_is_removed() -> None:
-    """A removed dashboard-level link must fail before URL policy checks pass."""
+    """The real policy path must reject a removed required dashboard link."""
     link: dict[str, object] = {
-        "title": "Open Runtime",
-        "url": "/d/bioetl-runtime?var-pipeline=$pipeline&from=$__from&to=$__to",
+        "title": "2. Runtime",
+        "url": (
+            "/d/bioetl-runtime?var-workflow=$workflow&var-pipeline=$pipeline"
+            "&var-run_type=$run_type&var-run_id=$run_id&from=$__from&to=$__to"
+        ),
         "includeVars": False,
     }
 
     with pytest.raises(AssertionError, match="must be present"):
-        _assert_top_level_cross_dashboard_handoff(
+        _assert_cross_dashboard_link_policy(
             dashboard_name="bioetl-overview-v2.json",
             current_uid="bioetl-overview-v2",
-            target_uid="bioetl-runtime",
             link=link,
-            url=str(link["url"]),
             dashboard_links=[],
         )
 

--- a/tests/unit/repo_backed/scripts/ai/mcp/test_repo_env_loaders.py
+++ b/tests/unit/repo_backed/scripts/ai/mcp/test_repo_env_loaders.py
@@ -28,6 +28,8 @@ ENV_NAMES = (
     "BIOETL_ENV_FILE",
     "BIOETL_REPO_ENV_LOADED",
     "BIOETL_SKIP_ENV_LOCAL",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
     "NEO4J_AUTH",
     "NEO4J_USERNAME",
     "NEO4J_PASSWORD",
@@ -123,6 +125,58 @@ def _powershell_values(result: subprocess.CompletedProcess[str]) -> tuple[str, s
     return username, password
 
 
+def test_bash_keeps_openai_and_openrouter_credentials_separate() -> None:
+    result = _run_bash(
+        "normalize_repo_env_aliases; "
+        "printf '%s\\n%s\\n' \"${OPENAI_API_KEY-unset}\" "
+        '"${OPENROUTER_API_KEY-unset}"',
+        env=_clean_env(
+            OPENAI_API_KEY="synthetic-openai-key",
+            OPENROUTER_API_KEY=None,
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["synthetic-openai-key", "unset"]
+
+
+@POWERSHELL_MARK
+def test_powershell_keeps_openai_and_openrouter_credentials_separate() -> None:
+    result = _run_powershell(
+        "Normalize-BioetlRepoEnvAliases; "
+        "[Console]::Out.WriteLine($env:OPENAI_API_KEY); "
+        "[Console]::Out.WriteLine($(if ($env:OPENROUTER_API_KEY) "
+        "{ $env:OPENROUTER_API_KEY } else { 'unset' }))",
+        env=_clean_env(
+            OPENAI_API_KEY="synthetic-openai-key",
+            OPENROUTER_API_KEY=None,
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["synthetic-openai-key", "unset"]
+
+
+@pytest.mark.parametrize(
+    ("openai_key", "openrouter_key"),
+    [("synthetic-openai-key", "synthetic-openrouter-key")],
+)
+def test_bash_preserves_distinct_provider_credentials(
+    openai_key: str, openrouter_key: str
+) -> None:
+    result = _run_bash(
+        "normalize_repo_env_aliases; "
+        'printf \'%s\\n%s\\n\' "$OPENAI_API_KEY" "$OPENROUTER_API_KEY"',
+        env=_clean_env(
+            OPENAI_API_KEY=openai_key,
+            OPENROUTER_API_KEY=openrouter_key,
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [openai_key, openrouter_key]
+
+
 @pytest.mark.parametrize(
     ("auth", "expected"),
     [
@@ -132,7 +186,7 @@ def _powershell_values(result: subprocess.CompletedProcess[str]) -> tuple[str, s
 )
 def test_bash_neo4j_auth_normalization(auth: str, expected: tuple[str, str]) -> None:
     result = _run_bash(
-        "normalize_repo_env_aliases && printf '%s\\n%s\\n' \"$NEO4J_USERNAME\" \"$NEO4J_PASSWORD\"",
+        'normalize_repo_env_aliases && printf \'%s\\n%s\\n\' "$NEO4J_USERNAME" "$NEO4J_PASSWORD"',
         env=_clean_env(NEO4J_AUTH=auth),
     )
 
@@ -201,7 +255,7 @@ def test_powershell_rejects_malformed_neo4j_auth_without_leaking(
 
 def test_bash_explicit_neo4j_credentials_take_precedence() -> None:
     result = _run_bash(
-        "normalize_repo_env_aliases && printf '%s\\n%s\\n' \"$NEO4J_USERNAME\" \"$NEO4J_PASSWORD\"",
+        'normalize_repo_env_aliases && printf \'%s\\n%s\\n\' "$NEO4J_USERNAME" "$NEO4J_PASSWORD"',
         env=_clean_env(
             NEO4J_AUTH="packed-user/packed-password",
             NEO4J_USERNAME="explicit-user",
@@ -228,11 +282,13 @@ def test_powershell_explicit_neo4j_credentials_take_precedence() -> None:
     assert _powershell_values(result) == ("explicit-user", "explicit-password")
 
 
-def test_bash_loader_reads_explicit_fixture_and_skips_local_overlay(tmp_path: Path) -> None:
+def test_bash_loader_reads_explicit_fixture_and_skips_local_overlay(
+    tmp_path: Path,
+) -> None:
     fixture = tmp_path / "fixture.envdata"
     fixture.write_text("NEO4J_AUTH=file-user/file/password\n", encoding="utf-8")
     result = _run_bash(
-        "load_repo_env_if_present && printf '%s\\n%s\\n' \"$NEO4J_USERNAME\" \"$NEO4J_PASSWORD\"",
+        'load_repo_env_if_present && printf \'%s\\n%s\\n\' "$NEO4J_USERNAME" "$NEO4J_PASSWORD"',
         env=_clean_env(
             BIOETL_ENV_FILE=str(fixture),
             BIOETL_SKIP_ENV_LOCAL="1",
@@ -261,11 +317,15 @@ def test_powershell_loader_reads_explicit_fixture_and_skips_local_overlay(
     assert _powershell_values(result) == ("file-user", "file/password")
 
 
-def test_loader_sources_govern_missing_credentials_and_local_skip_consistently() -> None:
+def test_loader_sources_govern_missing_credentials_and_local_skip_consistently() -> (
+    None
+):
     shell_source = BASH_LOADER.read_text(encoding="utf-8")
     powershell_source = POWERSHELL_LOADER.read_text(encoding="utf-8")
 
     assert 'env_local_file=""' in shell_source
-    assert "$envLocalFile = if ($env:BIOETL_SKIP_ENV_LOCAL -eq \"1\")" in powershell_source
+    assert (
+        '$envLocalFile = if ($env:BIOETL_SKIP_ENV_LOCAL -eq "1")' in powershell_source
+    )
     assert 'if [[ -z "${NEO4J_AUTH:-}"' in shell_source
     assert "if ($env:NEO4J_AUTH" in powershell_source

--- a/tests/unit/scripts/ai/mcp/test_patch_grok_mcp_tokens.py
+++ b/tests/unit/scripts/ai/mcp/test_patch_grok_mcp_tokens.py
@@ -2,9 +2,45 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from scripts.ai.mcp._patch_grok_mcp_tokens import bump_timeouts, wire_ref
+from scripts.ai.mcp._patch_grok_mcp_tokens import bump_timeouts, main, wire_ref
+
+
+def test_main_never_prints_configuration_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Status output must not expose MCP configuration or literal secrets."""
+    config_dir = tmp_path / ".grok"
+    config_dir.mkdir()
+    config_path = config_dir / "config.toml"
+    secret_marker = "literal-secret-marker-must-not-be-logged"
+    config_path.write_text(
+        "\n".join(
+            (
+                "[mcp_servers.ref]",
+                "enabled = true",
+                'url = "https://api.ref.tools/mcp"',
+                "startup_timeout_sec = 60",
+                f'literal_token = "{secret_marker}"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "missing-home")
+
+    main()
+
+    output = capsys.readouterr().out
+    assert "updated .grok/config.toml" in output
+    assert secret_marker not in output
+    assert "[mcp_servers.ref]" not in output
 
 
 class TestBumpTimeouts:
@@ -70,7 +106,7 @@ startup_timeout_sec = 60
 """
         result = wire_ref(text)
         assert 'headers = { "x-ref-api-key" = "${REF_TOOL_API_KEY}" }' in result
-        assert "url = \"https://api.ref.tools/mcp\"" in result
+        assert 'url = "https://api.ref.tools/mcp"' in result
 
     def test_wire_ref_single_quoted_url(self) -> None:
         """Test header wiring with single-quoted URL."""


### PR DESCRIPTION
## What changed

- removed implicit OpenAI-to-OpenRouter credential aliasing
- stopped `_patch_grok_mcp_tokens.py` from printing configuration contents
- renamed summed JUnit testcase durations so they are not presented as wall time
- made the Grafana required-link policy fail closed through its real caller path
- documented provider credential isolation and the explicit proxy-bypass opt-in
- added regression coverage for loader, redaction, telemetry, and link-policy behavior

The proxy opt-in, Neo4j authentication validation, and bounded stderr retention
implementations were already present on `main`; this change validates their
contracts and carries the closing references for the remaining audit issues.

## Validation

- MCP/Neo4j/protocol focused suite: `45 passed, 13 skipped`
- Grafana/CI/docs focused suite: `5 passed`
- Ruff check and format check
- Bash syntax check
- Python compile check
- GitHub Actions workflow YAML parse

## Issues

Closes #6441
Closes #6440
Closes #6439
Closes #6438
Closes #6437
Closes #6432
Closes #6431
Closes #6430
Closes #6418

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->