### PR TITLE
docs(hygiene): split root clutter cleanup categories for CodeRabbit CR-01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,10 +104,11 @@ git_commit_*.txt
 *_gitshow_err.txt
 log_test.txt
 
-# Root-level accidental test dumps (RH-01 / RH-03 / #6701 #6703).
+# Root-level accidental test dumps (RH-01 / RH-03 / CR-02 / #6701 #6703 #6718).
 # JUnit/chunked pytest XML and agent temp dumps must never be tracked at root.
 /uchunk*.xml
 /final_chunk*.xml
+/extra_chunk*.xml
 /tmp_sub_*.txt
 /temp_closeout.json
 /.tmp_test_run.log

--- a/docs/00-project/governance/root-local-clutter-cleanup.md
+++ b/docs/00-project/governance/root-local-clutter-cleanup.md
@@ -1,27 +1,47 @@
 # Root local clutter cleanup (operator guidance)
 
-**Status:** active  
-**Linked issues:** #6703 (RH-03), epic #6700  
-**Last verified:** 2026-07-27  
+**Status:** active
+**Linked issues:** #6703 (RH-03), #6717 (CR-01), epic #6700 / #6716
+**Last verified:** 2026-07-27
 
 This note documents **local-only** cleanup for the repository root. It does not
 redefine runtime behavior. Canonical policy remains
 `docs/00-project/governance/03-file-policy.md` §0 and
 `.github/root-allowlist.txt`.
 
-## Safe to delete locally (untracked)
+Also see `configs/quality/repo_structure_catalog.yaml` (`local_tolerated_root_dirs`)
+for machine-readable tolerated local roots.
+
+## 1. Safe ephemeral outputs (untracked)
+
+These are rebuildable or disposable **generated** surfaces. Safe to delete when
+untracked:
 
 | Pattern / path | Why |
 |---|---|
-| `uchunk*.xml`, `final_chunk*.xml` | Accidental JUnit / pytest XML dumps |
+| `uchunk*.xml`, `final_chunk*.xml`, `extra_chunk*.xml` | Accidental JUnit / pytest XML dumps |
 | `pytest_*.log`, `mcp-shell.log`, `*.log` at root | Local test/agent logs (also `*.log` gitignored) |
 | `tmp_sub_*.txt`, `temp_closeout.json`, `.tmp_test_run.log` | Agent scratch files |
 | `.coverage`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `.hypothesis/` | Tool caches |
 | `.venv/`, `.venv-win/`, `node_modules/` | Local environments |
 | `logs/`, `tmp/`, `test-output/`, `caddy/` | Local output trees (not retained git sinks) |
-| `.idea/`, `.qodo/` (local), `.agents/`, `.ai/`, `.grok/`, `.windsurf/`, `.junie/` | Editor/agent local state |
 
-## Forbidden without explicit per-task approval
+## 2. Local tooling / editor roots (delete only if rebuildable)
+
+These may hold **machine-local configuration** that is not always trivial to
+rebuild. Delete only after confirming the contents are disposable or can be
+regenerated (for example from `scripts/ai/codex/setup_mcp.py` or IDE import):
+
+| Pattern / path | Why |
+|---|---|
+| `.idea/` | PyCharm local project state (portable templates under `configs/ide/pycharm/`) |
+| `.qodo/` (local, untracked) | Local Qodo Desktop MCP/runtime state — not repo policy source |
+| `.agents/`, `.ai/`, `.grok/`, `.windsurf/`, `.junie/` | Local agent/editor runtime state (untracked by policy) |
+| `.cursor/`, `.vscode/`, `.gemini/` when **untracked** | Local editor mirrors; do not delete curated **tracked** shared metadata |
+
+If unsure, leave the directory alone and only remove files you created.
+
+## 3. Forbidden without explicit per-task approval
 
 | Path | Why |
 |---|---|
@@ -48,3 +68,4 @@ uv run python -m scripts.engineering.repo check-cleanliness --strict-untracked
 - `.github/workflows/root-hygiene.yml`
 - `configs/quality/root_hygiene_review_registry.yaml`
 - `configs/quality/repo_structure_catalog.yaml`
+- `docs/00-project/governance/03-file-policy.md` §0


### PR DESCRIPTION
## Summary

Close CodeRabbit residual follow-ups **CR-01 / CR-02** and provide a PR surface for **CR-03** (GitHub CodeRabbit App).

- Split root clutter cleanup doc into ephemeral outputs vs local tooling roots vs forbidden paths (#6717).
- Ignore root `extra_chunk*.xml` dumps; chunk files already purged from tree (#6718).
- Enables full CodeRabbit PR review against `.coderabbit.yaml` (#6719).

Closes #6717
Closes #6718
Closes #6719
Closes #6716

## Changes

- `docs/00-project/governance/root-local-clutter-cleanup.md` — three operator categories (CodeRabbit major fix)
- `.gitignore` — `/extra_chunk*.xml`

## Test plan

- [x] Doc tables restructured; tooling roots require rebuildable confirmation
- [x] Ignore pattern present
- [ ] CodeRabbit GitHub App auto-review on this PR
- [ ] `python -m scripts.engineering.repo check-cleanliness` on clean tree

## Checklist

- [x] No secrets
- [x] Conventional Commits title
- [x] Docs-only + gitignore (no layer changes)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/6720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->