### PR TITLE
feat(memory): establish governed agent memory architecture

### DIFF
--- a/src/memory/records.py
+++ b/src/memory/records.py
@@ -33,7 +33,7 @@ class SecurityClass(StrEnum):
     PUBLIC = "public"
     INTERNAL = "internal"
     CONFIDENTIAL = "confidential"
-    SECRET = "secret"
+    SECRET = "secret"  # pragma: allowlist secret
 
 
 class RecordStatus(StrEnum):

--- a/src/memory/security.py
+++ b/src/memory/security.py
@@ -15,14 +15,14 @@ class SecurityClassification(StrEnum):
     PUBLIC = "public"
     INTERNAL = "internal"
     CONFIDENTIAL = "confidential"
-    SECRET = "secret"
+    SECRET = "secret"  # pragma: allowlist secret
 
 
 class FindingKind(StrEnum):
     """Kinds of content that must not silently cross a persistence boundary."""
 
     PROMPT_INJECTION = "prompt_injection"
-    SECRET = "secret"
+    SECRET = "secret"  # pragma: allowlist secret
     PII = "pii"
 
 


### PR DESCRIPTION
## Summary

- establishes a vendor-neutral, repository-scoped memory registry and strict record envelope
- separates evidence, decisions, working state, user memory, audit ledger, handoff, cache, and derived state
- adds deterministic precedence, lifecycle, retention, freshness, migration, backup/recovery, locking, deduplication, and replay contracts
- disables shared file-backed MCP persistence by default and provides a complete persistence-off mode
- adds security classification, consent/ACL, secret/PII/prompt-injection barriers, and isolation tests
- removes tracked rebuild-only timeline JSONL projections and gates their policy

## Verification

- `263 passed`: memory unit, integration, security, architecture, and MCP persistence-mode suites
- `ruff check`: PASS
- `python -m memory.tooling.validate --json`: PASS, zero issues
- `check_skills_mirror.sh --check`: PASS
- `git diff --check origin/main <commit>`: PASS
- `scripts/ai/mcp/check.sh`: repository memory registration passed; local environment reports unrelated missing Docker MCP registration

## Scope safety

- no changes under `src/bioetl`
- no `.env` changes
- no technical-debt or retention budget increases
- external vendor/IDE-hosted memory remains explicitly `NOT_PROVEN`
- clean commit was built directly from `origin/main` to exclude unrelated shared-worktree changes

Closes #7175
Closes #7176
Closes #7177
Closes #7178
Closes #7179
Closes #7180
Closes #7181
Closes #7182
Closes #7183
Closes #7184
Closes #7185
Closes #7186
Closes #7187
Closes #7188
Closes #7189
Closes #7190
Closes #7191
Closes #7192
Closes #7193
Closes #7194
Closes #7195
Closes #7196
Closes #7197
Closes #7198
Closes #7199
Closes #7200
Closes #7201
Closes #7202
Closes #7203
Closes #7204
Closes #7205
Closes #7206
Closes #7207
Closes #7208
Closes #7209
Closes #7210

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/7221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->