### PR TITLE
test(governance): inventory declarative pytest suppressions

### DIFF
--- a/configs/quality/test_skip_inventory.yaml
+++ b/configs/quality/test_skip_inventory.yaml
@@ -7,12 +7,14 @@ source_of_truth:
   contract_root: tests/contract/
   integration_root: tests/integration/
 allowed_categories:
+- conditional_environment_guard
 - git_diff_scope_guard
 - live_endpoint_unavailability
 - live_network_opt_in_guard
 - optional_local_fixture_absence
 - replay_fixture_pointer_guard
 - snapshot_refresh_write_mode
+- temporary_known_failure
 entries:
 - path: tests/contract/_gold_schema_snapshot_registry.py
   suite: contract
@@ -138,6 +140,59 @@ entries:
   vcr_related: false
   review_date: '2026-06-02'
   rationale: Config loading checks may skip when optional provider/entity directories are absent in a reduced local checkout.
+- path: tests/integration/ci/test_track_d_fixture_control_plane_linkage.py
+  suite: integration
+  category: conditional_environment_guard
+  owner: '@bioetl-platform'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-09-30'
+  reviewed_skip_calls: 1
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: The reproducibility fixture-control-plane check is temporarily skipped on WSL cloud-mounted checkouts until the platform-specific filesystem limitation is removed.
+- path: tests/integration/determinism/test_reproducibility_determinism_gate.py
+  suite: integration
+  category: conditional_environment_guard
+  owner: '@bioetl-platform'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-09-30'
+  reviewed_skip_calls: 1
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: The deterministic replay gate is temporarily skipped on WSL cloud-mounted checkouts until the platform-specific filesystem limitation is removed.
+- path: tests/integration/idempotency/test_reproducibility_idempotency_gate.py
+  suite: integration
+  category: conditional_environment_guard
+  owner: '@bioetl-platform'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-09-30'
+  reviewed_skip_calls: 1
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: The idempotency replay gate is temporarily skipped on WSL cloud-mounted checkouts until the platform-specific filesystem limitation is removed.
+- path: tests/integration/infrastructure/storage/test_atomic.py
+  suite: integration
+  category: conditional_environment_guard
+  owner: '@bioetl-storage'
+  linked_issue: '#7249'
+  lifecycle: permanent_policy
+  reviewed_skip_calls: 2
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Windows-specific atomic replace and file-lock contracts are selected declaratively and are not applicable on non-Windows hosts.
+- path: tests/integration/test_docker_compose_smoke.py
+  suite: integration
+  category: live_network_opt_in_guard
+  owner: '@bioetl-platform'
+  linked_issue: '#7249'
+  lifecycle: permanent_policy
+  reviewed_skip_calls: 1
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Docker integration remains explicitly opt-in because Docker is an optional BioETL runtime surface.
 - path: tests/integration/test_dashboard_ux_report_freshness.py
   suite: integration
   category: git_diff_scope_guard
@@ -205,11 +260,55 @@ entries:
   owner: '@bioetl-observability'
   linked_issue: '#5562'
   lifecycle: permanent_policy
-  reviewed_skip_calls: 10
+  reviewed_skip_calls: 11
   vcr_related: false
   review_date: '2026-07-23'
   rationale: Silver Reject Explorer config integration tests skip the retired dashboard surface pending full retirement of
     residual fixtures.
+- path: tests/integration/grafana/test_silver_reject_explorer_copy.py
+  suite: integration
+  category: temporary_known_failure
+  owner: '@bioetl-observability'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-08-15'
+  reviewed_skip_calls: 1
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Residual assertions for the removed Silver Reject Explorer remain visible as expiring test debt pending deletion or conversion to negative retirement contracts.
+- path: tests/integration/test_grafana_dashboard_links.py
+  suite: integration
+  category: temporary_known_failure
+  owner: '@bioetl-observability'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-08-15'
+  reviewed_skip_calls: 8
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Retired Loki and Tempo drilldown assertions remain visible as expiring test debt rather than bypassing the suppression census.
+- path: tests/integration/test_grafana_layout_and_metadata.py
+  suite: integration
+  category: temporary_known_failure
+  owner: '@bioetl-observability'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-08-15'
+  reviewed_skip_calls: 2
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Retired Explore-layout assertions remain visible as expiring test debt rather than bypassing the suppression census.
+- path: tests/integration/test_grafana_surface_contracts.py
+  suite: integration
+  category: temporary_known_failure
+  owner: '@bioetl-observability'
+  linked_issue: '#7249'
+  lifecycle: temporary_debt
+  expires_on: '2026-08-15'
+  reviewed_skip_calls: 2
+  vcr_related: false
+  review_date: '2026-07-30'
+  rationale: Retired Loki surface assertions remain visible as expiring test debt rather than bypassing the suppression census.
 - path: tests/integration/test_grafana_variable_reference.py
   suite: integration
   category: live_endpoint_unavailability

--- a/tests/architecture/test_tech_debt_issues_5559_5563_closeout.py
+++ b/tests/architecture/test_tech_debt_issues_5559_5563_closeout.py
@@ -167,7 +167,7 @@ def test_issue_5562_skip_inventory_entries_are_individually_accountable() -> Non
             assert str(entry.get("expires_on", "")).strip()
         assert str(entry["rationale"]).strip()
 
-    assert entries_by_issue == {"#5562": 19, "#6570": 1}
+    assert entries_by_issue == {"#5562": 19, "#6570": 1, "#7249": 9}
 
 
 def test_issue_5563_excluded_non_gold_rows_are_burned_down_to_zero() -> None:


### PR DESCRIPTION
## Summary

Completes the AST-backed declarative pytest suppression governance introduced on main by synchronizing the YAML SSOT.

## Changes

- inventory conditional platform and Docker opt-in guards
- expose retired Grafana suppressions as expiring temporary debt
- update the historical accountability guard for the new issue-owned rows

## Verification

- `pytest tests/architecture/test_test_skip_inventory.py tests/architecture/test_coverage_verify_lane_contract.py tests/architecture/test_tech_debt_issues_5559_5563_closeout.py::test_issue_5562_skip_inventory_entries_are_individually_accountable -q` — 13 passed
- Ruff — passed
- `git diff --check` — passed

No debt thresholds, budgets, skips, xfails, or broad suppressions were added.

Fixes #7249
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/7253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->