### PR TITLE
fix(governance): restore generated artifact path safety

### DIFF
--- a/configs/quality/generated_artifact_routing.yaml
+++ b/configs/quality/generated_artifact_routing.yaml
@@ -33,12 +33,26 @@ allowed_output_roots:
     - docs/02-architecture/diagrams/views/svg/
     - docs/02-architecture/adr-registry.md
     - docs/02-architecture/adr-registry/
+    - docs/02-architecture/07-compatibility-facade-snapshot.md
+    - docs/02-architecture/policies/reproducibility-support-matrix.md
+    - docs/03-guides/dashboards/panel-title-inventory.md
+    - docs/03-guides/dashboards/navigation-contract.md
+    - docs/03-guides/dashboards/dux7-live-residual-protocol.md
+    - docs/03-guides/silver-schema-testing-guide.md
+    - docs/04-reference/api/
     - docs/04-reference/config_comparison_matrix.csv
+    - docs/04-reference/contracts/dq-contracts.md
     - docs/04-reference/passports/
+    - docs/05-engineering/chembl_protein_classification_migration_closeout.md
+    - docs/05-operations/runbooks/docker-compose-project-migration.md
+    - docs/05-operations/runbooks/docker-stability.md
     - docs/filters/inventory-baseline.csv
     - docs/filters/inventory-baseline.json
     - docs/filters/inventory-baseline.md
     - docs/00-project/governance/root-local-clutter-cleanup.md
+  generated_ai_mirrors:
+    - docs/00-project/ai/agents/
+    - docs/00-project/ai/skills/global/
   ignored_docs_exports:
     - docs/exports/
   local_generated_docs_helpers:

--- a/tests/architecture/test_generated_artifact_routing.py
+++ b/tests/architecture/test_generated_artifact_routing.py
@@ -65,6 +65,8 @@ def test_generated_artifact_routing_inventory_is_valid() -> None:
     assert payload["schema_version"] == 1
     routes = payload.get("routes")
     assert isinstance(routes, list) and routes, "routes must be a non-empty list"
+    allowed_roots = _allowed_output_roots(payload)
+    assert allowed_roots, "allowed_output_roots must declare reviewed destinations"
     forbidden_roots = tuple(payload.get("forbidden_output_roots") or ())
     assert forbidden_roots, "forbidden_output_roots must be declared"
 
@@ -95,15 +97,32 @@ def test_generated_artifact_routing_inventory_is_valid() -> None:
         assert isinstance(outputs, list) and outputs, f"{route_id}: outputs required"
         for output in outputs:
             assert isinstance(output, str), f"{route_id}: output must be a string"
-            # Temporarily skip path safety check for all outputs due to routing config drift
-            # TODO: Fix allowed_output_roots in generated_artifact_routing.yaml to include all output paths
-            # if output.startswith("docs/00-project/ai/skills/global/"):
-            #     continue
-            # if output == "docs/02-architecture/07-compatibility-facade-snapshot.md":
-            #     continue
-            # assert _is_safe_output_path(output, allowed_roots, forbidden_roots), (
-            #     f"{route_id}: unsafe generated artifact output path: {output}"
-            # )
+            assert _is_safe_output_path(output, allowed_roots, forbidden_roots), (
+                f"{route_id}: unsafe generated artifact output path: {output}"
+            )
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    (
+        "",
+        "../reports/generated.json",
+        "reports/../generated.json",
+        "output/generated.json",
+        "generated.json",
+    ),
+)
+def test_generated_artifact_routing_rejects_unsafe_paths(
+    unsafe_path: str,
+) -> None:
+    """Traversal, forbidden roots, and root-level outputs must fail closed."""
+    payload = _load_routing()
+
+    assert not _is_safe_output_path(
+        unsafe_path,
+        _allowed_output_roots(payload),
+        tuple(payload["forbidden_output_roots"]),
+    )
 
 
 def test_generated_artifact_routing_covers_core_generators() -> None:

--- a/tests/architecture/test_generated_artifact_routing.py
+++ b/tests/architecture/test_generated_artifact_routing.py
@@ -49,9 +49,12 @@ def _is_safe_output_path(
     allowed_roots: tuple[str, ...],
     forbidden_roots: tuple[str, ...],
 ) -> bool:
-    if not path or path.startswith("../") or "/../" in path:
+    if not path or ".." in Path(path).parts:
         return False
-    if not any(path.startswith(root) for root in allowed_roots):
+    if not any(
+        path.startswith(root) if root.endswith(("/", "-")) else path == root
+        for root in allowed_roots
+    ):
         return False
     if "/" not in path and path.endswith(FORBIDDEN_ROOT_OUTPUT_SUFFIXES):
         return False
@@ -85,13 +88,12 @@ def test_generated_artifact_routing_inventory_is_valid() -> None:
         # Skip generator existence check for fallback routes with non-file generators
         # (e.g., "multiple governed docs and quality generators", "manual closeout",
         # "docs API reference generation workflow", or combined generators with " and ")
-        if (
+        if not (
             "/" not in generator
             or generator.startswith(("multiple", "manual", "docs"))
             or " and " in generator
         ):
-            continue
-        assert (ROOT / generator).exists(), f"{route_id}: generator does not exist"
+            assert (ROOT / generator).exists(), f"{route_id}: generator does not exist"
 
         outputs = route.get("outputs")
         assert isinstance(outputs, list) and outputs, f"{route_id}: outputs required"
@@ -108,8 +110,10 @@ def test_generated_artifact_routing_inventory_is_valid() -> None:
         "",
         "../reports/generated.json",
         "reports/../generated.json",
+        "reports/..",
         "output/generated.json",
         "generated.json",
+        "docs/04-reference/config_comparison_matrix.csv.bak",
     ),
 )
 def test_generated_artifact_routing_rejects_unsafe_paths(
@@ -122,6 +126,15 @@ def test_generated_artifact_routing_rejects_unsafe_paths(
         unsafe_path,
         _allowed_output_roots(payload),
         tuple(payload["forbidden_output_roots"]),
+    )
+
+
+def test_generated_artifact_routing_rejects_forbidden_allowed_overlap() -> None:
+    """Forbidden roots take precedence over an overlapping allowed prefix."""
+    assert not _is_safe_output_path(
+        "output/generated.json",
+        ("output/",),
+        ("output/",),
     )
 
 


### PR DESCRIPTION
## Summary

- reconcile generated-artifact destinations with the reviewed routing SSOT
- restore fail-closed path-safety validation for all 69 routes / 124 outputs
- add traversal, forbidden-root, and root-level negative regression cases

## Validation

- focused generated-routing and governance tests pass
- root-hygiene and generated-artifact drift tests pass
- all 61 configs validate
- Ruff and diff checks pass
- independent scan: 69 routes, 124 outputs, unsafe_count=0

## Debt outcome

Improved. No budget, threshold, suppression, exemption, or broad repository-root allowance was added.

Fixes #6117
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/7258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->