### PR TITLE
fix(governance): validate technical-debt audit semantics

### DIFF
--- a/configs/quality/generated_artifact_routing.yaml
+++ b/configs/quality/generated_artifact_routing.yaml
@@ -50,6 +50,7 @@ allowed_output_roots:
     - docs/filters/inventory-baseline.json
     - docs/filters/inventory-baseline.md
     - docs/00-project/governance/root-local-clutter-cleanup.md
+    - reports/quality/total-tech-debt-audit-main-current.md
   generated_ai_mirrors:
     - docs/00-project/ai/agents/
     - docs/00-project/ai/skills/global/
@@ -79,6 +80,12 @@ forbidden_output_roots:
   - silver/
 
 routes:
+  - id: current-technical-debt-audit
+    generator: scripts/engineering/qa/technical_debt_audit_registry.py
+    output_kind: working_report
+    commit_policy: reviewed_generated
+    outputs:
+      - reports/quality/total-tech-debt-audit-main-current.md
   - id: file-merger-working-reports
     generator: src/tools/file_merger.py
     output_kind: working_report

--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -1,9 +1,25 @@
 version: 1
-current_audit_id: total-tech-debt-main-2026-07-27-r1
+current_audit_id: total-tech-debt-main-2026-07-30
 audits:
-- id: total-tech-debt-main-2026-07-27-r1
+- id: total-tech-debt-main-2026-07-30
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
+  audited_commit_sha: af206b51a9133f7a260ee9372ee869afdf7fc7bd
+  evidence_surface_sha256: 78f2d6b4b06ee374834b48817aecb5ded93ff8c82dbf2d2eff944f558294b47f
+  evidence_paths:
+  - configs/quality/compatibility_facade_inventory.yaml
+  - configs/quality/debt_scorecard.yaml
+  - reports/quality/architecture-quality-scorecard.json
+  - reports/quality/compatibility-importer-census.json
+  - reports/quality/dead-code-inventory.json
+  - reports/quality/debt-governance-gates.json
+  - reports/quality/module-coverage-inventory.json
+  - reports/quality/test-governance-current.json
+  reviewed_on: '2026-07-30'
+  linked_issue: '#7254'
+- id: total-tech-debt-main-2026-07-27-r1
+  status: superseded
+  report_path: docs/99-archive/reports/quality/total-tech-debt-audit-main-2026-07-27-r1.md
   audited_commit_sha: 947902209629f5666170cd49fbf776f4bcb5f3d2
   evidence_surface_sha256: 78f2d6b4b06ee374834b48817aecb5ded93ff8c82dbf2d2eff944f558294b47f
   evidence_paths:
@@ -17,6 +33,8 @@ audits:
   - reports/quality/test-governance-current.json
   reviewed_on: '2026-07-29'
   linked_issue: '#7038'
+  superseded_by: total-tech-debt-main-2026-07-30
+  superseded_on: '2026-07-30'
 - id: total-tech-debt-main-2026-07-27
   status: superseded
   report_path: docs/99-archive/reports/quality/total-tech-debt-audit-main-2026-07-27.md

--- a/docs/99-archive/reports/quality/total-tech-debt-audit-main-2026-07-27-r1.md
+++ b/docs/99-archive/reports/quality/total-tech-debt-audit-main-2026-07-27-r1.md
@@ -1,0 +1,69 @@
+# Total Technical Debt Audit: GitHub main
+
+Lifecycle status: superseded
+
+Audit date: 2026-07-29
+
+Audited repository: SatoryKono/BioactivityDataAcquisition
+
+Audited branch: main
+
+Audited commit SHA: `947902209629f5666170cd49fbf776f4bcb5f3d2`
+
+Evidence surface SHA-256: `78f2d6b4b06ee374834b48817aecb5ded93ff8c82dbf2d2eff944f558294b47f`
+
+Registry: configs/quality/technical_debt_audit_registry.yaml
+
+Refresh reason: CR-03 / #6695 regenerate from one consistent evidence snapshot after CodeRabbit audit remediation (CR-01/CR-02). No debt budget growth.
+
+## Executive summary
+
+1. Debt-governance gates: **45 pass / 0 fail** (`45/45` debt-governance gates passing).
+1. Architecture quality integral score: **9.41** (`good_targeted_improvements`). Integral score `9.41`.
+1. Module inventory (from `module-coverage-inventory.json` only):
+   - source_module_count: **2311**
+   - fully_covered: **1406**
+   - partially_covered: **816**
+   - no_executable_lines: **55**
+   - uncovered: **0**
+   - unmeasured: **0**
+   - check: fully + partial + no_exec + uncovered + unmeasured = 2277 == source_module_count
+1. Contract coverage matrix schema: **contract-coverage-matrix-v3** (v3: strict Gold required for availability).
+1. Constructor waivers (shrink-only inventory): **5** entries.
+1. Compatibility transition/sunset/expired: **0/0/0**; twin pairs: **0**.
+1. Layer violations: **0**.
+
+## Evidence anchors
+
+- `reports/quality/module-coverage-inventory.json`
+- `reports/quality/architecture-quality-scorecard.json`
+- `reports/quality/debt-governance-gates.json`
+- `reports/quality/contract-coverage-matrix.json`
+- `configs/quality/debt_scorecard.yaml`
+- `configs/quality/constructor_waivers.yaml`
+
+## Reproducibility
+
+```bash
+python -m scripts.engineering.qa report-module-coverage --allow-missing-coverage-xml
+python scripts/engineering/qa/report_architecture_quality_scorecard.py
+python -m scripts.engineering.qa report-contract-coverage-matrix
+python -m scripts.engineering.qa report-debt-governance-gates --update
+python -m scripts.engineering.qa validate-technical-debt-audit --json
+```
+
+## Compatibility retained entrypoints (importer census)
+
+| module | src importers | test importers |
+| --- | ---: | ---: |
+| `bioetl.domain.composite.config` | 0 | 39 |
+| `bioetl.application.composite.merger` | 0 | 5 |
+
+## TD2 residual closeout (2026-07-29)
+
+- Epic #7033 / children #7034–#7041: artifact drift cleared, hotspot re-export trim, shim review, scripts ratchet 17→15, public API interim review.
+
+## Related closeouts
+
+- CodeRabbit epic CR-00 / #6692 (children CR-01..CR-07)
+- Residual tech-debt epic TD-R-00 / #6676

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -2,54 +2,45 @@
 
 Lifecycle status: current
 
-Audit date: 2026-07-29
-
-Audited repository: SatoryKono/BioactivityDataAcquisition
-
-Audited branch: main
-
-Audited commit SHA: `947902209629f5666170cd49fbf776f4bcb5f3d2`
+Audited commit SHA: `af206b51a9133f7a260ee9372ee869afdf7fc7bd`
 
 Evidence surface SHA-256: `78f2d6b4b06ee374834b48817aecb5ded93ff8c82dbf2d2eff944f558294b47f`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
-Refresh reason: CR-03 / #6695 regenerate from one consistent evidence snapshot after CodeRabbit audit remediation (CR-01/CR-02). No debt budget growth.
+<!-- technical-debt-audit-summary: {"architecture_quality":{"integral_score":9.41,"interpretation":"good_targeted_improvements"},"audit_id":"total-tech-debt-main-2026-07-30","audited_commit_sha":"af206b51a9133f7a260ee9372ee869afdf7fc7bd","compatibility":{"expired":0,"retained_entrypoints":[{"module":"bioetl.domain.composite.config","src_importers":0,"test_importers":39},{"module":"bioetl.application.composite.merger","src_importers":0,"test_importers":5}],"sunset":0,"transition":0,"twin_pairs":0},"debt_governance":{"fail_count":0,"gate_count":45,"pass_count":45},"evidence_surface_sha256":"78f2d6b4b06ee374834b48817aecb5ded93ff8c82dbf2d2eff944f558294b47f","layer_violations":0,"module_inventory":{"fully_covered":1476,"no_executable_lines":94,"partially_covered":744,"source_module_count":2314,"uncovered":0,"unmeasured":0}} -->
 
 ## Executive summary
 
 1. Debt-governance gates: **45 pass / 0 fail** (`45/45` debt-governance gates passing).
 1. Architecture quality integral score: **9.41** (`good_targeted_improvements`). Integral score `9.41`.
-1. Module inventory (from `module-coverage-inventory.json` only):
-   - source_module_count: **2311**
-   - fully_covered: **1406**
-   - partially_covered: **816**
-   - no_executable_lines: **55**
+1. Module inventory:
+   - source_module_count: **2314**
+   - fully_covered: **1476**
+   - partially_covered: **744**
+   - no_executable_lines: **94**
    - uncovered: **0**
    - unmeasured: **0**
-   - check: fully + partial + no_exec + uncovered + unmeasured = 2277 == source_module_count
-1. Contract coverage matrix schema: **contract-coverage-matrix-v3** (v3: strict Gold required for availability).
-1. Constructor waivers (shrink-only inventory): **5** entries.
+   - check: status total = 2314 == source_module_count
 1. Compatibility transition/sunset/expired: **0/0/0**; twin pairs: **0**.
 1. Layer violations: **0**.
 
 ## Evidence anchors
 
-- `reports/quality/module-coverage-inventory.json`
-- `reports/quality/architecture-quality-scorecard.json`
-- `reports/quality/debt-governance-gates.json`
-- `reports/quality/contract-coverage-matrix.json`
+- `configs/quality/compatibility_facade_inventory.yaml`
 - `configs/quality/debt_scorecard.yaml`
-- `configs/quality/constructor_waivers.yaml`
+- `reports/quality/architecture-quality-scorecard.json`
+- `reports/quality/compatibility-importer-census.json`
+- `reports/quality/dead-code-inventory.json`
+- `reports/quality/debt-governance-gates.json`
+- `reports/quality/module-coverage-inventory.json`
+- `reports/quality/test-governance-current.json`
 
 ## Reproducibility
 
 ```bash
-python -m scripts.engineering.qa report-module-coverage --allow-missing-coverage-xml
-python scripts/engineering/qa/report_architecture_quality_scorecard.py
-python -m scripts.engineering.qa report-contract-coverage-matrix
-python -m scripts.engineering.qa report-debt-governance-gates --update
 python -m scripts.engineering.qa validate-technical-debt-audit --json
+python -m scripts.engineering.qa validate-technical-debt-audit --update-current
 ```
 
 ## Compatibility retained entrypoints (importer census)
@@ -58,12 +49,3 @@ python -m scripts.engineering.qa validate-technical-debt-audit --json
 | --- | ---: | ---: |
 | `bioetl.domain.composite.config` | 0 | 39 |
 | `bioetl.application.composite.merger` | 0 | 5 |
-
-## TD2 residual closeout (2026-07-29)
-
-- Epic #7033 / children #7034–#7041: artifact drift cleared, hotspot re-export trim, shim review, scripts ratchet 17→15, public API interim review.
-
-## Related closeouts
-
-- CodeRabbit epic CR-00 / #6692 (children CR-01..CR-07)
-- Residual tech-debt epic TD-R-00 / #6676

--- a/scripts/engineering/qa/README.md
+++ b/scripts/engineering/qa/README.md
@@ -42,7 +42,7 @@ python -m scripts.engineering.qa <command> [args...]
 | `report-invariant-audit-rebaseline` | `report_invariant_audit_rebaseline.py`              | Generate/check stale invariant-audit evidence matrix and duplicate-issue gates                    |
 | `report-architecture-debt-remote-main-baseline` | `report_architecture_debt_remote_main_baseline.py` | Generate/check clean remote-main architecture debt baseline artifacts                             |
 | `report-debt-governance-gates`   | `report_debt_governance_gates.py`                     | Generate/check normalized debt-reduction fail-fast gate rollup                                    |
-| `validate-technical-debt-audit`  | `technical_debt_audit_registry.py`                    | Validate and resolve the exact-SHA current technical-debt audit lifecycle                          |
+| `validate-technical-debt-audit`  | `technical_debt_audit_registry.py`                    | Render and semantically validate the exact-SHA current technical-debt audit lifecycle              |
 | `run-architecture-audit-read-only` | `run_architecture_audit_read_only.py`                | Run check-only architecture evidence diagnostics without pretest sync or artifact writes          |
 | `report-hotspots`                | `generate_hotspot_degradation_report.py`              | Generate performance hotspot degradation report                                                   |
 | `report-duplication-baseline`    | `report_duplication_baseline.py`                      | Generate report-only duplication baseline for `composition`/`application`                         |
@@ -85,7 +85,7 @@ python -m scripts.engineering.qa <command> [args...]
 | `report-invariant-audit-rebaseline` | When converting architecture/invariant audits into GitHub issues; validates stale paths, current anchors, and duplicate issue evidence        | Audit governance / issue triage gate       |
 | `report-architecture-debt-remote-main-baseline` | Before debt closeout; records clean `origin/main` architecture debt evidence from Git tree blobs                                      | Architecture debt closeout / CI drift check |
 | `report-debt-governance-gates`   | Before debt-reduction closeout; aggregates quality artifacts into normalized pass/fail/warn fail-fast gates                                      | Architecture debt closeout / CI gate       |
-| `validate-technical-debt-audit`  | When consuming or refreshing a technical-debt audit; rejects ambiguous current reports and stale evidence hashes                                 | Audit lifecycle / drift gate               |
+| `validate-technical-debt-audit`  | When consuming or refreshing a technical-debt audit; rejects ambiguous reports, stale evidence hashes, and semantic metric drift                   | Audit lifecycle / drift gate               |
 | `run-architecture-audit-read-only` | When collecting architecture audit evidence without allowing dev-wrapper pretest sync or generated-artifact writes                         | Manual, read-only audit                    |
 | `report-hotspots`                | After performance benchmark runs; generates degradation report from JSONL observations                                                           | Manual, on-demand                          |
 | `report-duplication-baseline`    | When reviewing duplication pressure in `composition` or `application`; generates report-only baseline artifacts without creating a blocking gate | Manual, on-demand                          |
@@ -141,6 +141,7 @@ python -m scripts.engineering.qa report-architecture-debt-remote-main-baseline -
 python -m scripts.engineering.qa report-debt-governance-gates --check
 python -m scripts.engineering.qa report-debt-governance-gates --update
 python -m scripts.engineering.qa validate-technical-debt-audit --json
+python -m scripts.engineering.qa validate-technical-debt-audit --update-current
 python -m scripts.engineering.qa run-architecture-audit-read-only
 python -m scripts.engineering.qa run-tests --suite unit-fast --skip-preflight -- --no-cov
 python -m scripts.engineering.qa run-tests --suite unit-parallel-safe --skip-preflight -- --no-cov

--- a/scripts/engineering/qa/technical_debt_audit_registry.py
+++ b/scripts/engineering/qa/technical_debt_audit_registry.py
@@ -16,6 +16,9 @@ import yaml
 DEFAULT_REGISTRY_PATH = Path("configs/quality/technical_debt_audit_registry.yaml")
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+SEMANTIC_SUMMARY_PATTERN = re.compile(
+    r"<!-- technical-debt-audit-summary: (?P<payload>\{.*\}) -->"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -228,6 +231,163 @@ def _validate_current_report_markers(root: Path, current: Any) -> list[str]:
     return issues
 
 
+def build_current_audit_semantic_summary(
+    root: Path,
+    current: TechnicalDebtAuditRecord,
+) -> dict[str, Any]:
+    """Build the report headline summary from the pinned evidence surface."""
+
+    def load_evidence(relative_path: str) -> dict[str, Any]:
+        if relative_path not in current.evidence_paths:
+            raise ValueError(f"semantic audit evidence is not pinned: {relative_path}")
+        payload = json.loads((root / relative_path).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"semantic audit evidence must be a mapping: {relative_path}"
+            )
+        return payload
+
+    coverage = load_evidence("reports/quality/module-coverage-inventory.json")
+    scorecard = load_evidence("reports/quality/architecture-quality-scorecard.json")
+    governance = load_evidence("reports/quality/debt-governance-gates.json")
+    compatibility = load_evidence("reports/quality/compatibility-importer-census.json")
+    coverage_summary = coverage["summary"]
+    status_counts = coverage_summary["status_counts"]
+    governance_summary = governance["summary"]
+    scorecard_metrics = scorecard["metrics"]
+    compatibility_summary = compatibility["summary"]
+    highlighted_modules = {
+        "bioetl.domain.composite.config",
+        "bioetl.application.composite.merger",
+    }
+    retained_entrypoints = [
+        {
+            "module": row["module_name"],
+            "src_importers": row["src_importer_count"],
+            "test_importers": row["test_importer_count"],
+        }
+        for row in compatibility.get("retained_entrypoints", [])
+        if row.get("module_name") in highlighted_modules
+    ]
+    return {
+        "audit_id": current.audit_id,
+        "audited_commit_sha": current.audited_commit_sha,
+        "evidence_surface_sha256": current.evidence_surface_sha256,
+        "debt_governance": {
+            "gate_count": governance_summary["gate_count"],
+            "pass_count": governance_summary["pass_count"],
+            "fail_count": governance_summary["fail_count"],
+        },
+        "architecture_quality": {
+            "integral_score": scorecard["integral_score"],
+            "interpretation": scorecard["interpretation"],
+        },
+        "module_inventory": {
+            "source_module_count": coverage_summary["source_module_count"],
+            "fully_covered": status_counts["fully_covered"],
+            "partially_covered": status_counts["partially_covered"],
+            "no_executable_lines": status_counts["no_executable_lines"],
+            "uncovered": status_counts["uncovered"],
+            "unmeasured": status_counts["unmeasured"],
+        },
+        "compatibility": {
+            "transition": scorecard_metrics["transition_compat_count"],
+            "sunset": scorecard_metrics["sunset_compat_count"],
+            "expired": scorecard_metrics["expired_compat_count"],
+            "twin_pairs": compatibility_summary["twin_pair_count"],
+            "retained_entrypoints": retained_entrypoints,
+        },
+        "layer_violations": scorecard_metrics["layer_violations"],
+    }
+
+
+def render_current_technical_debt_audit(
+    root: Path,
+    current: TechnicalDebtAuditRecord,
+) -> str:
+    """Render the current audit deterministically from its pinned evidence."""
+    summary = build_current_audit_semantic_summary(root, current)
+    module = summary["module_inventory"]
+    module_total = sum(
+        module[key]
+        for key in (
+            "fully_covered",
+            "partially_covered",
+            "no_executable_lines",
+            "uncovered",
+            "unmeasured",
+        )
+    )
+    semantic_json = json.dumps(summary, sort_keys=True, separators=(",", ":"))
+    governance = summary["debt_governance"]
+    architecture = summary["architecture_quality"]
+    compatibility = summary["compatibility"]
+    retained_rows = "".join(
+        f"| `{row['module']}` | {row['src_importers']} | {row['test_importers']} |\n"
+        for row in compatibility["retained_entrypoints"]
+    )
+    return (
+        "# Total Technical Debt Audit: GitHub main\n\n"
+        "Lifecycle status: current\n\n"
+        f"Audited commit SHA: `{current.audited_commit_sha}`\n\n"
+        f"Evidence surface SHA-256: `{current.evidence_surface_sha256}`\n\n"
+        f"Registry: {DEFAULT_REGISTRY_PATH.as_posix()}\n\n"
+        f"<!-- technical-debt-audit-summary: {semantic_json} -->\n\n"
+        "## Executive summary\n\n"
+        f"1. Debt-governance gates: **{governance['pass_count']} pass / "
+        f"{governance['fail_count']} fail** (`{governance['pass_count']}/"
+        f"{governance['gate_count']}` debt-governance gates passing).\n"
+        f"1. Architecture quality integral score: **{architecture['integral_score']}** "
+        f"(`{architecture['interpretation']}`). Integral score "
+        f"`{architecture['integral_score']}`.\n"
+        "1. Module inventory:\n"
+        f"   - source_module_count: **{module['source_module_count']}**\n"
+        f"   - fully_covered: **{module['fully_covered']}**\n"
+        f"   - partially_covered: **{module['partially_covered']}**\n"
+        f"   - no_executable_lines: **{module['no_executable_lines']}**\n"
+        f"   - uncovered: **{module['uncovered']}**\n"
+        f"   - unmeasured: **{module['unmeasured']}**\n"
+        f"   - check: status total = {module_total} == source_module_count\n"
+        "1. Compatibility transition/sunset/expired: "
+        f"**{compatibility['transition']}/{compatibility['sunset']}/"
+        f"{compatibility['expired']}**; twin pairs: "
+        f"**{compatibility['twin_pairs']}**.\n"
+        f"1. Layer violations: **{summary['layer_violations']}**.\n\n"
+        "## Evidence anchors\n\n"
+        + "".join(f"- `{path}`\n" for path in current.evidence_paths)
+        + "\n## Reproducibility\n\n"
+        "```bash\n"
+        "python -m scripts.engineering.qa validate-technical-debt-audit --json\n"
+        "python -m scripts.engineering.qa validate-technical-debt-audit "
+        "--update-current\n"
+        "```\n\n"
+        "## Compatibility retained entrypoints (importer census)\n\n"
+        "| module | src importers | test importers |\n"
+        "| --- | ---: | ---: |\n"
+        f"{retained_rows}"
+    )
+
+
+def _validate_current_semantics(root: Path, current: Any) -> list[str]:
+    report_path = root / current.report_path
+    if not report_path.is_file():
+        return []
+    match = SEMANTIC_SUMMARY_PATTERN.search(report_path.read_text(encoding="utf-8"))
+    if match is None:
+        return ["current audit is missing machine-readable semantic summary"]
+    try:
+        actual = json.loads(match.group("payload"))
+        expected = build_current_audit_semantic_summary(root, current)
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        return [f"current audit semantic summary is invalid: {exc}"]
+    if actual != expected:
+        return ["current audit semantic summary is stale"]
+    expected_report = render_current_technical_debt_audit(root, current)
+    if report_path.read_text(encoding="utf-8") != expected_report:
+        return ["current audit Markdown is not the deterministic rendered report"]
+    return []
+
+
 def validate_technical_debt_audit_registry(
     root: Path,
     registry_path: Path | None = None,
@@ -261,6 +421,7 @@ def validate_technical_debt_audit_registry(
     )
     issues.extend(_validate_current_evidence_hash(root, current))
     issues.extend(_validate_current_report_markers(root, current))
+    issues.extend(_validate_current_semantics(root, current))
     return issues
 
 
@@ -270,6 +431,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
     parser.add_argument("--print-current", action="store_true")
     parser.add_argument("--print-evidence-hash", action="store_true")
+    parser.add_argument("--update-current", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser
 
@@ -285,6 +447,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.print_evidence_hash:
         print(compute_evidence_surface_sha256(root, current.evidence_paths))
+        return 0
+    if args.update_current:
+        report_path = root / current.report_path
+        report_path.write_text(
+            render_current_technical_debt_audit(root, current),
+            encoding="utf-8",
+        )
+        print(f"Updated technical-debt audit: {current.report_path}")
         return 0
     issues = validate_technical_debt_audit_registry(root, args.registry)
     if args.json:

--- a/tests/unit/scripts/engineering/qa/test_technical_debt_audit_registry.py
+++ b/tests/unit/scripts/engineering/qa/test_technical_debt_audit_registry.py
@@ -18,6 +18,8 @@ import pytest
 
 from scripts.engineering.qa.technical_debt_audit_registry import (
     compute_evidence_surface_sha256,
+    load_technical_debt_audit_registry,
+    render_current_technical_debt_audit,
     resolve_current_technical_debt_audit,
     validate_technical_debt_audit_registry,
 )
@@ -26,19 +28,32 @@ pytestmark = pytest.mark.unit
 
 
 def _write_registry_fixture(root: Path) -> Path:
-    evidence = root / "reports/quality/evidence.json"
-    evidence.parent.mkdir(parents=True)
-    evidence.write_text('{"value":1}\n', encoding="utf-8")
+    evidence_payloads = {
+        "reports/quality/module-coverage-inventory.json": (
+            '{"summary":{"source_module_count":3,"status_counts":'
+            '{"fully_covered":1,"partially_covered":1,"no_executable_lines":1,'
+            '"uncovered":0,"unmeasured":0}}}\n'
+        ),
+        "reports/quality/architecture-quality-scorecard.json": (
+            '{"integral_score":9.5,"interpretation":"good",'
+            '"metrics":{"transition_compat_count":0,"sunset_compat_count":0,'
+            '"expired_compat_count":0,"layer_violations":0}}\n'
+        ),
+        "reports/quality/debt-governance-gates.json": (
+            '{"summary":{"gate_count":2,"pass_count":2,"fail_count":0}}\n'
+        ),
+        "reports/quality/compatibility-importer-census.json": (
+            '{"summary":{"twin_pair_count":0}}\n'
+        ),
+    }
+    for relative_path, content in evidence_payloads.items():
+        evidence = root / relative_path
+        evidence.parent.mkdir(parents=True, exist_ok=True)
+        evidence.write_text(content, encoding="utf-8")
     current_report = root / "reports/quality/current.md"
     evidence_hash = compute_evidence_surface_sha256(
         root,
-        ["reports/quality/evidence.json"],
-    )
-    current_report.write_text(
-        "Lifecycle status: current\n"
-        "Audited commit SHA: `1111111111111111111111111111111111111111`\n"
-        f"Evidence surface SHA-256: `{evidence_hash}`\n",
-        encoding="utf-8",
+        list(evidence_payloads),
     )
     archived_report = root / "docs/99-archive/reports/quality/old.md"
     archived_report.parent.mkdir(parents=True)
@@ -55,10 +70,15 @@ def _write_registry_fixture(root: Path) -> Path:
         "    audited_commit_sha: '1111111111111111111111111111111111111111'\n"
         f"    evidence_surface_sha256: '{evidence_hash}'\n"
         "    evidence_paths:\n"
-        "      - reports/quality/evidence.json\n"
-        "  - id: audit-old\n"
+        + "".join(f"      - {path}\n" for path in evidence_payloads)
+        + "  - id: audit-old\n"
         "    status: superseded\n"
         "    report_path: docs/99-archive/reports/quality/old.md\n",
+        encoding="utf-8",
+    )
+    _, records = load_technical_debt_audit_registry(root, registry.relative_to(root))
+    current_report.write_text(
+        render_current_technical_debt_audit(root, records[0]),
         encoding="utf-8",
     )
     return registry.relative_to(root)
@@ -80,8 +100,8 @@ def test_registry_resolves_exactly_one_current_audit(tmp_path: Path) -> None:
 
 def test_registry_detects_evidence_content_drift(tmp_path: Path) -> None:
     registry = _write_registry_fixture(tmp_path)
-    (tmp_path / "reports/quality/evidence.json").write_text(
-        '{"value":2}\n',
+    (tmp_path / "reports/quality/debt-governance-gates.json").write_text(
+        '{"summary":{"gate_count":2,"pass_count":1,"fail_count":1}}\n',
         encoding="utf-8",
     )
 
@@ -92,6 +112,26 @@ def test_registry_detects_evidence_content_drift(tmp_path: Path) -> None:
     )
 
     assert "current audit evidence_surface_sha256 is stale" in issues
+
+
+def test_registry_detects_semantic_metric_mutation(tmp_path: Path) -> None:
+    registry = _write_registry_fixture(tmp_path)
+    report = tmp_path / "reports/quality/current.md"
+    report.write_text(
+        report.read_text(encoding="utf-8").replace(
+            '"source_module_count":3',
+            '"source_module_count":4',
+        ),
+        encoding="utf-8",
+    )
+
+    issues = validate_technical_debt_audit_registry(
+        tmp_path,
+        registry,
+        verify_git_commit=False,
+    )
+
+    assert "current audit semantic summary is stale" in issues
 
 
 def test_evidence_hash_is_independent_of_checkout_line_endings(


### PR DESCRIPTION
## Summary

- render the current technical-debt audit deterministically from pinned evidence
- validate a machine-readable semantic summary and the complete rendered Markdown
- archive the superseded opaque report and add mutation coverage

## Verification

- `python -m scripts.engineering.qa validate-technical-debt-audit --json`
- `python -m scripts.engineering.qa report-debt-governance-gates --check`
- `python -m pytest tests/unit/scripts/engineering/qa/test_technical_debt_audit_registry.py tests/architecture/test_tech_debt_issues_5752_5755_closeout.py tests/architecture/test_generated_artifact_routing.py -q` (28 passed)
- `python -m pytest -q tests/architecture/test_debt_governance_telemetry_reporting.py tests/architecture/test_quality_debt_scorecard.py` (36 passed, 1 repository-defined skip)
- Ruff, scripts inventory, deterministic double-render, and `git diff --check` passed

No debt budget, threshold, exemption, suppression, skip, or xfail was added.

Fixes #7254
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/7260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->