### PR TITLE
feat(governance): enforce naming, SVG, and branch lifecycle gates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,6 +45,7 @@ Before contributing, read these documents:
 For the full local GitHub workflow, including worktrees, sync/rebase, PR creation, and cleanup, see:
 
 - [docs/03-guides/github-local-workflow.md](../docs/03-guides/github-local-workflow.md)
+- [GitHub branch naming and lifecycle policy](../docs/00-project/governance/05-github-policy.md#1-branch-strategy)
 
 ### Governance Metrics Note
 

--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -1,0 +1,51 @@
+name: Branch Hygiene
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  schedule:
+    - cron: "15 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-pr-branch-name:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR head branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          pattern='^(feat|fix|refactor|docs|test|chore|ci)/[a-z0-9]+([.-][a-z0-9]+)*$'
+          automation='^(dependabot|renovate|devin|bolt)/.+'
+          if [[ ! "$HEAD_REF" =~ $pattern && ! "$HEAD_REF" =~ $automation ]]; then
+            echo "Non-compliant branch name: $HEAD_REF" >&2
+            echo "Use <type>/<lowercase-kebab-description>." >&2
+            exit 1
+          fi
+
+  inventory:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Python + uv
+        uses: ./.github/actions/setup-python-uv
+      - name: Generate report-only branch inventory
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          uv run --frozen --no-build python -m scripts.engineering.repo \
+            generate-branch-cleanup-inventory \
+            --output reports/quality/branch-hygiene-latest.json
+      - name: Upload branch inventory
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: branch-hygiene-inventory
+          path: reports/quality/branch-hygiene-latest.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -454,6 +454,9 @@ jobs:
             -   name: Pre-merge naming/package consistency gate
                 run: uv run --frozen --no-build python -m scripts.engineering.qa check-naming-pkg --check
 
+            -   name: Pre-merge naming convention audit
+                run: uv run --frozen --no-build python -m scripts.engineering.qa check-naming --check
+
             -   name: DQ consistency validation (fail-fast)
                 run: uv run --frozen --no-build python -m scripts.engineering.qa validate-dq-consistency
 

--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,8 +4,8 @@ audits:
 - id: total-tech-debt-main-2026-07-27-r1
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
-  audited_commit_sha: 5eb10bc8852b685cf955149de153c24766886d9e
-  evidence_surface_sha256: d6c42c7f9ad7396cac3cdbd744f5c239182622a56a97eebe7c8c18baf18b3743
+  audited_commit_sha: c906599c766f3ed6871d184b18f36389a2d877ce
+  evidence_surface_sha256: 31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml
   - configs/quality/constructor_waivers.yaml

--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,8 +4,8 @@ audits:
 - id: total-tech-debt-main-2026-07-27-r1
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
-  audited_commit_sha: c906599c766f3ed6871d184b18f36389a2d877ce
-  evidence_surface_sha256: 31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4
+  audited_commit_sha: f0c5b1a8a48a9b68361e43b48a0a6d37ed9a820e
+  evidence_surface_sha256: e5791caa856537b31c16a044adc4f5e86ea945dfd40534bf7cc24c2b39df625e
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml
   - configs/quality/constructor_waivers.yaml

--- a/docs/00-project/governance/05-github-policy.md
+++ b/docs/00-project/governance/05-github-policy.md
@@ -1,19 +1,19 @@
 ______________________________________________________________________
 
-Version: 1.1.0
+Version: 1.2.0
 Status: active
 Class: published
 Owner: BioETL Team
 Reviewers:
 
 - BioETL Team
-  Last verified: '2026-05-26'
+  Last verified: '2026-07-31'
 
 ______________________________________________________________________
 
 # GitHub Interaction Policy
 
-*Synced with RULES.md v6.1.3 and ADR-047 | Last updated: 2026-05-26*
+*Synced with RULES.md and ADR-047 | Last updated: 2026-07-31*
 
 ______________________________________________________________________
 
@@ -46,6 +46,41 @@ ______________________________________________________________________
 - `feat/pubchem_compound-pipeline`
 - `fix/chembl-rate-limit-429`
 - `refactor/storage-clear-contract`
+
+Automation-owned branches MAY use a provider prefix already established by
+the integration (`dependabot/`, `renovate/`, `devin/`, `bolt/`). Human-created
+branches MUST use one of the project types above and a lowercase kebab-case
+description. Opaque names (`a1`, `tmp`, numeric-only names), date-only names,
+and persistent `backup/*` branches are non-compliant.
+
+### Branch Lifecycle
+
+| State | Required action | Retention |
+| --- | --- | --- |
+| Active PR or active worktree | Keep; never delete automatically | Until merged, closed, or explicitly abandoned |
+| Merged branch | Delete after the merge commit is reachable from `main` | Within 7 days |
+| Closed/unmerged branch | Owner review before deletion | Review after 30 days without activity |
+| Release or durable recovery point | Create an annotated tag; do not retain a backup branch | Tags follow release retention |
+
+Before deleting a local or remote branch, the operator MUST verify all of:
+
+1. it is not `main`, a protected branch, an active PR head, or checked out by
+   any worktree;
+1. its tip and merge status were refreshed from GitHub rather than taken from
+   a historical cleanup list;
+1. unmerged branches have an explicit owner decision (`keep`, `tag`, or
+   `delete`);
+1. the cleanup command is reviewed in dry-run form before apply.
+
+Branch-count ceilings MUST NOT be enforced by failing unrelated pull requests.
+CI may reject the current PR head when its name violates this policy. Scheduled
+branch inventory is report-only; deletion remains an explicit maintainer
+operation. Cleanup tooling MUST default to dry-run and MUST NOT infer deletion
+solely from age or a global branch-count target.
+
+Compliant examples: `fix/vcr-lfs-preflight`, `ci/branch-name-policy`,
+`docs/branch-lifecycle`. Non-compliant examples: `master_20260801`,
+`backup-before-merge`, `12345`, `temp-fix`.
 
 ______________________________________________________________________
 

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -38,7 +38,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "a15f2b7fd6925b5c7307f5b50cb72558135ba665b9e71d28aa4ad6971cae347c",
-    "test_governance_source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4"
+    "test_governance_source_tree_sha256": "d280f42761a09e6783a48aca3b632d86300da96907c09e1b681513c9d98eb6df"
   },
   "summary": {
     "by_alert_level": {
@@ -72,7 +72,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4",
+    "test_governance_source_tree_sha256": "d280f42761a09e6783a48aca3b632d86300da96907c09e1b681513c9d98eb6df",
     "total_flaky": 0,
     "total_test_files": 2171,
     "total_tests_analyzed": 23292

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -38,7 +38,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "a15f2b7fd6925b5c7307f5b50cb72558135ba665b9e71d28aa4ad6971cae347c",
-    "test_governance_source_tree_sha256": "51d8c3deb8f6bfa4409448ab3fcdc14d8123c4d9eda282b96b1912c6a849895c"
+    "test_governance_source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4"
   },
   "summary": {
     "by_alert_level": {
@@ -72,9 +72,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "51d8c3deb8f6bfa4409448ab3fcdc14d8123c4d9eda282b96b1912c6a849895c",
+    "test_governance_source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4",
     "total_flaky": 0,
-    "total_test_files": 2170,
-    "total_tests_analyzed": 23288
+    "total_test_files": 2171,
+    "total_tests_analyzed": 23292
   }
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2314,8 +2314,8 @@
         "test_*.py"
       ],
       "test_file_count_definition": "tests/**/test_*.py matching pyproject tool.pytest.ini_options.python_files",
-      "test_glob_file_count": 2170,
-      "test_python_file_count": 2401,
+      "test_glob_file_count": 2171,
+      "test_python_file_count": 2402,
       "top_level_directories": [
         "tests/architecture/",
         "tests/benchmarks/",
@@ -2355,13 +2355,13 @@
       "top_level_directory_count_including_pycache": 16
     },
     "top_duplicate_test_names": [],
-    "total_test_files": 2170,
-    "total_test_functions": 23288,
+    "total_test_files": 2171,
+    "total_test_functions": 23292,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "05150c24e8ff820e6504ee0599bbb6a4d22d24a650b15075d4b5836725b76769",
+  "source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,
@@ -2381,8 +2381,8 @@
       "test_*.py"
     ],
     "test_file_count_definition": "tests/**/test_*.py matching pyproject tool.pytest.ini_options.python_files",
-    "test_glob_file_count": 2170,
-    "test_python_file_count": 2401,
+    "test_glob_file_count": 2171,
+    "test_python_file_count": 2402,
     "top_level_directories": [
       "tests/architecture/",
       "tests/benchmarks/",
@@ -2422,8 +2422,8 @@
     "top_level_directory_count_including_pycache": 16
   },
   "top_duplicate_test_names": [],
-  "total_test_files": 2170,
-  "total_test_functions": 23288,
+  "total_test_files": 2171,
+  "total_test_functions": 23292,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2361,7 +2361,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "ee2387da93146374dbad04272ee334474a57372817dbe10ee9bef40578ab38b4",
+  "source_tree_sha256": "d280f42761a09e6783a48aca3b632d86300da96907c09e1b681513c9d98eb6df",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,17 +8,17 @@ Audited repository: SatoryKono/BioactivityDataAcquisition
 
 Audited branch: main
 
-Audited commit SHA: `c906599c766f3ed6871d184b18f36389a2d877ce`
+Audited commit SHA: `f0c5b1a8a48a9b68361e43b48a0a6d37ed9a820e`
 
-Evidence surface SHA-256: `31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4`
+Evidence surface SHA-256: `e5791caa856537b31c16a044adc4f5e86ea945dfd40534bf7cc24c2b39df625e`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
 <!-- technical-debt-audit-summary-v1
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
-  "audited_commit_sha": "c906599c766f3ed6871d184b18f36389a2d877ce",
-  "evidence_surface_sha256": "31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4",
+  "audited_commit_sha": "f0c5b1a8a48a9b68361e43b48a0a6d37ed9a820e",
+  "evidence_surface_sha256": "e5791caa856537b31c16a044adc4f5e86ea945dfd40534bf7cc24c2b39df625e",
   "metrics": {
     "architecture_integral_score": 9.41,
     "architecture_interpretation": "good_targeted_improvements",

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,17 +8,17 @@ Audited repository: SatoryKono/BioactivityDataAcquisition
 
 Audited branch: main
 
-Audited commit SHA: `5eb10bc8852b685cf955149de153c24766886d9e`
+Audited commit SHA: `c906599c766f3ed6871d184b18f36389a2d877ce`
 
-Evidence surface SHA-256: `d6c42c7f9ad7396cac3cdbd744f5c239182622a56a97eebe7c8c18baf18b3743`
+Evidence surface SHA-256: `31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
 <!-- technical-debt-audit-summary-v1
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
-  "audited_commit_sha": "5eb10bc8852b685cf955149de153c24766886d9e",
-  "evidence_surface_sha256": "d6c42c7f9ad7396cac3cdbd744f5c239182622a56a97eebe7c8c18baf18b3743",
+  "audited_commit_sha": "c906599c766f3ed6871d184b18f36389a2d877ce",
+  "evidence_surface_sha256": "31a366825d22d54e2954248046b829aa70ca40a26b556ebccf267a41084de3c4",
   "metrics": {
     "architecture_integral_score": 9.41,
     "architecture_interpretation": "good_targeted_improvements",

--- a/scripts/diagrams/strip_svg_foreign_object.py
+++ b/scripts/diagrams/strip_svg_foreign_object.py
@@ -10,10 +10,9 @@ Use-case:
 from __future__ import annotations
 
 import argparse
-import io
+import re
 import sys
 import tempfile
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -25,20 +24,17 @@ try:
 except ImportError:  # pragma: no cover - direct script execution
     from scripts.diagrams.diagram_paths import SOURCE_FAMILIES, render_dir
 
-SVG_NS = "http://www.w3.org/2000/svg"
-ET.register_namespace("", SVG_NS)
-
 SVG_DIRS = [render_dir(family, "svg") for family in SOURCE_FAMILIES]
 
-
-def _local_name(tag: str) -> str:
-    return tag.split("}", 1)[1] if "}" in tag else tag
-
-
-def _serialize_svg(tree: ET.ElementTree[ET.Element[str]]) -> str:
-    buffer = io.BytesIO()
-    tree.write(buffer, encoding="utf-8", xml_declaration=False)
-    return buffer.getvalue().decode("utf-8")
+FOREIGN_OBJECT_PATTERN = re.compile(
+    r"<(?:[A-Za-z_][\w.-]*:)?foreignObject\b[^>]*>.*?"
+    r"</(?:[A-Za-z_][\w.-]*:)?foreignObject\s*>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+SELF_CLOSING_FOREIGN_OBJECT_PATTERN = re.compile(
+    r"<(?:[A-Za-z_][\w.-]*:)?foreignObject\b[^>]*/\s*>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
 
 
 def _write_text_atomic(path: Path, payload: str) -> None:
@@ -58,27 +54,20 @@ def _write_text_atomic(path: Path, payload: str) -> None:
     temp_path.replace(path)
 
 
-def _strip_foreign_objects_tree(
-    path: Path,
-) -> tuple[ET.ElementTree[ET.Element[str]], int]:
-    tree = ET.parse(path)
-    root = tree.getroot()
-    removed = 0
-
-    for parent in root.iter():
-        for child in tuple(parent):
-            if _local_name(child.tag) != "foreignObject":
-                continue
-            parent.remove(child)
-            removed += 1
-
-    return tree, removed
+def _strip_foreign_objects_payload(payload: str) -> tuple[str, int]:
+    """Remove Mermaid label elements without requiring XML-valid XHTML content."""
+    payload, paired_count = FOREIGN_OBJECT_PATTERN.subn("", payload)
+    payload, self_closing_count = SELF_CLOSING_FOREIGN_OBJECT_PATTERN.subn(
+        "", payload
+    )
+    return payload, paired_count + self_closing_count
 
 
 def strip_foreign_objects(path: Path) -> int:
-    tree, removed = _strip_foreign_objects_tree(path)
+    payload = path.read_text(encoding="utf-8")
+    stripped, removed = _strip_foreign_objects_payload(payload)
     if removed > 0:
-        _write_text_atomic(path, _serialize_svg(tree))
+        _write_text_atomic(path, stripped)
     return removed
 
 
@@ -129,7 +118,8 @@ def main() -> int:
 
     changed = 0
     for path in files:
-        tree, removed = _strip_foreign_objects_tree(path)
+        payload = path.read_text(encoding="utf-8")
+        stripped, removed = _strip_foreign_objects_payload(payload)
         if removed == 0:
             continue
         changed += 1
@@ -138,7 +128,7 @@ def main() -> int:
         elif mode == "dry-run":
             print(f"~ {path} (would remove foreignObject -{removed})")
         else:
-            _write_text_atomic(path, _serialize_svg(tree))
+            _write_text_atomic(path, stripped)
             print(f"+ {path} (removed foreignObject -{removed})")
 
     if mode == "check" and changed > 0:

--- a/tests/architecture/test_branch_hygiene_workflow.py
+++ b/tests/architecture/test_branch_hygiene_workflow.py
@@ -1,0 +1,32 @@
+"""Contracts for branch naming and report-only lifecycle automation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/branch-hygiene.yml"
+POLICY = ROOT / "docs/00-project/governance/05-github-policy.md"
+
+
+def test_branch_hygiene_workflow_enforces_only_current_pr_head() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "HEAD_REF: ${{ github.head_ref }}" in workflow
+    assert "validate-pr-branch-name" in workflow
+    assert "generate-branch-cleanup-inventory" in workflow
+    assert "github.event_name != 'pull_request'" in workflow
+    assert "apply-branch-cleanup" not in workflow
+
+
+def test_branch_lifecycle_policy_protects_active_work() -> None:
+    policy = POLICY.read_text(encoding="utf-8")
+
+    assert "active PR head" in policy
+    assert "checked out by" in policy and "worktree" in policy
+    assert "MUST default to dry-run" in policy
+    assert "Branch-count ceilings MUST NOT be enforced" in policy

--- a/tests/architecture/test_naming_package_consistency_gate.py
+++ b/tests/architecture/test_naming_package_consistency_gate.py
@@ -96,6 +96,14 @@ def test_tests_workflow_runs_naming_package_consistency_gate() -> None:
     assert "python -m scripts.engineering.qa check-naming-pkg --check" in workflow
 
 
+def test_tests_workflow_runs_full_naming_audit() -> None:
+    """Required pre-merge CI must enforce the canonical naming audit."""
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = (repo_root / ".github/workflows/tests.yml").read_text(encoding="utf-8")
+    assert "Pre-merge naming convention audit" in workflow
+    assert "python -m scripts.engineering.qa check-naming --check" in workflow
+
+
 def test_collect_src_tree_uses_git_tracked_inventory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/architecture/test_strip_svg_foreign_object.py
+++ b/tests/architecture/test_strip_svg_foreign_object.py
@@ -95,3 +95,28 @@ def test_strip_foreign_objects_is_idempotent(tmp_path: Path) -> None:
 
     assert first_removed == 1
     assert second_removed == 0
+
+
+def test_strip_foreign_objects_accepts_mermaid_html_entities(tmp_path: Path) -> None:
+    """Generated Mermaid XHTML may be valid HTML but not strict XML."""
+    module = _load_module()
+    svg_path = tmp_path / "chembl-generated.svg"
+    svg_path.write_text(
+        """
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <g class="nodeLabel">
+            <text class="fo-fallback">Activity ID</text>
+            <foreignObject width="180" height="40">
+              <div xmlns="http://www.w3.org/1999/xhtml">Activity&nbsp;ID<br>required</div>
+            </foreignObject>
+          </g>
+        </svg>
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    assert module.strip_foreign_objects(svg_path) == 1
+    payload = svg_path.read_text(encoding="utf-8")
+    assert "foreignObject" not in payload
+    assert "Activity ID" in payload
+    ET.fromstring(payload)

--- a/tests/architecture/test_test_telemetry_governance.py
+++ b/tests/architecture/test_test_telemetry_governance.py
@@ -12,17 +12,12 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
-
-import pytest
-
 from pathlib import Path
 
-import json
+import pytest
 import yaml
-from scripts.engineering.ci.update_test_telemetry_baseline import (
-    compute_test_telemetry_source_tree_sha256,
-)
 
 
 pytestmark = pytest.mark.architecture


### PR DESCRIPTION
## Summary
- make foreignObject stripping tolerate Mermaid HTML entities while retaining fallback text and downstream visibility/SVGO gates
- run the canonical naming audit in required pre-merge Tests CI
- document branch naming/lifecycle/tag and safe cleanup policy
- add PR-head naming enforcement plus scheduled report-only branch inventory
- refresh zero-ratchet test/flaky evidence and repin the technical-debt audit

## Validation
- targeted architecture suite: 24 passed
- canonical naming audit: 0 violations
- test-governance and flaky evidence checks: pass
- technical-debt audit validator: pass
- documentation links/specs/configs: pass

## Environment limitation
The canonical six-diagram local renderer could not launch Chromium because the host lacks libnss3. CI must provide final all-six render evidence before #7296 is closed.

Supports #7296, #7337, #7351, #7352, #7255, and #7038. Branch cleanup #7350 was bounded to the sole fresh-inventory garbage branch a1; it was deleted, while active/unreviewed branches were preserved.