### PR TITLE
fix(ci): reconcile governance after main sync

### DIFF
--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,7 +4,7 @@ audits:
 - id: total-tech-debt-main-2026-07-27-r1
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
-  audited_commit_sha: 4968777992838ae9a263a2e03300fd2f09d95603
+  audited_commit_sha: d6f45bed76113fb4b28e47e799e84f273f668e7c
   evidence_surface_sha256: af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml

--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,8 +4,8 @@ audits:
 - id: total-tech-debt-main-2026-07-27-r1
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
-  audited_commit_sha: 91882f95f7b3f2f65fd3d1243d884679199302e9
-  evidence_surface_sha256: cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a
+  audited_commit_sha: 4968777992838ae9a263a2e03300fd2f09d95603
+  evidence_surface_sha256: af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml
   - configs/quality/constructor_waivers.yaml

--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -4,8 +4,8 @@ audits:
 - id: total-tech-debt-main-2026-07-27-r1
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
-  audited_commit_sha: 7ad5c39affa43cb9a928729afa1ce137895ca422
-  evidence_surface_sha256: 182de59245fc42d87a4fd9d15f895b19b34124c74403901fff992f194f30ee37
+  audited_commit_sha: 91882f95f7b3f2f65fd3d1243d884679199302e9
+  evidence_surface_sha256: cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml
   - configs/quality/constructor_waivers.yaml

--- a/docs/02-architecture/generated/pipeline-dataflows/chembl_activity/pipeline-passport.md
+++ b/docs/02-architecture/generated/pipeline-dataflows/chembl_activity/pipeline-passport.md
@@ -10,7 +10,7 @@ Effective loader: `scripts.docs.passports.source_facts.load_effective_pipeline_f
 
 This passport is generated from the resolved effective configuration and live schema contracts. It describes the current runtime projection; it does not widen or repair the pipeline contract.
 
-Canonical cross-layer passport: [`chembl_activity`](../../../../04-reference/passports/pipelines/chembl-activity.md). This file remains a diagram companion.
+Canonical cross-layer passport: [`chembl_activity`](../../../../04-reference/passports/pipelines/chembl_activity.md). This file remains a diagram companion.
 
 ## Linked Views
 

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -38,7 +38,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "a15f2b7fd6925b5c7307f5b50cb72558135ba665b9e71d28aa4ad6971cae347c",
-    "test_governance_source_tree_sha256": "30551178c10a64cdf3d257e49f2cd306f08c2332728f672563a1eca063c42cb0"
+    "test_governance_source_tree_sha256": "59107d7b1e3df25266e4127c69160583037fd55f3aa54973b2e982531dc87664"
   },
   "summary": {
     "by_alert_level": {
@@ -72,9 +72,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "30551178c10a64cdf3d257e49f2cd306f08c2332728f672563a1eca063c42cb0",
+    "test_governance_source_tree_sha256": "59107d7b1e3df25266e4127c69160583037fd55f3aa54973b2e982531dc87664",
     "total_flaky": 0,
     "total_test_files": 2171,
-    "total_tests_analyzed": 23293
+    "total_tests_analyzed": 23294
   }
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2356,12 +2356,12 @@
     },
     "top_duplicate_test_names": [],
     "total_test_files": 2171,
-    "total_test_functions": 23293,
+    "total_test_functions": 23294,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "30551178c10a64cdf3d257e49f2cd306f08c2332728f672563a1eca063c42cb0",
+  "source_tree_sha256": "59107d7b1e3df25266e4127c69160583037fd55f3aa54973b2e982531dc87664",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,
@@ -2423,7 +2423,7 @@
   },
   "top_duplicate_test_names": [],
   "total_test_files": 2171,
-  "total_test_functions": 23293,
+  "total_test_functions": 23294,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,7 +8,7 @@ Audited repository: SatoryKono/BioactivityDataAcquisition
 
 Audited branch: main
 
-Audited commit SHA: `4968777992838ae9a263a2e03300fd2f09d95603`
+Audited commit SHA: `d6f45bed76113fb4b28e47e799e84f273f668e7c`
 
 Evidence surface SHA-256: `af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca`
 
@@ -17,7 +17,7 @@ Registry: configs/quality/technical_debt_audit_registry.yaml
 <!-- technical-debt-audit-summary-v1
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
-  "audited_commit_sha": "4968777992838ae9a263a2e03300fd2f09d95603",
+  "audited_commit_sha": "d6f45bed76113fb4b28e47e799e84f273f668e7c",
   "evidence_surface_sha256": "af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca",
   "metrics": {
     "architecture_integral_score": 9.41,

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,17 +8,17 @@ Audited repository: SatoryKono/BioactivityDataAcquisition
 
 Audited branch: main
 
-Audited commit SHA: `91882f95f7b3f2f65fd3d1243d884679199302e9`
+Audited commit SHA: `4968777992838ae9a263a2e03300fd2f09d95603`
 
-Evidence surface SHA-256: `cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a`
+Evidence surface SHA-256: `af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
 <!-- technical-debt-audit-summary-v1
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
-  "audited_commit_sha": "91882f95f7b3f2f65fd3d1243d884679199302e9",
-  "evidence_surface_sha256": "cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a",
+  "audited_commit_sha": "4968777992838ae9a263a2e03300fd2f09d95603",
+  "evidence_surface_sha256": "af9cf6b74e2137095078537cef5ce660fd929185d637dfeea02d956b1f2ae2ca",
   "metrics": {
     "architecture_integral_score": 9.41,
     "architecture_interpretation": "good_targeted_improvements",

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -8,17 +8,17 @@ Audited repository: SatoryKono/BioactivityDataAcquisition
 
 Audited branch: main
 
-Audited commit SHA: `7ad5c39affa43cb9a928729afa1ce137895ca422`
+Audited commit SHA: `91882f95f7b3f2f65fd3d1243d884679199302e9`
 
-Evidence surface SHA-256: `182de59245fc42d87a4fd9d15f895b19b34124c74403901fff992f194f30ee37`
+Evidence surface SHA-256: `cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
 <!-- technical-debt-audit-summary-v1
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
-  "audited_commit_sha": "7ad5c39affa43cb9a928729afa1ce137895ca422",
-  "evidence_surface_sha256": "182de59245fc42d87a4fd9d15f895b19b34124c74403901fff992f194f30ee37",
+  "audited_commit_sha": "91882f95f7b3f2f65fd3d1243d884679199302e9",
+  "evidence_surface_sha256": "cceef78d4631f3dbca8368ccaa2b9b3f13f05bd341111076d7df529c007e3a2a",
   "metrics": {
     "architecture_integral_score": 9.41,
     "architecture_interpretation": "good_targeted_improvements",

--- a/scripts/diagrams/check_diagram_artifacts.py
+++ b/scripts/diagrams/check_diagram_artifacts.py
@@ -16,8 +16,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+REPO_ROOT = SCRIPT_DIR.parents[1]
+for import_root in (REPO_ROOT, SCRIPT_DIR):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
 
 try:
     from .diagram_paths import VISUAL_SMOKE_MANIFEST

--- a/tests/architecture/test_diagram_artifact_check.py
+++ b/tests/architecture/test_diagram_artifact_check.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import pytest
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -102,6 +103,20 @@ def test_parse_args_supports_optional_png_requirement() -> None:
     args = module.parse_args([])
 
     assert args.require_png is False
+
+
+def test_direct_script_execution_loads_repository_package() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "diagrams" / "check_diagram_artifacts.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_png_compatibility_manifest_is_svg_only_and_curated() -> None:


### PR DESCRIPTION
## Summary
- remove the stale test-telemetry import found by PR #7357 CI
- merge current main and regenerate test-governance/flaky snapshots from the final tree
- repin the technical-debt audit to the verified merge evidence

## Validation
- Ruff targeted check passes
- test-telemetry architecture tests pass
- test-governance, flaky, dead-code and debt gates pass
- technical-debt audit validator returns ok

Follow-up to #7357. Supports #7038 and the CI closeout chain.