### PR TITLE
⚡ Bolt: Optimize duplicate content hash counting

### DIFF
--- a/src/bioetl/application/services/dq/silver_statistics.py
+++ b/src/bioetl/application/services/dq/silver_statistics.py
@@ -235,8 +235,10 @@ class SilverStatisticsCalculator:
         hash_collision_count: int | None = None
         if "_content_hash" in df.columns:
             hash_counts = df["_content_hash"].value_counts()
-            duplicates = hash_counts.filter(pl.col("count") > 1)
-            hash_collision_count = len(duplicates)
+            # Opt: Use select(sum).item() instead of filter().height to avoid materializing a new intermediate DataFrame in memory
+            hash_collision_count = int(
+                hash_counts.select((pl.col("count") > 1).sum()).item()
+            )
         return _check_content_hash_integrity_stats(len(df), hash_collision_count)
 
     def distribution_to_dict(


### PR DESCRIPTION
💡 What: Replaced memory-intensive `len(df.filter(...))` with efficient `int(df.select(expr.sum()).item())` in content hash DQ checks.
🎯 Why: The original pattern materialized a complete intermediate DataFrame just to get a count, causing unnecessary memory allocations during large DQ checks.
📊 Impact: Avoids allocating a new DataFrame array in memory.
🔬 Measurement: Observe lower memory usage and execution time during silver DQ checks.

---
*PR created automatically by Jules for task [7493584567351726182](https://jules.google.com/task/7493584567351726182) started by @SatoryKono*