### PR TITLE
fix(ci): regenerate passports and governance baselines (audit R2)

### DIFF
--- a/docs/04-reference/passports/completeness-report.json
+++ b/docs/04-reference/passports/completeness-report.json
@@ -10,6 +10,6 @@
   "orphan_passports": [],
   "passport_schema_version": "1.0.0",
   "registry_config_mismatches": [],
-  "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2",
+  "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638",
   "unresolved_aliases": []
 }

--- a/docs/04-reference/passports/generated/pipelines/chembl_activity.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_activity.json
@@ -697,7 +697,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:dc87c52dcd56cdd02fffb6b9c8884ffacb5e9daf0d13cacb8511e158653c4868",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_assay.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_assay.json
@@ -485,7 +485,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:336f4830865dcecf0c181380f8779d357a9fbb84090231b288a49ae2912e5afe",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_assay_parameters.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_assay_parameters.json
@@ -334,7 +334,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:a9e3d0e4ab6a4dc7fc305ab0848092cc951fd541ed3ed1084ba06879363b8362",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_cell_line.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_cell_line.json
@@ -290,7 +290,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:0fe7bcdcdb218c4b9865c60bea651e4abeb51230e8f2bc4a18770e1c858d2bcb",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_compound_record.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_compound_record.json
@@ -220,7 +220,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:39ea654a8ba32d70a635c8fbcaea58d2cc2dbfdab46f3a74f8021f73d174fedf",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_molecule.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_molecule.json
@@ -562,7 +562,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:795101d6b628d760ccb45e2ca82d13254ae3a3cec2f1dff7199129f801c38aeb",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_protein_class.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_protein_class.json
@@ -250,7 +250,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:be1d7bfcea4a9da99683c32a84a180d747017f3b052b0bbf6e3e1178fa613247",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_publication.json
@@ -295,7 +295,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:23dedf7528a08265a8323a17d69f4256d53c31f000dc247cb332495da8472163",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_publication_similarity.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_publication_similarity.json
@@ -237,7 +237,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:67563c93b810f81060382cea75c5295b06dea6bbbdae1f46655a25a045073d83",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_publication_term.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_publication_term.json
@@ -227,7 +227,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:9502fc7bee33288d5197a3a6ef4f32febdd710daaf3677342eaf0317d6698167",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_subcellular_fraction.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_subcellular_fraction.json
@@ -199,7 +199,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:2938415b0228a2d9cc25b6070f0666786c94f34e4f48a34bc08e56ad4fafd735",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_target.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_target.json
@@ -388,7 +388,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:1159eb255f8942869bbdf58d24082bb94211a315acae8a28b2c01190054af270",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_target_component.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_target_component.json
@@ -257,7 +257,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:17100346b0118a3bf82b36588bd6854607b640cf02283886857a7551876f320a",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_target_protein_classification.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_target_protein_classification.json
@@ -461,7 +461,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:bdfb46964f99f30557e8610e238d59225e792749d5b14f93136299342ddf0312",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/chembl_tissue.json
+++ b/docs/04-reference/passports/generated/pipelines/chembl_tissue.json
@@ -276,7 +276,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:12c20e767133e9b044676700ca3fa77ddc2375c5cc3e2af401de19b3faf01e35",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/composite_activity.json
+++ b/docs/04-reference/passports/generated/pipelines/composite_activity.json
@@ -459,7 +459,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:89722f5089d793afd9a25d7ae30c29f64a2d5f2364152ad906e8da78742e935a",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "dq_execution": {

--- a/docs/04-reference/passports/generated/pipelines/composite_assay.json
+++ b/docs/04-reference/passports/generated/pipelines/composite_assay.json
@@ -349,7 +349,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:dd39c6922fbc64494621c6310164ca665743024c778b1e629a642d90f3396a5d",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "dq_execution": {

--- a/docs/04-reference/passports/generated/pipelines/composite_molecule.json
+++ b/docs/04-reference/passports/generated/pipelines/composite_molecule.json
@@ -402,7 +402,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:dfecae3285dd9ef27db73d6b02144f048ba387b3fc51d9591db3a079490216a8",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "dq_execution": {

--- a/docs/04-reference/passports/generated/pipelines/composite_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/composite_publication.json
@@ -689,7 +689,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:d5de91911fd1bc4292fc03d7b12c15b62c9b49ccc9124c96424cd6f457887475",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "dq_execution": {

--- a/docs/04-reference/passports/generated/pipelines/composite_target.json
+++ b/docs/04-reference/passports/generated/pipelines/composite_target.json
@@ -723,7 +723,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:9899e26e84e1fb808d5d90c9c18171b0216015c4bc80dfba87ae077cc456c998",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "dq_execution": {

--- a/docs/04-reference/passports/generated/pipelines/crossref_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/crossref_publication.json
@@ -307,7 +307,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:dd62e5fac5055956862ef3c0f0d4878a6c2ca9fa23b709f559eab77b8b2c88a7",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/openalex_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/openalex_publication.json
@@ -332,7 +332,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:5b64b91c35dd3e9e01c0d7ec6177e57860a3fd4d55614da57f1935bc6a1cc3ef",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/pubchem_compound.json
+++ b/docs/04-reference/passports/generated/pipelines/pubchem_compound.json
@@ -507,7 +507,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:0db04561947095b76b42ad9f5b274a04be7a1177146df9717c7adc94c7aa002f",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/pubmed_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/pubmed_publication.json
@@ -333,7 +333,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:790b4f6e533862819e3f7098bb1fd368c0e532f74c3216cc62dbb2ce9861b6ed",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/semanticscholar_publication.json
+++ b/docs/04-reference/passports/generated/pipelines/semanticscholar_publication.json
@@ -299,7 +299,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:f51802163632b5793e64e1038b007d92cd613d7d9f42144889cf4e822cc99dc8",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/uniprot_idmapping.json
+++ b/docs/04-reference/passports/generated/pipelines/uniprot_idmapping.json
@@ -272,7 +272,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:e84ee14b38ed888c4f979f7f36a04afb5be393ad47bdde2772a2241e215cc454",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/pipelines/uniprot_protein.json
+++ b/docs/04-reference/passports/generated/pipelines/uniprot_protein.json
@@ -824,7 +824,7 @@
   "provenance": {
     "projector_version": "1.1.0",
     "semantic_content_hash": "sha256:c030e68b2afe348f54066a7db68b21d6877f29f453b3162bdeb12383c0e8b4b8",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "silver": {
     "column_projection": {

--- a/docs/04-reference/passports/generated/workflows/chembl_activity.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_activity.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a866a622eb803ddbff76ffe460f8f2281433e5984bfe1d725d80a1b3e8345a9b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_assay.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_assay.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:cbbf739f9469c7d16e0637383dd9dc0428b1b88f4851181780bf7df4897f4a21",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_assay_parameters.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_assay_parameters.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0b3142f418b4eebb5c1f722ff652e9023a54425ef25f0e018cd65dcb41edc0b2",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_baseline.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_baseline.json
@@ -296,7 +296,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0c4b8bf263380d40361ca35749e64226a7862c11313569d72a65ef08728b0ab6",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_cell_line.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_cell_line.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:73ad4e999157048a2a40ae5269ce5d690a30854eee43286332c0dcc3e14dcc0a",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_compound_record.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_compound_record.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:7eaf09b9c73e2d7681c3879ff8e46d9d48320f5d8f1dfcbadb109aff83b5af61",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_core.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_core.json
@@ -165,7 +165,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:70660158eba16dccd689e75213e6619edf5777b8b5b03cee61b91e657576cf2c",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_molecule.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_molecule.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:668b8650301346ef70e9a7ed872709bc59f856cd0641aa34754788051e015f16",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_protein_class.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_protein_class.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:c2c883371501a1d4f646be76bcc1372a4cf1051c36717ed6adce8cc63d497938",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_publication.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_publication.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:282a38e0e4e636b3824c74ef04ba190c4547ccd5d749540f239124e87a18fc11",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_publication_similarity.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_publication_similarity.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:4931ea9889f2280eaafa83d4063f5724db7006d2b4db4783ce54868bba921cc0",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_publication_term.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_publication_term.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:33f64f63cd6ea3b9d7689a48dfa1a992ff235035c7fae8009564dbe2cb4c53c0",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_reference_pack.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_reference_pack.json
@@ -151,7 +151,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:af8a9911fdccdd9c9f1d44175a8b3680d54339214ee098e41d4915489a5bed18",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_subcellular_fraction.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_subcellular_fraction.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0bf1bb4dbe175d830e7ab1b8e7d6e51a5af7178aa195e2d47b51919af1999b26",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_target.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_target.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:e385ed0dc0bb661463b66b521d16b852d279826068055db71ea1354f2737da0b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_target_component.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_target_component.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a345e1ab54e7d6870fe44ec7cfcc3a32c12f769fd3a7ec5d7aabd9db13425715",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_target_protein_classification.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_target_protein_classification.json
@@ -101,7 +101,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:10f2e7302852ac8372299a8a5cccbea0a59437992ca7a8b0394a6321f996956b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/chembl_tissue.json
+++ b/docs/04-reference/passports/generated/workflows/chembl_tissue.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a857a41f69deaa9647c4d78c945750a9e057df30880fdb5747517906229319f9",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/crossref_publication.json
+++ b/docs/04-reference/passports/generated/workflows/crossref_publication.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:5a0fb10c9e3632d23d6818012eb4959a7f7d8e067162cc7fe03bc3d4f2574a78",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/openalex_publication.json
+++ b/docs/04-reference/passports/generated/workflows/openalex_publication.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:c6cfeea4142f76d56aa6aa6ccd74c68a8251dbef0f3f07443e2817a7eba3cc79",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/pubchem_compound.json
+++ b/docs/04-reference/passports/generated/workflows/pubchem_compound.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a589b3d2dccc5c58d72f52421153e318f063a0cd7a7f7a39c9e25c7c7460db9c",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/publication_provider_pack.json
+++ b/docs/04-reference/passports/generated/workflows/publication_provider_pack.json
@@ -76,7 +76,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:b7e1e544b55a11eeecef4fc54abf4e06b2ad905ff604973ee2218f89ff749089",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/pubmed_publication.json
+++ b/docs/04-reference/passports/generated/workflows/pubmed_publication.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:d73d95a6819a4c4bf0bda962cf13f965a1e825071a61dfa06569182154b36e93",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/semanticscholar_publication.json
+++ b/docs/04-reference/passports/generated/workflows/semanticscholar_publication.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:65f474c29afce07b3499652309a4fe755f675b7abfc373364db4769da05d8c67",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/uniprot_idmapping.json
+++ b/docs/04-reference/passports/generated/workflows/uniprot_idmapping.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:936e63203227f577e285dc725be4128ab9d582a950dd2ace418f7faf31ef2721",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/uniprot_protein.json
+++ b/docs/04-reference/passports/generated/workflows/uniprot_protein.json
@@ -58,7 +58,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:6722ab88df38bcb8dad15251c9ebea51c66bffd4066abbde0b019fdb15c70875",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/generated/workflows/uniprot_support_pack.json
+++ b/docs/04-reference/passports/generated/workflows/uniprot_support_pack.json
@@ -64,7 +64,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:3047b05777e58b59403e1da784676283d545918b137d1b32a857513a3dcf10df",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-activity.md
+++ b/docs/04-reference/passports/workflows/chembl-activity.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_activity`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a866a622eb803ddbff76ffe460f8f2281433e5984bfe1d725d80a1b3e8345a9b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-assay-parameters.md
+++ b/docs/04-reference/passports/workflows/chembl-assay-parameters.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_assay_parameters`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0b3142f418b4eebb5c1f722ff652e9023a54425ef25f0e018cd65dcb41edc0b2",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-assay.md
+++ b/docs/04-reference/passports/workflows/chembl-assay.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_assay`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:cbbf739f9469c7d16e0637383dd9dc0428b1b88f4851181780bf7df4897f4a21",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-baseline.md
+++ b/docs/04-reference/passports/workflows/chembl-baseline.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_baseline`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -313,7 +313,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0c4b8bf263380d40361ca35749e64226a7862c11313569d72a65ef08728b0ab6",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-cell-line.md
+++ b/docs/04-reference/passports/workflows/chembl-cell-line.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_cell_line`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:73ad4e999157048a2a40ae5269ce5d690a30854eee43286332c0dcc3e14dcc0a",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-compound-record.md
+++ b/docs/04-reference/passports/workflows/chembl-compound-record.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_compound_record`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:7eaf09b9c73e2d7681c3879ff8e46d9d48320f5d8f1dfcbadb109aff83b5af61",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-core.md
+++ b/docs/04-reference/passports/workflows/chembl-core.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_core`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -182,7 +182,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:70660158eba16dccd689e75213e6619edf5777b8b5b03cee61b91e657576cf2c",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-molecule.md
+++ b/docs/04-reference/passports/workflows/chembl-molecule.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_molecule`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:668b8650301346ef70e9a7ed872709bc59f856cd0641aa34754788051e015f16",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-protein-class.md
+++ b/docs/04-reference/passports/workflows/chembl-protein-class.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_protein_class`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:c2c883371501a1d4f646be76bcc1372a4cf1051c36717ed6adce8cc63d497938",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-publication-similarity.md
+++ b/docs/04-reference/passports/workflows/chembl-publication-similarity.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_publication_similarity`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:4931ea9889f2280eaafa83d4063f5724db7006d2b4db4783ce54868bba921cc0",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-publication-term.md
+++ b/docs/04-reference/passports/workflows/chembl-publication-term.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_publication_term`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:33f64f63cd6ea3b9d7689a48dfa1a992ff235035c7fae8009564dbe2cb4c53c0",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-publication.md
+++ b/docs/04-reference/passports/workflows/chembl-publication.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_publication`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:282a38e0e4e636b3824c74ef04ba190c4547ccd5d749540f239124e87a18fc11",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-reference-pack.md
+++ b/docs/04-reference/passports/workflows/chembl-reference-pack.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_reference_pack`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -168,7 +168,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:af8a9911fdccdd9c9f1d44175a8b3680d54339214ee098e41d4915489a5bed18",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-subcellular-fraction.md
+++ b/docs/04-reference/passports/workflows/chembl-subcellular-fraction.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_subcellular_fraction`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:0bf1bb4dbe175d830e7ab1b8e7d6e51a5af7178aa195e2d47b51919af1999b26",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-target-component.md
+++ b/docs/04-reference/passports/workflows/chembl-target-component.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_target_component`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a345e1ab54e7d6870fe44ec7cfcc3a32c12f769fd3a7ec5d7aabd9db13425715",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-target-protein-classification.md
+++ b/docs/04-reference/passports/workflows/chembl-target-protein-classification.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_target_protein_classification`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -118,7 +118,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:10f2e7302852ac8372299a8a5cccbea0a59437992ca7a8b0394a6321f996956b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-target.md
+++ b/docs/04-reference/passports/workflows/chembl-target.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_target`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:e385ed0dc0bb661463b66b521d16b852d279826068055db71ea1354f2737da0b",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/chembl-tissue.md
+++ b/docs/04-reference/passports/workflows/chembl-tissue.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:chembl_tissue`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a857a41f69deaa9647c4d78c945750a9e057df30880fdb5747517906229319f9",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/crossref-publication.md
+++ b/docs/04-reference/passports/workflows/crossref-publication.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:crossref_publication`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:5a0fb10c9e3632d23d6818012eb4959a7f7d8e067162cc7fe03bc3d4f2574a78",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/openalex-publication.md
+++ b/docs/04-reference/passports/workflows/openalex-publication.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:openalex_publication`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:c6cfeea4142f76d56aa6aa6ccd74c68a8251dbef0f3f07443e2817a7eba3cc79",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/pubchem-compound.md
+++ b/docs/04-reference/passports/workflows/pubchem-compound.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:pubchem_compound`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:a589b3d2dccc5c58d72f52421153e318f063a0cd7a7f7a39c9e25c7c7460db9c",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/publication-provider-pack.md
+++ b/docs/04-reference/passports/workflows/publication-provider-pack.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:publication_provider_pack`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -93,7 +93,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:b7e1e544b55a11eeecef4fc54abf4e06b2ad905ff604973ee2218f89ff749089",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/pubmed-publication.md
+++ b/docs/04-reference/passports/workflows/pubmed-publication.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:pubmed_publication`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:d73d95a6819a4c4bf0bda962cf13f965a1e825071a61dfa06569182154b36e93",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/semanticscholar-publication.md
+++ b/docs/04-reference/passports/workflows/semanticscholar-publication.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:semanticscholar_publication`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:65f474c29afce07b3499652309a4fe755f675b7abfc373364db4769da05d8c67",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/uniprot-idmapping.md
+++ b/docs/04-reference/passports/workflows/uniprot-idmapping.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:uniprot_idmapping`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:936e63203227f577e285dc725be4128ab9d582a950dd2ace418f7faf31ef2721",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/uniprot-protein.md
+++ b/docs/04-reference/passports/workflows/uniprot-protein.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:uniprot_protein`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -75,7 +75,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:6722ab88df38bcb8dad15251c9ebea51c66bffd4066abbde0b019fdb15c70875",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {

--- a/docs/04-reference/passports/workflows/uniprot-support-pack.md
+++ b/docs/04-reference/passports/workflows/uniprot-support-pack.md
@@ -5,7 +5,7 @@
 - Kind: `workflow`
 - Typed identity: `workflow:uniprot_support_pack`
 - Schema: `1.0.0`
-- Source revision: `472577b054a097dd85a559c2da2966f3c9c6f5a2`
+- Source revision: `dc9df1ebc45136000f02821f185b8a1dfad53638`
 
 ## Evidence
 
@@ -81,7 +81,7 @@
   "provenance": {
     "projector_version": "1.0.0",
     "semantic_content_hash": "sha256:3047b05777e58b59403e1da784676283d545918b137d1b32a857513a3dcf10df",
-    "source_revision": "472577b054a097dd85a559c2da2966f3c9c6f5a2"
+    "source_revision": "dc9df1ebc45136000f02821f185b8a1dfad53638"
   },
   "source_references": [
     {


### PR DESCRIPTION
## Summary
Regenerates passport corpus and rebinds governance baselines on current main tip.

| Finding | Issue |
| --- | ---: |
| CI-C1-002 passports | #7423 |
| CI-C1-003 dep-map | #7410 |
| CI-C1-004 hotspot | #7424 |
| CI-C1-005 test-gov | #7425 |

**Head:** `5ac7dfbed75b1dfe55ad0d22e94c4aa438f6f2bc`

## Test plan
- [x] local passports/dep-map/hotspot/test-gov/ruff format check
- [ ] GitHub docs-governance + governance-preflight + config-schema-preflight
