### PR TITLE
fix(ci): audit R2 passports, governance, ADR-050 links

### DIFF
--- a/docs/02-architecture/decisions/ADR-050-silver-structural-gold-semantic-filter-boundary.md
+++ b/docs/02-architecture/decisions/ADR-050-silver-structural-gold-semantic-filter-boundary.md
@@ -247,5 +247,5 @@ Implementation and follow-up work must verify:
 - [ADR-045: Data Quality Contract System](ADR-045-dq-contract-system.md)
 - [ADR-046: Checkpoint Versus Ledger-Based Resume](ADR-046-checkpoint-vs-ledger-resume.md)
 - [ADR-047: Workflow Control Plane for Declarative Workflows](ADR-047-workflow-control-plane.md)
-- [Retired Silver-filter draft](../../filters/retired-silver-filters-structural-scope.md)
-- [Silver-to-Gold migration plan](../../filters/migration-plan.md)
+- [Retired Silver-filter draft](../../99-archive/filters/retired-silver-filters-structural-scope.md)
+- [Silver-to-Gold migration plan](../../99-archive/filters/migration-plan.md)

--- a/docs/reports/generated/documentation-cleanup-inventory.json
+++ b/docs/reports/generated/documentation-cleanup-inventory.json
@@ -57697,7 +57697,7 @@
       "generator": null,
       "github_issue_number": null,
       "github_issue_url": null,
-      "inbound_links": 0,
+      "inbound_links": 1,
       "lifecycle": null,
       "outbound_links": 0,
       "owner": "BioETL Team",
@@ -57725,7 +57725,7 @@
       "generator": null,
       "github_issue_number": null,
       "github_issue_url": null,
-      "inbound_links": 0,
+      "inbound_links": 1,
       "lifecycle": null,
       "outbound_links": 0,
       "owner": "BioETL Team",
@@ -61437,8 +61437,8 @@
       "canonical_successor": null,
       "catalog_lifecycle": null,
       "commit_policy": null,
-      "declared_class": "repo-only",
-      "declared_status": "active",
+      "declared_class": null,
+      "declared_status": null,
       "diagram_kind": null,
       "duplicate_group": null,
       "duplicate_resolution": null,
@@ -61824,6 +61824,34 @@
       "status": "Working",
       "surface_family": "working",
       "tracking_state": "tracked"
+    },
+    {
+      "canonical_successor": null,
+      "catalog_lifecycle": null,
+      "commit_policy": null,
+      "declared_class": null,
+      "declared_status": null,
+      "diagram_kind": null,
+      "duplicate_group": null,
+      "duplicate_resolution": null,
+      "extension": ".json",
+      "freshness": "review-required",
+      "generated_route": null,
+      "generated_route_exception": null,
+      "generator": null,
+      "github_issue_number": null,
+      "github_issue_url": null,
+      "inbound_links": 0,
+      "lifecycle": "docs_reports_curated_or_historical_report",
+      "outbound_links": 0,
+      "owner": "BioETL Team",
+      "path": "docs/reports/docs-link-check-report.json",
+      "recommended_action": "archive-after-migration",
+      "root_doc_kind": null,
+      "section": "reports",
+      "status": "Working",
+      "surface_family": "working",
+      "tracking_state": "ignored_local"
     },
     {
       "canonical_successor": null,
@@ -68413,7 +68441,7 @@
       "active_quality_baseline": 30,
       "closeout_evidence": 53,
       "docs_reports_curated_entrypoint": 2,
-      "docs_reports_curated_or_historical_report": 1,
+      "docs_reports_curated_or_historical_report": 2,
       "docs_reports_generated_or_route_owned": 6,
       "docs_reports_retention_sensitive_evidence": 21,
       "generated_skill_license_mirror": 5,
@@ -68429,7 +68457,7 @@
     },
     "by_recommended_action": {
       "archive-after-github-state-check": 312,
-      "archive-after-migration": 81,
+      "archive-after-migration": 82,
       "generate-automatically": 861,
       "keep": 1158,
       "reconcile-with-github-state": 4
@@ -68460,7 +68488,7 @@
       "mkdocs.yml": 1,
       "plans": 2,
       "plugins": 4,
-      "reports": 204,
+      "reports": 205,
       "ru": 3,
       "security": 2
     },
@@ -68469,19 +68497,20 @@
       "Archived": 141,
       "Canonical": 73,
       "Generated": 861,
-      "Working": 480
+      "Working": 481
     },
     "by_surface_family": {
       "active": 861,
       "archive": 141,
       "canonical": 73,
       "generated": 861,
-      "working": 480
+      "working": 481
     },
     "by_tracking_state": {
+      "ignored_local": 1,
       "tracked": 2416
     },
-    "docs_reports_local_count": 30,
+    "docs_reports_local_count": 31,
     "duplicate_group_count": 6,
     "generated_route_count": 69,
     "generated_without_route_count": 217,
@@ -68495,8 +68524,8 @@
     },
     "scan_error_count": 0,
     "scan_errors": [],
-    "total_doc_like": 2416,
-    "total_doc_like_ignored_local": 0,
+    "total_doc_like": 2417,
+    "total_doc_like_ignored_local": 1,
     "total_doc_like_tracked": 2416
   }
 }

--- a/docs/reports/generated/documentation-cleanup-inventory.md
+++ b/docs/reports/generated/documentation-cleanup-inventory.md
@@ -7,9 +7,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Doc-like files | 2416 |
+| Doc-like files | 2417 |
 | Tracked doc-like files | 2416 |
-| Ignored local docs/reports files | 0 |
+| Ignored local docs/reports files | 1 |
 | Duplicate groups | 6 |
 | Generated without route or exception | 0 |
 | Generated routes | 69 |
@@ -18,6 +18,7 @@
 
 | Tracking State | Count |
 | --- | --- |
+| ignored_local | 1 |
 | tracked | 2416 |
 
 ## Lifecycle Counts
@@ -29,7 +30,7 @@
 | active_quality_baseline | 30 |
 | closeout_evidence | 53 |
 | docs_reports_curated_entrypoint | 2 |
-| docs_reports_curated_or_historical_report | 1 |
+| docs_reports_curated_or_historical_report | 2 |
 | docs_reports_generated_or_route_owned | 6 |
 | docs_reports_retention_sensitive_evidence | 21 |
 | generated_skill_license_mirror | 5 |
@@ -61,7 +62,7 @@
 | Archived | 141 |
 | Canonical | 73 |
 | Generated | 861 |
-| Working | 480 |
+| Working | 481 |
 
 ## Surface Families
 
@@ -71,14 +72,14 @@
 | archive | 141 |
 | canonical | 73 |
 | generated | 861 |
-| working | 480 |
+| working | 481 |
 
 ## Recommended Actions
 
 | Action | Count |
 | --- | --- |
 | archive-after-github-state-check | 312 |
-| archive-after-migration | 81 |
+| archive-after-migration | 82 |
 | generate-automatically | 861 |
 | keep | 1158 |
 | reconcile-with-github-state | 4 |
@@ -91,6 +92,7 @@
 | `docs/00-project/ai/skills/global/documentation-audit/references/report-template.md` | Working | 0 | archive-after-migration |
 | `docs/03-guides/dashboards/migration-map-v2.md` | Working | 3 | archive-after-migration |
 | `docs/reports/dashboard-ux-checks/README.md` | Working | 0 | archive-after-migration |
+| `docs/reports/docs-link-check-report.json` | Working | 0 | archive-after-migration |
 | `reports/ai/issue-7340-specialized-subsystem-analysis-20260731.md` | Working | 0 | archive-after-migration |
 | `reports/ai/issue-7348-comprehensive-skills-analysis-20260731.md` | Working | 0 | archive-after-migration |
 | `reports/docs-evidence/README.md` | Working | 2 | archive-after-migration |
@@ -166,7 +168,6 @@
 | `reports/semantic_pipeline_audit/semantic_pipeline_audit_2026-07-01.md` | Working | 0 | archive-after-migration |
 | `reports/semantic_pipeline_audit/semantic_pipeline_audit_exhaustive_2026-07-01.md` | Working | 0 | archive-after-migration |
 | `reports/semantic_pipeline_audit/semantic_pipeline_audit_manifest_2026-07-01.json` | Working | 0 | archive-after-migration |
-| `reports/semantic_pipeline_audit/semantic_residual_backlog_2026-07-01.json` | Working | 0 | archive-after-migration |
 
 ## Generated Artifact Examples
 
@@ -304,6 +305,7 @@
 | --- | --- | --- | --- |
 | `docs/reports/README.md` | tracked | docs_reports_curated_entrypoint | keep |
 | `docs/reports/dashboard-ux-checks/README.md` | tracked | docs_reports_curated_or_historical_report | archive-after-migration |
+| `docs/reports/docs-link-check-report.json` | ignored_local | docs_reports_curated_or_historical_report | archive-after-migration |
 | `docs/reports/evidence/INDEX.md` | tracked | docs_reports_retention_sensitive_evidence | keep |
 | `docs/reports/evidence/README.md` | tracked | docs_reports_retention_sensitive_evidence | keep |
 | `docs/reports/evidence/project-legacy-compatibility-remediation/03-synthesis/CROSS-SYNTHESIS-project-legacy-compatibility-remediation.md` | tracked | docs_reports_retention_sensitive_evidence | keep |


### PR DESCRIPTION
CI audit R2. Commits include passport regen + ADR-050 archive links. `43dcb8849e893a84563c990783421e2e0bbb6025`