### PR TITLE
fix(tech-debt): cycle-2 restore missing closeout evidence artifacts

### DIFF
--- a/docs/02-architecture/decisions/ADR-050-silver-structural-gold-semantic-filter-boundary.md
+++ b/docs/02-architecture/decisions/ADR-050-silver-structural-gold-semantic-filter-boundary.md
@@ -247,5 +247,5 @@ Implementation and follow-up work must verify:
 - [ADR-045: Data Quality Contract System](ADR-045-dq-contract-system.md)
 - [ADR-046: Checkpoint Versus Ledger-Based Resume](ADR-046-checkpoint-vs-ledger-resume.md)
 - [ADR-047: Workflow Control Plane for Declarative Workflows](ADR-047-workflow-control-plane.md)
-- [Retired Silver-filter draft](../../99-archive/filters/retired-silver-filters-structural-scope.md)
-- [Silver-to-Gold migration plan](../../99-archive/filters/migration-plan.md)
+- [Retired Silver-filter draft](../../99-archive/filters/retired-silver-filters-structural-scope.md) — historical draft *(archived)*
+- [Silver-to-Gold migration plan](../../99-archive/filters/migration-plan.md) — historical migration context *(archived)*

--- a/reports/quality/duplication-baseline.json
+++ b/reports/quality/duplication-baseline.json
@@ -1,0 +1,1905 @@
+{
+  "summary": {
+    "snapshot_date": "2026-07-23",
+    "targets": 2,
+    "total_duplicate_clusters": 103,
+    "total_raw_duplicate_clusters": 107,
+    "total_excluded_duplicate_clusters": 4
+  },
+  "normalization": {
+    "exclude_module_patterns": [],
+    "exclude_actionability_categories": []
+  },
+  "trend": {
+    "status": "no_prior_snapshot",
+    "snapshot_date": "2026-07-23"
+  },
+  "reduction_leverage_ranking": [
+    {
+      "target": "src/bioetl/composition",
+      "duplicate_clusters": 35,
+      "dominant_actionability_category": "composition_runtime_wiring_pattern",
+      "dominant_actionability_cluster_count": 35,
+      "low_risk_cluster_count": 35,
+      "low_risk_cluster_share": 1.0,
+      "recommended_first_wave": false
+    },
+    {
+      "target": "src/bioetl/application",
+      "duplicate_clusters": 68,
+      "dominant_actionability_category": "export_facade_or_package_barrel",
+      "dominant_actionability_cluster_count": 65,
+      "low_risk_cluster_count": 65,
+      "low_risk_cluster_share": 0.9559,
+      "recommended_first_wave": false
+    }
+  ],
+  "first_wave": {
+    "status": "selected",
+    "target": "src/bioetl/composition",
+    "duplicate_clusters": 35,
+    "dominant_actionability_category": "composition_runtime_wiring_pattern",
+    "selection_rule": "prefer low-risk actionability families with bounded cluster counts, then maximize duplicate reduction leverage"
+  },
+  "targets": [
+    {
+      "target": "src/bioetl/composition",
+      "returncode": 8,
+      "duplicate_count": 35,
+      "raw_duplicate_count": 35,
+      "excluded_duplicate_count": 0,
+      "actionability": [
+        {
+          "category": "composition_runtime_wiring_pattern",
+          "duplicate_clusters": 35
+        }
+      ],
+      "top_pairs": [
+        {
+          "modules": [
+            "bioetl.composition.bootstrap.runtime._composite_control_plane_builder_support",
+            "bioetl.composition.runtime_builders.run_manifest_support"
+          ],
+          "duplicate_clusters": 2
+        },
+        {
+          "modules": [
+            "bioetl.composition.factories.services.builder",
+            "bioetl.composition.factories.services.pipeline_builder"
+          ],
+          "duplicate_clusters": 2
+        },
+        {
+          "modules": [
+            "bioetl.composition.providers._creation",
+            "bioetl.composition.providers.provider_registry"
+          ],
+          "duplicate_clusters": 2
+        },
+        {
+          "modules": [
+            "bioetl.composition.runtime_builders._run_manifest_control_plane_paths",
+            "bioetl.composition.runtime_builders._run_manifest_data_roots"
+          ],
+          "duplicate_clusters": 2
+        },
+        {
+          "modules": [
+            "bioetl.composition._pipeline_execution",
+            "bioetl.composition.execution_api"
+          ],
+          "duplicate_clusters": 1
+        }
+      ],
+      "clusters": [
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.control_plane_api",
+              "start_line": 116,
+              "end_line": 138
+            },
+            {
+              "module": "bioetl.composition.control_plane_service_access",
+              "start_line": 52,
+              "end_line": 73
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.runtime_builders._run_manifest_control_plane_paths",
+              "start_line": 21,
+              "end_line": 39
+            },
+            {
+              "module": "bioetl.composition.runtime_builders._run_manifest_data_roots",
+              "start_line": 88,
+              "end_line": 106
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.services.builder",
+              "start_line": 84,
+              "end_line": 114
+            },
+            {
+              "module": "bioetl.composition.factories.services.pipeline_builder",
+              "start_line": 71,
+              "end_line": 99
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.pipeline.control_plane_artifacts",
+              "start_line": 24,
+              "end_line": 35
+            },
+            {
+              "module": "bioetl.composition.pipeline_runner_request",
+              "start_line": 52,
+              "end_line": 63
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.dq.__init__",
+              "start_line": 21,
+              "end_line": 39
+            },
+            {
+              "module": "bioetl.composition.providers.__init__",
+              "start_line": 72,
+              "end_line": 90
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.runtime_builders._run_manifest_control_plane_paths",
+              "start_line": 37,
+              "end_line": 51
+            },
+            {
+              "module": "bioetl.composition.runtime_builders._run_manifest_data_roots",
+              "start_line": 114,
+              "end_line": 133
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.pipeline.factory_method_helpers",
+              "start_line": 121,
+              "end_line": 131
+            },
+            {
+              "module": "bioetl.composition.factories.transformer_factory",
+              "start_line": 118,
+              "end_line": 128
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.storage._bronze",
+              "start_line": 55,
+              "end_line": 65
+            },
+            {
+              "module": "bioetl.composition.factories.storage._gold",
+              "start_line": 59,
+              "end_line": 69
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition._resource_management",
+              "start_line": 27,
+              "end_line": 38
+            },
+            {
+              "module": "bioetl.composition.resources_api",
+              "start_line": 21,
+              "end_line": 31
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.cli.checkpoint",
+              "start_line": 157,
+              "end_line": 178
+            },
+            {
+              "module": "bioetl.composition.bootstrap.cli.health",
+              "start_line": 72,
+              "end_line": 87
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.runtime.observability_bundle",
+              "start_line": 212,
+              "end_line": 219
+            },
+            {
+              "module": "bioetl.composition.bootstrap.runtime.pipeline_bootstrap_phases",
+              "start_line": 105,
+              "end_line": 112
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.runtime._composite_control_plane_builder_support",
+              "start_line": 44,
+              "end_line": 51
+            },
+            {
+              "module": "bioetl.composition.runtime_builders.run_manifest_contract_identity",
+              "start_line": 30,
+              "end_line": 46
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.datasource.data_source_factory",
+              "start_line": 76,
+              "end_line": 84
+            },
+            {
+              "module": "bioetl.composition.factories.services.bundle",
+              "start_line": 175,
+              "end_line": 196
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.pipeline._creation_wiring",
+              "start_line": 97,
+              "end_line": 104
+            },
+            {
+              "module": "bioetl.composition.factories.pipeline._factory_method_types",
+              "start_line": 50,
+              "end_line": 59
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.services.builder",
+              "start_line": 120,
+              "end_line": 133
+            },
+            {
+              "module": "bioetl.composition.factories.services.pipeline_builder",
+              "start_line": 105,
+              "end_line": 125
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.storage.factory",
+              "start_line": 31,
+              "end_line": 40
+            },
+            {
+              "module": "bioetl.composition.factories.storage.storage_factory",
+              "start_line": 16,
+              "end_line": 23
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.providers._creation",
+              "start_line": 49,
+              "end_line": 62
+            },
+            {
+              "module": "bioetl.composition.providers.provider_registry",
+              "start_line": 150,
+              "end_line": 161
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.providers._creation",
+              "start_line": 178,
+              "end_line": 186
+            },
+            {
+              "module": "bioetl.composition.providers.provider_registry",
+              "start_line": 181,
+              "end_line": 188
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.runtime_builders._runner_control_plane_policy",
+              "start_line": 108,
+              "end_line": 127
+            },
+            {
+              "module": "bioetl.composition.runtime_builders._runner_control_plane_policy_support",
+              "start_line": 153,
+              "end_line": 171
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.entrypoints",
+              "start_line": 35,
+              "end_line": 41
+            },
+            {
+              "module": "bioetl.composition.execution_api",
+              "start_line": 30,
+              "end_line": 36
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition._pipeline_execution",
+              "start_line": 119,
+              "end_line": 133
+            },
+            {
+              "module": "bioetl.composition.execution_api",
+              "start_line": 104,
+              "end_line": 110
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.assembly.health_server",
+              "start_line": 41,
+              "end_line": 47
+            },
+            {
+              "module": "bioetl.composition.health_api",
+              "start_line": 73,
+              "end_line": 85
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.__init__",
+              "start_line": 105,
+              "end_line": 111
+            },
+            {
+              "module": "bioetl.composition.registry_api",
+              "start_line": 44,
+              "end_line": 50
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.runtime._composite_control_plane_builder_support",
+              "start_line": 184,
+              "end_line": 190
+            },
+            {
+              "module": "bioetl.composition.runtime_builders.run_manifest_support",
+              "start_line": 93,
+              "end_line": 99
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.observability_api",
+              "start_line": 11,
+              "end_line": 17
+            },
+            {
+              "module": "bioetl.composition.factories.services.observability_api",
+              "start_line": 11,
+              "end_line": 17
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.datasource.data_source_factory",
+              "start_line": 76,
+              "end_line": 82
+            },
+            {
+              "module": "bioetl.composition.providers.registration_biblio",
+              "start_line": 171,
+              "end_line": 177
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.providers._models",
+              "start_line": 8,
+              "end_line": 19
+            },
+            {
+              "module": "bioetl.composition.providers.provider_registry",
+              "start_line": 34,
+              "end_line": 45
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.entrypoints",
+              "start_line": 86,
+              "end_line": 91
+            },
+            {
+              "module": "bioetl.composition.observability_api",
+              "start_line": 125,
+              "end_line": 130
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.pipeline_runner_request",
+              "start_line": 57,
+              "end_line": 62
+            },
+            {
+              "module": "bioetl.composition.runtime_builders._run_manifest_refs",
+              "start_line": 104,
+              "end_line": 109
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.bootstrap.runtime._composite_control_plane_builder_support",
+              "start_line": 203,
+              "end_line": 208
+            },
+            {
+              "module": "bioetl.composition.runtime_builders.run_manifest_support",
+              "start_line": 101,
+              "end_line": 106
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories._observability_wiring",
+              "start_line": 148,
+              "end_line": 153
+            },
+            {
+              "module": "bioetl.composition.factories.services.bundle",
+              "start_line": 174,
+              "end_line": 179
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.pipeline._creation_wiring",
+              "start_line": 112,
+              "end_line": 117
+            },
+            {
+              "module": "bioetl.composition.factories.services._bundle_support",
+              "start_line": 124,
+              "end_line": 129
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.factories.services.bundle",
+              "start_line": 88,
+              "end_line": 93
+            },
+            {
+              "module": "bioetl.composition.factories.services.factory",
+              "start_line": 114,
+              "end_line": 119
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.providers._chembl_target_protein_classification_helpers",
+              "start_line": 175,
+              "end_line": 190
+            },
+            {
+              "module": "bioetl.composition.runtime_builders.input_snapshot_resolution",
+              "start_line": 120,
+              "end_line": 128
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\composition\\services\\__init__.py",
+          "line": 1,
+          "actionability_category": "composition_runtime_wiring_pattern",
+          "modules": [
+            {
+              "module": "bioetl.composition.runtime_builders._manifest_publication_context_support",
+              "start_line": 158,
+              "end_line": 163
+            },
+            {
+              "module": "bioetl.composition.runtime_builders.run_manifest_builder",
+              "start_line": 185,
+              "end_line": 190
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "src/bioetl/application",
+      "returncode": 8,
+      "duplicate_count": 68,
+      "raw_duplicate_count": 72,
+      "excluded_duplicate_count": 4,
+      "actionability": [
+        {
+          "category": "export_facade_or_package_barrel",
+          "duplicate_clusters": 65
+        },
+        {
+          "category": "pipeline_transformer_contract_pattern",
+          "duplicate_clusters": 3
+        }
+      ],
+      "top_pairs": [
+        {
+          "modules": [
+            "bioetl.application.services.lineage.metadata_lineage_dataset_nodes",
+            "bioetl.application.services.lineage.metadata_output_support"
+          ],
+          "duplicate_clusters": 4
+        },
+        {
+          "modules": [
+            "bioetl.application.services.lineage.metadata_lineage_fragments_gold",
+            "bioetl.application.services.lineage.metadata_lineage_fragments_silver"
+          ],
+          "duplicate_clusters": 4
+        },
+        {
+          "modules": [
+            "bioetl.application.workflow.transforms.reconcile_foreign_keys",
+            "bioetl.application.workflow.transforms.reconcile_rows"
+          ],
+          "duplicate_clusters": 3
+        },
+        {
+          "modules": [
+            "bioetl.application.composite.dependency_join_context_builders",
+            "bioetl.application.composite.enricher_join_execution"
+          ],
+          "duplicate_clusters": 2
+        },
+        {
+          "modules": [
+            "bioetl.application.services._checkpoint_compatibility_runtime_identity",
+            "bioetl.application.services._checkpoint_compatibility_runtime_identity_details"
+          ],
+          "duplicate_clusters": 2
+        }
+      ],
+      "clusters": [
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_foreign_keys",
+              "start_line": 182,
+              "end_line": 214
+            },
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_rows",
+              "start_line": 162,
+              "end_line": 199
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_node_builders",
+              "start_line": 42,
+              "end_line": 62
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_nodes",
+              "start_line": 25,
+              "end_line": 45
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._checkpoint_compatibility_runtime_identity",
+              "start_line": 127,
+              "end_line": 144
+            },
+            {
+              "module": "bioetl.application.services._checkpoint_compatibility_runtime_identity_details",
+              "start_line": 95,
+              "end_line": 112
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_support_mixin",
+              "start_line": 68,
+              "end_line": 86
+            },
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_support_types",
+              "start_line": 42,
+              "end_line": 61
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_support_runtime",
+              "start_line": 112,
+              "end_line": 135
+            },
+            {
+              "module": "bioetl.application.core.batch_checkpoint_recovery_service",
+              "start_line": 170,
+              "end_line": 192
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_foreign_keys",
+              "start_line": 169,
+              "end_line": 181
+            },
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_rows",
+              "start_line": 149,
+              "end_line": 161
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._checkpoint_compatibility_runtime_identity",
+              "start_line": 178,
+              "end_line": 189
+            },
+            {
+              "module": "bioetl.application.services._checkpoint_compatibility_runtime_identity_details",
+              "start_line": 73,
+              "end_line": 84
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_gold",
+              "start_line": 234,
+              "end_line": 255
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_silver",
+              "start_line": 168,
+              "end_line": 190
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.execution.cli_run_orchestration_models",
+              "start_line": 45,
+              "end_line": 57
+            },
+            {
+              "module": "bioetl.application.services.execution.pipeline_runner_models",
+              "start_line": 86,
+              "end_line": 96
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_dataset_nodes",
+              "start_line": 99,
+              "end_line": 109
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_output_support",
+              "start_line": 63,
+              "end_line": 73
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_gold",
+              "start_line": 222,
+              "end_line": 232
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_silver",
+              "start_line": 145,
+              "end_line": 155
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.coordinator",
+              "start_line": 57,
+              "end_line": 67
+            },
+            {
+              "module": "bioetl.application.composite.dependency_coordinator",
+              "start_line": 46,
+              "end_line": 57
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.join_key_normalization",
+              "start_line": 105,
+              "end_line": 116
+            },
+            {
+              "module": "bioetl.application.composite.join_key_resolution_helpers",
+              "start_line": 75,
+              "end_line": 95
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.merge_service",
+              "start_line": 167,
+              "end_line": 176
+            },
+            {
+              "module": "bioetl.application.composite.merger_orchestration",
+              "start_line": 207,
+              "end_line": 216
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.checkpoint._anchor_context",
+              "start_line": 20,
+              "end_line": 44
+            },
+            {
+              "module": "bioetl.application.composite.checkpoint.state",
+              "start_line": 51,
+              "end_line": 60
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.export_execution",
+              "start_line": 133,
+              "end_line": 156
+            },
+            {
+              "module": "bioetl.application.services.export_service",
+              "start_line": 245,
+              "end_line": 264
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_foreign_keys",
+              "start_line": 100,
+              "end_line": 122
+            },
+            {
+              "module": "bioetl.application.workflow.transforms.reconcile_rows",
+              "start_line": 39,
+              "end_line": 56
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_stage_support_mixin",
+              "start_line": 48,
+              "end_line": 62
+            },
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_stage_support_types",
+              "start_line": 38,
+              "end_line": 50
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.quarantine_manager",
+              "start_line": 71,
+              "end_line": 79
+            },
+            {
+              "module": "bioetl.application.services.data_quality_service",
+              "start_line": 42,
+              "end_line": 72
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._observability_workflow_quarantine_support",
+              "start_line": 32,
+              "end_line": 48
+            },
+            {
+              "module": "bioetl.application.services._quarantine_service_filtered_helpers",
+              "start_line": 29,
+              "end_line": 41
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._quarantine_service_replay_purge_sync",
+              "start_line": 83,
+              "end_line": 92
+            },
+            {
+              "module": "bioetl.application.services._quarantine_service_status_sync",
+              "start_line": 124,
+              "end_line": 133
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_gold",
+              "start_line": 30,
+              "end_line": 48
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_silver",
+              "start_line": 29,
+              "end_line": 47
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.dependency_join_context_builders",
+              "start_line": 126,
+              "end_line": 133
+            },
+            {
+              "module": "bioetl.application.composite.dependency_joiner",
+              "start_line": 250,
+              "end_line": 264
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.dependency_join_context_builders",
+              "start_line": 89,
+              "end_line": 96
+            },
+            {
+              "module": "bioetl.application.composite.enricher_join_execution",
+              "start_line": 91,
+              "end_line": 98
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "pipeline_transformer_contract_pattern",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.target_protein_classification_summary",
+              "start_line": 12,
+              "end_line": 19
+            },
+            {
+              "module": "bioetl.application.pipelines.chembl.target_protein_classification_summary",
+              "start_line": 19,
+              "end_line": 27
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_merge_stage_runtime",
+              "start_line": 76,
+              "end_line": 83
+            },
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_stage_dependency_state_flow",
+              "start_line": 81,
+              "end_line": 88
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.batch_executor_runtime_state",
+              "start_line": 17,
+              "end_line": 24
+            },
+            {
+              "module": "bioetl.application.services.execution.pipeline_runner_models",
+              "start_line": 29,
+              "end_line": 36
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.lifecycle.shutdown",
+              "start_line": 86,
+              "end_line": 110
+            },
+            {
+              "module": "bioetl.application.services.shutdown_service",
+              "start_line": 174,
+              "end_line": 202
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.observability.observer",
+              "start_line": 53,
+              "end_line": 61
+            },
+            {
+              "module": "bioetl.application.observability.observer_context_mixin",
+              "start_line": 33,
+              "end_line": 41
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.checkpoint_service",
+              "start_line": 76,
+              "end_line": 92
+            },
+            {
+              "module": "bioetl.application.services.quarantine_service",
+              "start_line": 95,
+              "end_line": 111
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq_report_models",
+              "start_line": 16,
+              "end_line": 25
+            },
+            {
+              "module": "bioetl.application.services.health_service",
+              "start_line": 36,
+              "end_line": 45
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq_report_models",
+              "start_line": 15,
+              "end_line": 24
+            },
+            {
+              "module": "bioetl.application.services.medallion_lifecycle",
+              "start_line": 51,
+              "end_line": 60
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._metrics_service_gateway_support",
+              "start_line": 20,
+              "end_line": 29
+            },
+            {
+              "module": "bioetl.application.services.metrics_service",
+              "start_line": 44,
+              "end_line": 53
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_dataset_nodes",
+              "start_line": 118,
+              "end_line": 127
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_output_support",
+              "start_line": 96,
+              "end_line": 105
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_gold",
+              "start_line": 58,
+              "end_line": 65
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_fragments_silver",
+              "start_line": 61,
+              "end_line": 68
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.dependency_join_context_builders",
+              "start_line": 120,
+              "end_line": 126
+            },
+            {
+              "module": "bioetl.application.composite.enricher_join_execution",
+              "start_line": 92,
+              "end_line": 98
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.join_planner_helpers",
+              "start_line": 68,
+              "end_line": 80
+            },
+            {
+              "module": "bioetl.application.composite.merger_output_mixin",
+              "start_line": 30,
+              "end_line": 41
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.checkpoint.load_service",
+              "start_line": 194,
+              "end_line": 200
+            },
+            {
+              "module": "bioetl.application.core.lifecycle.checkpoint_manager",
+              "start_line": 70,
+              "end_line": 76
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.batch_operation_errors",
+              "start_line": 9,
+              "end_line": 19
+            },
+            {
+              "module": "bioetl.application.services.dq_report_models",
+              "start_line": 16,
+              "end_line": 24
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "pipeline_transformer_contract_pattern",
+          "modules": [
+            {
+              "module": "bioetl.application.core.pre_silver_adapter_mixin",
+              "start_line": 60,
+              "end_line": 66
+            },
+            {
+              "module": "bioetl.application.pipelines.common.publication_assembly",
+              "start_line": 167,
+              "end_line": 173
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "pipeline_transformer_contract_pattern",
+          "modules": [
+            {
+              "module": "bioetl.application.core.pre_silver_finalization_flow",
+              "start_line": 62,
+              "end_line": 68
+            },
+            {
+              "module": "bioetl.application.pipelines.common.publication_transformer_records",
+              "start_line": 156,
+              "end_line": 162
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.lifecycle.cleanup_service",
+              "start_line": 227,
+              "end_line": 233
+            },
+            {
+              "module": "bioetl.application.services.medallion_lifecycle",
+              "start_line": 133,
+              "end_line": 139
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.wiring.__init__",
+              "start_line": 37,
+              "end_line": 46
+            },
+            {
+              "module": "bioetl.application.services.control_plane.replay.__init__",
+              "start_line": 132,
+              "end_line": 141
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.debug_export_collector_helpers",
+              "start_line": 117,
+              "end_line": 138
+            },
+            {
+              "module": "bioetl.application.services.debug_export_helpers",
+              "start_line": 262,
+              "end_line": 292
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq_report_generation_mixin",
+              "start_line": 39,
+              "end_line": 49
+            },
+            {
+              "module": "bioetl.application.services.dq_report_service",
+              "start_line": 32,
+              "end_line": 48
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq_report_models",
+              "start_line": 15,
+              "end_line": 21
+            },
+            {
+              "module": "bioetl.application.services.vacuum_service",
+              "start_line": 31,
+              "end_line": 37
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.export_service",
+              "start_line": 46,
+              "end_line": 54
+            },
+            {
+              "module": "bioetl.application.services.vacuum_service",
+              "start_line": 33,
+              "end_line": 45
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.health_service",
+              "start_line": 36,
+              "end_line": 44
+            },
+            {
+              "module": "bioetl.application.services.medallion_lifecycle",
+              "start_line": 52,
+              "end_line": 60
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.medallion_maintenance_mixin",
+              "start_line": 14,
+              "end_line": 22
+            },
+            {
+              "module": "bioetl.application.services.metrics_service",
+              "start_line": 44,
+              "end_line": 52
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.workflow_runner_service",
+              "start_line": 62,
+              "end_line": 72
+            },
+            {
+              "module": "bioetl.application.services.workflow_transform_service",
+              "start_line": 38,
+              "end_line": 46
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._metrics_service_gateway_support",
+              "start_line": 20,
+              "end_line": 28
+            },
+            {
+              "module": "bioetl.application.services.execution.pipeline_run_execution_service",
+              "start_line": 22,
+              "end_line": 30
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._quarantine_service_replay_purge_sync",
+              "start_line": 76,
+              "end_line": 82
+            },
+            {
+              "module": "bioetl.application.services._quarantine_service_status_sync",
+              "start_line": 117,
+              "end_line": 123
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq.gold_analyzer",
+              "start_line": 143,
+              "end_line": 149
+            },
+            {
+              "module": "bioetl.application.services.dq.silver_check_executor",
+              "start_line": 147,
+              "end_line": 162
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq._checks_basic",
+              "start_line": 36,
+              "end_line": 56
+            },
+            {
+              "module": "bioetl.application.services.dq._checks_integrity",
+              "start_line": 30,
+              "end_line": 44
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.__init__",
+              "start_line": 14,
+              "end_line": 20
+            },
+            {
+              "module": "bioetl.application.services.lineage.lineage_inspection_service",
+              "start_line": 23,
+              "end_line": 29
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_dataset_nodes",
+              "start_line": 103,
+              "end_line": 109
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_output_support",
+              "start_line": 99,
+              "end_line": 105
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.lineage.metadata_lineage_dataset_nodes",
+              "start_line": 121,
+              "end_line": 127
+            },
+            {
+              "module": "bioetl.application.services.lineage.metadata_output_support",
+              "start_line": 67,
+              "end_line": 73
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.join_key_resolution",
+              "start_line": 131,
+              "end_line": 136
+            },
+            {
+              "module": "bioetl.application.composite.join_key_resolution_helpers",
+              "start_line": 116,
+              "end_line": 121
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_stage_support_types",
+              "start_line": 34,
+              "end_line": 39
+            },
+            {
+              "module": "bioetl.application.composite.runner_pkg.runner_stage_types",
+              "start_line": 26,
+              "end_line": 31
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.batch_operation_errors",
+              "start_line": 9,
+              "end_line": 14
+            },
+            {
+              "module": "bioetl.application.services.vacuum_service",
+              "start_line": 32,
+              "end_line": 37
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core._batch_tracing_support",
+              "start_line": 12,
+              "end_line": 17
+            },
+            {
+              "module": "bioetl.application.observability.span_attribute_values",
+              "start_line": 6,
+              "end_line": 11
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core._runner_observability",
+              "start_line": 29,
+              "end_line": 34
+            },
+            {
+              "module": "bioetl.application.services.data_quality_anomalies",
+              "start_line": 215,
+              "end_line": 220
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.core.lifecycle.checkpoint_identity_overrides",
+              "start_line": 28,
+              "end_line": 33
+            },
+            {
+              "module": "bioetl.application.services._checkpoint_compatibility_runtime_identity",
+              "start_line": 32,
+              "end_line": 37
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services._observability_workflow_checkpoint_support",
+              "start_line": 18,
+              "end_line": 23
+            },
+            {
+              "module": "bioetl.application.services.checkpoint_compatibility_policy",
+              "start_line": 11,
+              "end_line": 16
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.checkpoint_service",
+              "start_line": 93,
+              "end_line": 107
+            },
+            {
+              "module": "bioetl.application.services.quarantine_service",
+              "start_line": 112,
+              "end_line": 126
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.contract_migration_models",
+              "start_line": 6,
+              "end_line": 11
+            },
+            {
+              "module": "bioetl.application.services.contract_migration_service",
+              "start_line": 4,
+              "end_line": 9
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.export_execution",
+              "start_line": 113,
+              "end_line": 118
+            },
+            {
+              "module": "bioetl.application.services.export_service",
+              "start_line": 245,
+              "end_line": 250
+            }
+          ]
+        },
+        {
+          "path": "src\\bioetl\\application\\workflow\\transforms\\__init__.py",
+          "line": 1,
+          "actionability_category": "export_facade_or_package_barrel",
+          "modules": [
+            {
+              "module": "bioetl.application.services.dq._checks_integrity",
+              "start_line": 172,
+              "end_line": 195
+            },
+            {
+              "module": "bioetl.application.services.dq._checks_statistical",
+              "start_line": 98,
+              "end_line": 111
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/reports/quality/observability-export-dashboard-rollout-closeout.json
+++ b/reports/quality/observability-export-dashboard-rollout-closeout.json
@@ -1,0 +1,261 @@
+{
+  "debt_budget_outcome": "reduced_or_unchanged",
+  "generated_by": "codex",
+  "generated_on": "2026-06-30",
+  "issues": [
+    {
+      "evidence": [
+        "reports/quality/observability-export-dashboard-rollout-closeout.json",
+        "tests/architecture/test_observability_export_dashboard_rollout_closeout.py"
+      ],
+      "number": 5716,
+      "status": "closed-ready",
+      "title": "program/observability governed dashboard ledger export rollout"
+    },
+    {
+      "evidence": [
+        "docs/02-architecture/decisions/ADR-017-observability-architecture.md",
+        "docs/02-architecture/decisions/ADR-019-observability-port-enforcement.md"
+      ],
+      "number": 5717,
+      "status": "closed-ready",
+      "title": "baseline discovery and architecture gate"
+    },
+    {
+      "evidence": [
+        "docs/04-reference/contracts/observability-rollout-contracts.md",
+        "src/bioetl/domain/observability_contract.py",
+        "src/bioetl/domain/observability_event_mapping.py",
+        "tests/unit/domain/test_observability_event_mapping.py"
+      ],
+      "number": 5718,
+      "status": "closed-ready",
+      "title": "observability event taxonomy alignment"
+    },
+    {
+      "evidence": [
+        "docs/04-reference/contracts/observability-rollout-contracts.md",
+        "src/bioetl/domain/control_plane/run_ledger.py",
+        "tests/architecture/test_quarantine_immutability.py"
+      ],
+      "number": 5719,
+      "status": "closed-ready",
+      "title": "projection state-machine invariants"
+    },
+    {
+      "evidence": [
+        "configs/contracts/errors/error_catalog.yaml",
+        "src/bioetl/domain/error_classifier.py",
+        "src/bioetl/infrastructure/errors/exception_mapper.py",
+        "tests/architecture/test_observability_export_dashboard_rollout_closeout.py"
+      ],
+      "number": 5720,
+      "status": "closed-ready",
+      "title": "canonical error catalog"
+    },
+    {
+      "evidence": [
+        "docs/04-reference/contracts/observability-rollout-contracts.md",
+        "src/bioetl/domain/control_plane/run_ledger.py",
+        "src/bioetl/application/services/control_plane/ledger/service.py",
+        "src/bioetl/infrastructure/control_plane/file_run_ledger_store.py"
+      ],
+      "number": 5721,
+      "status": "closed-ready",
+      "title": "control-plane projection strategy"
+    },
+    {
+      "evidence": [
+        "configs/quality/observability_metric_governance.yaml",
+        "configs/quality/observability_metric_declarations.yaml",
+        "grafana/prometheus-rules/bioetl_observability.yml",
+        "grafana/prometheus-rules/tests/bioetl_observability.test.yml",
+        "tests/architecture/test_observability_metric_governance.py"
+      ],
+      "number": 5722,
+      "status": "closed-ready",
+      "title": "low-cardinality operational metrics"
+    },
+    {
+      "evidence": [
+        "docs/04-reference/contracts/gold-schemas.md",
+        "docs/04-reference/contracts/observability-rollout-contracts.md",
+        "tests/architecture/test_gold_schema_contracts.py",
+        "tests/integration/test_grafana_dashboard_query_governance.py"
+      ],
+      "number": 5723,
+      "status": "closed-ready",
+      "title": "stable Gold/read-model contracts"
+    },
+    {
+      "evidence": [
+        "src/bioetl/domain/ports/export.py",
+        "src/bioetl/application/services/export_models.py",
+        "src/bioetl/application/services/export_manifests.py",
+        "src/bioetl/application/services/export_service.py",
+        "src/bioetl/interfaces/cli/commands/export.py",
+        "docs/security/export-policy.md",
+        "tests/unit/application/services/test_export_service.py"
+      ],
+      "number": 5724,
+      "status": "closed-ready",
+      "title": "governed export use case"
+    },
+    {
+      "evidence": [
+        ".github/workflows/tests.yml",
+        "tests/integration/test_grafana_config.py",
+        "tests/integration/test_grafana_dashboard_query_governance.py",
+        "tests/integration/test_prometheus_rules_config.py",
+        "tests/architecture/test_gold_schema_contracts.py"
+      ],
+      "number": 5725,
+      "status": "closed-ready",
+      "title": "dashboard/rule/contract drift CI"
+    },
+    {
+      "evidence": [
+        "grafana/dashboards/bioetl-control-plane-v1.json",
+        "grafana/dashboards/bioetl-overview-v2.json",
+        "grafana/dashboards/bioetl-runtime.json",
+        "grafana/dashboards/bioetl-dq-v2.json",
+        "grafana/dashboards/bioetl-provider-health-v2.json",
+        "docs/03-guides/dashboards/README.md",
+        "grafana/README.md"
+      ],
+      "number": 5726,
+      "status": "closed-ready",
+      "title": "Grafana dashboard extension"
+    },
+    {
+      "evidence": [
+        "docs/security/rbac-matrix.md",
+        "docs/security/export-policy.md",
+        "grafana/provisioning/datasources-core/prometheus.yml",
+        "tests/integration/test_grafana_datasource_provisioning.py"
+      ],
+      "number": 5727,
+      "status": "closed-ready",
+      "title": "RBAC and secure export hardening"
+    },
+    {
+      "evidence": [
+        "reports/quality/observability-export-dashboard-rollout-closeout.json",
+        "tests/architecture/test_observability_export_dashboard_rollout_closeout.py",
+        "tests/architecture/test_strict_architecture_contracts.py",
+        "tests/architecture/test_observability_metric_governance.py",
+        "tests/integration/test_grafana_dashboard_query_governance.py"
+      ],
+      "number": 5728,
+      "status": "closed-ready",
+      "title": "rollout sequencing and final architecture verification"
+    }
+  ],
+  "outcomes": {
+    "5716": {
+      "extension_first_policy": true,
+      "program_status": "sequenced_and_gate_backed",
+      "run_ledger_reused": true
+    },
+    "5717": {
+      "production_files_created_by_baseline": 0
+    },
+    "5718": {
+      "domain_io_allowed": false,
+      "event_contract": "docs/04-reference/contracts/observability-rollout-contracts.md"
+    },
+    "5719": {
+      "projection_states_are_read_model_only": true,
+      "quarantine_payload_immutable": true
+    },
+    "5720": {
+      "catalog": "configs/contracts/errors/error_catalog.yaml",
+      "grouping_contract": "canonical_code_only",
+      "severity_changes_require_tests": true
+    },
+    "5721": {
+      "projection_strategy": "reuse_existing_run_ledger",
+      "sql_migrations_added": 0
+    },
+    "5722": {
+      "forbidden_labels": [
+        "run_id",
+        "record_id",
+        "payload_hash",
+        "manifest_id",
+        "execution_fingerprint",
+        "file_path"
+      ]
+    },
+    "5723": {
+      "dashboard_source_contract": "stable_gold_read_model_or_recording_rule",
+      "raw_bronze_silver_dashboard_queries_allowed": false
+    },
+    "5724": {
+      "checksum_manifest_path": true,
+      "expiry_metadata": true,
+      "export_audit_ref": true,
+      "role_sensitive_redaction": true
+    },
+    "5725": {
+      "ci_contract_drift_validation": true,
+      "ci_dashboard_validation": true,
+      "ci_prometheus_rule_validation": true
+    },
+    "5726": {
+      "extension_first": true,
+      "new_top_level_dashboards": 0,
+      "raw_sensitive_datasource_exposure_allowed": false
+    },
+    "5727": {
+      "export_policy": "docs/security/export-policy.md",
+      "rbac_matrix": "docs/security/rbac-matrix.md",
+      "secrets_in_dashboards_allowed": false
+    },
+    "5728": {
+      "final_closeout_gate": "tests/architecture/test_observability_export_dashboard_rollout_closeout.py",
+      "manual_review_surfaces": [
+        "live Grafana render/audit requires local services",
+        "HTTP download adapters must enforce expires_at before serving files"
+      ]
+    }
+  },
+  "program_order": [
+    5717,
+    5718,
+    5719,
+    5720,
+    5721,
+    5722,
+    5723,
+    5724,
+    5725,
+    5726,
+    5727,
+    5728,
+    5716
+  ],
+  "ratchets": {
+    "application_infrastructure_import_violations": {
+      "current": 0,
+      "max": 0
+    },
+    "domain_io_violations": {
+      "current": 0,
+      "max": 0
+    },
+    "forbidden_prometheus_identifier_labels": {
+      "current": 0,
+      "max": 0
+    },
+    "new_sql_event_store_files": {
+      "current": 0,
+      "max": 0
+    },
+    "new_top_level_dashboard_files": {
+      "current": 0,
+      "max": 0
+    }
+  },
+  "schema_version": "observability-export-dashboard-rollout-closeout-v1"
+}

--- a/reports/quality/refactoring-followups-6097-6100-closeout.json
+++ b/reports/quality/refactoring-followups-6097-6100-closeout.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "refactoring-followups-6097-6100-closeout-v1",
+  "reviewed_on": "2026-07-08",
+  "debt_budget_policy": "flat_or_decreasing_only",
+  "issues": [
+    {
+      "number": 6097,
+      "status": "closed-ready",
+      "title": "RF-005: Freeze and clarify public facade and entrypoint ownership",
+      "evidence": [
+        "configs/quality/compatibility_facade_inventory.yaml",
+        "reports/quality/compatibility-importer-census.json",
+        "tests/architecture/test_public_facade_inventory.py",
+        "tests/architecture/test_public_surface_importer_census_governance.py"
+      ],
+      "decision": "retained public entrypoints and export facades remain stable public API seams with explicit owners, call-site policy, migration path, and exit criteria"
+    },
+    {
+      "number": 6098,
+      "status": "closed-ready",
+      "title": "RF-006: Reduce accepted runtime import SCC budget",
+      "evidence": [
+        "src/bioetl/infrastructure/storage/support/_atomic_replace.py",
+        "src/bioetl/infrastructure/storage/support/atomic_group.py",
+        "src/bioetl/infrastructure/storage/support/atomic_ops.py",
+        "tests/architecture/test_runtime_import_scc.py",
+        "configs/quality/test_governance_audit.yaml"
+      ],
+      "decision": "atomic write replace/error primitives were split into a directed support module and the reviewed runtime SCC budget was ratcheted from 3 to 2"
+    },
+    {
+      "number": 6099,
+      "status": "closed-ready",
+      "title": "RF-007: Simplify config contract evolution governance",
+      "evidence": [
+        "scripts/schema/generate_config_matrix.py",
+        "reports/quality/config-discrepancy-baseline.json",
+        "reports/quality/contract-registry-diagnostics.json",
+        "configs/quality/config_compatibility_registry.yaml",
+        "tests/architecture/test_config_discrepancy_metrics_ratchets.py"
+      ],
+      "decision": "generated config parameter taxonomy now publishes group owners and a compatibility-preserving evolution policy tied to the config compatibility registry"
+    },
+    {
+      "number": 6100,
+      "status": "closed-ready",
+      "title": "RF-008: Add VCR and replay preflight reliability gate",
+      "evidence": [
+        "scripts/engineering/qa/vcr/check_replay_preflight.py",
+        "tests/unit/scripts/qa/test_vcr_replay_preflight.py",
+        "scripts/engineering/qa/vcr/__main__.py",
+        "scripts/engineering/qa/__main__.py",
+        "docs/03-guides/testing.md"
+      ],
+      "decision": "replay-heavy lanes have a fast preflight command that reports exact unresolved cassette pointers before pytest setup and documents git lfs pull remediation"
+    }
+  ],
+  "ratchets": {
+    "retained_entrypoint_count": {
+      "current": 12,
+      "max": 12,
+      "source": "reports/quality/compatibility-importer-census.json"
+    },
+    "retained_public_export_facade_count": {
+      "current": 4,
+      "max": 4,
+      "source": "reports/quality/compatibility-importer-census.json"
+    },
+    "reviewed_runtime_scc_budget": {
+      "opening": 3,
+      "current": 2,
+      "max": 2,
+      "source": "tests/architecture/test_runtime_import_scc.py"
+    },
+    "config_inconsistent_parameter_count": {
+      "current": 0,
+      "max": 0,
+      "source": "reports/quality/config-discrepancy-baseline.json"
+    },
+    "contract_registry_blocking_issue_count": {
+      "current": 0,
+      "max": 0,
+      "source": "reports/quality/contract-registry-diagnostics.json"
+    },
+    "vcr_unowned_cassette_count": {
+      "current": 0,
+      "max": 0,
+      "source": "reports/quality/vcr-metadata-catalog.json"
+    }
+  },
+  "validation": [
+    "uv run pytest tests/architecture/test_runtime_import_scc.py",
+    "uv run pytest tests/unit/infrastructure/storage/test_atomic_write_group.py",
+    "uv run pytest tests/unit/scripts/qa/test_vcr_replay_preflight.py",
+    "uv run pytest tests/architecture/test_config_discrepancy_metrics_ratchets.py",
+    "uv run pytest tests/architecture/test_refactoring_followups_6097_6100_closeout.py"
+  ]
+}

--- a/reports/quality/semantic-ddd-use-case-audit-2026-06-17.md
+++ b/reports/quality/semantic-ddd-use-case-audit-2026-06-17.md
@@ -1,0 +1,119 @@
+# Semantic DDD and Use-Case Audit - 2026-06-17
+
+Issue scope: #5316.
+
+## Scope
+
+This audit covers the architecture-debt closeout wave for #5306, #5312, #5313,
+#5244, #5314, #5315, and #5316. It is intentionally scoped to the touched
+runtime and evidence surfaces, not a full repository semantic audit.
+
+Reviewed runtime surfaces:
+
+- `src/bioetl/application/services/control_plane/manifest/diagnostics/base.py`
+- `src/bioetl/application/services/control_plane/manifest/diagnostics/replay_readiness.py`
+- `src/bioetl/application/services/control_plane/manifest/diagnostics/summary.py`
+- `src/bioetl/application/services/control_plane/manifest/inspection_service.py`
+- `src/bioetl/application/services/control_plane/manifest/inspection_result_model.py`
+- `src/bioetl/application/services/control_plane/manifest/diagnostics/diagnostic_context.py`
+- `src/bioetl/application/services/control_plane/manifest/diagnostics/replay_invariants/nested_mapping.py`
+- `src/bioetl/application/services/control_plane/replay/_historical_snapshot_certification_modes.py`
+- `src/bioetl/application/services/control_plane/replay/_historical_snapshot_materialization_modes.py`
+- `src/bioetl/application/services/control_plane/workflow/execution_incremental_metadata.py`
+- `src/bioetl/application/services/control_plane/workflow/execution_recording_context.py`
+- `src/bioetl/composition/runtime_builders/_run_manifest_create_spec_support.py`
+- `src/bioetl/composition/runtime_builders/_effective_config_artifact_builder_support.py`
+- `src/bioetl/composition/runtime_builders/effective_config_artifact_builder.py`
+- `tests/unit/application/services/test_checkpoint_execution_identity_alignment.py`
+- `tests/unit/application/services/control_plane/test_helper_module_coverage.py`
+
+## Architectural Facts
+
+- `docs/02-architecture/01-domain-layer.md` defines the Domain layer as pure
+  business logic, entities, value objects, aggregates, domain events, ports,
+  and validation rules. It must not depend on Application, Infrastructure, or
+  Interfaces.
+- `docs/02-architecture/05-composition-layer.md` defines Composition as the
+  root that assembles components across Domain, Application, and Infrastructure
+  and performs dependency injection.
+- `.importlinter` enforces the same directionality: Domain must not import
+  other layers, Application must not import Composition, Infrastructure, or
+  Interfaces, Composition must not import Interfaces, and Interfaces must not
+  directly import Infrastructure.
+
+## Findings
+
+1. Domain purity is preserved for the touched surfaces.
+
+   The edited application modules consume domain value/policy types where
+   needed, but no touched Domain module imports Application, Composition,
+   Infrastructure, or Interfaces. No domain behavior was moved into
+   Composition.
+
+2. Use-case ownership remains in Application.
+
+   Control-plane manifest diagnostics, replay readiness projection,
+   checkpoint execution identity projection, and historical replay helper
+   classification remain under `bioetl.application.services`. These modules
+   orchestrate control-plane use-case state and evidence projection; they do
+   not instantiate infrastructure adapters or composition roots.
+
+3. Composition changes remain composition-root work.
+
+   The runtime-builder edits reduce compatibility-facade indirection by
+   importing narrower support helpers directly inside
+   `bioetl.composition.runtime_builders`. Composition importing Application
+   and Domain contracts is allowed by the documented layer model because
+   Composition owns wiring and bootstrap assembly.
+
+4. Retained public entrypoints are API-governance debt, not DDD aggregate
+   violations.
+
+   The #5315 review keeps all 13 retained public seams because they are
+   sanctioned public API paths or canonical model/use-case seams. This does
+   not move domain invariants out of Domain or create cross-layer semantic
+   ownership drift.
+
+5. The new coverage anchors do not introduce production semantics.
+
+   `tests/unit/application/services/control_plane/test_helper_module_coverage.py`
+   exercises helper contracts and edge cases to remove unmeasured module
+   warnings. It does not define runtime behavior or broaden production API
+   ownership.
+
+## Inferences
+
+- Splitting diagnostics helpers lowers fan-in pressure without changing the
+  semantic owner: diagnostics remain an Application control-plane use case.
+- Direct imports from smaller runtime-builder support modules are safer than
+  routing through broad facades because they make the composition dependency
+  graph more explicit.
+- The remaining retained entrypoint count should be managed by public API
+  lifecycle review, not by DDD refactoring.
+
+## Uncertainties
+
+- This artifact is a scoped semantic audit for the touched architecture-debt
+  wave. It does not claim to audit every BioETL pipeline or provider semantic
+  path.
+- Full historical replay semantics are validated by the reproducibility and
+  golden-fixture suites; this audit only checks DDD/use-case placement for the
+  modules touched by this closeout wave.
+
+## Validation Evidence
+
+- `python -m scripts.engineering.qa report-debt-governance-gates --check`:
+  all 26 debt gates passed, including `hotspot_family_baseline_budget_warnings`
+  and `module_coverage_unmeasured_modules`.
+- `python -m scripts.engineering.qa report-module-coverage --check`: module
+  coverage inventory is current and reports zero unmeasured modules.
+- `python scripts/engineering/qa/generate_architecture_dependency_map.py --check`:
+  generated dependency map is current.
+- `python -m scripts.engineering.qa report-compatibility-importer-census --check`:
+  retained public entrypoint census is current.
+
+## Closeout Verdict
+
+No DDD or use-case ownership regression was found in the touched surfaces. The
+architecture-debt wave can close #5316 with this scoped artifact as the
+required semantic DDD/use-case audit evidence.

--- a/reports/quality/tech-debt-issue-6062-closeout.json
+++ b/reports/quality/tech-debt-issue-6062-closeout.json
@@ -23,7 +23,7 @@
         "outcome": "reduced_to_top_level_direct_helper_import"
       },
       {
-        "scope": "DeltaTable",
+        "scope": "delta_table",
         "import": "from deltalake import DeltaTable as _DeltaTable",
         "classification": "optional dependency and compatibility patch-point",
         "outcome": "retained_lazy"
@@ -94,10 +94,10 @@
     "function_scoped_import_count": 2,
     "retained": [
       {
-        "scope": "DeltaTable",
+        "scope": "delta_table",
         "import": "from deltalake import DeltaTable as _DeltaTable",
         "classification": "optional dependency and compatibility patch-point",
-        "rationale": "Preserves Delta object laziness and canonical monkeypatch path bioetl.infrastructure.storage.gold_writer.DeltaTable."
+        "rationale": "Preserves Delta object laziness and canonical monkeypatch path bioetl.infrastructure.storage.gold_writer.delta_table."
       },
       {
         "scope": "write_deltalake",

--- a/reports/quality/tech-debt-issue-6062-closeout.json
+++ b/reports/quality/tech-debt-issue-6062-closeout.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "tech-debt-issue-6062-closeout-v1",
+  "issue": 6062,
+  "status": "closeable",
+  "debt_outcome": "improved",
+  "budget_growth_allowed": false,
+  "closed_on": "2026-07-08",
+  "scope": {
+    "primary_file": "src/bioetl/infrastructure/storage/gold_writer.py",
+    "support_files": [
+      "src/bioetl/infrastructure/storage/gold/writer_implementation.py",
+      "src/bioetl/infrastructure/storage/gold/writer_request.py"
+    ],
+    "target_metric": "function_scoped_imports"
+  },
+  "before": {
+    "function_scoped_import_count": 12,
+    "inventory": [
+      {
+        "scope": "_normalize_scd_config",
+        "import": "from bioetl.infrastructure.storage.gold.writer_facade_runtime import normalize_scd_config",
+        "classification": "compatibility patch-point",
+        "outcome": "reduced_to_top_level_direct_helper_import"
+      },
+      {
+        "scope": "DeltaTable",
+        "import": "from deltalake import DeltaTable as _DeltaTable",
+        "classification": "optional dependency and compatibility patch-point",
+        "outcome": "retained_lazy"
+      },
+      {
+        "scope": "write_deltalake",
+        "import": "from deltalake import write_deltalake as _write_deltalake",
+        "classification": "optional dependency and compatibility patch-point",
+        "outcome": "retained_lazy"
+      },
+      {
+        "scope": "GoldWriter.__init__",
+        "import": "from bioetl.infrastructure.storage.gold.writer_support import _resolve_runtime_services",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level_focused_runtime_module"
+      },
+      {
+        "scope": "GoldWriter.write_gold",
+        "import": "from bioetl.domain.ports.noop import _NoOpSpan",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level"
+      },
+      {
+        "scope": "GoldWriter.write_gold",
+        "import": "from bioetl.domain.types import GoldSchemaPolicyByVersion, ScdConfig, resolve_gold_contract_version",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level"
+      },
+      {
+        "scope": "GoldWriter.write_gold",
+        "import": "from bioetl.infrastructure.storage.gold.writer_support import _build_gold_write_request, _resolve_active_gold_schema",
+        "classification": "accidental hidden coupling",
+        "outcome": "replaced_with_top_level_imports_from_focused_modules"
+      },
+      {
+        "scope": "GoldWriter._write_dual_targets",
+        "import": "from bioetl.infrastructure.storage.gold.writer_facade_runtime import write_dual_targets as _write_dual_targets",
+        "classification": "accidental hidden coupling",
+        "outcome": "replaced_with_top_level_writer_implementation_import"
+      },
+      {
+        "scope": "GoldWriter._write_single_target",
+        "import": "from bioetl.infrastructure.storage.gold.writer_facade_runtime import write_single_target as _write_single_target",
+        "classification": "accidental hidden coupling",
+        "outcome": "replaced_with_top_level_writer_implementation_import"
+      },
+      {
+        "scope": "GoldWriter._prepare_write_gold",
+        "import": "from bioetl.infrastructure.storage.gold.pipeline_helpers import prepare_gold_write as _prepare_write_gold_impl",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level"
+      },
+      {
+        "scope": "GoldWriter._post_write_gold",
+        "import": "from bioetl.infrastructure.storage.gold.pipeline_helpers import post_write_gold as _post_write_gold_impl",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level"
+      },
+      {
+        "scope": "GoldWriter._set_write_span_attributes",
+        "import": "from bioetl.infrastructure.storage.gold.pipeline_helpers import set_gold_write_span_attributes as _set_write_span_attributes_impl",
+        "classification": "accidental hidden coupling",
+        "outcome": "hoisted_to_top_level"
+      }
+    ]
+  },
+  "after": {
+    "function_scoped_import_count": 2,
+    "retained": [
+      {
+        "scope": "DeltaTable",
+        "import": "from deltalake import DeltaTable as _DeltaTable",
+        "classification": "optional dependency and compatibility patch-point",
+        "rationale": "Preserves Delta object laziness and canonical monkeypatch path bioetl.infrastructure.storage.gold_writer.DeltaTable."
+      },
+      {
+        "scope": "write_deltalake",
+        "import": "from deltalake import write_deltalake as _write_deltalake",
+        "classification": "optional dependency and compatibility patch-point",
+        "rationale": "Preserves Delta writer laziness and canonical monkeypatch path bioetl.infrastructure.storage.gold_writer.write_deltalake."
+      }
+    ],
+    "accidental_hidden_coupling_count": 0
+  },
+  "support_cleanup": [
+    "Hoisted GoldWriteRequest import in gold/writer_request.py.",
+    "Reused the existing _GoldWriteRequest top-level alias in gold/writer_implementation.py."
+  ],
+  "validation": [
+    "pytest tests/architecture/test_runtime_import_scc.py -q",
+    "pytest tests/architecture/test_tech_debt_issue_6062_closeout.py -q",
+    "pytest tests/unit/infrastructure/storage/test_gold_writer.py tests/unit/infrastructure/storage/test_gold_writer_integration.py tests/integration/infrastructure/storage/test_gold_writer_versioning.py tests/integration/infrastructure/storage/test_gold_writer_read_cleanup.py -q"
+  ]
+}

--- a/reports/quality/tech-debt-issues-5343-5346-closeout.json
+++ b/reports/quality/tech-debt-issues-5343-5346-closeout.json
@@ -1,0 +1,78 @@
+{
+  "snapshot_date": "2026-06-18",
+  "status": "implemented_local_closeable",
+  "budget_policy": "no_growth_ratchet_only",
+  "issues": [
+    {
+      "issue": "#5343",
+      "theme": "Runtime builder manifest creation support fragmentation",
+      "debt_types": [
+        "Migration leftovers",
+        "Duplication",
+        "Composition debt"
+      ],
+      "action": "Folded run-manifest creation support policy/create-spec helpers into one owner module, removed the deleted support path from governance allowlists, and kept manifest-builder tests on the canonical support seam.",
+      "risk": "medium",
+      "evidence": [
+        "src/bioetl/composition/runtime_builders/_run_manifest_creation_support.py",
+        "src/bioetl/composition/runtime_builders/run_manifest_builder.py",
+        "configs/quality/debt_scorecard.yaml",
+        "tests/unit/composition/runtime_builders/test_run_manifest_support.py",
+        "tests/unit/composition/runtime_builders/test_run_manifest_builder.py"
+      ]
+    },
+    {
+      "issue": "#5344",
+      "theme": "Config/contract/registry duplication visibility outside JSCPD",
+      "debt_types": [
+        "Governance gap",
+        "Duplication",
+        "Config debt"
+      ],
+      "action": "Extended the config-surface backlog collector with a structured duplication audit for configs/** and added an architecture guard that keeps the committed duplication artifact synchronized with the live collector.",
+      "risk": "low",
+      "evidence": [
+        "scripts/engineering/qa/report_config_surface_backlog.py",
+        "reports/quality/config-surface-backlog.json",
+        "tests/architecture/test_config_surface_entity_residual_plateau.py"
+      ]
+    },
+    {
+      "issue": "#5345",
+      "theme": "Compatibility filename inventory ratchet after facade retirements",
+      "debt_types": [
+        "Test debt",
+        "Compatibility debt",
+        "Governance gap"
+      ],
+      "action": "Reclassified the Gold nullable numeric integration test as an active contract gate, renamed it to a canonical contract filename, and ratcheted compatibility filename governance from 32 to 31 without dropping coverage.",
+      "risk": "low",
+      "evidence": [
+        "tests/integration/config/test_gold_nullable_numeric_contract.py",
+        "configs/quality/test_governance_audit.yaml",
+        "configs/quality/integration_vcr_policy.yaml",
+        "reports/quality/test-governance-current.json",
+        "tests/architecture/test_test_governance_audit.py"
+      ]
+    },
+    {
+      "issue": "#5346",
+      "theme": "Date-only content-hash compatibility inventory burn-down",
+      "debt_types": [
+        "Determinism risk",
+        "Compatibility debt",
+        "Config debt"
+      ],
+      "action": "Moved four low-risk entity configs from explicit v1_date compatibility to the v2_datetime_utc default and tightened architecture guards so the migrated surfaces cannot silently fall back into the date-only inventory.",
+      "risk": "medium",
+      "evidence": [
+        "configs/entities/crossref/publication.yaml",
+        "configs/entities/openalex/publication.yaml",
+        "configs/entities/semanticscholar/publication.yaml",
+        "configs/entities/uniprot/idmapping.yaml",
+        "configs/quality/determinism_identity_policy.yaml",
+        "tests/architecture/test_content_hash_datetime_policy_inventory.py"
+      ]
+    }
+  ]
+}

--- a/reports/quality/tech-debt-issues-5387-5394-closeout.json
+++ b/reports/quality/tech-debt-issues-5387-5394-closeout.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "tech-debt-issues-5387-5394-closeout-v1",
+  "generated_by": "codex",
+  "snapshot_date": "2026-07-01",
+  "source_ref": "origin/main@438bf67df9981e04e21f897e87d84c8c2aa98636",
+  "issues": [
+    {
+      "number": 5387,
+      "priority": "P0",
+      "type": "Contract drift / governance debt",
+      "status": "closed_by_live_gate",
+      "evidence": [
+        "tests/architecture/test_architecture_quality_scorecard.py::test_architecture_quality_scorecard_module_coverage_evidence_is_consistent",
+        "reports/quality/architecture-quality-scorecard.json",
+        "reports/quality/module-coverage-inventory.json"
+      ],
+      "outcome": "Scorecard module counts and module-coverage hashes are required to match the canonical module coverage inventory."
+    },
+    {
+      "number": 5388,
+      "priority": "P1",
+      "type": "Compatibility debt",
+      "status": "closed_by_ratchet",
+      "evidence": [
+        "tests/architecture/test_compatibility_importer_census_governance.py",
+        "configs/quality/compatibility_facade_inventory.yaml",
+        "reports/quality/compatibility-importer-census.json",
+        "configs/quality/debt_scorecard.yaml#sanctioned_public_entrypoint_governance"
+      ],
+      "outcome": "Retained public entrypoints and export facades remain explicitly inventoried and bounded by no-growth budgets."
+    },
+    {
+      "number": 5389,
+      "priority": "P1",
+      "type": "Architectural violation risk / control-plane hotspot",
+      "status": "closed_by_boundary_evidence",
+      "evidence": [
+        "src/bioetl/application/services/control_plane/{manifest,ledger,replay,effective_config,workflow}",
+        "reports/quality/control-plane-duplication.json",
+        "reports/quality/semantic-ddd-use-case-audit-2026-06-17.md",
+        "reports/quality/hotspot-family-baseline.json"
+      ],
+      "outcome": "Control-plane use-case ownership is represented by explicit owner packages and the control-plane duplication report remains clean."
+    },
+    {
+      "number": 5390,
+      "priority": "P1",
+      "type": "Test debt",
+      "status": "closed_by_zero_review_debt",
+      "evidence": [
+        "reports/quality/vcr-metadata-catalog.json",
+        "tests/architecture/test_vcr_metadata_catalog_drift.py",
+        "tests/architecture/test_vcr_metadata_inventory.py"
+      ],
+      "outcome": "VCR metadata review debt is zero while cassette ownership and duplicate-stem checks remain active."
+    },
+    {
+      "number": 5391,
+      "priority": "P1",
+      "type": "Compatibility debt / contract drift risk",
+      "status": "closed_by_no_growth_taxonomy_ratchet",
+      "evidence": [
+        "configs/quality/debt_scorecard.yaml#parameter_taxonomy",
+        "reports/quality/config-discrepancy-baseline.json",
+        "reports/quality/config-compatibility-legacy-taxonomy-review.json",
+        "tests/architecture/test_config_taxonomy_review.py",
+        "tests/architecture/test_quality_debt_scorecard.py"
+      ],
+      "outcome": "compatibility_legacy taxonomy counts are owner-reviewed and bounded by no-growth budgets."
+    },
+    {
+      "number": 5392,
+      "priority": "P2",
+      "type": "Test debt",
+      "status": "regressed_after_bounded_tail_reduction",
+      "evidence": [
+        "tests/unit/infrastructure/storage/metadata/test_builder_base.py",
+        "reports/coverage/coverage.xml",
+        "reports/quality/module-coverage-inventory.json",
+        "reports/quality/architecture-quality-scorecard.json"
+      ],
+      "coverage_tail_delta": {
+        "before_below_85_module_count": 105,
+        "after_below_85_module_count": 104,
+        "below_85_module_count_delta": -1,
+        "improved_module": "src/bioetl/infrastructure/storage/metadata/builder_base.py",
+        "before_coverage_percent": 54.08,
+        "after_coverage_percent": 87.76
+      },
+      "current_live_coverage": {
+        "below_85_module_count": 51,
+        "uncovered_module_count": 0,
+        "unmeasured_module_count": 0,
+        "improved_module_current_coverage_percent": 87.76,
+        "improved_module_current_status": "partially_covered"
+      },
+      "outcome": "The original bounded improvement remains reflected in the current canonical coverage inventory; the below-85 tail is rebaselined to the live inventory (51 modules) and remains open until paid down further."
+    },
+    {
+      "number": 5393,
+      "priority": "P2",
+      "type": "Duplication / governance debt",
+      "status": "closed_by_visibility_baseline",
+      "evidence": [
+        "reports/quality/full-app-duplication-baseline.json",
+        "reports/quality/full-app-duplication-baseline.md",
+        "tests/architecture/test_duplication_report_governance.py::test_full_app_duplication_baseline_covers_audit_visibility_scope"
+      ],
+      "outcome": "Full-app duplication visibility covers adapters, pipelines, composition bootstrap, and CLI interfaces in report-only baseline mode."
+    },
+    {
+      "number": 5394,
+      "priority": "P2",
+      "type": "Compatibility debt / determinism risk",
+      "status": "closed_by_compatibility_seam_guard",
+      "evidence": [
+        "src/bioetl/application/core/lifecycle/checkpoint_load_validation.py",
+        "src/bioetl/application/services/control_plane/manifest/validation.py",
+        "tests/architecture/test_checkpoint_compatibility_runtime_facade_usage.py",
+        "tests/architecture/test_checkpoint_compatibility_policy_surface.py",
+        "tests/unit/application/services/test_checkpoint_execution_identity_alignment.py"
+      ],
+      "outcome": "Legacy checkpoint metadata hydration is confined to the checkpoint load-validation seam, while manifest creation fails closed on missing canonical config identity anchors."
+    }
+  ],
+  "debt_budget_outcome": "unchanged_or_improved",
+  "notes": [
+    "No technical-debt budgets were increased.",
+    "Coverage-tail evidence improved by representing existing focused tests in the canonical coverage inventory.",
+    "Compatibility surfaces remain bounded by existing no-growth ratchets rather than relaxed."
+  ]
+}

--- a/reports/quality/tech-debt-issues-5395-5401-closeout.json
+++ b/reports/quality/tech-debt-issues-5395-5401-closeout.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "tech-debt-issues-5395-5401-closeout-v1",
+  "snapshot_date": "2026-06-18",
+  "status": "implemented_local_closeable",
+  "budget_policy": "no_growth_ratchet_only",
+  "debt_budget_outcome": "flat",
+  "issues": [
+    {
+      "number": 5395,
+      "theme": "Replay-critical wall-clock seam classification",
+      "status": "closed_by_architecture_registry",
+      "evidence": [
+        "configs/quality/time_seam_classification.yaml",
+        "tests/architecture/test_time_seam_classification.py",
+        "tests/architecture/test_replay_critical_time_seams.py",
+        "tests/architecture/test_replay_time_seam_inventory.py"
+      ],
+      "outcome": "Direct wall-clock calls in src/bioetl are classified as operator_time_allowed or runtime_clock_adapter; replay_time_forbidden has no active exceptions."
+    },
+    {
+      "number": 5396,
+      "theme": "Bounded representative Gold replay golden tests",
+      "status": "closed_by_no_network_golden_fixture",
+      "evidence": [
+        "tests/fixtures/golden/reproducibility/gold_replay_representative_v1.json",
+        "tests/contract/test_gold_replay_golden_fixtures.py",
+        "tests/fixtures/golden/gold/chembl_activity_dq_bundle_v1.json",
+        "tests/fixtures/golden/gold/pubmed_publication_dq_bundle_v1.json",
+        "tests/fixtures/golden/gold/composite_publication_dq_bundle_v1.json"
+      ],
+      "outcome": "Provider, publication, and composite Gold representatives have deterministic output hashes plus manifest, checkpoint, and ledger anchors without live API access."
+    },
+    {
+      "number": 5397,
+      "theme": "Generated artifact drift workflow hardening",
+      "status": "closed_by_workflow_guard",
+      "evidence": [
+        "docs/05-operations/runbooks/generated-artifact-drift-workflow.md",
+        "tests/architecture/test_generated_artifact_drift_workflow.py",
+        "configs/quality/generated_artifact_routing.yaml",
+        "tests/architecture/test_generated_artifact_routing.py"
+      ],
+      "outcome": "Generated-artifact closeout now requires local/CI command parity, a decreased|flat|increased debt outcome, and architecture review rather than budget growth for increases."
+    },
+    {
+      "number": 5398,
+      "theme": "Bronze/Silver/Gold layer contract coverage matrix",
+      "status": "closed_by_layer_matrix",
+      "evidence": [
+        "reports/quality/layer-contract-coverage-matrix.json",
+        "reports/quality/layer-contract-coverage-matrix.md",
+        "tests/architecture/test_layer_contract_coverage_matrix.py",
+        "reports/quality/contract-coverage-matrix.json",
+        "tests/architecture/test_contract_coverage_matrix_integrity.py"
+      ],
+      "outcome": "Each active entity config has Bronze, Silver, and Gold layer rows with strict, moderate, structural_only, or not_applicable coverage classification."
+    },
+    {
+      "number": 5399,
+      "theme": "Quarantine storage payload immutability and status audit trail",
+      "status": "closed_by_storage_level_contract_test",
+      "evidence": [
+        "tests/unit/infrastructure/quarantine/test_unified_quarantine.py::TestUnifiedQuarantineUpdateStatus::test_update_status_only_mutates_status_column",
+        "tests/architecture/test_quarantine_immutability.py",
+        "src/bioetl/infrastructure/quarantine/unified.py"
+      ],
+      "outcome": "Status transitions update only dq_status by payload_hash predicate; stored payload bytes and payload_hash are not rewritten."
+    },
+    {
+      "number": 5400,
+      "theme": "Hotspot family coupling and metrics-driven decomposition",
+      "status": "closed_by_hotspot_family_ratchets",
+      "evidence": [
+        "reports/quality/hotspot-family-baseline.json",
+        "reports/quality/hotspot-family-baseline.md",
+        "tests/architecture/test_hotspot_growth_family_ratchets.py",
+        "tests/architecture/test_hotspot_fan_in_family_ratchets.py",
+        "tests/architecture/test_hotspot_duplication_family_ratchets.py"
+      ],
+      "outcome": "Hotspot-family decomposition remains metrics-driven: budget_warnings=0, no duplicate clusters, and file-growth/fan-in limits are enforced without budget increases."
+    },
+    {
+      "number": 5401,
+      "theme": "Architecture governance mirror synchronization",
+      "status": "closed_by_mirror_evidence_index",
+      "evidence": [
+        "docs/02-architecture/governance-audit-evidence.md",
+        "tests/architecture/test_generated_artifact_drift_workflow.py::test_architecture_governance_evidence_doc_is_mirror_only",
+        "reports/quality/architecture-quality-scorecard.json",
+        "reports/quality/hotspot-family-baseline.json"
+      ],
+      "outcome": "Architecture governance docs point to machine-readable evidence artifacts and explicitly remain mirror-only rather than redefining runtime behavior."
+    }
+  ],
+  "notes": [
+    "No technical-debt budgets were increased.",
+    "New evidence is bounded to docs, tests, configs, and reports; no src/bioetl production code was changed.",
+    "Layer matrix supplements the existing strict Gold contract matrix without replacing its generator or drift gate."
+  ]
+}

--- a/reports/quality/tech-debt-issues-5490-5499-closeout.json
+++ b/reports/quality/tech-debt-issues-5490-5499-closeout.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "tech-debt-issues-5490-5499-closeout-v1",
+  "debt_budget_outcome": "reduced_or_unchanged",
+  "issues": [
+    {
+      "number": 5490,
+      "status": "closed-ready",
+      "summary": "Infrastructure config package-root facade stays on zero first-party growth with issue-specific inventory linkage."
+    },
+    {
+      "number": 5492,
+      "status": "closed-ready",
+      "summary": "Retained composition public export budgets were reduced while compatibility wrappers stayed explicit."
+    },
+    {
+      "number": 5494,
+      "status": "closed-ready",
+      "summary": "Ranked low-tail coverage targets now promote tier violations to blocking under regression-mode governance."
+    },
+    {
+      "number": 5496,
+      "status": "closed-ready",
+      "summary": "Control-plane root now routes through explicit bounded-context seams including the new forensic seam."
+    },
+    {
+      "number": 5497,
+      "status": "closed-ready",
+      "summary": "Runtime Pandera monkeypatching was retired in favor of fail-fast validation for unsupported Python 3.14+ matrices."
+    },
+    {
+      "number": 5499,
+      "status": "closed-ready",
+      "summary": "First-party imports were migrated from bioetl.domain.composite.config to the narrower package-root surface."
+    }
+  ]
+}

--- a/reports/quality/tech-debt-issues-5507-5509-closeout.json
+++ b/reports/quality/tech-debt-issues-5507-5509-closeout.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "tech-debt-issues-5507-5509-closeout-v1",
+  "debt_budget_outcome": "reduced_or_unchanged",
+  "issues": [
+    {
+      "number": 5507,
+      "status": "closed-ready",
+      "summary": "CLI config bootstrap now consumes the shared runtime_builders.config_access owner seam instead of binding infra config loaders directly."
+    },
+    {
+      "number": 5508,
+      "status": "closed-ready",
+      "summary": "Maintenance CLI access now routes through a narrow composition owner seam and no longer keeps maintenance_api alive as a first-party importer chain."
+    },
+    {
+      "number": 5509,
+      "status": "closed-ready",
+      "summary": "Contract policy loading now requires explicit hash and rollout metadata in entity configs, retiring legacy hash and rollout compatibility backfills."
+    }
+  ]
+}

--- a/reports/quality/tech-debt-issues-5510-5516-closeout.json
+++ b/reports/quality/tech-debt-issues-5510-5516-closeout.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "tech-debt-issues-5510-5516-closeout-v1",
+  "reviewed_on": "2026-06-22",
+  "debt_budget_outcome": "reduced_or_unchanged",
+  "issues": [
+    {
+      "number": 5510,
+      "title": "refactor(control-plane): enforce zero-first-party growth for the application control-plane package-root facade",
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/application_control_plane_root_facade_inventory.yaml",
+        "reports/quality/compatibility-importer-census.json",
+        "reports/quality/compatibility-importer-census.md",
+        "tests/architecture/test_public_surface_importer_census_governance.py"
+      ]
+    },
+    {
+      "number": 5511,
+      "title": "refactor(duplication): burn down the low-risk CLI command contract-shell duplication wave",
+      "status": "closed-ready",
+      "evidence": [
+        "reports/quality/full-app-duplication-baseline.json",
+        "reports/quality/full-app-duplication-baseline.md",
+        "src/bioetl/interfaces/cli/commands/domains/shared/public_module_alias.py",
+        "src/bioetl/interfaces/cli/commands/domains/health/command.py",
+        "src/bioetl/interfaces/cli/commands/domains/quarantine/command.py",
+        "src/bioetl/interfaces/cli/commands/domains/diagnostics/command.py",
+        "src/bioetl/interfaces/cli/commands/domains/composite/runtime.py"
+      ]
+    },
+    {
+      "number": 5512,
+      "title": "refactor(duplication): collapse the composition bootstrap runtime wiring duplicates",
+      "status": "closed-ready",
+      "evidence": [
+        "reports/quality/full-app-duplication-baseline.json",
+        "reports/quality/full-app-duplication-baseline.md",
+        "src/bioetl/composition/bootstrap/runtime_public_exports.py",
+        "src/bioetl/composition/bootstrap/__init__.py",
+        "src/bioetl/composition/bootstrap/runtime/__init__.py",
+        "src/bioetl/composition/bootstrap/runtime/_composite_plan_runtime_support.py"
+      ]
+    },
+    {
+      "number": 5513,
+      "title": "test(coverage): finish the tracing low-tail owner tests and close the remaining warn-to-block gap",
+      "status": "closed-ready",
+      "evidence": [
+        "configs/quality/module_coverage_gates.yaml",
+        "tests/unit/infrastructure/observability/test_tracing.py"
+      ]
+    },
+    {
+      "number": 5514,
+      "title": "governance(test): materialize a reviewed flaky-test burndown artifact from test-swarm telemetry",
+      "status": "closed-ready",
+      "evidence": [
+        "reports/quality/flaky-test-burndown-review.json",
+        "reports/test-swarm/SWARM-001/flakiness-database.json",
+        "tests/architecture/test_tech_debt_issues_5514_5515_governance.py"
+      ]
+    },
+    {
+      "number": 5515,
+      "title": "governance(observability): materialize a reviewed unused-event debt artifact and enforce drift checks",
+      "status": "closed-ready",
+      "evidence": [
+        "reports/observability/runtime_cardinality_inventory.json",
+        "reports/observability/runtime_cardinality_review.json",
+        "tests/architecture/test_tech_debt_issues_5514_5515_governance.py"
+      ]
+    },
+    {
+      "number": 5516,
+      "title": "refactor(config/contracts): remove the remaining root-hash selector projection residue from contract_policy_loader",
+      "status": "closed-ready",
+      "evidence": [
+        "src/bioetl/infrastructure/config/contract_policy_loader.py",
+        "tests/unit/infrastructure/config/test_contract_policy_loader.py"
+      ]
+    }
+  ],
+  "metrics": {
+    "control_plane_root_src_importer_count": 0,
+    "cli_duplicate_clusters": 10,
+    "bootstrap_duplicate_clusters": 1,
+    "tier_violation_mode": "block",
+    "tracing_rank1_status": "focused_owner_tests_added",
+    "flaky_total": 0,
+    "unused_declared_observability_events_count": 0,
+    "runtime_cardinality_review_required_count": 0
+  }
+}

--- a/reports/quality/tech-debt-issues-6032-6034-6037-closeout.json
+++ b/reports/quality/tech-debt-issues-6032-6034-6037-closeout.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "tech-debt-issues-6032-6034-6037-closeout-v1",
+  "generated_on": "2026-07-07",
+  "issues": [
+    {
+      "number": 6032,
+      "status": "closeable-local-evidence",
+      "title": "Reduce application_core fan-in saturation before further runtime growth",
+      "evidence": {
+        "hotspot_family_baseline": "reports/quality/hotspot-family-baseline.json",
+        "family": "application_core",
+        "opening_max_internal_fan_in": 10,
+        "current_max_internal_fan_in": 7,
+        "current_max_internal_fan_in_module": "bioetl.application.core.span_helpers",
+        "legacy_hotspot_module": "bioetl.application.core.batch_runtime_failure_policy",
+        "di_guard": "tests/architecture/test_di_runtime_inline_construction.py::test_application_runtime_inline_dependency_construction_is_zero"
+      },
+      "closeout_rationale": "application_core no longer sits at its reviewed max_internal_fan_in budget; operation-only exception consumers now import the narrower batch_operation_errors owner while RF-005 runtime failure-policy users keep their compatibility facade."
+    },
+    {
+      "number": 6034,
+      "status": "closeable-local-evidence",
+      "title": "Tighten composition runtime builder seams and preserve DI-only responsibilities",
+      "evidence": {
+        "hotspot_family_baseline": "reports/quality/hotspot-family-baseline.json",
+        "composition_bootstrap_runtime_current_max_internal_fan_in": 2,
+        "composition_bootstrap_runtime_budget": 3,
+        "composition_runtime_builders_current_max_internal_fan_in": 4,
+        "composition_runtime_builders_budget": 5,
+        "run_manifest_support_internal_importers": 3,
+        "di_guard": "tests/architecture/test_di_runtime_inline_construction.py::test_application_runtime_inline_dependency_construction_is_zero"
+      },
+      "closeout_rationale": "composition_bootstrap_runtime gained actual fan-in headroom below budget, and the opening run_manifest_support builder hotspot dropped to three direct internal importers without growing composition_runtime_builders overall fan-in."
+    },
+    {
+      "number": 6037,
+      "status": "closeable-local-evidence",
+      "title": "Enforce freshness and burn down reviewed runtime import SCCs",
+      "evidence": {
+        "runtime_scc_test": "tests/architecture/test_runtime_import_scc.py",
+        "reviewed_runtime_scc_budget_max": 4,
+        "accepted_runtime_scc_count": 3,
+        "freshness_floor": "2026-07-01",
+        "refreshed_scc_owner": "interfaces.http.control_plane_identity",
+        "refreshed_scc_review_date": "2026-07-07",
+        "refreshed_scc_linked_issue": "#6037"
+      },
+      "closeout_rationale": "runtime SCC acceptances now parse and enforce a freshness floor; the stale control-plane identity SCC acceptance is refreshed under #6037 and the accepted SCC inventory did not grow."
+    }
+  ]
+}

--- a/scripts/check_entity_config_parity.py
+++ b/scripts/check_entity_config_parity.py
@@ -16,6 +16,7 @@ Exit Codes:
 
 # Compatibility wrapper
 
+import re
 import sys
 from pathlib import Path
 
@@ -79,23 +80,14 @@ class ParityChecker:
 
             provider = provider_dir.name
             for spec_file in provider_dir.glob("*spec.md"):
-                # Extract entity from filename (e.g., "05-activity-spec.md" -> "activity")
-                entity = spec_file.stem.replace("-spec", "").split("-")[-1]
-
-                # Handle common naming mismatches
-                entity_mapping = {
-                    "class": "protein_class",
-                    "line": "cell_line",
-                    "parameters": "assay_parameters",
-                    "record": "compound_record",
-                    "component": "target_component",
-                    "term": "publication_term",
-                    "similarity": "publication_similarity",
-                    "fraction": "subcellular_fraction",
-                }
-
-                # Use mapped name if available, otherwise use original
-                mapped_entity = entity_mapping.get(entity, entity)
+                # Extract entity from filename:
+                # "05-activity-spec.md" -> "activity"
+                # "11-target-protein-classification-spec.md" -> "target_protein_classification"
+                stem = spec_file.stem
+                if stem.endswith("-spec"):
+                    stem = stem[: -len("-spec")]
+                stem = re.sub(r"^\d+-", "", stem)
+                mapped_entity = stem.replace("-", "_")
                 specs[(provider, mapped_entity)] = spec_file
 
         return specs

--- a/scripts/engineering/qa/check_dashboard_visual_semantics.py
+++ b/scripts/engineering/qa/check_dashboard_visual_semantics.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 DASHBOARDS_DIR = Path("grafana/dashboards")
+
+# Grafana payloads are recursively heterogeneous JSON.  Keep the dynamic type
+# at this file-format boundary while exposing precise panel collections to the
+# validation helpers below.
+type JsonObject = dict[str, Any]
 
 # Dashboard / panel title identities (python:S1192).
 DASHBOARD_RUNTIME = "bioetl-runtime.json"
@@ -25,12 +31,12 @@ PANEL_MONITOR_MANIFEST_LEDGER_INTEGRITY = "Monitor Manifest & Ledger Failures"
 PANEL_INSPECT_TELEMETRY_MISSING = "Monitor Telemetry Coverage"
 UNTITLED_PANEL_TITLE = "<untitled>"
 
-EXPECTED_STEPS = [
+EXPECTED_STEPS: list[JsonObject] = [
     {"color": "green", "value": None},
     {"color": "orange", "value": 1},
     {"color": "red", "value": 2},
 ]
-EXPECTED_STEPS_BY_PANEL = {
+EXPECTED_STEPS_BY_PANEL: dict[tuple[str, str], list[JsonObject]] = {
     (DASHBOARD_RUNTIME, PANEL_MONITOR_RUNTIME_BLOCKERS): [
         {"color": "green", "value": None},
         {"color": "red", "value": 1},
@@ -46,7 +52,7 @@ EXPECTED_STEPS_BY_PANEL = {
         {"color": "red", "value": 900},
     ],
 }
-EXPECTED_UNKNOWN_MAPPING = {
+EXPECTED_UNKNOWN_MAPPING: JsonObject = {
     "type": "special",
     "options": {"match": "null", "result": {"text": "UNKNOWN", "color": "gray"}},
 }
@@ -82,7 +88,7 @@ SCALAR_TREND_TIMESERIES_PANELS = {
     (DASHBOARD_OVERVIEW_V2, "Gold Lifecycle Trend"),
 }
 ALLOWED_TABLE_CELL_OPTION_TYPES = {"auto", "color-background", "color-text"}
-EXPLICIT_VALUE_MAPPING_STAT_PANELS = {
+EXPLICIT_VALUE_MAPPING_STAT_PANELS: dict[tuple[str, str], JsonObject] = {
     (DASHBOARD_OVERVIEW_V2, "Status"): {
         "0": {"text": "OK", "color": "green"},
         "1": {"text": "WARN", "color": "orange"},
@@ -149,12 +155,12 @@ REQUIRED_TRUST_MARKER_PANELS = {
 }
 
 
-def _grid_pos(panel: dict[str, object]) -> dict[str, object]:
+def _grid_pos(panel: JsonObject) -> JsonObject:
     grid_pos = panel.get("gridPos", {})
     return grid_pos if isinstance(grid_pos, dict) else {}
 
 
-def _grid_rectangles_overlap(left: dict[str, object], right: dict[str, object]) -> bool:
+def _grid_rectangles_overlap(left: JsonObject, right: JsonObject) -> bool:
     left_grid = _grid_pos(left)
     right_grid = _grid_pos(right)
     left_x = int(left_grid.get("x", 0))
@@ -171,7 +177,7 @@ def _grid_rectangles_overlap(left: dict[str, object], right: dict[str, object]) 
 
 
 def _collapsed_row_grid_overlap_errors(
-    dashboard_path: Path, row_panel: dict[str, object]
+    dashboard_path: Path, row_panel: JsonObject
 ) -> list[str]:
     nested_panels = [
         panel for panel in row_panel.get("panels", []) if isinstance(panel, dict)
@@ -189,8 +195,8 @@ def _collapsed_row_grid_overlap_errors(
     return errors
 
 
-def iter_panels(panels: list[dict[str, object]]) -> list[dict[str, object]]:
-    collected: list[dict[str, object]] = []
+def iter_panels(panels: list[JsonObject]) -> list[JsonObject]:
+    collected: list[JsonObject] = []
     for panel in panels:
         if panel.get("type") == "row" and isinstance(panel.get("panels"), list):
             collected.extend(iter_panels(panel["panels"]))
@@ -200,7 +206,7 @@ def iter_panels(panels: list[dict[str, object]]) -> list[dict[str, object]]:
 
 
 def _stat_color_mode_error(
-    dashboard_path: Path, title: str, defaults: dict[str, object]
+    dashboard_path: Path, title: str, defaults: JsonObject
 ) -> str | None:
     if defaults.get("color", {}).get("mode") == "thresholds":
         return None
@@ -208,7 +214,7 @@ def _stat_color_mode_error(
 
 
 def _stat_threshold_steps_error(
-    dashboard_path: Path, title: str, defaults: dict[str, object]
+    dashboard_path: Path, title: str, defaults: JsonObject
 ) -> str | None:
     expected_steps = _expected_threshold_steps(dashboard_path, str(title))
     steps = defaults.get("thresholds", {}).get("steps")
@@ -218,7 +224,10 @@ def _stat_threshold_steps_error(
 
 
 def _stat_unknown_mapping_error(
-    dashboard_path: Path, title: str, panel: dict[str, object], mappings: list
+    dashboard_path: Path,
+    title: str,
+    panel: JsonObject,
+    mappings: list[JsonObject],
 ) -> str | None:
     if not _requires_unknown_mapping(panel):
         return None
@@ -228,7 +237,7 @@ def _stat_unknown_mapping_error(
 
 
 def _stat_background_color_mode_error(
-    dashboard_path: Path, title: str, panel: dict[str, object]
+    dashboard_path: Path, title: str, panel: JsonObject
 ) -> str | None:
     if (dashboard_path.name, str(title)) not in BACKGROUND_SEVERITY_STAT_PANELS:
         return None
@@ -238,7 +247,7 @@ def _stat_background_color_mode_error(
 
 
 def _stat_value_mapping_error(
-    dashboard_path: Path, title: str, mappings: list
+    dashboard_path: Path, title: str, mappings: list[JsonObject]
 ) -> str | None:
     expected_value_mapping = EXPLICIT_VALUE_MAPPING_STAT_PANELS.get(
         (dashboard_path.name, str(title))
@@ -260,7 +269,7 @@ def _stat_value_mapping_error(
 
 
 def _stat_panel_visual_semantics_errors(
-    dashboard_path: Path, panel: dict[str, object]
+    dashboard_path: Path, panel: JsonObject
 ) -> list[str]:
     title = panel.get("title", UNTITLED_PANEL_TITLE)
     defaults = panel.get("fieldConfig", {}).get("defaults", {})
@@ -276,7 +285,7 @@ def _stat_panel_visual_semantics_errors(
 
 
 def _gauge_panel_visual_semantics_errors(
-    dashboard_path: Path, panel: dict[str, object]
+    dashboard_path: Path, panel: JsonObject
 ) -> list[str]:
     title = panel.get("title", UNTITLED_PANEL_TITLE)
     options = panel.get("options", {})
@@ -295,7 +304,7 @@ def _gauge_panel_visual_semantics_errors(
 
 
 def _table_panel_visual_semantics_errors(
-    dashboard_path: Path, panel: dict[str, object]
+    dashboard_path: Path, panel: JsonObject
 ) -> list[str]:
     title = panel.get("title", UNTITLED_PANEL_TITLE)
     field_config = panel.get("fieldConfig", {})
@@ -328,7 +337,7 @@ def _table_panel_visual_semantics_errors(
 
 
 def _timeseries_panel_visual_semantics_errors(
-    dashboard_path: Path, panel: dict[str, object]
+    dashboard_path: Path, panel: JsonObject
 ) -> list[str]:
     title = str(panel.get("title", UNTITLED_PANEL_TITLE))
     tooltip = panel.get("options", {}).get("tooltip", {})
@@ -352,7 +361,7 @@ def _timeseries_panel_visual_semantics_errors(
 
 def _expected_threshold_steps(
     dashboard_path: Path, title: str
-) -> list[dict[str, object]] | None:
+) -> list[JsonObject] | None:
     custom_steps = EXPECTED_STEPS_BY_PANEL.get((dashboard_path.name, title))
     if custom_steps is not None:
         return custom_steps
@@ -361,7 +370,7 @@ def _expected_threshold_steps(
     return None
 
 
-def _requires_unknown_mapping(panel: dict[str, object]) -> bool:
+def _requires_unknown_mapping(panel: JsonObject) -> bool:
     title = str(panel.get("title", ""))
     defaults = panel.get("fieldConfig", {}).get("defaults", {})
     return defaults.get("noValue") == "UNKNOWN" or any(
@@ -369,7 +378,7 @@ def _requires_unknown_mapping(panel: dict[str, object]) -> bool:
     )
 
 
-def _l0_terminology_errors(dashboard_path: Path, panel: dict[str, object]) -> list[str]:
+def _l0_terminology_errors(dashboard_path: Path, panel: JsonObject) -> list[str]:
     if dashboard_path.name not in L0_DASHBOARD_FILES:
         return []
 
@@ -383,14 +392,14 @@ def _l0_terminology_errors(dashboard_path: Path, panel: dict[str, object]) -> li
     ]
 
 
-def _is_status_like_panel(panel: dict[str, object]) -> bool:
+def _is_status_like_panel(panel: JsonObject) -> bool:
     title = str(panel.get("title", "")).lower()
     description = str(panel.get("description", "")).lower()
     return any(token in title or token in description for token in STATUS_PANEL_TOKENS)
 
 
 def _stat_threshold_color_errors(
-    dashboard_path: Path, panel: dict[str, object]
+    dashboard_path: Path, panel: JsonObject
 ) -> list[str]:
     if panel.get("type") != "stat":
         return []
@@ -404,7 +413,7 @@ def _stat_threshold_color_errors(
     return [f"{dashboard_path}: stat panel '{title}' must use color.mode=thresholds"]
 
 
-def _status_panel_errors(dashboard_path: Path, panel: dict[str, object]) -> list[str]:
+def _status_panel_errors(dashboard_path: Path, panel: JsonObject) -> list[str]:
     if panel.get("type") not in {"stat", "gauge"} or not _is_status_like_panel(panel):
         return []
     return _stat_panel_visual_semantics_errors(
@@ -412,7 +421,7 @@ def _status_panel_errors(dashboard_path: Path, panel: dict[str, object]) -> list
     ) + _l0_terminology_errors(dashboard_path, panel)
 
 
-def _panel_type_errors(dashboard_path: Path, panel: dict[str, object]) -> list[str]:
+def _panel_type_errors(dashboard_path: Path, panel: JsonObject) -> list[str]:
     panel_type = panel.get("type")
     if panel_type == "gauge":
         return _gauge_panel_visual_semantics_errors(dashboard_path, panel)
@@ -423,7 +432,7 @@ def _panel_type_errors(dashboard_path: Path, panel: dict[str, object]) -> list[s
     return []
 
 
-def _panel_expressions(panel: dict[str, object]) -> list[str]:
+def _panel_expressions(panel: JsonObject) -> list[str]:
     return [
         str(target.get("expr", ""))
         for target in panel.get("targets", [])
@@ -432,7 +441,7 @@ def _panel_expressions(panel: dict[str, object]) -> list[str]:
 
 
 def _fail_closed_panel_errors(
-    dashboard_path: Path, panel: dict[str, object], expected_no_value: str | None
+    dashboard_path: Path, panel: JsonObject, expected_no_value: str | None
 ) -> list[str]:
     if expected_no_value is None:
         return []
@@ -452,7 +461,7 @@ def _fail_closed_panel_errors(
     return errors
 
 
-def _panel_errors(dashboard_path: Path, panel: dict[str, object]) -> list[str]:
+def _panel_errors(dashboard_path: Path, panel: JsonObject) -> list[str]:
     title = str(panel.get("title", ""))
     panel_key = (dashboard_path.name, title)
     expected_no_value = FAIL_CLOSED_NO_ZERO_FALLBACK_PANELS.get(panel_key)
@@ -464,7 +473,9 @@ def _panel_errors(dashboard_path: Path, panel: dict[str, object]) -> list[str]:
     )
 
 
-def _collapsed_row_errors(dashboard_path: Path, panels: list) -> list[str]:
+def _collapsed_row_errors(
+    dashboard_path: Path, panels: list[JsonObject]
+) -> list[str]:
     return [
         error
         for panel in panels
@@ -473,14 +484,16 @@ def _collapsed_row_errors(dashboard_path: Path, panels: list) -> list[str]:
     ]
 
 
-def _trust_marker_is_above_fold(panel: dict[str, object]) -> bool:
+def _trust_marker_is_above_fold(panel: JsonObject) -> bool:
     grid_pos = panel.get("gridPos", {})
     # Trust markers must stay on the first screen, including the dedicated
     # first-screen evidence row used by the Runtime dashboard at y=23.
     return isinstance(grid_pos, dict) and int(grid_pos.get("y", 999)) <= 23
 
 
-def _trust_marker_panel_errors(dashboard_path: Path, panels: list) -> list[str]:
+def _trust_marker_panel_errors(
+    dashboard_path: Path, panels: list[JsonObject]
+) -> list[str]:
     required_panels = REQUIRED_TRUST_MARKER_PANELS.get(dashboard_path.name, set())
     if not required_panels:
         return []
@@ -501,8 +514,8 @@ def _trust_marker_panel_errors(dashboard_path: Path, panels: list) -> list[str]:
 
 
 def _dashboard_errors(dashboard_path: Path) -> list[str]:
-    payload = json.loads(dashboard_path.read_text(encoding="utf-8"))
-    panels = payload.get("panels", [])
+    payload = cast(JsonObject, json.loads(dashboard_path.read_text(encoding="utf-8")))
+    panels = cast(list[JsonObject], payload.get("panels", []))
     errors = [
         error
         for panel in iter_panels(panels)

--- a/scripts/ops/observability/grafana/_apply_ds2_all.py
+++ b/scripts/ops/observability/grafana/_apply_ds2_all.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 from pathlib import Path
+from typing import Any, Iterator, cast
 
 ROOT = Path(__file__).resolve().parents[4]
 DASH = ROOT / "grafana" / "dashboards"
@@ -17,20 +18,25 @@ DASHBOARD_CONTROL_PLANE_V1 = "bioetl-control-plane-v1.json"
 PANEL_PRIMARY_RECOVERY = "Review First Recovery Action"
 PANEL_NEXT_ACTION_REPLAY_DIAGNOSTICS = "Next Action: Replay Diagnostics"
 
+# Grafana dashboards are recursively heterogeneous JSON documents.  This
+# script intentionally mutates that external boundary in place, so ``Any`` is
+# confined to the JSON object alias instead of leaking into product code.
+type JsonObject = dict[str, Any]
 
-def walk(panels):
+
+def walk(panels: list[JsonObject] | None) -> Iterator[JsonObject]:
     for p in panels or []:
         yield p
         yield from walk(p.get("panels"))
 
 
-def load_dash(name: str) -> dict[str, object]:
+def load_dash(name: str) -> JsonObject:
     path = DASH / name
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = cast(JsonObject, json.loads(path.read_text(encoding="utf-8")))
     return data
 
 
-def save_dash(name: str, data: dict[str, object]) -> None:
+def save_dash(name: str, data: JsonObject) -> None:
     path = DASH / name
     path.write_text(
         json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
@@ -136,7 +142,7 @@ def fix_runtime() -> None:
     print("runtime 9105 OK", p9105["type"], p9105["title"])
 
 
-def _incident_status_mappings() -> list[dict[str, object]]:
+def _incident_status_mappings() -> list[JsonObject]:
     return [
         {
             "type": "value",
@@ -157,7 +163,7 @@ def _incident_status_mappings() -> list[dict[str, object]]:
     ]
 
 
-def _incident_status_thresholds() -> dict[str, object]:
+def _incident_status_thresholds() -> JsonObject:
     return {
         "mode": "absolute",
         "steps": [
@@ -169,7 +175,7 @@ def _incident_status_thresholds() -> dict[str, object]:
     }
 
 
-def _incident_value_override() -> dict[str, object]:
+def _incident_value_override() -> JsonObject:
     return {
         "matcher": {
             "id": "byRegexp",
@@ -197,7 +203,7 @@ def _incident_value_override() -> dict[str, object]:
 
 
 def _fix_incident_table(
-    panel: dict[str, object], *, value_override: dict[str, object]
+    panel: JsonObject, *, value_override: JsonObject
 ) -> None:
     fc = panel.setdefault("fieldConfig", {})
     defaults = fc.setdefault("defaults", {})
@@ -209,7 +215,7 @@ def _fix_incident_table(
     fc["overrides"] = [deepcopy(value_override)]
 
 
-def _apply_incident_status_panel(panel: dict[str, object]) -> None:
+def _apply_incident_status_panel(panel: JsonObject) -> None:
     defaults = panel.setdefault("fieldConfig", {}).setdefault("defaults", {})
     defaults["mappings"] = _incident_status_mappings()
     defaults["thresholds"] = _incident_status_thresholds()
@@ -244,7 +250,7 @@ def _incident_handoff_urls() -> dict[int, str]:
     }
 
 
-def _apply_incident_handoffs(by_id: dict[str, object]) -> None:
+def _apply_incident_handoffs(by_id: dict[int, JsonObject]) -> None:
     for pid, url in _incident_handoff_urls().items():
         if pid not in by_id:
             continue
@@ -254,7 +260,7 @@ def _apply_incident_handoffs(by_id: dict[str, object]) -> None:
         ]
 
 
-def _incident_domain_links() -> list[dict[str, object]]:
+def _incident_domain_links() -> list[JsonObject]:
     return [
         {
             "title": "Open Pipeline Diagnostics",
@@ -298,7 +304,7 @@ def _incident_domain_links() -> list[dict[str, object]]:
     ]
 
 
-def _ranked_suspects_panel(*, value_override: dict[str, object]) -> dict[str, object]:
+def _ranked_suspects_panel(*, value_override: JsonObject) -> JsonObject:
     return {
         "id": 2010,
         "type": "table",
@@ -400,9 +406,9 @@ def _ranked_suspects_panel(*, value_override: dict[str, object]) -> dict[str, ob
 
 
 def _layout_incident_core_panels(
-    by_id: dict[str, object],
+    by_id: dict[int, JsonObject],
     *,
-    value_override: dict[str, object],
+    value_override: JsonObject,
 ) -> None:
     """Apply grid positions and NBA content for core incident panels."""
     nav = by_id.get(1000)
@@ -439,9 +445,9 @@ def _layout_incident_core_panels(
 
 
 def _incident_detail_row(
-    by_id: dict[str, object], *, value_override: dict[str, object]
-) -> dict[str, object]:
-    detail_row = {
+    by_id: dict[int, JsonObject], *, value_override: JsonObject
+) -> JsonObject:
+    detail_row: JsonObject = {
         "id": 2099,
         "type": "row",
         "title": "Domain suspect detail (forensics)",
@@ -567,14 +573,14 @@ def fix_trust() -> None:
     print("trust OK")
 
 
-def _append_desc_note(panel: dict[str, object], *, marker: str, note: str) -> None:
+def _append_desc_note(panel: JsonObject, *, marker: str, note: str) -> None:
     """Append a description note when the marker is not already present."""
     desc = panel.get("description") or ""
     if marker not in desc:
         panel["description"] = (desc + note).strip()
 
 
-def _fix_dq_panels(dq: dict[str, object]) -> None:
+def _fix_dq_panels(dq: JsonObject) -> None:
     for panel in walk(dq.get("panels")):
         if panel.get("title") == "Status" and panel.get("type") == "stat":
             _append_desc_note(
@@ -599,7 +605,7 @@ def _fix_dq_panels(dq: dict[str, object]) -> None:
             )
 
 
-def _is_fleet_matrix_panel(panel: dict[str, object]) -> bool:
+def _is_fleet_matrix_panel(panel: JsonObject) -> bool:
     title = panel.get("title") or ""
     if panel.get("type") not in {"table", "bargauge"}:
         return False
@@ -609,7 +615,7 @@ def _is_fleet_matrix_panel(panel: dict[str, object]) -> bool:
     return y <= 25
 
 
-def _provider_context_link() -> dict[str, object]:
+def _provider_context_link() -> JsonObject:
     return {
         "title": "Open selected provider context",
         "url": (
@@ -622,7 +628,7 @@ def _provider_context_link() -> dict[str, object]:
     }
 
 
-def _fix_provider_health_panels(ph: dict[str, object]) -> None:
+def _fix_provider_health_panels(ph: JsonObject) -> None:
     for panel in walk(ph.get("panels")):
         if not _is_fleet_matrix_panel(panel):
             continue
@@ -656,7 +662,7 @@ _RUN_EXPLORER_GUIDE_CONTENT = (
 
 
 def _shift_run_explorer_panels(
-    run_explorer: dict[str, object], *, delta_y: int = 3
+    run_explorer: JsonObject, *, delta_y: int = 3
 ) -> None:
     for panel in run_explorer.get("panels") or []:
         grid_pos = panel.get("gridPos") or {}
@@ -664,13 +670,13 @@ def _shift_run_explorer_panels(
             grid_pos["y"] = int(grid_pos["y"]) + delta_y
 
 
-def _fix_run_explorer_panels(run_explorer: dict[str, object]) -> None:
+def _fix_run_explorer_panels(run_explorer: JsonObject) -> None:
     for panel in run_explorer.get("panels") or []:
         if panel.get("id") == 1 and panel.get("type") == "text":
             panel.setdefault("options", {})["mode"] = "markdown"
             panel["options"]["content"] = _RUN_EXPLORER_BROWSE_CONTENT
             return
-    guide = {
+    guide: JsonObject = {
         "id": 9405,
         "type": "text",
         "title": "Browse · Selected run",

--- a/scripts/ops/observability/grafana/_apply_ds2_all.py
+++ b/scripts/ops/observability/grafana/_apply_ds2_all.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, cast
 
 ROOT = Path(__file__).resolve().parents[4]
 DASH = ROOT / "grafana" / "dashboards"
@@ -101,8 +102,9 @@ def fix_runtime() -> None:
                 "tooltip": {"mode": "multi", "sort": "desc"},
             }
         if p.get("id") == 9991 or str(p.get("title") or "").startswith("First Action"):
-            p.setdefault("options", {})["mode"] = "markdown"
-            p["options"]["content"] = (
+            options = cast(JsonObject, p.setdefault("options", {}))
+            options["mode"] = "markdown"
+            options["content"] = (
                 "**Next best actions**\n"
                 "1. Read **Status** + Metrics Evidence (confidence) before treating OK as final.\n"
                 "2. Localize via **Aggregate Stage Lag** + Runtime Blockers.\n"

--- a/src/bioetl/application/services/control_plane/manifest/diagnostics/base.py
+++ b/src/bioetl/application/services/control_plane/manifest/diagnostics/base.py
@@ -17,8 +17,14 @@ from bioetl.application.services.control_plane.manifest.diagnostics.base_replay_
 )
 from bioetl.application.services.control_plane.manifest.diagnostics.checkpoint_projection import (
     build_checkpoint_anchor_projection as _build_checkpoint_anchor_projection,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.checkpoint_projection import (
     build_current_checkpoint_anchor_payload as _build_current_checkpoint_anchor_payload,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.checkpoint_projection import (
     build_resume_anchor_comparison as _build_resume_anchor_comparison,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.checkpoint_projection import (
     resolve_resume_identity_maps as _resolve_resume_identity_maps,
 )
 from bioetl.application.services.control_plane.manifest.diagnostics.summary_support import (

--- a/src/bioetl/application/services/control_plane/manifest/diagnostics/base_payload_sections.py
+++ b/src/bioetl/application/services/control_plane/manifest/diagnostics/base_payload_sections.py
@@ -27,7 +27,11 @@ from bioetl.application.services.control_plane.manifest.diagnostics.snapshot_sta
 )
 from bioetl.application.services.control_plane.manifest.diagnostics.snapshot_support import (
     collect_input_snapshot_content_hashes as _collect_input_snapshot_content_hashes,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.snapshot_support import (
     collect_input_snapshot_ids as _collect_input_snapshot_ids,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.snapshot_support import (
     compute_input_snapshot_identity_fingerprint as _compute_input_snapshot_identity_fingerprint,
 )
 from bioetl.application.services.control_plane.manifest.replay_family_contract_payload import (

--- a/src/bioetl/application/services/control_plane/manifest/diagnostics/replay_invariants/replay_blockers.py
+++ b/src/bioetl/application/services/control_plane/manifest/diagnostics/replay_invariants/replay_blockers.py
@@ -9,8 +9,14 @@ from bioetl.application.services.control_plane.manifest.diagnostics.replay_invar
 )
 from bioetl.application.services.control_plane.run_manifest_exact_replay_blockers import (
     append_mode_exact_replay_blockers as _append_mode_exact_replay_blockers,
+)
+from bioetl.application.services.control_plane.run_manifest_exact_replay_blockers import (
     dependency_lock_exact_replay_blockers as _dependency_lock_exact_replay_blockers,
+)
+from bioetl.application.services.control_plane.run_manifest_exact_replay_blockers import (
     profile_exact_replay_blockers as _profile_exact_replay_blockers,
+)
+from bioetl.application.services.control_plane.run_manifest_exact_replay_blockers import (
     snapshot_exact_replay_blockers as _snapshot_exact_replay_blockers,
 )
 from bioetl.domain.control_plane import ReplayCapability, RunManifest

--- a/src/bioetl/application/services/control_plane/manifest/diagnostics/summary.py
+++ b/src/bioetl/application/services/control_plane/manifest/diagnostics/summary.py
@@ -17,8 +17,14 @@ from bioetl.application.services.control_plane.manifest.diagnostics.composite_pr
 )
 from bioetl.application.services.control_plane.manifest.diagnostics.summary_support import (
     build_exact_replay_anchors as _build_exact_replay_anchors,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.summary_support import (
     build_final_summary_updates as _build_final_summary_updates,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.summary_support import (
     build_identity_graph as _build_identity_graph,
+)
+from bioetl.application.services.control_plane.manifest.diagnostics.summary_support import (
     build_runtime_views as _build_runtime_views,
 )
 from bioetl.domain.control_plane import RunLedgerEntry, RunManifest

--- a/src/bioetl/application/services/control_plane/manifest/inspection_service.py
+++ b/src/bioetl/application/services/control_plane/manifest/inspection_service.py
@@ -20,10 +20,20 @@ from bioetl.application.services.control_plane.manifest.inspection_helpers impor
 )
 from bioetl.application.services.control_plane.manifest.inspection_models import (
     _RUN_MANIFEST_INSPECTION_MODEL_EXPORTS as _RUN_MANIFEST_INSPECTION_MODEL_EXPORTS,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     RunManifestDiffEntry as RunManifestDiffEntry,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     RunManifestDiffResult as RunManifestDiffResult,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     RunManifestInspectionCorruptionError as RunManifestInspectionCorruptionError,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     RunManifestInspectionResult as RunManifestInspectionResult,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     RunManifestVerifyResult as RunManifestVerifyResult,
 )
 from bioetl.application.services.control_plane.manifest.inspection_verification import (

--- a/src/bioetl/application/services/control_plane/manifest/inspection_verification.py
+++ b/src/bioetl/application/services/control_plane/manifest/inspection_verification.py
@@ -14,10 +14,20 @@ from bioetl.application.services.control_plane.manifest.inspection_helpers impor
 )
 from bioetl.application.services.control_plane.manifest.inspection_models import (
     effective_config_artifact_anchor as _effective_config_artifact_anchor,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     effective_config_missing_evidence as _effective_config_missing_evidence,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     json_equal as json_equal,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     manifest_effective_config_anchor as _manifest_effective_config_anchor,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     parse_run_id as parse_run_id,
+)
+from bioetl.application.services.control_plane.manifest.inspection_models import (
     resolve_verify_verdict as resolve_verify_verdict,
 )
 from bioetl.domain.control_plane import RunManifest

--- a/src/bioetl/application/services/control_plane/replay/_historical_certification_support.py
+++ b/src/bioetl/application/services/control_plane/replay/_historical_certification_support.py
@@ -11,7 +11,11 @@ from bioetl.application.services.control_plane.ledger.service import (
 )
 from bioetl.application.services.control_plane.replay._historical_certification_models import (
     HistoricalReplayCertificationProtocol as HistoricalReplayCertificationProtocol,
+)
+from bioetl.application.services.control_plane.replay._historical_certification_models import (
     HistoricalReplayCertificationResult as HistoricalReplayCertificationResult,
+)
+from bioetl.application.services.control_plane.replay._historical_certification_models import (
     HistoricalReplayCertificationResultAssembler as HistoricalReplayCertificationResultAssembler,
 )
 from bioetl.application.services.control_plane.replay._historical_certification_models import (

--- a/src/bioetl/application/services/control_plane/replay/historical_corpus_service.py
+++ b/src/bioetl/application/services/control_plane/replay/historical_corpus_service.py
@@ -13,9 +13,17 @@ from bioetl.application.services.control_plane.replay.historical_certification_s
 )
 from bioetl.application.services.control_plane.replay.historical_corpus_models import (
     HistoricalReplayBulkCertificationRecord as HistoricalReplayBulkCertificationRecord,
+)
+from bioetl.application.services.control_plane.replay.historical_corpus_models import (
     HistoricalReplayBulkCertificationResult as HistoricalReplayBulkCertificationResult,
+)
+from bioetl.application.services.control_plane.replay.historical_corpus_models import (
     HistoricalReplayBulkCertificationSpec as HistoricalReplayBulkCertificationSpec,
+)
+from bioetl.application.services.control_plane.replay.historical_corpus_models import (
     HistoricalReplayCertifiabilityInventory as HistoricalReplayCertifiabilityInventory,
+)
+from bioetl.application.services.control_plane.replay.historical_corpus_models import (
     HistoricalReplayCertifiabilityRecord as HistoricalReplayCertifiabilityRecord,
 )
 from bioetl.application.services.control_plane.replay.historical_corpus_policy import (

--- a/src/bioetl/application/services/control_plane/replay/reproducibility_score_cards_categories.py
+++ b/src/bioetl/application/services/control_plane/replay/reproducibility_score_cards_categories.py
@@ -4,19 +4,38 @@ from __future__ import annotations
 
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     CATEGORY_SCORER_EXPORTS as _CATEGORY_SCORER_EXPORTS,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_checkpoint_safety as score_checkpoint_safety,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_determinism as score_determinism,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_idempotency as score_idempotency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_layer_consistency as score_layer_consistency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_lineage_completeness as score_lineage_completeness,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_replay_readiness as score_replay_readiness,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
     score_run_identity as score_run_identity,
 )
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_types import (
     PROFILE_SCORE_THRESHOLDS as PROFILE_SCORE_THRESHOLDS,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_types import (
     JsonDict as JsonDict,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_types import (
     ScoreCardRecord as ScoreCardRecord,
 )
+
 __all__ = [
     "PROFILE_SCORE_THRESHOLDS",
     "JsonDict",

--- a/src/bioetl/application/services/control_plane/replay/reproducibility_score_cards_category_scores.py
+++ b/src/bioetl/application/services/control_plane/replay/reproducibility_score_cards_category_scores.py
@@ -4,15 +4,26 @@ from __future__ import annotations
 
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_core import (
     score_checkpoint_safety as score_checkpoint_safety,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_core import (
     score_determinism as score_determinism,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_core import (
     score_idempotency as score_idempotency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_core import (
     score_run_identity as score_run_identity,
 )
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_extended import (
     score_layer_consistency as score_layer_consistency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_extended import (
     score_lineage_completeness as score_lineage_completeness,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores_extended import (
     score_replay_readiness as score_replay_readiness,
 )
+
 # Shared public scorer export names — also consumed by run-manifest score-card
 # facade so the export roster is defined once (R0801 residual, issue #7398).
 CATEGORY_SCORER_EXPORTS: tuple[str, ...] = (

--- a/src/bioetl/application/services/control_plane/run_manifest_reproducibility_score_cards.py
+++ b/src/bioetl/application/services/control_plane/run_manifest_reproducibility_score_cards.py
@@ -10,13 +10,29 @@ from bioetl.application.services.control_plane.replay.reproducibility_score_card
 )
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     PROFILE_SCORE_THRESHOLDS as PROFILE_SCORE_THRESHOLDS,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     ScoreCardRecord as ScoreCardRecord,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_checkpoint_safety as score_checkpoint_safety,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_determinism as score_determinism,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_idempotency as score_idempotency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_layer_consistency as score_layer_consistency,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_lineage_completeness as score_lineage_completeness,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_replay_readiness as score_replay_readiness,
+)
+from bioetl.application.services.control_plane.replay.reproducibility_score_cards_categories import (
     score_run_identity as score_run_identity,
 )
 from bioetl.application.services.control_plane.replay.reproducibility_score_cards_category_scores import (
@@ -24,8 +40,11 @@ from bioetl.application.services.control_plane.replay.reproducibility_score_card
 )
 from bioetl.application.services.control_plane.run_manifest_reproducibility_claims import (
     build_executable_run_contract_claim as build_executable_run_contract_claim,
+)
+from bioetl.application.services.control_plane.run_manifest_reproducibility_claims import (
     build_historical_replay_universe_exact_replay_claim as build_historical_replay_universe_exact_replay_claim,
 )
+
 JsonDict = dict[str, object]
 __all__ = [
     "PROFILE_SCORE_THRESHOLDS",


### PR DESCRIPTION
## Summary

Tech-debt audit **Cycle 2**.

Fixes #7400 (partial/major): restore missing architecture closeout evidence artifacts and re-align issue-6062 retained lazy-import inventory with live `gold_writer.delta_table`.

Also supports residual verification for #7418 (ruff I001 on control_plane currently clean on this branch).

## Test plan
- [x] `pytest tests/architecture/test_tech_debt_issues_6032_6034_6037_closeout.py`
- [x] `pytest tests/architecture/test_tech_debt_issue_6062_closeout.py`
- [x] `ruff check .../control_plane --select I`
