### PR TITLE
chore(tests): refresh governance source hash

### DIFF
--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "c3da7e97639ab066df55ba8ea262a73963a47984470cdb2747352286209208da"
+    "test_governance_source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "c3da7e97639ab066df55ba8ea262a73963a47984470cdb2747352286209208da",
+    "test_governance_source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf",
     "total_flaky": 0,
     "total_test_files": 2175,
     "total_tests_analyzed": 23326

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2360,7 +2360,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "c3da7e97639ab066df55ba8ea262a73963a47984470cdb2747352286209208da",
+  "source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,


### PR DESCRIPTION
## Summary

Refresh the committed test-governance source-tree fingerprint and synchronize the downstream flaky-test burndown evidence.

Closes #7425.

## Root cause

`reports/quality/test-governance-current.json` was generated before the final test-source content at `1edb3df` was committed. Test counts were already correct, but the committed `source_tree_sha256` did not match the live collector. The flaky-test review embeds that fingerprint and therefore also required synchronization.

## Changes

- refresh `reports/quality/test-governance-current.json::source_tree_sha256`
- refresh both matching fingerprint fields in `reports/quality/flaky-test-burndown-review.json`
- preserve all suite counts, zero-growth budgets, and flaky-test totals unchanged

## Validation

- `python -m scripts.engineering.qa.refresh_test_governance_baseline --check`: PASS
- `python -m scripts.engineering.qa.report_test_governance_audit --check`: PASS
- `python -m scripts.engineering.qa report-flaky-test-burndown-review --check`: PASS
- `python -m scripts.engineering.qa report-debt-governance-gates --check`: PASS
- `python -m scripts.engineering.qa check-exemptions`: PASS, score 100.0, total 0/0
- targeted consumer suite: PASS, 78 tests
- `git diff --check`: PASS

Targeted suite covered:

- the complete `tests/architecture/test_test_governance_audit.py`
- flaky-burndown unit and architecture consumers
- ADR enforcement matrix drift guard
- cached-Bronze pipeline-factory regression guard

## Governance impact

- Technical debt: unchanged
- New exemptions: none
- Budget/threshold increases: none
- Runtime behavior: unchanged
- Documentation/runtime mirrors: not applicable
- `.env` surfaces: untouched
