### PR TITLE
chore(tests): refresh post-merge governance hash

### DIFF
--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf"
+    "test_governance_source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf",
+    "test_governance_source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0",
     "total_flaky": 0,
     "total_test_files": 2175,
     "total_tests_analyzed": 23326

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2360,7 +2360,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "4eeaf3fec4eafca2d00024f278eab0a681b2762fa779ba9a6b8a1eb01d24dabf",
+  "source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,


### PR DESCRIPTION
## Summary

Refresh the test-governance source-tree fingerprint against the actual merged `main` tip and synchronize the downstream flaky-test review.

Closes #7425.
Follow-up to #7475.

## Root cause

While #7475 was awaiting review, `main` advanced with commit `2ea182b63e`, which changed `tests/unit/memory/test_tooling.py`. The first refresh was correct for its validated base, but its hash was stale by the time GitHub merged it onto the newer base. Post-merge verification caught the mismatch immediately and #7425 was reopened.

## Changes

- refresh `test-governance-current.json::source_tree_sha256` from `4eeaf3fe…` to `f1e70dd7…`
- synchronize both flaky-test burndown fingerprint fields
- leave test counts, flaky totals, and debt budgets unchanged

## Validation

- `report_test_governance_audit --check`: PASS
- `report-flaky-test-burndown-review --check`: PASS
- `report-debt-governance-gates --check`: PASS
- targeted consumer suite: PASS, 78 tests
- `git diff --check`: PASS
- technical-debt outcome: unchanged; no exemptions or budget increases

## Delivery safeguard

Before merge, the current `main` SHA and intervening test-tree diff will be checked again. After merge, the live generator will be executed on merged `origin/main` before #7425 is considered complete.
