### PR TITLE
fix(governance): refresh clean LFS closeout evidence

### DIFF
--- a/reports/quality/config-contract-registry-artifact-duplication.json
+++ b/reports/quality/config-contract-registry-artifact-duplication.json
@@ -47,7 +47,6 @@
     "reports/quality/*ownership*.json": 2,
     "reports/quality/*ownership*.md": 1,
     "reports/quality/*registry*.json": 3,
-    "reports/quality/*registry*.md": 1,
     "tests/fixtures/contracts/**/*.json": 7,
     "tests/fixtures/contracts/**/*.yaml": 1,
     "tests/fixtures/golden/**/*.json": 30
@@ -60,9 +59,9 @@
     "contract": 47,
     "golden": 27,
     "quality_report": 9,
-    "registry": 26
+    "registry": 25
   },
-  "total_files": 291,
+  "total_files": 290,
   "tracked_extensions": [
     ".csv",
     ".json",

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0"
+    "test_governance_source_tree_sha256": "f0b5f57cb31140731b820afd0b516176491b6c28d9d85e75bd134b8a89bac3f1"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0",
+    "test_governance_source_tree_sha256": "f0b5f57cb31140731b820afd0b516176491b6c28d9d85e75bd134b8a89bac3f1",
     "total_flaky": 0,
     "total_test_files": 2175,
     "total_tests_analyzed": 23326

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2360,7 +2360,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "f1e70dd7bb97c9aed94dec398e0e4a846edd8fbd9f9a9d7f23cfe5ffff48fec0",
+  "source_tree_sha256": "f0b5f57cb31140731b820afd0b516176491b6c28d9d85e75bd134b8a89bac3f1",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 106,


### PR DESCRIPTION
## Summary

- rebind `test-governance-current.json` to the clean checkout with real Git LFS fixtures
- refresh the dependent flaky-test burndown fingerprint (`total_flaky = 0`)
- refresh config/contract/registry duplication evidence from a clean tree (`duplicate_groups = 0`, `total_files: 291 -> 290`)

This completes the post-merge governance evidence needed for #7410, #7468, #7470, and #7474. #7452 is absorbed by #7474.

## Validation

- `python -m scripts.engineering.qa report-artifact-duplication-audit --check`
- `python -m scripts.engineering.qa report-flaky-test-burndown-review --check`
- `python -m scripts.engineering.qa report-dep-map --check`
- `python -m scripts.engineering.repo check-inventory --check --manifest configs/quality/scripts_inventory_manifest.json --check-lifecycle --forbid-evaluate-active --lifecycle-registry configs/quality/scripts_lifecycle_registry.json`
- `python -m scripts.engineering.qa report-architecture-debt-remote-main-baseline --check`
- LFS-aware `report_test_governance_audit --check`
- targeted architecture/unit suite: 52 passed

Debt budgets, exemptions, ratchets, and thresholds are unchanged.