### PR TITLE
fix(ci): rebind inventory + artifact-duplication audit (CI-C1)

### DIFF
--- a/reports/quality/config-contract-registry-artifact-duplication.json
+++ b/reports/quality/config-contract-registry-artifact-duplication.json
@@ -47,6 +47,7 @@
     "reports/quality/*ownership*.json": 2,
     "reports/quality/*ownership*.md": 1,
     "reports/quality/*registry*.json": 3,
+    "reports/quality/*registry*.md": 1,
     "tests/fixtures/contracts/**/*.json": 7,
     "tests/fixtures/contracts/**/*.yaml": 1,
     "tests/fixtures/golden/**/*.json": 30
@@ -59,9 +60,9 @@
     "contract": 47,
     "golden": 27,
     "quality_report": 9,
-    "registry": 25
+    "registry": 26
   },
-  "total_files": 290,
+  "total_files": 291,
   "tracked_extensions": [
     ".csv",
     ".json",


### PR DESCRIPTION
## Summary
Cycle 1 of CI audit 3-cycle program (`CI-C1-001`, `CI-C1-002`).

### Findings
| ID | Issue | Fix |
| --- | --- | --- |
| CI-C1-001 | #7480 scripts inventory reference drift | regenerate `configs/quality/scripts_inventory_manifest.json` (local commit `c875e0a0d1`; **inventory may still need full push if only partial is on remote**) |
| CI-C1-002 | #7481 artifact-duplication drift | regenerate `reports/quality/config-contract-registry-artifact-duplication.json` (remote `c62327fa`) |

### Acceptance
- [ ] `check-inventory --check` exit 0
- [ ] `report-artifact-duplication-audit --check` exit 0
- [ ] Tests `governance-preflight` inventory + duplication steps green

### Notes
- No debt budget increases
- No exemptions added
- Architecture layers not changed