### PR TITLE
fix(ci): ignore transient docs link report in cleanup inventory

### DIFF
--- a/scripts/docs/checks/documentation_cleanup_inventory.py
+++ b/scripts/docs/checks/documentation_cleanup_inventory.py
@@ -159,6 +159,11 @@ SKIP_TEXT_SCAN_PATHS = {
     "reports/merged_output.txt",
     "reports/project_structure.md",
 }
+# CI writes this ignored report immediately before running the cleanup inventory
+# check. It is a transient upload artifact, not a local documentation surface.
+LOCAL_DOC_REPORT_SCAN_EXCLUSIONS = {
+    "docs/reports/docs-link-check-report.json",
+}
 SKIP_TEXT_SCAN_SUFFIXES = {".csv", EXT_JSON}
 MAX_LOCAL_DOC_REPORT_FILES = 25_000
 QUARANTINED_PATH_MARKERS = (
@@ -227,6 +232,8 @@ def _handle_scan_entry(
     """Process one scandir entry. Return False when the file limit is exceeded."""
     entry_path = Path(entry.path)
     relative = _repo_relative(entry_path)
+    if relative in LOCAL_DOC_REPORT_SCAN_EXCLUSIONS:
+        return True
     try:
         if entry.is_dir(follow_symlinks=False):
             if _is_quarantined_path(relative):
@@ -237,9 +244,7 @@ def _handle_scan_entry(
         if entry.is_file(follow_symlinks=False) and _is_doc_like(relative):
             paths.append(relative)
             if len(paths) > MAX_LOCAL_DOC_REPORT_FILES:
-                errors.append(
-                    _scan_error(root_relative, "LocalScanFileLimitExceeded")
-                )
+                errors.append(_scan_error(root_relative, "LocalScanFileLimitExceeded"))
                 return False
     except OSError as error:
         errors.append(_scan_error(relative, error.__class__.__name__))
@@ -582,9 +587,7 @@ def _outgoing_links(text: str) -> list[str]:
         # Split scheme prefixes so S5332 does not flag this filter itself.
         _http = "http" + "://"
         _https = "https" + "://"
-        if not raw or raw.startswith(
-            ("#", _http, _https, "mailto:", "tel:", "app://")
-        ):
+        if not raw or raw.startswith(("#", _http, _https, "mailto:", "tel:", "app://")):
             continue
         if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", raw) and not re.match(
             r"^[A-Za-z]:[\\/]", raw
@@ -687,11 +690,7 @@ def _duplicate_groups(texts: dict[str, str]) -> dict[str, int]:
 def _diagram_kind_from_mmd(path: str) -> str | None:
     if "/class-diagrams/90-pkg-" in path:
         return "diagram_generated_source"
-    if (
-        "/architecture/" in path
-        or "/class-diagrams/" in path
-        or "/foundation/" in path
-    ):
+    if "/architecture/" in path or "/class-diagrams/" in path or "/foundation/" in path:
         return "diagram_canonical_source"
     return None
 
@@ -720,8 +719,6 @@ def _diagram_kind(path: str) -> str | None:
         if mmd_kind is not None:
             return mmd_kind
     return _diagram_kind_from_path_markers(path)
-
-
 
 
 def _classify_from_lifecycle(
@@ -1325,10 +1322,14 @@ def _write_if_changed(path: Path, content: str) -> bool:
     from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
 
     safe_path = resolve_output_path(path, root=REPO_ROOT)
-    if safe_path.exists() and safe_path.read_text(encoding="utf-8") == content:  # NOSONAR
+    if (
+        safe_path.exists() and safe_path.read_text(encoding="utf-8") == content
+    ):  # NOSONAR
         return False
     safe_path.parent.mkdir(parents=True, exist_ok=True)
-    safe_path.write_text(content, encoding="utf-8")  # NOSONAR - confined by resolve_output_path
+    safe_path.write_text(
+        content, encoding="utf-8"
+    )  # NOSONAR - confined by resolve_output_path
     return True
 
 

--- a/tests/unit/scripts/test_documentation_cleanup_inventory.py
+++ b/tests/unit/scripts/test_documentation_cleanup_inventory.py
@@ -171,6 +171,24 @@ def test_safe_iter_local_doc_tree_reports_quarantined_paths(
     ]
 
 
+def test_safe_iter_local_doc_tree_ignores_transient_link_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CI link report must not make the cleanup inventory self-invalidating."""
+    reports_root = tmp_path / "docs" / "reports"
+    reports_root.mkdir(parents=True)
+    (reports_root / "index.md").write_text("# Reports\n", encoding="utf-8")
+    (reports_root / "docs-link-check-report.json").write_text(
+        '{"status": "ok"}\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(inventory, "PROJECT_ROOT", tmp_path)
+
+    paths, errors = inventory._safe_iter_local_doc_tree("docs/reports")
+
+    assert paths == ["docs/reports/index.md"]
+    assert errors == []
+
+
 def test_generated_route_violations_reports_unowned_generated_rows() -> None:
     """Generator checks must fail when generated docs lack route ownership."""
     payload = {


### PR DESCRIPTION
## Summary

- exclude the ignored `docs/reports/docs-link-check-report.json` upload artifact from the local documentation cleanup scan
- add a regression test reproducing the exact Docs & Diagrams step ordering

## Root cause

The workflow creates the ignored link-check report before `python -m scripts.docs verify`. The cleanup inventory then treated that transient upload artifact as a local documentation surface, making both committed cleanup inventory files appear stale.

## Validation

- `pytest tests/unit/scripts/test_documentation_cleanup_inventory.py tests/architecture/test_documentation_cleanup_inventory.py -q` — 36 passed
- exact CI sequence: create `docs/reports/docs-link-check-report.json`, then `python -m scripts.docs generate-cleanup-inventory --check` — passed
- `python -m scripts.docs verify --skip-build` — passed
- `ruff check` — passed
- `ruff format --check .` — 5129 files formatted

Follow-up required to make the overall Docs & Diagrams workflow green for #7402.