### PR TITLE
chore(docs): refresh cleanup inventory after main merges

### DIFF
--- a/docs/reports/generated/documentation-cleanup-inventory.json
+++ b/docs/reports/generated/documentation-cleanup-inventory.json
@@ -62905,6 +62905,62 @@
       "generator": null,
       "github_issue_number": null,
       "github_issue_url": null,
+      "inbound_links": 0,
+      "lifecycle": "working_report",
+      "outbound_links": 0,
+      "owner": "BioETL Team",
+      "path": "reports/ai/memory-audit-20260804/FINAL-REPORT.md",
+      "recommended_action": "archive-after-migration",
+      "root_doc_kind": null,
+      "section": "reports",
+      "status": "Working",
+      "surface_family": "working",
+      "tracking_state": "tracked"
+    },
+    {
+      "canonical_successor": null,
+      "catalog_lifecycle": null,
+      "commit_policy": null,
+      "declared_class": null,
+      "declared_status": null,
+      "diagram_kind": null,
+      "duplicate_group": null,
+      "duplicate_resolution": null,
+      "extension": ".md",
+      "freshness": "review-required",
+      "generated_route": null,
+      "generated_route_exception": null,
+      "generator": null,
+      "github_issue_number": null,
+      "github_issue_url": null,
+      "inbound_links": 0,
+      "lifecycle": "working_report",
+      "outbound_links": 0,
+      "owner": "BioETL Team",
+      "path": "reports/ai/memory-audit-20260804/execution-ledger.md",
+      "recommended_action": "archive-after-migration",
+      "root_doc_kind": null,
+      "section": "reports",
+      "status": "Working",
+      "surface_family": "working",
+      "tracking_state": "tracked"
+    },
+    {
+      "canonical_successor": null,
+      "catalog_lifecycle": null,
+      "commit_policy": null,
+      "declared_class": null,
+      "declared_status": null,
+      "diagram_kind": null,
+      "duplicate_group": null,
+      "duplicate_resolution": null,
+      "extension": ".md",
+      "freshness": "review-required",
+      "generated_route": null,
+      "generated_route_exception": null,
+      "generator": null,
+      "github_issue_number": null,
+      "github_issue_url": null,
       "inbound_links": 2,
       "lifecycle": "working_report",
       "outbound_links": 0,
@@ -68957,11 +69013,11 @@
       "live_issue_mirror": 4,
       "plans_governance_entrypoint": 1,
       "published_skill_reference_redirect": 33,
-      "working_report": 92
+      "working_report": 94
     },
     "by_recommended_action": {
       "archive-after-github-state-check": 312,
-      "archive-after-migration": 87,
+      "archive-after-migration": 89,
       "generate-automatically": 861,
       "keep": 1171,
       "reconcile-with-github-state": 4
@@ -68992,7 +69048,7 @@
       "mkdocs.yml": 1,
       "plans": 2,
       "plugins": 4,
-      "reports": 221,
+      "reports": 223,
       "ru": 3,
       "security": 2
     },
@@ -69001,17 +69057,17 @@
       "Archived": 141,
       "Canonical": 73,
       "Generated": 861,
-      "Working": 498
+      "Working": 500
     },
     "by_surface_family": {
       "active": 862,
       "archive": 141,
       "canonical": 73,
       "generated": 861,
-      "working": 498
+      "working": 500
     },
     "by_tracking_state": {
-      "tracked": 2435
+      "tracked": 2437
     },
     "docs_reports_local_count": 30,
     "duplicate_group_count": 6,
@@ -69027,8 +69083,8 @@
     },
     "scan_error_count": 0,
     "scan_errors": [],
-    "total_doc_like": 2435,
+    "total_doc_like": 2437,
     "total_doc_like_ignored_local": 0,
-    "total_doc_like_tracked": 2435
+    "total_doc_like_tracked": 2437
   }
 }

--- a/docs/reports/generated/documentation-cleanup-inventory.md
+++ b/docs/reports/generated/documentation-cleanup-inventory.md
@@ -7,8 +7,8 @@
 
 | Metric | Value |
 | --- | --- |
-| Doc-like files | 2435 |
-| Tracked doc-like files | 2435 |
+| Doc-like files | 2437 |
+| Tracked doc-like files | 2437 |
 | Ignored local docs/reports files | 0 |
 | Duplicate groups | 6 |
 | Generated without route or exception | 0 |
@@ -18,7 +18,7 @@
 
 | Tracking State | Count |
 | --- | --- |
-| tracked | 2435 |
+| tracked | 2437 |
 
 ## Lifecycle Counts
 
@@ -41,7 +41,7 @@
 | live_issue_mirror | 4 |
 | plans_governance_entrypoint | 1 |
 | published_skill_reference_redirect | 33 |
-| working_report | 92 |
+| working_report | 94 |
 
 ## GitHub Issue Drafts And Packs
 
@@ -61,7 +61,7 @@
 | Archived | 141 |
 | Canonical | 73 |
 | Generated | 861 |
-| Working | 498 |
+| Working | 500 |
 
 ## Surface Families
 
@@ -71,14 +71,14 @@
 | archive | 141 |
 | canonical | 73 |
 | generated | 861 |
-| working | 498 |
+| working | 500 |
 
 ## Recommended Actions
 
 | Action | Count |
 | --- | --- |
 | archive-after-github-state-check | 312 |
-| archive-after-migration | 87 |
+| archive-after-migration | 89 |
 | generate-automatically | 861 |
 | keep | 1171 |
 | reconcile-with-github-state | 4 |
@@ -94,6 +94,8 @@
 | `docs/reports/dashboard-ux-checks/README.md` | Working | 0 | archive-after-migration |
 | `reports/ai/issue-7340-specialized-subsystem-analysis-20260731.md` | Working | 0 | archive-after-migration |
 | `reports/ai/issue-7348-comprehensive-skills-analysis-20260731.md` | Working | 0 | archive-after-migration |
+| `reports/ai/memory-audit-20260804/FINAL-REPORT.md` | Working | 0 | archive-after-migration |
+| `reports/ai/memory-audit-20260804/execution-ledger.md` | Working | 0 | archive-after-migration |
 | `reports/docs-evidence/README.md` | Working | 2 | archive-after-migration |
 | `reports/observability/audit-20260727-live-operator-truth/CLOSEOUT.md` | Working | 0 | archive-after-migration |
 | `reports/observability/audit-20260727-live-operator-truth/grafana-live-snapshot.json` | Working | 0 | archive-after-migration |
@@ -165,8 +167,6 @@
 | `reports/review/S2.2-services-pipelines.md` | Working | 0 | archive-after-migration |
 | `reports/semantic_pipeline_audit/base_config_semantic_coverage_2026-07-01.json` | Working | 0 | archive-after-migration |
 | `reports/semantic_pipeline_audit/critical_inconsistencies_2026-07-01.md` | Working | 0 | archive-after-migration |
-| `reports/semantic_pipeline_audit/recommended_canonical_fields_2026-07-01.csv` | Working | 0 | archive-after-migration |
-| `reports/semantic_pipeline_audit/semantic_cluster_registry_2026-07-01.json` | Working | 0 | archive-after-migration |
 
 ## Generated Artifact Examples
 


### PR DESCRIPTION
## Summary

- regenerate `docs/reports/generated/documentation-cleanup-inventory.json`
- regenerate the Markdown inventory mirror after the new memory-audit reports/docs landed on main

This is the deterministic generated-artifact refresh requested by the failing `Docs & Diagrams` log. It does not change a technical-debt budget; it records two newly tracked report files.

## Validation

- exact CI sequence including the transient link report, then `generate-cleanup-inventory --check` — passed
- `python -m scripts.docs verify --skip-build` — passed
- cleanup inventory unit + architecture tests — passed
- stream profile tests — 15 passed
- `ruff check .` — passed
- `ruff format --check .` — 5129 files formatted
- `chembl_activity` dataflow check — current