### PR TITLE
fix(compat): zone-C closeout #7494 #6892 #7495 #6646

### DIFF
--- a/configs/quality/chembl_entity_mapping_compatibility.yaml
+++ b/configs/quality/chembl_entity_mapping_compatibility.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+policy_scope: chembl_entity_mapping_compatibility
+linked_issue: "#7495"
+reviewed_on: "2026-08-04"
+review_by: "2026-09-30"
+owner: "@bioetl-adapters"
+decision: retain_external_compatibility_zero_first_party_src
+rationale: >-
+  ENTITY_MAPPING is a legacy re-export of build_legacy_entity_mapping() with
+  zero first-party production importers. External consumers are unspecified, so
+  removal is not yet proven safe. Retain with lifecycle metadata and a
+  zero-src-import ratchet until external migration evidence exists.
+new_src_import_policy: fail_fast_review_required
+alias:
+  symbol: ENTITY_MAPPING
+  module: bioetl.infrastructure.adapters.chembl.entity_mapper
+  path: src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
+  lifecycle: retained_external_compatibility
+  consumer_class: external_unspecified
+  canonical_target: >-
+    bioetl.infrastructure.adapters.chembl.entity_mapper.ChemblEntityMapper /
+    bioetl.infrastructure.adapters.chembl._entity_mapping_lookup.build_legacy_entity_mapping
+  max_src_importer_count: 0
+  allowed_src_importers: []
+  external_breaking_change_required: true
+  review_date: "2026-09-30"
+  migration_path: >-
+    Use ChemblEntityMapper.get_resource_url / resolve_resource_name instead of
+    ENTITY_MAPPING[entity] dictionary lookups.
+  exit_criteria: >-
+    Remove only after external importer evidence is empty or a coordinated
+    major-version breaking-change notice is published.
+  owner_tests:
+    - tests/integration/adapters/test_chembl.py
+    - tests/architecture/test_chembl_entity_mapping_lifecycle.py

--- a/configs/quality/semantic_compatibility_residue_inventory.yaml
+++ b/configs/quality/semantic_compatibility_residue_inventory.yaml
@@ -1,6 +1,10 @@
 version: 1
 policy_scope: semantic_compatibility_residue
 schema_version: 1
+# Provider identities MUST be a flat list of canonical provider keys.
+# Field membership for nullable/alias residue lives in the executable
+# baseline (tests/fixtures/contracts/publication_schema_compatibility.v1.yaml)
+# and is bound by contract tests for SSOT parity.
 retained_fields:
 - field_name: deprecated_aliases
   owner: bioetl.domain.value_objects.publication
@@ -26,11 +30,6 @@ retained_fields:
   external_breaking_change_required: true
   providers:
     - chembl
-      - publication_type_raw
-      - publication_doi
-      - publication_pmid
-      - publication_pmc_id
-      - oa_status
     - pubmed
     - crossref
     - openalex

--- a/configs/quality/unit_assert_density_policy.yaml
+++ b/configs/quality/unit_assert_density_policy.yaml
@@ -4,11 +4,12 @@ schema_version: 1
 owner: "@bioetl-platform"
 linked_issues:
   - 6646
-reviewed_on: "2026-07-27"
+reviewed_on: "2026-08-04"
 
 policy:
   allow_parametrized_external_asserts: true
   forbid_empty_test_bodies: true
+  require_schema_reference_in_schema_modules: true
   review_threshold_asserts_per_test: 0.5
 
 reviewed_modules:
@@ -23,6 +24,12 @@ reviewed_modules:
     classification: table_driven_parametrized
   - path: tests/unit/domain/schemas/semanticscholar/test_semanticscholar_publication_validation.py
     classification: table_driven_parametrized
+  - path: tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
+    classification: schema_validation_parametrized
+    notes: >-
+      Semantic Scholar field/schema suite must call SemanticScholarPublicationSchema
+      validate() (or assert_schema_validates_frame) for valid/invalid cases.
+      Bare pass and self-fulfilled regex-only checks are forbidden (C1-TS-001).
   - path: tests/unit/domain/schemas/chembl/test_chembl_publication_validation.py
     classification: table_driven_parametrized
   - path: tests/unit/application/observability/test_pipeline_metrics.py
@@ -31,4 +38,5 @@ reviewed_modules:
 
 action: >-
   Keep table-driven patterns; prefer strengthening shared helpers over
-  duplicating assert lines into every parametrized case.
+  duplicating assert lines into every parametrized case. Schema modules must
+  exercise the owner Pandera model rather than standalone literal asserts.

--- a/reports/quality/test-bootstrap-fixture-scope-profile.json
+++ b/reports/quality/test-bootstrap-fixture-scope-profile.json
@@ -1,7 +1,8 @@
 {
   "schema_version": "test-bootstrap-fixture-scope-profile-v1",
-  "issue": 6042,
-  "profiled_on": "2026-07-07",
+  "issue": 6892,
+  "supersedes_issue": 6042,
+  "profiled_on": "2026-08-04",
   "scope": "tests/unit/composition/bootstrap",
   "debt_budget_policy": "flat_or_decreasing_only",
   "command": ".venv/bin/python -m pytest tests/unit/composition/bootstrap -q --durations=10 --tb=short",
@@ -10,7 +11,17 @@
     "test_count": 393,
     "test_file_count": 43,
     "bootstrap_reference_count": 939,
-    "local_conftest_present": false
+    "local_conftest_present": true,
+    "local_conftest_path": "tests/unit/composition/bootstrap/conftest.py",
+    "session_scoped_immutable_fixtures": [
+      "bootstrap_metadata_cache",
+      "cached_bootstrap_metadata"
+    ],
+    "function_scoped_mutable_clones": [
+      "fresh_pipeline_registry",
+      "fresh_provider_registry"
+    ],
+    "isolation_proof": "tests/unit/composition/bootstrap/test_bootstrap_metadata_cache_isolation.py"
   },
   "slowest_durations": [
     {
@@ -43,6 +54,7 @@
     "broad_scope_changes_made": false,
     "session_scope_allowed_without_isolation_proof": false,
     "requires_state_isolation_proof": true,
+    "session_scope_isolation_proven": true,
     "allowed_session_scope_targets": [
       "immutable config payloads",
       "read-only registry metadata",
@@ -57,7 +69,7 @@
   },
   "closeout_decision": {
     "status": "closed-ready",
-    "decision": "profile_before_widening_fixture_scope",
-    "rationale": "The bootstrap lane already passes, but the slowest case builds a runner surface with many mutable collaborators. Fixture scope should not be widened until candidate state is proven immutable or reset between tests."
+    "decision": "session_immutable_catalog_cache_with_per_test_clones",
+    "rationale": "Session-scoped fixtures are limited to immutable bootstrap catalog metadata (BootstrapMetadataCache / CachedBootstrapMetadata). Mutable pipeline/provider registries remain function-scoped clones via fresh_pipeline_registry and fresh_provider_registry. Isolation proof lives in test_bootstrap_metadata_cache_isolation.py."
   }
 }

--- a/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
+++ b/src/bioetl/infrastructure/adapters/chembl/entity_mapper.py
@@ -36,7 +36,7 @@ from bioetl.infrastructure.adapters.chembl.constants import (
     CHEMBL_API_BASE,
 )
 
-__all__ = ["ChemblEntityMapper"]
+__all__ = ["ChemblEntityMapper", "ENTITY_MAPPING", "ENTITY_MAPPING_LIFECYCLE"]
 
 
 class ChemblEntityMapper:
@@ -219,6 +219,36 @@ class ChemblEntityMapper:
 # =============================================================================
 # Backward Compatibility Alias
 # =============================================================================
-# Re-export for existing imports (deprecated, use domain.registry directly)
+# Deprecated public alias retained for external compatibility only.
+# First-party code MUST use ChemblEntityMapper / resolve_resource_name instead.
+# Lifecycle is inventoried in configs/quality/chembl_entity_mapping_compatibility.yaml
+# and ratcheted by tests/architecture/test_chembl_entity_mapping_lifecycle.py (#7495).
+
+ENTITY_MAPPING_LIFECYCLE: dict[str, object] = {
+    "symbol": "ENTITY_MAPPING",
+    "module": "bioetl.infrastructure.adapters.chembl.entity_mapper",
+    "status": "retained_external_compatibility",
+    "owner": "bioetl.infrastructure.adapters.chembl",
+    "consumer_class": "external_unspecified",
+    "canonical_target": (
+        "bioetl.infrastructure.adapters.chembl.entity_mapper.ChemblEntityMapper "
+        "/ bioetl.infrastructure.adapters.chembl._entity_mapping_lookup."
+        "build_legacy_entity_mapping / resolve_resource_name"
+    ),
+    "sunset_status": "retained_until_external_migration_evidence",
+    "review_date": "2026-09-30",
+    "external_breaking_change_required": True,
+    "internal_callers_zero": True,
+    "max_src_importer_count": 0,
+    "migration_path": (
+        "Replace ENTITY_MAPPING[entity] lookups with "
+        "ChemblEntityMapper.get_resource_url(entity) or resolve_resource_name(entity)."
+    ),
+    "exit_criteria": (
+        "Remove the alias only after importer census shows zero external consumers "
+        "or a coordinated major-version breaking-change notice is published."
+    ),
+    "linked_issue": 7495,
+}
 
 ENTITY_MAPPING: dict[str, str] = build_legacy_entity_mapping()

--- a/tests/architecture/test_chembl_entity_mapping_lifecycle.py
+++ b/tests/architecture/test_chembl_entity_mapping_lifecycle.py
@@ -1,0 +1,117 @@
+# pyright: reportArgumentType=false
+# pyright: reportAttributeAccessIssue=false
+# pyright: reportCallIssue=false
+# pyright: reportIndexIssue=false
+# pyright: reportMissingTypeArgument=false
+# pyright: reportGeneralTypeIssues=false
+# pyright: reportOptionalMemberAccess=false
+# pyright: reportOperatorIssue=false
+# pyright: reportAbstractUsage=false
+# PD5 test mock/fixture surface — product NewTypes/Ports stay strict.
+"""Lifecycle ratchet for deprecated ChEMBL ENTITY_MAPPING alias (#7495)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bioetl.infrastructure.adapters.chembl._entity_mapping_lookup import (
+    build_legacy_entity_mapping,
+)
+from bioetl.infrastructure.adapters.chembl.entity_mapper import (
+    CHEMBL_API_BASE,
+    ENTITY_MAPPING,
+    ENTITY_MAPPING_LIFECYCLE,
+    ChemblEntityMapper,
+)
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "configs/quality/chembl_entity_mapping_compatibility.yaml"
+
+
+def _load_inventory() -> dict[str, object]:
+    payload = yaml.safe_load(INVENTORY.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _src_entity_mapping_importers() -> list[str]:
+    """Return first-party src paths that reference ENTITY_MAPPING (excluding owner)."""
+    owner = Path("src/bioetl/infrastructure/adapters/chembl/entity_mapper.py")
+    hits: list[str] = []
+    for path in (ROOT / "src").rglob("*.py"):
+        rel = path.relative_to(ROOT).as_posix()
+        if Path(rel) == owner:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"\bENTITY_MAPPING\b", text):
+            hits.append(rel)
+    return sorted(hits)
+
+
+def test_entity_mapping_lifecycle_inventory_is_complete() -> None:
+    inventory = _load_inventory()
+    alias = inventory["alias"]
+    assert isinstance(alias, dict)
+    assert inventory["decision"] == "retain_external_compatibility_zero_first_party_src"
+    assert inventory["new_src_import_policy"] == "fail_fast_review_required"
+    assert alias["symbol"] == "ENTITY_MAPPING"
+    assert alias["max_src_importer_count"] == 0
+    assert alias["allowed_src_importers"] == []
+    assert alias["external_breaking_change_required"] is True
+    assert str(alias["review_date"]) >= "2026-09-30"
+    assert alias["migration_path"]
+    assert alias["exit_criteria"]
+    for rel in alias["owner_tests"]:
+        assert (ROOT / str(rel)).is_file(), rel
+
+
+def test_entity_mapping_module_lifecycle_matches_inventory() -> None:
+    inventory = _load_inventory()
+    alias = inventory["alias"]
+    assert isinstance(alias, dict)
+    assert ENTITY_MAPPING_LIFECYCLE["symbol"] == alias["symbol"]
+    assert ENTITY_MAPPING_LIFECYCLE["internal_callers_zero"] is True
+    assert ENTITY_MAPPING_LIFECYCLE["max_src_importer_count"] == 0
+    assert ENTITY_MAPPING_LIFECYCLE["linked_issue"] == 7495
+    assert (ROOT / str(alias["path"])).is_file()
+
+
+def test_entity_mapping_has_zero_first_party_src_importers() -> None:
+    importers = _src_entity_mapping_importers()
+    assert importers == [], (
+        "ENTITY_MAPPING must keep zero first-party src importers; "
+        f"found: {importers}"
+    )
+
+
+def test_entity_mapping_equals_canonical_builder() -> None:
+    """Alias must remain a pure re-export of build_legacy_entity_mapping()."""
+    expected = build_legacy_entity_mapping()
+    assert ENTITY_MAPPING == expected
+    assert ENTITY_MAPPING["compound"] == "molecule"
+    assert ENTITY_MAPPING["publication"] == "document"
+    assert ENTITY_MAPPING["activity"] == "activity"
+    assert ENTITY_MAPPING["target"] == "target"
+    assert ENTITY_MAPPING["assay"] == "assay"
+    assert ENTITY_MAPPING["document"] == "document"
+    assert ENTITY_MAPPING["document_similarity"] == "document_similarity"
+    assert ENTITY_MAPPING["document_term"] == "document"
+
+
+def test_entity_mapping_urls_match_chembl_entity_mapper() -> None:
+    """Known-entity keys in the legacy map align with ChemblEntityMapper URLs."""
+    for entity, resource in ENTITY_MAPPING.items():
+        if not ChemblEntityMapper.is_known_entity(entity):
+            assert entity.startswith("document")
+            assert resource
+            continue
+        url = ChemblEntityMapper.get_resource_url(entity)
+        assert url == f"{CHEMBL_API_BASE}/{resource}"
+        assert resource in url
+        assert not url.endswith(".json")

--- a/tests/architecture/test_test_infrastructure_refactor_closeout_6042_6044.py
+++ b/tests/architecture/test_test_infrastructure_refactor_closeout_6042_6044.py
@@ -34,24 +34,58 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def test_issue_6042_bootstrap_profile_blocks_unproven_scope_widening() -> None:
+    """Bootstrap profile stays live-topology-bound (#6042 remainder / #6892)."""
     profile = _load_json(BOOTSTRAP_PROFILE)
+    bootstrap_root = ROOT / "tests" / "unit" / "composition" / "bootstrap"
+    local_conftest = bootstrap_root / "conftest.py"
+    isolation_proof = bootstrap_root / "test_bootstrap_metadata_cache_isolation.py"
 
     assert profile["schema_version"] == "test-bootstrap-fixture-scope-profile-v1"
-    assert profile["issue"] == 6042
+    assert profile["issue"] in {6042, 6892}
     assert profile["debt_budget_policy"] == "flat_or_decreasing_only"
     assert profile["result"]["status"] == "pass"
     assert profile["result"]["test_count"] >= 300
     assert profile["result"]["test_file_count"] == len(
-        list((ROOT / "tests" / "unit" / "composition" / "bootstrap").rglob("test_*.py"))
+        list(bootstrap_root.rglob("test_*.py"))
     )
-    assert profile["result"]["local_conftest_present"] is False
+
+    # Live topology parity: do not hard-code a stale local_conftest_present
+    # literal. The profile must match the filesystem.
+    assert local_conftest.is_file()
+    assert profile["result"]["local_conftest_present"] is True
+    assert profile["result"]["local_conftest_path"] == (
+        "tests/unit/composition/bootstrap/conftest.py"
+    )
+    assert isolation_proof.is_file()
+    assert profile["result"]["isolation_proof"] == (
+        "tests/unit/composition/bootstrap/test_bootstrap_metadata_cache_isolation.py"
+    )
+
+    conftest_text = local_conftest.read_text(encoding="utf-8")
+    assert 'scope="session"' in conftest_text
+    assert "bootstrap_metadata_cache" in conftest_text
+    assert "cached_bootstrap_metadata" in conftest_text
+    assert "fresh_pipeline_registry" in conftest_text
+    assert "fresh_provider_registry" in conftest_text
+    assert set(profile["result"]["session_scoped_immutable_fixtures"]) == {
+        "bootstrap_metadata_cache",
+        "cached_bootstrap_metadata",
+    }
+    assert set(profile["result"]["function_scoped_mutable_clones"]) == {
+        "fresh_pipeline_registry",
+        "fresh_provider_registry",
+    }
 
     policy = profile["fixture_scope_policy"]
     assert policy["broad_scope_changes_made"] is False
     assert policy["session_scope_allowed_without_isolation_proof"] is False
     assert policy["requires_state_isolation_proof"] is True
+    assert policy["session_scope_isolation_proven"] is True
     assert "mutable service instances" in policy["blocked_session_scope_targets"]
     assert profile["closeout_decision"]["status"] == "closed-ready"
+    assert profile["closeout_decision"]["decision"] == (
+        "session_immutable_catalog_cache_with_per_test_clones"
+    )
 
 
 def test_issue_6044_support_helper_ownership_map_is_complete() -> None:

--- a/tests/architecture/test_unit_assert_density_policy.py
+++ b/tests/architecture/test_unit_assert_density_policy.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -21,17 +22,69 @@ pytestmark = pytest.mark.architecture
 
 _REPO = Path(__file__).resolve().parents[2]
 _POLICY = _REPO / "configs/quality/unit_assert_density_policy.yaml"
+_S2_SCHEMA_MODULE = (
+    "tests/unit/domain/schemas/semanticscholar/test_publication_schema.py"
+)
 
 
 def test_unit_assert_density_policy_reviews_known_low_ratio_modules() -> None:
     payload = yaml.safe_load(_POLICY.read_text(encoding="utf-8"))
     assert payload["policy"]["forbid_empty_test_bodies"] is True
+    assert payload["policy"]["require_schema_reference_in_schema_modules"] is True
     reviewed = payload["reviewed_modules"]
     assert isinstance(reviewed, list) and reviewed
+    paths = {str(row["path"]) for row in reviewed}
+    assert _S2_SCHEMA_MODULE in paths
     for row in reviewed:
         path = _REPO / row["path"]
         assert path.is_file(), f"missing reviewed module {row['path']}"
         assert row["classification"] in {
             "table_driven_parametrized",
+            "schema_validation_parametrized",
             "metrics_side_effect_spy",
         }
+
+
+def test_semanticscholar_publication_schema_suite_exercises_owner_schema() -> None:
+    """C1-TS-001: no bare-pass / no self-fulfilled regex-only suite."""
+    path = _REPO / _S2_SCHEMA_MODULE
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    assert "SemanticScholarPublicationSchema" in source
+    assert "assert_schema_validates_frame" in source or ".validate(" in source
+
+    empty_pass_tests: list[str] = []
+    schema_touching = 0
+    test_functions = 0
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            members = node.body
+            class_name = node.name
+        elif isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            members = [node]
+            class_name = ""
+        else:
+            continue
+        for item in members:
+            if not isinstance(item, ast.FunctionDef):
+                continue
+            if not item.name.startswith("test_"):
+                continue
+            test_functions += 1
+            body = [stmt for stmt in item.body if not isinstance(stmt, ast.Expr)]
+            if len(body) == 1 and isinstance(body[0], ast.Pass):
+                empty_pass_tests.append(f"{class_name}.{item.name}")
+            item_src = ast.get_source_segment(source, item) or ""
+            if (
+                "SemanticScholarPublicationSchema" in item_src
+                or "assert_schema_validates_frame" in item_src
+            ):
+                schema_touching += 1
+
+    assert not empty_pass_tests, f"empty pass-only tests: {empty_pass_tests}"
+    assert test_functions >= 20
+    assert schema_touching >= int(test_functions * 0.7), (
+        f"only {schema_touching}/{test_functions} tests reference "
+        "SemanticScholarPublicationSchema / assert_schema_validates_frame"
+    )

--- a/tests/contract/test_publication_schema_contracts.py
+++ b/tests/contract/test_publication_schema_contracts.py
@@ -531,6 +531,75 @@ class TestSchemaVersioning:
             assert "external_breaking_change_required" in entry
             assert "providers" in entry
 
+    def test_inventory_providers_are_canonical_identities(self) -> None:
+        """Provider entries must be flat scalar identities matching SCHEMA_MAP.
+
+        Regression for malformed YAML where field bullets nested under a
+        provider list item collapse into a single plain scalar such as
+        ``chembl - publication_type_raw - publication_doi - ...``.
+        """
+        inventory = _load_semantic_compatibility_inventory()
+        retained_fields = inventory["retained_fields"]
+        assert isinstance(retained_fields, list)
+
+        for entry in retained_fields:
+            providers = entry["providers"]
+            assert isinstance(providers, list), (
+                f"{entry['field_name']}: providers must be a YAML list, got "
+                f"{type(providers).__name__}"
+            )
+            assert providers, f"{entry['field_name']}: providers must be non-empty"
+            for provider in providers:
+                assert isinstance(provider, str), (
+                    f"{entry['field_name']}: provider must be str, got "
+                    f"{type(provider).__name__}: {provider!r}"
+                )
+                assert " " not in provider, (
+                    f"{entry['field_name']}: provider identity must not contain "
+                    f"spaces (malformed nested scalar?): {provider!r}"
+                )
+                assert "-" not in provider or provider in self.SCHEMA_MAP, (
+                    f"{entry['field_name']}: provider identity looks like a "
+                    f"collapsed field list: {provider!r}"
+                )
+                assert provider in self.SCHEMA_MAP, (
+                    f"{entry['field_name']}: unknown provider {provider!r}; "
+                    f"expected subset of {sorted(self.SCHEMA_MAP)}"
+                )
+            assert set(providers) == set(self.SCHEMA_MAP), (
+                f"{entry['field_name']}: providers {sorted(providers)} must equal "
+                f"SCHEMA_MAP keys {sorted(self.SCHEMA_MAP)}"
+            )
+
+    def test_inventory_and_baseline_provider_sets_are_parity_bound(self) -> None:
+        """Inventory retained categories and baseline sections share one provider SSOT."""
+        inventory = _load_semantic_compatibility_inventory()
+        compatibility = _load_compatibility_baseline()
+        retained_fields = inventory["retained_fields"]
+        assert isinstance(retained_fields, list)
+
+        inventory_by_name = {
+            str(entry["field_name"]): entry for entry in retained_fields
+        }
+        assert set(inventory_by_name) == {
+            "deprecated_aliases",
+            "nullable_compatibility_fields",
+        }
+
+        for section_name, entry in inventory_by_name.items():
+            baseline_section = compatibility[section_name]
+            assert isinstance(baseline_section, dict)
+            baseline_providers = baseline_section["providers"]
+            assert isinstance(baseline_providers, dict)
+            inventory_providers = set(entry["providers"])
+            assert inventory_providers == set(baseline_providers) == set(
+                self.SCHEMA_MAP
+            ), (
+                f"{section_name}: inventory providers {sorted(inventory_providers)} "
+                f"must match baseline {sorted(baseline_providers)} and SCHEMA_MAP "
+                f"{sorted(self.SCHEMA_MAP)}"
+            )
+
     def test_inventory_references_baseline_file(self) -> None:
         """Publication baseline must reference the machine-readable inventory."""
         compatibility = _load_compatibility_baseline()

--- a/tests/integration/adapters/test_chembl.py
+++ b/tests/integration/adapters/test_chembl.py
@@ -223,16 +223,30 @@ class TestChemblAdapterUnit:
     """Unit tests for ChemblAdapter that don't require HTTP calls."""
 
     def test_entity_url_generation(self) -> None:
-        """Test URL generation for different entity types."""
+        """ENTITY_MAPPING resources match ChemblEntityMapper for known entities."""
+        from bioetl.infrastructure.adapters.chembl._entity_mapping_lookup import (
+            build_legacy_entity_mapping,
+        )
         from bioetl.infrastructure.adapters.chembl.entity_mapper import (
             CHEMBL_API_BASE,
             ENTITY_MAPPING,
+            ChemblEntityMapper,
         )
 
-        for _entity, resource in ENTITY_MAPPING.items():
-            expected_url = f"{CHEMBL_API_BASE}/{resource}.json"
-            # Verify mapping exists
-            assert resource in expected_url
+        assert ENTITY_MAPPING == build_legacy_entity_mapping()
+        assert ENTITY_MAPPING["compound"] == "molecule"
+        assert ENTITY_MAPPING["publication"] == "document"
+
+        for entity, resource in ENTITY_MAPPING.items():
+            assert isinstance(entity, str) and entity
+            assert isinstance(resource, str) and resource
+            if not ChemblEntityMapper.is_known_entity(entity):
+                assert entity.startswith("document")
+                continue
+            url = ChemblEntityMapper.get_resource_url(entity)
+            assert url == f"{CHEMBL_API_BASE}/{resource}"
+            assert resource in url
+            assert url.startswith(CHEMBL_API_BASE)
 
     def test_api_base_url(self) -> None:
         """API base URL should be correct."""

--- a/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
+++ b/tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
@@ -7,37 +7,18 @@
 # pyright: reportOptionalMemberAccess=false
 # pyright: reportOperatorIssue=false
 # pyright: reportAbstractUsage=false
-# PD5 test mock/fixture surface — product NewTypes/Ports stay strict (#6997+#6998+#6999+#7000).
-# pyright: reportUndefinedVariable=false
-# pyright: reportPossiblyUnboundVariable=false
-# pyright: reportTypedDictNotRequiredAccess=false
-# pyright: reportOptionalSubscript=false
-# pyright: reportOptionalOperand=false
-# pyright: reportOptionalCall=false
-# pyright: reportOptionalIterable=false
-# pyright: reportIncompatibleMethodOverride=false
-# pyright: reportIncompatibleVariableOverride=false
-# pyright: reportUninitializedInstanceVariable=false
-# pyright: reportReturnType=false
-# pyright: reportInvalidCast=false
-# pyright: reportAssignmentType=false
-# pyright: reportImplicitAbstractClass=false
-# pyright: reportFunctionMemberAccess=false
-# pyright: reportConstantRedefinition=false
-# pyright: reportInvalidTypeForm=false
 # PD6 residual test mock/fixture surface — product NewTypes/Ports stay strict (#7048).
-# tests/unit/domain/schemas/semanticscholar/test_publication_schema.py
 """Unit tests for Semantic Scholar Publication Schema field validations.
 
-Tests focus on Semantic Scholar-specific field constraints.
-ETL metadata fields are validated separately by base schema tests.
+Exercises SemanticScholarPublicationSchema via Pandera validate() on
+minimal fixtures. Field-table density is intentional (#6646); empty
+pass-bodies and self-fulfilled regex-only checks are forbidden.
 """
 
 from __future__ import annotations
 
-import re
-
 import pandas as pd
+import pandera as pa
 import pytest
 
 from bioetl.domain.schemas.common.publication_base import LOOKUP_METHODS
@@ -45,296 +26,286 @@ from bioetl.domain.schemas.semanticscholar.publication import (
     OA_STATUS_VALUES,
     SemanticScholarPublicationSchema,
 )
+from bioetl.domain.validation import MAX_PUBLICATION_YEAR, MIN_PUBLICATION_YEAR
+from tests.unit.domain.schemas._schema_validation_assertions import (
+    assert_schema_validates_frame,
+)
 
 pytestmark = pytest.mark.unit
 
 
 class TestPaperIdValidation:
-    """Tests for paper_id field validation."""
+    def test_valid_paper_id_format(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["paper_id"] = "649def34f8be52c8b66281af98ae884c09aef38b"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_paper_id_format(self) -> None:
-        """Test that valid 40-char hex paper_id passes."""
-        valid_id = "649def34f8be52c8b66281af98ae884c09aef38b"
-        pattern = r"^[a-f0-9]{40}$"
-        assert re.match(pattern, valid_id) is not None
+    def test_invalid_paper_id_too_short(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["paper_id"] = "abc123"
+        with pytest.raises(pa.errors.SchemaError, match="paper_id"):
+            SemanticScholarPublicationSchema.validate(df)
 
-    def test_invalid_paper_id_too_short(self) -> None:
-        """Test that short paper_id fails pattern."""
-        invalid_id = "abc123"
-        pattern = r"^[a-f0-9]{40}$"
-        assert re.match(pattern, invalid_id) is None
-
-    def test_invalid_paper_id_not_hex(self) -> None:
-        """Test that non-hex paper_id fails pattern."""
-        invalid_id = "invalid-not-hex-characters-need-40-total"
-        pattern = r"^[a-f0-9]{40}$"
-        assert re.match(pattern, invalid_id) is None
+    def test_invalid_paper_id_not_hex(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["paper_id"] = "invalid-not-hex-characters-need-40-total"
+        with pytest.raises(pa.errors.SchemaError, match="paper_id"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestDoiValidation:
-    """Tests for DOI field validation."""
+    def test_valid_doi_format(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["doi"] = "10.1038/s41586-024-07487-w"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_doi_format(self) -> None:
-        """Test valid DOI format."""
-        valid_doi = "10.1038/s41586-024-07487-w"
-        pattern = r"^10\.\d{4,}/.*$"
-        assert re.match(pattern, valid_doi) is not None
-
-    def test_invalid_doi_format(self) -> None:
-        """Test invalid DOI format fails."""
-        invalid_doi = "not-a-valid-doi"
-        pattern = r"^10\.\d{4,}/.*$"
-        assert re.match(pattern, invalid_doi) is None
+    def test_invalid_doi_format(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["doi"] = "not-a-valid-doi"
+        with pytest.raises(pa.errors.SchemaError, match="doi"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestPmidValidation:
-    """Tests for PMID field validation."""
+    def test_valid_pmid_numeric(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["pmid"] = "12345678"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_pmid_numeric(self) -> None:
-        """Test valid numeric PMID."""
-        valid_pmid = "12345678"
-        pattern = r"^\d+$"
-        assert re.match(pattern, valid_pmid) is not None
-
-    def test_invalid_pmid_non_numeric(self) -> None:
-        """Test invalid non-numeric PMID fails."""
-        invalid_pmid = "abc-not-numeric"
-        pattern = r"^\d+$"
-        assert re.match(pattern, invalid_pmid) is None
+    def test_invalid_pmid_non_numeric(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["pmid"] = "abc-not-numeric"
+        with pytest.raises(pa.errors.SchemaError, match="pmid"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestPmcIdValidation:
-    """Tests for PMCID field validation."""
+    def test_pmc_id_validation__valid_pmc_id_format__e264e3a6(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["pmc_id"] = "PMC1234567"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_pmc_id_validation__valid_pmc_id_format__e264e3a6(self) -> None:
-        """Test valid PMCID with PMC prefix."""
-        valid_pmc_id = "PMC1234567"
-        pattern = r"^PMC\d+$"
-        assert re.match(pattern, valid_pmc_id) is not None
-
-    def test_invalid_pmc_id_no_prefix(self) -> None:
-        """Test PMCID without PMC prefix fails."""
-        invalid_pmc_id = "1234567"
-        pattern = r"^PMC\d+$"
-        assert re.match(pattern, invalid_pmc_id) is None
+    def test_invalid_pmc_id_no_prefix(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["pmc_id"] = "1234567"
+        with pytest.raises(pa.errors.SchemaError, match="pmc_id"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestYearValidation:
-    """Tests for year field validation."""
+    def test_valid_year_in_range(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_year"] = 2024
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    @staticmethod
-    def _is_supported_year(year: int) -> bool:
-        return 1500 <= year <= 2100
+    def test_year_at_lower_bound(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_year"] = MIN_PUBLICATION_YEAR
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_year_in_range(self) -> None:
-        """Test year within valid range."""
-        assert self._is_supported_year(2024)
+    def test_year_below_lower_bound(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_year"] = MIN_PUBLICATION_YEAR - 1
+        with pytest.raises(pa.errors.SchemaError, match="publication_year"):
+            SemanticScholarPublicationSchema.validate(df)
 
-    def test_year_at_lower_bound(self) -> None:
-        """Test year at lower bound."""
-        assert self._is_supported_year(1500)
-
-    def test_year_below_lower_bound(self) -> None:
-        """Test year below lower bound fails."""
-        assert not self._is_supported_year(1499)
-
-    def test_year_above_upper_bound(self) -> None:
-        """Test year above upper bound fails."""
-        assert not self._is_supported_year(2101)
+    def test_year_above_upper_bound(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_year"] = MAX_PUBLICATION_YEAR + 1
+        with pytest.raises(pa.errors.SchemaError, match="publication_year"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestPublicationDateValidation:
-    """Tests for publication_date field validation."""
+    def test_valid_date_format(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_date"] = "2024-05-15"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_date_format(self) -> None:
-        """Test valid ISO date format YYYY-MM-DD."""
-        valid_date = "2024-05-15"
-        pattern = r"^\d{4}-\d{2}-\d{2}$"
-        assert re.match(pattern, valid_date) is not None
-
-    def test_invalid_date_format_slash(self) -> None:
-        """Test invalid date format with slashes."""
-        invalid_date = "15/05/2024"
-        pattern = r"^\d{4}-\d{2}-\d{2}$"
-        assert re.match(pattern, invalid_date) is None
+    def test_invalid_date_format_slash(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["publication_date"] = "15/05/2024"
+        with pytest.raises(pa.errors.SchemaError, match="publication_date"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestMetricsValidation:
-    """Tests for citations_received and citations_made validation."""
+    def test_valid_citation_count(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["citations_received"] = 42
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_citation_count(self) -> None:
-        """Test valid non-negative citation count."""
-        valid_count = 42
-        assert valid_count >= 0
+    def test_invalid_negative_citation_count(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["citations_received"] = -1
+        with pytest.raises(pa.errors.SchemaError):
+            SemanticScholarPublicationSchema.validate(df)
 
-    def test_invalid_negative_citation_count(self) -> None:
-        """Test negative citation count fails."""
-        invalid_count = -1
-        assert not (invalid_count >= 0)
+    def test_valid_reference_count(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["citations_made"] = 85
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_reference_count(self) -> None:
-        """Test valid non-negative reference count."""
-        valid_count = 85
-        assert valid_count >= 0
-
-    def test_invalid_negative_reference_count(self) -> None:
-        """Test negative reference count fails."""
-        invalid_count = -1
-        assert not (invalid_count >= 0)
+    def test_invalid_negative_reference_count(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["citations_made"] = -1
+        with pytest.raises(pa.errors.SchemaError):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestCorpusIdValidation:
-    """Tests for corpus_id field validation."""
+    def test_valid_corpus_id(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["corpus_id"] = 123456
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_corpus_id(self) -> None:
-        """Test valid non-negative corpus_id."""
-        valid_id = 123456
-        assert valid_id >= 0
-
-    def test_invalid_negative_corpus_id(self) -> None:
-        """Test negative corpus_id fails."""
-        invalid_id = -1
-        assert not (invalid_id >= 0)
+    def test_invalid_negative_corpus_id(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["corpus_id"] = -1
+        with pytest.raises(pa.errors.SchemaError, match="corpus_id"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestOaStatusValidation:
-    """Tests for oa_status enum validation (normalized to lowercase)."""
-
     @pytest.mark.parametrize("status", OA_STATUS_VALUES)
-    def test_valid_oa_status(self, status: str) -> None:
-        """Test all valid open access status values."""
-        assert status in OA_STATUS_VALUES
+    def test_valid_oa_status(
+        self,
+        status: str,
+        minimal_semanticscholar_publication_df: pd.DataFrame,
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["oa_status"] = status
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_invalid_oa_status(self) -> None:
-        """Test invalid open access status."""
-        invalid_status = "INVALID"
-        assert invalid_status not in OA_STATUS_VALUES
+    def test_invalid_oa_status(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["oa_status"] = "INVALID"
+        with pytest.raises(pa.errors.SchemaError, match="oa_status"):
+            SemanticScholarPublicationSchema.validate(df)
 
     def test_oa_status_values_are_lowercase(self) -> None:
-        """Test that all OA status values are lowercase."""
         for status in OA_STATUS_VALUES:
-            assert status == status.lower(), f"Status {status} should be lowercase"
-
-    def test_oa_status_includes_closed(self) -> None:
-        """Test that 'closed' is included in valid OA status values."""
+            assert status == status.lower()
         assert "closed" in OA_STATUS_VALUES
 
 
 class TestLookupMethodValidation:
-    """Tests for _lookup_method enum validation."""
-
     @pytest.mark.parametrize("method", LOOKUP_METHODS)
-    def test_valid_lookup_method(self, method: str) -> None:
-        """Test all valid lookup method values."""
-        assert method in LOOKUP_METHODS
+    def test_valid_lookup_method(
+        self,
+        method: str,
+        minimal_semanticscholar_publication_df: pd.DataFrame,
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["_lookup_method"] = method
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_invalid_lookup_method(self) -> None:
-        """Test invalid lookup method."""
-        invalid_method = "invalid_method"
-        assert invalid_method not in LOOKUP_METHODS
+    def test_invalid_lookup_method(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["_lookup_method"] = "invalid_method"
+        with pytest.raises(pa.errors.SchemaError):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestSourceValidation:
-    """Tests for source field validation."""
+    def test_valid_source(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        assert df["_source"].iloc[0] == "semanticscholar"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_source(self) -> None:
-        """Test source must be 'semanticscholar'."""
-        valid_source = "semanticscholar"
-        assert valid_source == "semanticscholar"
-
-    def test_invalid_source(self) -> None:
-        """Test invalid source value."""
-        invalid_source = "other_source"
-        assert invalid_source != "semanticscholar"
+    def test_invalid_source_field_contract(self) -> None:
+        field_info = SemanticScholarPublicationSchema.__dict__['_source']
+        assert field_info.nullable is False
+        assert any("equal_to" in getattr(check, "name", str(check)) for check in field_info.checks)
+        assert any("semanticscholar" in str(check) for check in field_info.checks)
 
 
 class TestSchemaFieldDefinitions:
-    """Tests that verify schema field definitions exist and have correct properties.
-
-    Note: pandera doesn't include underscore-prefixed fields in schema.columns,
-    so we only test the public business fields here.
-    """
-
     def test_schema_has_semanticscholar_fields(self) -> None:
-        """Test schema defines all required Semantic Scholar fields."""
         schema = SemanticScholarPublicationSchema.to_schema()
-        # Note: underscore-prefixed fields are not exposed in schema.columns
-        # by pandera, so we only test public business fields here
-        # Note: pmc_id, arxiv_id excluded per design (2026-01)
         required_fields = [
-            "paper_id",
-            "doi",
-            "pmid",
-            "dblp_id",
-            "corpus_id",
-            "title",
-            "abstract",
-            "tldr",
-            "publication_year",
-            "publication_date",
-            "journal",
-            "volume",
-            "page_range",
-            "citations_received",
-            "citations_made",
-            "influential_citation_count",
-            "is_oa",
-            "open_access_url",
-            "oa_status",
-            "subject_fields",
-            "publication_type",
-            "publication_types",
-            "authors",
-            # Note: _source is not in schema.columns because pandera ignores
-            # underscore-prefixed fields. It's validated through Arrow schema instead.
+            "paper_id", "doi", "pmid", "dblp_id", "corpus_id", "title",
+            "abstract", "tldr", "publication_year", "publication_date",
+            "journal", "volume", "page_range", "citations_received",
+            "citations_made", "influential_citation_count", "is_oa",
+            "open_access_url", "oa_status", "subject_fields",
+            "publication_type", "publication_types", "authors",
         ]
-
         for field in required_fields:
             assert field in schema.columns, f"Missing field: {field}"
 
     def test_paper_id_not_nullable(self) -> None:
-        """Test paper_id is not nullable."""
         schema = SemanticScholarPublicationSchema.to_schema()
         paper_id_col = schema.columns.get("paper_id")
         assert paper_id_col is not None
         assert paper_id_col.nullable is False
 
-    def test_source_field_validated(self) -> None:
-        """Test _source field is validated during schema check.
-
-        Note: underscore-prefixed fields are not exposed in schema.columns
-        by pandera, but they are still validated at runtime.
-        This test verifies _source validation indirectly through the
-        test fixtures that include the field.
-        """
-        # The _source field is validated through the valid_record fixture
-        # in other test classes. This test documents the expected behavior.
-        pass
+    def test_source_field_validated(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        field_info = SemanticScholarPublicationSchema.__dict__['_source']
+        assert field_info.nullable is False
+        assert any("semanticscholar" in str(check) for check in field_info.checks)
+        ok = minimal_semanticscholar_publication_df.copy()
+        assert ok["_source"].iloc[0] == "semanticscholar"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, ok)
 
     def test_optional_fields_nullable(self) -> None:
-        """Test optional string fields are nullable."""
         schema = SemanticScholarPublicationSchema.to_schema()
-        # Note: underscore-prefixed fields like _original_id are not exposed
-        # Note: pmc_id, arxiv_id excluded per design (2026-01)
         nullable_fields = [
-            "doi",
-            "pmid",
-            "dblp_id",
-            "title",
-            "abstract",
-            "tldr",
-            "publication_date",
-            "journal",
-            "volume",
-            "page_range",
-            "open_access_url",
-            "oa_status",
-            "subject_fields",
-            "publication_type",
-            "publication_types",
-            "authors",
+            "doi", "pmid", "dblp_id", "title", "abstract", "tldr",
+            "publication_date", "journal", "volume", "page_range",
+            "open_access_url", "oa_status", "subject_fields",
+            "publication_type", "publication_types", "authors",
         ]
-
         for field in nullable_fields:
             col = schema.columns.get(field)
             assert col is not None, f"Missing field: {field}"
@@ -342,71 +313,87 @@ class TestSchemaFieldDefinitions:
 
 
 class TestContentHashValidation:
-    """Tests for content_hash format validation."""
+    def test_valid_content_hash_format(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["content_hash"] = "a" * 64
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_valid_content_hash_format(self) -> None:
-        """Test valid 64-char hex content_hash."""
-        valid_hash = "a" * 64
-        pattern = r"^[a-f0-9]{64}$"
-        assert re.match(pattern, valid_hash) is not None
-
-    def test_invalid_content_hash_short(self) -> None:
-        """Test short content_hash fails."""
-        invalid_hash = "short"
-        pattern = r"^[a-f0-9]{64}$"
-        assert re.match(pattern, invalid_hash) is None
+    def test_invalid_content_hash_short(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        df = minimal_semanticscholar_publication_df.copy()
+        df["content_hash"] = "short"
+        with pytest.raises(pa.errors.SchemaError, match="content_hash"):
+            SemanticScholarPublicationSchema.validate(df)
 
 
 class TestDataFrameWithPandas:
-    """Tests using pandas DataFrame str methods."""
+    def test_paper_id_pattern_with_dataframe(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        good = minimal_semanticscholar_publication_df.copy()
+        good["paper_id"] = "649def34f8be52c8b66281af98ae884c09aef38b"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, good)
+        bad = minimal_semanticscholar_publication_df.copy()
+        bad["paper_id"] = "invalid"
+        with pytest.raises(pa.errors.SchemaError, match="paper_id"):
+            SemanticScholarPublicationSchema.validate(bad)
 
-    def test_paper_id_pattern_with_dataframe(self) -> None:
-        """Test paper_id pattern with pandas DataFrame."""
-        df = pd.DataFrame(
-            {"paper_id": ["649def34f8be52c8b66281af98ae884c09aef38b", "invalid"]}
-        )
-        # Valid 40-char hex pattern
-        matches = df["paper_id"].str.match(r"^[a-f0-9]{40}$")
-        assert bool(matches.iloc[0]) is True
-        assert bool(matches.iloc[1]) is False
+    def test_doi_pattern_with_dataframe(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        good = minimal_semanticscholar_publication_df.copy()
+        good["doi"] = "10.1038/s41586-024-07487-w"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, good)
+        bad = minimal_semanticscholar_publication_df.copy()
+        bad["doi"] = "invalid-doi"
+        with pytest.raises(pa.errors.SchemaError, match="doi"):
+            SemanticScholarPublicationSchema.validate(bad)
 
-    def test_doi_pattern_with_dataframe(self) -> None:
-        """Test DOI pattern with pandas DataFrame."""
-        df = pd.DataFrame({"doi": ["10.1038/s41586-024-07487-w", "invalid-doi"]})
-        matches = df["doi"].str.match(r"^10\.\d{4,}/.*$")
-        assert bool(matches.iloc[0]) is True
-        assert bool(matches.iloc[1]) is False
-
-    def test_publication_date_pattern_with_dataframe(self) -> None:
-        """Test publication_date pattern with pandas DataFrame."""
-        df = pd.DataFrame({"publication_date": ["2024-05-15", "15/05/2024"]})
-        matches = df["publication_date"].str.match(r"^\d{4}-\d{2}-\d{2}$")
-        assert bool(matches.iloc[0]) is True
-        assert bool(matches.iloc[1]) is False
+    def test_publication_date_pattern_with_dataframe(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        good = minimal_semanticscholar_publication_df.copy()
+        good["publication_date"] = "2024-05-15"
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, good)
+        bad = minimal_semanticscholar_publication_df.copy()
+        bad["publication_date"] = "15/05/2024"
+        with pytest.raises(pa.errors.SchemaError, match="publication_date"):
+            SemanticScholarPublicationSchema.validate(bad)
 
 
 class TestNewFieldValidations:
-    """Tests for newly added fields (dblp_id, influential_citation_count)."""
-
-    def test_dblp_id_nullable(self) -> None:
-        """Test dblp_id field is nullable."""
+    def test_dblp_id_nullable(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
         schema = SemanticScholarPublicationSchema.to_schema()
         dblp_col = schema.columns.get("dblp_id")
         assert dblp_col is not None
         assert dblp_col.nullable is True
+        df = minimal_semanticscholar_publication_df.copy()
+        df["dblp_id"] = None
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_influential_citation_count_nullable(self) -> None:
-        """Test influential_citation_count field is nullable."""
+    def test_influential_citation_count_nullable(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
         schema = SemanticScholarPublicationSchema.to_schema()
         col = schema.columns.get("influential_citation_count")
         assert col is not None
         assert col.nullable is True
+        df = minimal_semanticscholar_publication_df.copy()
+        df["influential_citation_count"] = None
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, df)
 
-    def test_influential_citation_count_must_be_non_negative(self) -> None:
-        """Test influential_citation_count must be >= 0."""
-        # This tests the schema constraint ge=0
-        valid_count = 0
-        assert valid_count >= 0
-
-        invalid_count = -1
-        assert invalid_count < 0  # Would fail schema validation
+    def test_influential_citation_count_must_be_non_negative(
+        self, minimal_semanticscholar_publication_df: pd.DataFrame
+    ) -> None:
+        good = minimal_semanticscholar_publication_df.copy()
+        good["influential_citation_count"] = 0
+        assert_schema_validates_frame(SemanticScholarPublicationSchema, good)
+        bad = minimal_semanticscholar_publication_df.copy()
+        bad["influential_citation_count"] = -1
+        with pytest.raises(pa.errors.SchemaError):
+            SemanticScholarPublicationSchema.validate(bad)


### PR DESCRIPTION
## Summary

Closes the independent domain/compatibility/bootstrap stream (Zone C):

- **#7494** — fix malformed publication semantic residue inventory YAML (provider identities were nested field bullets collapsing into one scalar); bind inventory ↔ baseline ↔ `SCHEMA_MAP` parity with regression tests
- **#6892** — refresh bootstrap fixture-scope profile to live topology (`local_conftest_present=true`, session immutable catalog cache + per-test mutable clones + isolation proof)
- **#7495** — govern deprecated ChEMBL `ENTITY_MAPPING` with lifecycle inventory, zero first-party import ratchet, and non-tautological mapping assertions
- **#6646** — rewrite Semantic Scholar `test_publication_schema.py` to exercise Pandera validation; strengthen assert-density policy against bare `pass` / self-fulfilled regex suites

## Test plan

- [x] `tests/contract/test_publication_schema_contracts.py::TestSchemaVersioning`
- [x] `tests/architecture/test_test_infrastructure_refactor_closeout_6042_6044.py::test_issue_6042_bootstrap_profile_blocks_unproven_scope_widening`
- [x] `tests/architecture/test_chembl_entity_mapping_lifecycle.py`
- [x] `tests/architecture/test_unit_assert_density_policy.py`
- [x] `tests/unit/domain/schemas/semanticscholar/test_publication_schema.py`
- [x] `tests/integration/adapters/test_chembl.py::TestChemblAdapterUnit`

**Result:** 72 passed (focused suite)

Closes #7494
Closes #6892
Closes #7495
Closes #6646