### PR TITLE
fix(ci): stabilize CI-C1 closeout gates (#7515-#7521)

### DIFF
--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-04T18:03:07.811853+00:00",
+  "generated_at": "2026-08-04T19:25:28.580626+00:00",
   "summary": {
     "total_scripts": 575,
     "status_counts": {
@@ -5022,7 +5022,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 427,
+          "line": 429,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/data_quality/run_silver_gold_filter_parity.py --check"
         },
@@ -8905,13 +8905,13 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 390,
+          "line": 392,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.ci neo4j-memory"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 551,
+          "line": 553,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.ci neo4j-memory-live"
         },
@@ -9335,7 +9335,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 1037,
+          "line": 1039,
           "source_group": "ci",
           "text": "scripts/engineering/ci/run_pytest_resilient.py \\"
         },
@@ -11902,7 +11902,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 433,
+          "line": 435,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.qa check-naming-pkg --check"
         },
@@ -12271,7 +12271,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 374,
+          "line": 376,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/engineering/qa/check_test_audit_preflight.py --strict"
         },
@@ -12962,7 +12962,7 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 600,
+          "line": 602,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/engineering/qa/generate_architecture_dependency_map.py --check"
         },
@@ -15784,7 +15784,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 371,
+          "line": 373,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.repo check-catalog --catalog scripts/engineering/repo/catalog.yaml"
         },
@@ -15841,7 +15841,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 363,
+          "line": 365,
           "source_group": "ci",
           "text": "uv run --frozen --no-build python -m scripts.engineering.repo check-inventory \\"
         },
@@ -20277,7 +20277,7 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 424,
+          "line": 426,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.schema generate-config-matrix --check"
         }

--- a/docs/02-architecture/generated/module-dependency-map.json
+++ b/docs/02-architecture/generated/module-dependency-map.json
@@ -6,7 +6,7 @@
     "cross_layer_group_edges": 55,
     "cross_layer_group_edges_total": 310,
     "violations": 0,
-    "source_fingerprint": "c97030a0658c27c791befc52c74470f35ffdc0b24828b2e9d9eadb4d9648a3f4"
+    "source_fingerprint": "6bd048da64ab60f88955e3335376cfdf85251f7e7f158ed95af84783f547b808"
   },
   "layer_edges": [
     {

--- a/docs/03-guides/dashboards/panel-contract-inventory.json
+++ b/docs/03-guides/dashboards/panel-contract-inventory.json
@@ -1816,13 +1816,12 @@
       "datasource_type": "prometheus",
       "documents_backend_down": false,
       "documents_valid_empty": false,
-      "formula": "round((sum(increase(bioetl_silver_validation_failures_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)) + ((sum(increase(bioetl_dq_soft_threshold_exceeded_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)) * 0))",
+      "formula": "round((sum(increase(bioetl_silver_validation_failures_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
       "kind": "promql",
       "panel_id": 7,
-      "panel_title": "Monitor Silver Validation Failures",
-      "query": "round((sum(increase(bioetl_silver_validation_failures_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)) + ((sum(increase(bioetl_dq_soft_threshold_exceeded_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)) * 0))",
+      "panel_title": "Monitor Silver Validation Failures (range composite)",
+      "query": "round((sum(increase(bioetl_silver_validation_failures_total{pipeline=~\"$pipeline\"}[$__range])) or vector(0)))",
       "query_tokens": [
-        "bioetl_dq_soft_threshold_exceeded_total",
         "bioetl_silver_validation_failures_total"
       ],
       "ref_id": "A",
@@ -2519,7 +2518,16 @@
       "query_tokens": [],
       "ref_id": "A",
       "runbook_urls": [],
-      "thresholds": [],
+      "thresholds": [
+        {
+          "color": "green",
+          "value": null
+        },
+        {
+          "color": "orange",
+          "value": 1
+        }
+      ],
       "unit": ""
     },
     {
@@ -2733,8 +2741,12 @@
       "runbook_urls": [],
       "thresholds": [
         {
-          "color": "green",
+          "color": "gray",
           "value": null
+        },
+        {
+          "color": "green",
+          "value": 0
         },
         {
           "color": "orange",
@@ -2743,6 +2755,10 @@
         {
           "color": "red",
           "value": 2
+        },
+        {
+          "color": "gray",
+          "value": 3
         }
       ],
       "unit": "none"
@@ -3754,8 +3770,12 @@
       "runbook_urls": [],
       "thresholds": [
         {
-          "color": "green",
+          "color": "gray",
           "value": null
+        },
+        {
+          "color": "green",
+          "value": 0
         },
         {
           "color": "orange",
@@ -3785,8 +3805,12 @@
       "runbook_urls": [],
       "thresholds": [
         {
-          "color": "green",
+          "color": "gray",
           "value": null
+        },
+        {
+          "color": "green",
+          "value": 0
         },
         {
           "color": "orange",
@@ -3816,8 +3840,12 @@
       "runbook_urls": [],
       "thresholds": [
         {
-          "color": "green",
+          "color": "gray",
           "value": null
+        },
+        {
+          "color": "green",
+          "value": 0
         },
         {
           "color": "orange",
@@ -5087,8 +5115,12 @@
       "runbook_urls": [],
       "thresholds": [
         {
-          "color": "green",
+          "color": "gray",
           "value": null
+        },
+        {
+          "color": "green",
+          "value": 0
         },
         {
           "color": "orange",

--- a/grafana/dashboards/bioetl-run-explorer-v1.json
+++ b/grafana/dashboards/bioetl-run-explorer-v1.json
@@ -352,8 +352,8 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 12,
-        "y": 14
+        "x": 0,
+        "y": 48
       },
       "datasource": "BioETL Ops HTTP",
       "description": "Do not put full UUIDs into Prometheus labels. DUX4-23/25: Canonical RUN hub — only board with first-class ID/Processed KPIs. Expected empty ≠ red failure (DUX3-03). Bronze/Silver/Gold accounting hub (Ops HTTP). Canonical portfolio hub for Processed Records. Valid empty: no matching accounting rows for the selected run. Backend unavailable is distinct; check /health/live",

--- a/grafana/dashboards/bioetl-run-explorer-v1.json
+++ b/grafana/dashboards/bioetl-run-explorer-v1.json
@@ -353,7 +353,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 29
       },
       "datasource": "BioETL Ops HTTP",
       "description": "Do not put full UUIDs into Prometheus labels. DUX4-23/25: Canonical RUN hub — only board with first-class ID/Processed KPIs. Expected empty ≠ red failure (DUX3-03). Bronze/Silver/Gold accounting hub (Ops HTTP). Canonical portfolio hub for Processed Records. Valid empty: no matching accounting rows for the selected run. Backend unavailable is distinct; check /health/live",

--- a/reports/quality/architecture-debt-remote-main-baseline.json
+++ b/reports/quality/architecture-debt-remote-main-baseline.json
@@ -1,12 +1,12 @@
 {
   "artifacts": [
     {
-      "blob_sha256": "34b4a5e037e6db33094c0a75e73863ad01de6048f12668406066545ecb637b37",
+      "blob_sha256": "7b4c045c32202aa37491844590a1daee9bafae5dbec354172d98cd667ce19f52",
       "introduced_after_remote_main": false,
       "path": "reports/quality/architecture-quality-scorecard.json",
       "required": true,
       "required_on_remote": true,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true,
         "integral_score": 9.41,
@@ -15,19 +15,19 @@
       }
     },
     {
-      "blob_sha256": "ccd7bba42b4bcac295863c82eebcd032df6104d81f143c188a7a9094f128b737",
+      "blob_sha256": "030669ed8407e2d7e4049f6e62f6864122c0e0e7dbc73c2f482115e4ac91898b",
       "introduced_after_remote_main": false,
       "path": "reports/quality/module-coverage-inventory.json",
       "required": true,
       "required_on_remote": true,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true,
         "coverage_xml_sha256": "fb530e62125256526d43fb0d095621adf2b13e79b827d80b8c96882853368011",
         "schema_version": 1,
         "snapshot_date": "2026-07-28",
         "source_module_count": 2314,
-        "source_tree_sha256": "fa7fca1db1d19c16b22cc0795b766f579c4ced33402df185674d174412fb64cc",
+        "source_tree_sha256": "7c89fc409ddfbb569b1f3375e16311dffe0d557ba77ec1fd8f27a366da4e8dfb",
         "unmeasured_module_count": 0
       }
     },
@@ -37,7 +37,7 @@
       "path": "reports/quality/compatibility-importer-census.json",
       "required": true,
       "required_on_remote": true,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true,
         "retained_entrypoint_count": 12,
@@ -50,7 +50,7 @@
       "path": "reports/quality/dead-code-inventory.json",
       "required": true,
       "required_on_remote": true,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true,
         "repo_wide_untriaged_zero_import_candidate_count": 0,
@@ -63,7 +63,7 @@
       "path": "reports/quality/contract-registry-diagnostics.json",
       "required": true,
       "required_on_remote": true,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true,
         "blocking_issue_count": 0,
@@ -76,13 +76,13 @@
       "path": "reports/observability/runtime_cardinality_inventory.json",
       "required": false,
       "required_on_remote": false,
-      "source_revision": "de84d5b235367585325c4476cfe4284489a8de54",
+      "source_revision": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
       "summary": {
         "available": true
       }
     }
   ],
-  "baseline_artifact_fingerprint": "463988fd997f4e3b47f032ee0021360265a9bbcade3185d5c8a0450a94c5fd5b",
+  "baseline_artifact_fingerprint": "74c5333d26acbb844a3dffad4eb515e74649f2614c8cf4aad6871ce32573e268",
   "branch": "main",
   "dirty_closeout_guard": {
     "command": "git status --porcelain --untracked-files=no",
@@ -102,9 +102,9 @@
   ],
   "local_tracking_ref": "origin/main",
   "local_tracking_ref_matches_remote": true,
-  "local_tracking_ref_sha": "de84d5b235367585325c4476cfe4284489a8de54",
+  "local_tracking_ref_sha": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
   "remote": "origin",
   "remote_main_ref": "refs/heads/main",
-  "remote_main_sha": "de84d5b235367585325c4476cfe4284489a8de54",
+  "remote_main_sha": "175570edbe64fc2b6ac0c97aa5aa9181ddbd7009",
   "schema_version": 1
 }

--- a/reports/quality/architecture-debt-remote-main-baseline.md
+++ b/reports/quality/architecture-debt-remote-main-baseline.md
@@ -4,13 +4,13 @@
 
 - evidence_source: `remote_main_git_tree`
 - remote_main_ref: `refs/heads/main`
-- baseline_artifact_fingerprint: `463988fd997f4e3b47f032ee0021360265a9bbcade3185d5c8a0450a94c5fd5b`
+- baseline_artifact_fingerprint: `74c5333d26acbb844a3dffad4eb515e74649f2614c8cf4aad6871ce32573e268`
 - local_tracking_ref_matches_remote: `True`
 
 | artifact | blob_sha256 | available | required_on_remote | introduced_after_remote_main |
 | --- | --- | --- | --- | --- |
-| `reports/quality/architecture-quality-scorecard.json` | `34b4a5e037e6db33094c0a75e73863ad01de6048f12668406066545ecb637b37` | `True` | `True` | `False` |
-| `reports/quality/module-coverage-inventory.json` | `ccd7bba42b4bcac295863c82eebcd032df6104d81f143c188a7a9094f128b737` | `True` | `True` | `False` |
+| `reports/quality/architecture-quality-scorecard.json` | `7b4c045c32202aa37491844590a1daee9bafae5dbec354172d98cd667ce19f52` | `True` | `True` | `False` |
+| `reports/quality/module-coverage-inventory.json` | `030669ed8407e2d7e4049f6e62f6864122c0e0e7dbc73c2f482115e4ac91898b` | `True` | `True` | `False` |
 | `reports/quality/compatibility-importer-census.json` | `4d30277a49ac1c7f05d23d2f615169a4f907e32b9dda47deeb171b630b1a162c` | `True` | `True` | `False` |
 | `reports/quality/dead-code-inventory.json` | `fee01ee052be632556b31282bf738eeea94e77803f8fbbf6f76dec32c4653465` | `True` | `True` | `False` |
 | `reports/quality/contract-registry-diagnostics.json` | `691ae784ed4f90f7835fed4706fbb586e7d7184b8ddc965a7fd5cab6ef3a2dce` | `True` | `True` | `False` |

--- a/reports/quality/architecture-quality-scorecard.json
+++ b/reports/quality/architecture-quality-scorecard.json
@@ -225,7 +225,7 @@
     },
     "dependency_map": {
       "path": "docs/02-architecture/generated/module-dependency-map.json",
-      "source_fingerprint": "c97030a0658c27c791befc52c74470f35ffdc0b24828b2e9d9eadb4d9648a3f4"
+      "source_fingerprint": "6bd048da64ab60f88955e3335376cfdf85251f7e7f158ed95af84783f547b808"
     },
     "duplication_baseline": {
       "path": "reports/quality/full-app-duplication-baseline.json",

--- a/reports/quality/config-contract-registry-artifact-duplication.json
+++ b/reports/quality/config-contract-registry-artifact-duplication.json
@@ -47,7 +47,6 @@
     "reports/quality/*ownership*.json": 2,
     "reports/quality/*ownership*.md": 1,
     "reports/quality/*registry*.json": 3,
-    "reports/quality/*registry*.md": 1,
     "tests/fixtures/contracts/**/*.json": 7,
     "tests/fixtures/contracts/**/*.yaml": 1,
     "tests/fixtures/golden/**/*.json": 30
@@ -60,9 +59,9 @@
     "contract": 47,
     "golden": 27,
     "quality_report": 9,
-    "registry": 26
+    "registry": 25
   },
-  "total_files": 292,
+  "total_files": 291,
   "tracked_extensions": [
     ".csv",
     ".json",

--- a/reports/quality/config-surface-backlog.json
+++ b/reports/quality/config-surface-backlog.json
@@ -296,7 +296,7 @@
         ".yml",
         ".json"
       ],
-      "files_scanned": 229,
+      "files_scanned": 230,
       "ignored_by_jscpd_patterns": [
         "**/configs/**",
         "**/*.yaml",

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "1f7bc8554f3830cde51bb90082b96a24f69b809b1741d3e9a6709ed19a58a843"
+    "test_governance_source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112"
   },
   "summary": {
     "by_alert_level": {
@@ -74,9 +74,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "1f7bc8554f3830cde51bb90082b96a24f69b809b1741d3e9a6709ed19a58a843",
+    "test_governance_source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112",
     "total_flaky": 0,
     "total_test_files": 2177,
-    "total_tests_analyzed": 23299
+    "total_tests_analyzed": 23288
   }
 }

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112"
+    "test_governance_source_tree_sha256": "07e5777a26c3f829161fba74b2bd04aa7ed728776479d227a0b9ab2702382ed5"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112",
+    "test_governance_source_tree_sha256": "07e5777a26c3f829161fba74b2bd04aa7ed728776479d227a0b9ab2702382ed5",
     "total_flaky": 0,
     "total_test_files": 2177,
     "total_tests_analyzed": 23288

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "97645d9cab9ceac05deb11cdc6aa2b58b5fa1466ff859135b9412cc5bf50b7e6",
+  "source_tree_sha256": "861260bfd49059fdc4adb12df813c02cffd378344e5f001c6e8698fd5c2e4874",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2314,7 +2314,6 @@
         "tests/unit/"
       ],
       "top_level_directories_including_pycache": [
-        "tests/__pycache__/",
         "tests/architecture/",
         "tests/benchmarks/",
         "tests/contract/",
@@ -2332,16 +2331,16 @@
         "tests/unit/"
       ],
       "top_level_directory_count": 15,
-      "top_level_directory_count_including_pycache": 16
+      "top_level_directory_count_including_pycache": 15
     },
     "top_duplicate_test_names": [],
     "total_test_files": 2177,
-    "total_test_functions": 23299,
+    "total_test_functions": 23288,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "1f7bc8554f3830cde51bb90082b96a24f69b809b1741d3e9a6709ed19a58a843",
+  "source_tree_sha256": "97645d9cab9ceac05deb11cdc6aa2b58b5fa1466ff859135b9412cc5bf50b7e6",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,
@@ -2381,7 +2380,6 @@
       "tests/unit/"
     ],
     "top_level_directories_including_pycache": [
-      "tests/__pycache__/",
       "tests/architecture/",
       "tests/benchmarks/",
       "tests/contract/",
@@ -2399,11 +2397,11 @@
       "tests/unit/"
     ],
     "top_level_directory_count": 15,
-    "top_level_directory_count_including_pycache": 16
+    "top_level_directory_count_including_pycache": 15
   },
   "top_duplicate_test_names": [],
   "total_test_files": 2177,
-  "total_test_functions": 23299,
+  "total_test_functions": 23288,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "861260bfd49059fdc4adb12df813c02cffd378344e5f001c6e8698fd5c2e4874",
+  "source_tree_sha256": "d735775d23ddba9341c12c3c6c5e592693d2004ea3e1c478ace6f02288af7a67",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "d735775d23ddba9341c12c3c6c5e592693d2004ea3e1c478ace6f02288af7a67",
+  "source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "d1c1ebfefc142e9cc45513a84c79f32dab9f45eb33cd5dd74d76a2387d51d112",
+  "source_tree_sha256": "07e5777a26c3f829161fba74b2bd04aa7ed728776479d227a0b9ab2702382ed5",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/scripts/engineering/qa/report_test_governance_audit.py
+++ b/scripts/engineering/qa/report_test_governance_audit.py
@@ -236,8 +236,8 @@ def _read_source_tree_bytes(path: Path) -> bytes:
     """Read one source-tree file for the freshness hash.
 
     Normalize newlines to LF so Windows working trees with CRLF smudge produce
-    the same ``source_tree_sha256`` as Linux CI checkouts (eol=lf in
-    ``.gitattributes``).
+    the same source_tree_sha256 as Linux CI checkouts (eol=lf in
+    .gitattributes).
     """
     from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
 
@@ -250,6 +250,7 @@ def _read_source_tree_bytes(path: Path) -> bytes:
 ", b"
 ").replace(b"", b"
 ")
+
 
 
 @cache

--- a/scripts/engineering/qa/report_test_governance_audit.py
+++ b/scripts/engineering/qa/report_test_governance_audit.py
@@ -246,8 +246,7 @@ def _read_source_tree_bytes(path: Path) -> bytes:
         "rb"
     ) as handle:  # NOSONAR - path confined by resolve_output_path
         payload = handle.read()
-    return payload.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
-
+    return payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
 
 
 @cache

--- a/scripts/engineering/qa/report_test_governance_audit.py
+++ b/scripts/engineering/qa/report_test_governance_audit.py
@@ -246,10 +246,7 @@ def _read_source_tree_bytes(path: Path) -> bytes:
         "rb"
     ) as handle:  # NOSONAR - path confined by resolve_output_path
         payload = handle.read()
-    return payload.replace(b"
-", b"
-").replace(b"", b"
-")
+    return payload.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
 
 
 

--- a/scripts/engineering/qa/report_test_governance_audit.py
+++ b/scripts/engineering/qa/report_test_governance_audit.py
@@ -233,14 +233,23 @@ def _source_tree_hash_workers(total_files: int) -> int:
 
 
 def _read_source_tree_bytes(path: Path) -> bytes:
-    """Read one source-tree file for the freshness hash."""
+    """Read one source-tree file for the freshness hash.
+
+    Normalize newlines to LF so Windows working trees with CRLF smudge produce
+    the same ``source_tree_sha256`` as Linux CI checkouts (eol=lf in
+    ``.gitattributes``).
+    """
     from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
 
     safe_path = resolve_output_path(path, root=REPO_ROOT)
     with safe_path.open(
         "rb"
     ) as handle:  # NOSONAR - path confined by resolve_output_path
-        return handle.read()
+        payload = handle.read()
+    return payload.replace(b"
+", b"
+").replace(b"", b"
+")
 
 
 @cache

--- a/tests/architecture/test_docs_governance_workflow.py
+++ b/tests/architecture/test_docs_governance_workflow.py
@@ -24,7 +24,7 @@ def test_tests_workflow_keeps_docs_only_changes_out_of_heavy_matrix() -> None:
     workflow = Path(".github/workflows/tests.yml").read_text(encoding="utf-8")
 
     assert "paths-ignore:" in workflow
-    assert "'docs/**'" in workflow
+    assert "'docs/**'" in workflow or '"docs/**"' in workflow
 
 
 def test_docs_workflow_runs_lightweight_docs_governance_profile() -> None:

--- a/tests/architecture/test_observability_metric_governance.py
+++ b/tests/architecture/test_observability_metric_governance.py
@@ -416,10 +416,9 @@ def test_tests_workflow_keeps_local_cardinality_fallback_out_of_release_gate() -
     assert workflow.index("--allow-local-cardinality-fallback") < workflow.index(
         "Review observability runtime cardinality evidence"
     )
-    release_gate = workflow.split(
-        "-   name: Review observability runtime cardinality evidence",
-        1,
-    )[1]
+    marker = "name: Review observability runtime cardinality evidence"
+    assert marker in workflow
+    release_gate = workflow.split(marker, 1)[1]
     assert "--fail-on-degraded-live-review" in release_gate
     assert "--allow-local-cardinality-fallback" not in release_gate
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
+import contextlib
 import enum
 import gc
-import importlib.util
 import inspect
 import os
 import pathlib
@@ -278,7 +278,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # Register a compatibility flag when no plugin already owns it. A
     # present-but-inactive pytest-recording install must not leave the option
     # unregistered (control-plane-e2e / CI-C1 closeout).
-    try:
+    with contextlib.suppress(ValueError):
         parser.addoption(
             "--vcr-record",
             action="store",
@@ -288,9 +288,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                 "(none|once|new_episodes|all). Prefer VCR_RECORD_MODE env."
             ),
         )
-    except ValueError:
-        # Already registered by pytest-recording / pytest-vcr.
-        pass
 
 
 def pytest_cmdline_main(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,17 +275,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Enable richer pilot-only live contract suites (equivalent to BIOETL_PILOT_SOAK_TESTS=true).",
     )
     # Workflows may pass --vcr-record=... Prefer VCR_RECORD_MODE when possible.
-    # Register a compatibility flag whenever no plugin already owns it — a
+    # Register a compatibility flag when no plugin already owns it. A
     # present-but-inactive pytest-recording install must not leave the option
     # unregistered (control-plane-e2e / CI-C1 closeout).
-    option_names = {opt.dest for opt in parser._anonymous.options}  # noqa: SLF001
-    option_names.update(
-        name.lstrip("-").replace("-", "_")
-        for group in parser._groups  # noqa: SLF001
-        for opt in getattr(group, "options", [])
-        for name in getattr(opt, "names", ())
-    )
-    if "vcr_record" not in option_names:
+    try:
         parser.addoption(
             "--vcr-record",
             action="store",
@@ -295,6 +288,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                 "(none|once|new_episodes|all). Prefer VCR_RECORD_MODE env."
             ),
         )
+    except ValueError:
+        # Already registered by pytest-recording / pytest-vcr.
+        pass
 
 
 def pytest_cmdline_main(config):

--- a/tests/integration/test_grafana_dashboard_metric_semantics.py
+++ b/tests/integration/test_grafana_dashboard_metric_semantics.py
@@ -1796,12 +1796,16 @@ def test_processed_records_parameter_rows_sort_and_display_cleanly(
     )
     identity = panels[identity_id]
     processed = panels[processed_id]
-    assert identity.get("gridPos", {}).get("h") == processed.get(
-        "gridPos", {}
-    ).get("h") == 6
-    assert identity.get("options", {}).get("cellHeight") == processed.get(
-        "options", {}
-    ).get("cellHeight") == "sm"
+    assert (
+        identity.get("gridPos", {}).get("h")
+        == processed.get("gridPos", {}).get("h")
+        == 6
+    )
+    assert (
+        identity.get("options", {}).get("cellHeight")
+        == processed.get("options", {}).get("cellHeight")
+        == "sm"
+    )
     default_identity_cell_options = (
         identity.get("fieldConfig", {})
         .get("defaults", {})


### PR DESCRIPTION
## Summary
- Fix `tests/conftest.py` `--vcr-record` fallback that crashed pytest collection (`TypeError: 'method' object is not iterable`), which dual-failed root-hygiene unit tests and smoke/control-plane lanes.
- Ruff-format `tests/integration/test_grafana_dashboard_metric_semantics.py` for the strict lint format gate.
- Restamp drifted CI governance artifacts: dependency map fingerprint, test-governance snapshots, scripts inventory, scorecard/debt gates, residual backlog, artifact duplication.

## Context
Follow-up to merged #7531 / main tips `7e2c787` + `7a4c08d` + `175570ed` which fixed:
- `.agents` root tooling approval (#root hygiene)
- PowerShell proxy restore on Linux (`repo-backed-unit` green)
- Grafana panel title/docs + transparent threshold color
- VCR_RECORD_MODE preference for control-plane

## Issues
Closes remaining red gates for #7515 #7516 #7517 #7518 #7519 #7520 #7521 after evidence on this PR head.

## Test plan
- [ ] root-hygiene / no-pyc green
- [ ] lint + arch-tests green
- [ ] governance-preflight + config-schema-preflight green
- [ ] repo-backed-unit green
- [ ] smoke-check + control-plane-e2e not dual-fail on missing junit