### PR TITLE
fix(ci): ruff-format selectors + restamp test-governance for CI-C1

### DIFF
--- a/docs/02-architecture/generated/module-dependency-map.json
+++ b/docs/02-architecture/generated/module-dependency-map.json
@@ -6,7 +6,7 @@
     "cross_layer_group_edges": 55,
     "cross_layer_group_edges_total": 310,
     "violations": 0,
-    "source_fingerprint": "6505e24880b98dfed5a1144be705487930f9b6031ff7672e65bcf6398dadf981"
+    "source_fingerprint": "effb241806b8f59e75e522e5584f4292ba3bd4c3210c4660c3d500b20e30643e"
   },
   "layer_edges": [
     {

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "980bd0a0c4d06baa1b47ec6050441ab25dcb11c8fe9f1eed42e24667a16551fe"
+    "test_governance_source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 2,
-    "test_governance_source_tree_sha256": "980bd0a0c4d06baa1b47ec6050441ab25dcb11c8fe9f1eed42e24667a16551fe",
+    "test_governance_source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140",
     "total_flaky": 0,
     "total_test_files": 2178,
     "total_tests_analyzed": 23291

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2367,7 +2367,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "980bd0a0c4d06baa1b47ec6050441ab25dcb11c8fe9f1eed42e24667a16551fe",
+  "source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/src/bioetl/interfaces/http/_control_plane_selector_records.py
+++ b/src/bioetl/interfaces/http/_control_plane_selector_records.py
@@ -163,7 +163,9 @@ def _build_selector_record(
         manifest_id=manifest.manifest_id,
         started_at=started_at,
         started_at_source=(
-            "run_ledger_started_event" if started_entry else "manifest_created_at_fallback"
+            "run_ledger_started_event"
+            if started_entry
+            else "manifest_created_at_fallback"
         ),
         completed_at=completed_at,
         completed_at_source=(

--- a/tests/unit/interfaces/http/test_control_plane_identity_helper_branches.py
+++ b/tests/unit/interfaces/http/test_control_plane_identity_helper_branches.py
@@ -346,7 +346,9 @@ def test_selector_payload_helpers_cover_empty_selected_and_ordering_edges() -> N
     ]
     assert options["run_status"] == ["unknown", "success"]
     assert selector_payloads.defaults_payload()["run_type_fallback"] == "backfill"
-    assert selector_payloads.defaults_payload()["run_id_list_order"] == "started_at_desc"
+    assert (
+        selector_payloads.defaults_payload()["run_id_list_order"] == "started_at_desc"
+    )
 
     assert selector_payloads.exact_run_only_fallback_values(None) == []
     assert selector_payloads.exact_run_only_fallback_values("  ") == []

--- a/tests/unit/interfaces/http/test_control_plane_selector_filters.py
+++ b/tests/unit/interfaces/http/test_control_plane_selector_filters.py
@@ -50,9 +50,7 @@ def _record(
     run_status: str,
     completed_offset: int,
 ) -> SelectorRecord:
-    stamp = datetime(2026, 7, 7, 9, 0, tzinfo=UTC) + timedelta(
-        minutes=completed_offset
-    )
+    stamp = datetime(2026, 7, 7, 9, 0, tzinfo=UTC) + timedelta(minutes=completed_offset)
     return SelectorRecord(
         manifest=cast(Any, None),
         workflow=workflow_candidates[0],


### PR DESCRIPTION
## Summary
Follow-up after #7561 merge:
- ruff-format control-plane selector modules/tests (quality-and-architecture / lint)
- restamp test-governance + flaky burndown after format

## Related
#7515 #7517 #7519 (artifact/lint gates)