### PR TITLE
fix(observability): Ops HTTP :8000 defaults; disable Quarantine Explorer ensure

### DIFF
--- a/.codex/skills/grafana-dashboard-render/SKILL.md
+++ b/.codex/skills/grafana-dashboard-render/SKILL.md
@@ -14,8 +14,8 @@ This skill is for:
 
 - full runtime-render refresh of `grafana/dashboards/*.json`
 - preflight checks before a dashboard audit
-- live reviewed panel validation against Grafana, Prometheus, and Quarantine
-  Explorer
+- live reviewed panel validation against Grafana, Prometheus, and BioETL Ops
+  HTTP (`bioetl health server` on `:8000`)
 - diagnosing render failures such as `401`, missing Playwright runtime, or
   missing Chromium shared libraries
 
@@ -110,8 +110,8 @@ Interpretation:
 - `grafana-render-auth: ok` means render-sensitive auth is valid
 - `playwright-runtime: ok/error` tells you whether browser fallback can work on
   this host
-- `quarantine-explorer: ok/error` tells you whether HTTP-backed dashboard panels
-  can be audited safely
+- `quarantine-explorer` / Ops HTTP probe: prefer BioETL Ops HTTP health on
+  `:8000` for HTTP-backed identity panels (Explorer UI removed 2026-07-23)
 
 If preflight fails, report the failing check explicitly before attempting more
 render work.
@@ -205,7 +205,7 @@ uv run python -m scripts.ops audit-live-grafana \
   --pipeline <pipeline> \
   --run-type <run_type> \
   --run-id <run_id> \
-  --app-base-url http://127.0.0.1:8081 \
+  --app-base-url http://127.0.0.1:8000 \
   --output /tmp/live-panel-audit.json
 ```
 
@@ -216,7 +216,7 @@ Use this when the user cares about:
 - checkpoint freshness
 - DQ freshness
 - zero-vs-no-data semantics
-- Silver Reject Explorer denominator behavior
+- control-plane identity / Ops HTTP tables
 
 ### 6. Audit only runtime renders
 
@@ -255,8 +255,8 @@ When blocked:
   `GRAFANA_USERNAME` / `GF_SECURITY_ADMIN_USER`). Do not document or commit a
   default password; preflight fails closed when auth material is missing.
 - Service-account auth may be provided through `GRAFANA_SERVICE_ACCOUNT_TOKEN`.
-- Quarantine Explorer-backed dashboards may require a live BioETL HTTP backend
-  on `127.0.0.1:8081`.
+- BioETL Ops HTTP identity panels require a live `bioetl health server` on
+  `127.0.0.1:8000` (not Quarantine Explorer / `:8081`).
 
 ## Validation Checklist
 

--- a/.junie/skills/grafana-dashboard-render/SKILL.md
+++ b/.junie/skills/grafana-dashboard-render/SKILL.md
@@ -14,8 +14,8 @@ This skill is for:
 
 - full runtime-render refresh of `grafana/dashboards/*.json`
 - preflight checks before a dashboard audit
-- live reviewed panel validation against Grafana, Prometheus, and Quarantine
-  Explorer
+- live reviewed panel validation against Grafana, Prometheus, and BioETL Ops
+  HTTP (`bioetl health server` on `:8000`)
 - diagnosing render failures such as `401`, missing Playwright runtime, or
   missing Chromium shared libraries
 
@@ -110,8 +110,8 @@ Interpretation:
 - `grafana-render-auth: ok` means render-sensitive auth is valid
 - `playwright-runtime: ok/error` tells you whether browser fallback can work on
   this host
-- `quarantine-explorer: ok/error` tells you whether HTTP-backed dashboard panels
-  can be audited safely
+- `quarantine-explorer` / Ops HTTP probe: prefer BioETL Ops HTTP health on
+  `:8000` for HTTP-backed identity panels (Explorer UI removed 2026-07-23)
 
 If preflight fails, report the failing check explicitly before attempting more
 render work.
@@ -205,7 +205,7 @@ uv run python -m scripts.ops audit-live-grafana \
   --pipeline <pipeline> \
   --run-type <run_type> \
   --run-id <run_id> \
-  --app-base-url http://127.0.0.1:8081 \
+  --app-base-url http://127.0.0.1:8000 \
   --output /tmp/live-panel-audit.json
 ```
 
@@ -216,7 +216,7 @@ Use this when the user cares about:
 - checkpoint freshness
 - DQ freshness
 - zero-vs-no-data semantics
-- Silver Reject Explorer denominator behavior
+- control-plane identity / Ops HTTP tables
 
 ### 6. Audit only runtime renders
 
@@ -255,8 +255,8 @@ When blocked:
   `GRAFANA_USERNAME` / `GF_SECURITY_ADMIN_USER`). Do not document or commit a
   default password; preflight fails closed when auth material is missing.
 - Service-account auth may be provided through `GRAFANA_SERVICE_ACCOUNT_TOKEN`.
-- Quarantine Explorer-backed dashboards may require a live BioETL HTTP backend
-  on `127.0.0.1:8081`.
+- BioETL Ops HTTP identity panels require a live `bioetl health server` on
+  `127.0.0.1:8000` (not Quarantine Explorer / `:8081`).
 
 ## Validation Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CLI observability backend defaults (#7562–#7565):**
+  `--ensure-observability-backend` now defaults to **off**;
+  `DEFAULT_HEALTH_SERVER_PORT` / Ops HTTP identity surface is **8000**.
+  When ensure is explicitly enabled, the detached backend starts
+  `bioetl health server` (BioETL Ops HTTP), not `quarantine serve`.
+  Grafana dashboard audit cycle defaults match. Operator docs and skills
+  residual Explorer wording aligned to Ops HTTP.
+
 - **Monitoring surface reduction (2026-07-23, strategy A soft + hard removals):**
   Opt-in monitoring stack is Prometheus / Pushgateway / Grafana / image-renderer
   only (`make docker-start-monitoring`). **Removed** from shipping Docker/UI:

--- a/docs/00-project/ai/skills/local/grafana-dashboard-render/SKILL.md
+++ b/docs/00-project/ai/skills/local/grafana-dashboard-render/SKILL.md
@@ -1,9 +1,3 @@
-> Mirror status: This file is a published/internal mirror under `docs/00-project/ai/**`. It is not a canonical runtime surface.
-> Canonical runtime source: `.codex/skills/grafana-dashboard-render/SKILL.md`
-> Governance: AI_RUNTIME_MIRROR_OWNERSHIP.md
-> Edit the runtime source first, then refresh this mirror.
-______________________________________________________________________
-
 ---
 name: grafana-dashboard-render
 description: Render, preflight-check, and capture runtime evidence for shipped BioETL Grafana dashboards. Use when the task is to produce reproducible dashboard renders, validate Grafana render/auth readiness, run live reviewed panel audits, or explain why full render is blocked on the current host.
@@ -20,8 +14,8 @@ This skill is for:
 
 - full runtime-render refresh of `grafana/dashboards/*.json`
 - preflight checks before a dashboard audit
-- live reviewed panel validation against Grafana, Prometheus, and Quarantine
-  Explorer
+- live reviewed panel validation against Grafana, Prometheus, and BioETL Ops
+  HTTP (`bioetl health server` on `:8000`)
 - diagnosing render failures such as `401`, missing Playwright runtime, or
   missing Chromium shared libraries
 
@@ -31,17 +25,16 @@ dashboard JSON, queries, navigation, or operator-facing UX.
 ## BioETL Runtime Policy
 
 - Project runtime contract: `../../../AGENTS.md`
+- Memory policy: `../../../docs/00-project/ai/agents/guides/MEMORY_USAGE.md`
+- Post-change validation: `../../../docs/00-project/ai/agents/policy/POST_CHANGE_VALIDATION.md`
 
 ## Source Of Truth
 
-- Normative index: `../../../../NORMATIVE_SOURCES.md`
-- Root runtime contract: `../../../../../../AGENTS.md`
-- Project rules: `../../../../RULES.md`
-- Requirements: `../../../../../01-requirements/REQUIREMENTS.md`
-- Accepted ADRs in `../../../../../02-architecture/decisions/`
-- Memory policy: `../../../agents/guides/MEMORY_USAGE.md`
-- Post-change validation: `../../../agents/policy/POST_CHANGE_VALIDATION.md`
-
+- Root runtime contract: `../../../AGENTS.md`
+- Project rules: `../../../docs/00-project/RULES.md`
+- Requirements: `../../../docs/01-requirements/REQUIREMENTS.md`
+- Accepted ADRs: `../../../docs/02-architecture/decisions`
+- Normative index: `../../../docs/00-project/NORMATIVE_SOURCES.md`
 - Shared Grafana/Prometheus prerequisites: [../grafana-dashboard-extension/references/grafana-prometheus-prerequisites.md](../grafana-dashboard-extension/references/grafana-prometheus-prerequisites.md)
 - Shipped dashboards: `grafana/dashboards/*.json`
 - Canonical screenshot tooling:
@@ -117,8 +110,8 @@ Interpretation:
 - `grafana-render-auth: ok` means render-sensitive auth is valid
 - `playwright-runtime: ok/error` tells you whether browser fallback can work on
   this host
-- `quarantine-explorer: ok/error` tells you whether HTTP-backed dashboard panels
-  can be audited safely
+- `quarantine-explorer` / Ops HTTP probe: prefer BioETL Ops HTTP health on
+  `:8000` for HTTP-backed identity panels (Explorer UI removed 2026-07-23)
 
 If preflight fails, report the failing check explicitly before attempting more
 render work.
@@ -212,7 +205,7 @@ uv run python -m scripts.ops audit-live-grafana \
   --pipeline <pipeline> \
   --run-type <run_type> \
   --run-id <run_id> \
-  --app-base-url http://127.0.0.1:8081 \
+  --app-base-url http://127.0.0.1:8000 \
   --output /tmp/live-panel-audit.json
 ```
 
@@ -223,7 +216,7 @@ Use this when the user cares about:
 - checkpoint freshness
 - DQ freshness
 - zero-vs-no-data semantics
-- Silver Reject Explorer denominator behavior
+- control-plane identity / Ops HTTP tables
 
 ### 6. Audit only runtime renders
 
@@ -262,8 +255,8 @@ When blocked:
   `GRAFANA_USERNAME` / `GF_SECURITY_ADMIN_USER`). Do not document or commit a
   default password; preflight fails closed when auth material is missing.
 - Service-account auth may be provided through `GRAFANA_SERVICE_ACCOUNT_TOKEN`.
-- Quarantine Explorer-backed dashboards may require a live BioETL HTTP backend
-  on `127.0.0.1:8081`.
+- BioETL Ops HTTP identity panels require a live `bioetl health server` on
+  `127.0.0.1:8000` (not Quarantine Explorer / `:8081`).
 
 ## Validation Checklist
 

--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -235,7 +235,7 @@ dashboards `0. Control Plane`, `2. Runtime`, `3. Provider Health`,
 | --- | ---:| --- | --- |
 | `Inspect Scope & Evidence` | `9400` | Question and evidence-scope banner | Visible text contains the primary dashboard question and short plain-language definitions of the evidence scopes used on the page. Selector values and datasource details stay in the panel tooltip/description. |
 | `Status` | `9401` | Compact dashboard verdict | Prometheus status for the dashboard role; no `$run_id` Prometheus filtering. `5. Workflow` is selected-range evidence and must say so. |
-| `ID` | `9402` | Local control-plane identity | HTTP/Infinity `Quarantine Explorer` table from `/ops/control-plane/identity-table`; exact `run_id` is preserved HTTP identity context across primary dashboards. The two visible columns are `parameter` and `value`; rows cover run/manifest IDs, Provider.Entity version, contract schema, execution flags, replay capability/mode, checkpoint anchors, optional composite run, and identity health. |
+| `ID` | `9402` | Local control-plane identity | HTTP/Infinity `BioETL Ops HTTP` table from `/ops/control-plane/identity-table`; exact `run_id` is preserved HTTP identity context across primary dashboards. The two visible columns are `parameter` and `value`; rows cover run/manifest IDs, Provider.Entity version, contract schema, execution flags, replay capability/mode, checkpoint anchors, optional composite run, and identity health. |
 | `Processed Records` | `9403` | Current stage/outcome accounting evidence | HTTP/Infinity table from `/ops/observability/processed-records`, backed by compact `bioetl_processed_records_*` recording rules and canonical `bioetl_stage_records_total` outcomes. It shows non-zero Bronze, Silver outcome, and Gold outcome rows only, with `value` plus canonical formatted `percentage` columns. Internal `row_status` is hidden. `value` uses a space as the thousands separator, is left-padded to the displayed `bronze [total]` width, and is right-aligned in the table. Bronze is `100%`; `silver [valid]` and `gold [valid]` use one decimal; secondary outcomes use up to three decimals with trailing zeroes trimmed. Silver and Gold percentages use Bronze total. Status, accounted subtotal, and delta rows stay out of the compact table. Missing accounting series are no-data/instrumentation gaps, not OK. |
 
 Normative rules:
@@ -335,7 +335,7 @@ Datasource categories:
 
 - **Primary operator datasource**: Prometheus for current verdict, current
   causes, selected-range evidence, and KPI panels.
-- **Secondary forensic datasource**: Quarantine Explorer HTTP API for row-level
+- **Secondary forensic datasource**: BioETL Ops HTTP HTTP API for row-level
   reject exploration and payload/detail inspection.
 - **Investigative handoff surfaces**: Loki / Tempo through `Explore Logs` and
   `Explore Traces`; these are handoffs, not shipped dashboards.

--- a/docs/03-guides/dashboards/panels/bioetl-control-plane-v1-panels.md
+++ b/docs/03-guides/dashboards/panels/bioetl-control-plane-v1-panels.md
@@ -14,7 +14,7 @@ JSON is the source of truth.
   `run_type`, `run_id`.
 - Prometheus summary panels normalize the selected `pipeline` when the metric
   family stores workflow-prefixed pipeline labels.
-- `Quarantine Explorer` table/stat panels depend on the detached HTTP control
+- `BioETL Ops HTTP` table/stat panels depend on the detached HTTP control
   plane backend rather than Prometheus.
 
 ## Panel inventory
@@ -26,12 +26,12 @@ JSON is the source of truth.
 | 1000 | Navigate Dashboards | text | Static | Static navigation handoff into related dashboards and incident paths. | shared shell | No thresholds; operator routing only. |
 | 9400 | Inspect Scope & Evidence | text | Static | Replay-safety question plus plain-language definitions of current, selected-run, and unknown evidence. | shared shell | No thresholds; interpretive guidance only. |
 | 9401 | Monitor Replay Readiness | stat | Prometheus | Evidence-aware replay/resume verdict from `bioetl_control_plane_current_status_trusted`; gates replay blockers, checkpoint freshness/presence, and required telemetry. | shared shell | `0=OK`, `1=WARN`, `2=CRIT`, `3=INCOMPLETE`, `null=UNKNOWN`. `INCOMPLETE` blocks replay/resume approval. |
-| 9402 | Review Run Summary | table | Quarantine Explorer | Identity anchors for the selected workflow/pipeline/run scope. | shared shell | No numeric threshold; forensic handoff table. |
-| 9403 | Review Processed Records | table | Quarantine Explorer | Current processed-record evidence for the selected run scope. | shared shell | No numeric threshold; read-path evidence table. |
+| 9402 | Review Run Summary | table | BioETL Ops HTTP | Identity anchors for the selected workflow/pipeline/run scope. | shared shell | No numeric threshold; forensic handoff table. |
+| 9403 | Review Processed Records | table | BioETL Ops HTTP | Current processed-record evidence for the selected run scope. | shared shell | No numeric threshold; read-path evidence table. |
 | 9410 | Explain Missing Identity Data | text | Static | Neutral visible fallback when the Control Plane identity table returns no visible rows. | shared shell | No thresholds; prevents blank first-screen identity space. |
 | 9411 | Explain Missing Record Counts | text | Static | Neutral visible fallback when the Control Plane accounting table returns no visible rows. | shared shell | No thresholds; distinguishes missing accounting evidence from zero records. |
 | 891 | Monitor Replay Safety | stat | Prometheus | Replay-safety blocker state for the selected scope. | shared shell | Severity/value mapping. |
-| 892 | Monitor Checkpoint Age | stat | Quarantine Explorer | Current checkpoint freshness lag from HTTP-backed control-plane evidence. | shared shell | Numeric lag; no PromQL threshold in doc. |
+| 892 | Monitor Checkpoint Age | stat | BioETL Ops HTTP | Current checkpoint freshness lag from HTTP-backed control-plane evidence. | shared shell | Numeric lag; no PromQL threshold in doc. |
 | 893 | Monitor Manifest & Ledger Failures | stat | Prometheus | Current manifest/ledger failure state from `bioetl_manifest_ledger_failures_15m`. | shared shell | Severity/value mapping. |
 | 907 | Monitor Telemetry Coverage | stat | Prometheus | Missing-control-plane-telemetry signal from `bioetl_control_plane_telemetry_missing_5m`. | shared shell | Value mapping distinguishes no-data vs telemetry-missing. |
 | 906 | Review Recovery Action | text | Static | Static operator next-step guidance for replay/control-plane incidents. | shared shell | Drilldown router into the replay-safety row below. |
@@ -97,13 +97,13 @@ JSON is the source of truth.
 
 | ID | Title | Type | Datasource | Query / purpose | Variables | Thresholds / drilldown |
 | --- | --- | --- | --- | --- | --- | --- |
-| 905 | Inspect Run Identity Evidence | row | Static | Collapsed identity-evidence and handoff section; the copyable identity anchor panels `9404` and `9407` remain above it on the first path. | shared shell | Groups remaining Quarantine Explorer evidence without replacing the first-screen replay/resume summary. |
-| 9404 | Review Identity Anchors | table | Quarantine Explorer | Compact forensic identity anchors for the selected scope; use after ID, Replay Safety, Checkpoint Freshness, Manifest/Ledger, and Telemetry summary cards. | shared shell | Forensic handoff table. |
-| 9405 | Review Identity Gaps | table | Quarantine Explorer | Compact missing identity surface inventory for the selected scope. | shared shell | Gap table; no numeric threshold. |
-| 9406 | Compare Checkpoint Anchors | table | Quarantine Explorer | Compact side-by-side checkpoint anchor comparison. | shared shell | Comparison table; operator drilldown surface. |
-| 9407 | Copy Identity Values | table | Quarantine Explorer | Compact copy-ready IDs/anchors for incident handoff. | shared shell | Handoff table only. |
-| 9408 | Review Required Replay Anchors | table | Quarantine Explorer | Compact priority replay/evidence anchors for first-line investigation. | shared shell | Incident handoff table. |
-| 9409 | Review Additional Forensic Anchors | table | Quarantine Explorer | Compact secondary forensic anchors for deeper analysis. | shared shell | Incident handoff table. |
+| 905 | Inspect Run Identity Evidence | row | Static | Collapsed identity-evidence and handoff section; the copyable identity anchor panels `9404` and `9407` remain above it on the first path. | shared shell | Groups remaining BioETL Ops HTTP evidence without replacing the first-screen replay/resume summary. |
+| 9404 | Review Identity Anchors | table | BioETL Ops HTTP | Compact forensic identity anchors for the selected scope; use after ID, Replay Safety, Checkpoint Freshness, Manifest/Ledger, and Telemetry summary cards. | shared shell | Forensic handoff table. |
+| 9405 | Review Identity Gaps | table | BioETL Ops HTTP | Compact missing identity surface inventory for the selected scope. | shared shell | Gap table; no numeric threshold. |
+| 9406 | Compare Checkpoint Anchors | table | BioETL Ops HTTP | Compact side-by-side checkpoint anchor comparison. | shared shell | Comparison table; operator drilldown surface. |
+| 9407 | Copy Identity Values | table | BioETL Ops HTTP | Compact copy-ready IDs/anchors for incident handoff. | shared shell | Handoff table only. |
+| 9408 | Review Required Replay Anchors | table | BioETL Ops HTTP | Compact priority replay/evidence anchors for first-line investigation. | shared shell | Incident handoff table. |
+| 9409 | Review Additional Forensic Anchors | table | BioETL Ops HTTP | Compact secondary forensic anchors for deeper analysis. | shared shell | Incident handoff table. |
 | 139 | Review Uncovered Replay Signals | text | Static | Static reminder of residual replay-safety signals to inspect after core blockers. | shared shell | No thresholds; review checklist only. |
 
 ### Run context (thin) -> Run Explorer hub
@@ -172,7 +172,7 @@ panels; HTTP-backed identity panels are documented in the inventory above.
   so replay blockers cannot render green when checkpoint evidence is missing or
   stale (`>=900s` WARN, `>=3600s` CRIT) or required telemetry is incomplete.
 - `Checkpoint Freshness Lag`, `ID`, `Processed Records`, and the identity
-  evidence tables are HTTP-backed `Quarantine Explorer` surfaces rather than
+  evidence tables are HTTP-backed `BioETL Ops HTTP` surfaces rather than
   Prometheus metric panels.
 - Thresholds and value mappings not spelled out above should be taken from the
   shipped panel JSON; this page documents the panel inventory, datasource

--- a/docs/03-guides/dashboards/panels/bioetl-workflow-overview-panels.md
+++ b/docs/03-guides/dashboards/panels/bioetl-workflow-overview-panels.md
@@ -22,7 +22,7 @@ Dashboard `5. Workflow` was retired in epic #6647. Workflow evidence now lives o
   `pipeline_context`, `pipeline_context_exact`, `run_type_context`,
   `run_type_context_exact`, `provider_context`, `provider_context_exact`,
   `step_status`, and `step_kind`.
-- `ID` and `Processed Records` use the detached `Quarantine Explorer`
+- `ID` and `Processed Records` use the detached `BioETL Ops HTTP`
   datasource; the rest of the dashboard is Prometheus-backed.
 
 ## Panel inventory
@@ -35,8 +35,8 @@ Dashboard `5. Workflow` was retired in epic #6647. Workflow evidence now lives o
 | 9400 | Inspect Scope & Evidence | text | Static | Static explanation of selector context, datasource posture, and workflow evidence boundaries. | shared shell | No thresholds; interpretive guidance only. |
 | 9401 | Status | stat | Prometheus | Selected-range workflow severity synthesized from failed workflow runs and skipped/non-success step evidence. | shared shell | `OK` is neutral gray selected-range evidence, not a live-run health claim. |
 | 9404 | Pipeline Status | stat | Prometheus | Supporting workflow pipeline verdict from `bioetl_workflow_pipeline_verdict_status`; no runtime fallback. | shared shell + context selectors | `SUPPORTING OK` is neutral; absent workflow pipeline evidence is `NOT RESOLVED`, never green. |
-| 9402 | ID | table | Quarantine Explorer | Identity anchors for the selected workflow/pipeline/run scope. | shared shell | Forensic handoff table. |
-| 9403 | Processed Records | table | Quarantine Explorer | Processed-record evidence for the selected workflow/pipeline/run scope. | shared shell | Evidence table; no numeric threshold. |
+| 9402 | ID | table | BioETL Ops HTTP | Identity anchors for the selected workflow/pipeline/run scope. | shared shell | Forensic handoff table. |
+| 9403 | Processed Records | table | BioETL Ops HTTP | Processed-record evidence for the selected workflow/pipeline/run scope. | shared shell | Evidence table; no numeric threshold. |
 | 2 | Failed Workflow Runs / Range | stat | Prometheus | Failed workflow-run count over the selected range. | shared shell | Zero maps to neutral `0 · valid empty range`. |
 | 3 | Failed Pipeline Steps / Range | stat | Prometheus | Failed workflow step events with `step_kind="pipeline"`. | shared shell | Zero maps to neutral `0 · valid empty range`. |
 | 9410 | Failed Entity Pipeline Runs / Range | stat | Prometheus | Failed entity pipeline runs over the selected range. | shared shell + context selectors | Count panel. |

--- a/docs/03-guides/dashboards/panels/dashboard-panels-guide.md
+++ b/docs/03-guides/dashboards/panels/dashboard-panels-guide.md
@@ -23,7 +23,7 @@
 2. **Тип визуализации** - graph, stat, table, heatmap и т.д.
 3. **Назначение** - что показывает панель
 4. **Источники данных** — фактический datasource: Prometheus metric family,
-   Quarantine Explorer HTTP endpoint, Loki или Grafana metadata. HTTP-backed
+   BioETL Ops HTTP HTTP endpoint, Loki или Grafana metadata. HTTP-backed
    identity/forensic panels нельзя документировать как Prometheus panels.
 5. **Формулы/запросы** - PromQL запросы
 6. **Фильтры/переменные** - какие переменные Grafana используются

--- a/docs/03-guides/dashboards/variable-reference.md
+++ b/docs/03-guides/dashboards/variable-reference.md
@@ -139,7 +139,7 @@ Explorer subset safety, and zero unexplained values.
   - `$pipeline_context` is preserved from source dashboard links
   - `$adapter` is optional detail scope, not required on handoff
 - `bioetl-silver-reject-explorer`
-  - `$pipeline` is required before Quarantine Explorer reads are trustworthy
+  - `$pipeline` is required before BioETL Ops HTTP reads are trustworthy
   - `$reason_code`, `$field`, `$quarantine_run_id`, `$payload_hash` are explorer-only narrowing filters
 - `bioetl-overview-v2`
   - `$workflow`, `$pipeline`, and `$run_type` define the aggregate L0 context

--- a/docs/03-guides/running-pipelines.md
+++ b/docs/03-guides/running-pipelines.md
@@ -124,11 +124,12 @@ published family default, поэтому этот флаг не является
 guardrails.
 
 HTTP identity helpers for Grafana (`ID` / control-plane selectors) are served by
-the main **`bioetl health server`** (Docker default `:8000`, datasource
-**BioETL Ops HTTP**). The former detached Quarantine Explorer on `:8081` and
-auto-ensure path for `quarantine serve` are **not** part of the default surface
-after 2026-07-23. For opt-out of any remaining observability-backend helpers use
-`--no-ensure-observability-backend` where the CLI still exposes that flag.
+the main **`bioetl health server`** (default **`:8000`**, datasource
+**BioETL Ops HTTP**). CLI default does **not** auto-start any detached
+observability backend (`--ensure-observability-backend` is off). Quarantine
+Explorer / `quarantine serve` on `:8081` is not part of the shipping surface.
+Optional opt-in: `--ensure-observability-backend` starts `bioetl health server`
+on `--observability-backend-port` (default 8000).
 
 Для inspection используются команды:
 

--- a/docs/03-guides/workflows.md
+++ b/docs/03-guides/workflows.md
@@ -509,8 +509,9 @@ The current CLI surface that matters most for packs is:
 - `--incremental` for ordinary offset-driven launches that should advance from
   the latest successful execution rather than replay an old occurrence;
 - `--only-steps` when an operator needs one bounded subset of the pack DAG;
-- `--ensure-observability-backend` and `--observability-backend-port` when the
-  operator wants Grafana ID/detail panels to have a live detached backend.
+- optional `--ensure-observability-backend` and `--observability-backend-port`
+  (default **8000**) when the operator wants Grafana ID/detail panels backed by
+  a detached **BioETL Ops HTTP** / `bioetl health server` (default ensure is off).
 
 #### `chembl_reference_pack`
 
@@ -575,7 +576,7 @@ Canonical examples:
 
 ```bash
 bioetl workflow run uniprot_support_pack --dry-run
-bioetl workflow run uniprot_support_pack --incremental --observability-backend-port 18081
+bioetl workflow run uniprot_support_pack --incremental --ensure-observability-backend
 bioetl workflow run uniprot_support_pack --resume-manifest-id wf-manifest-2026-06-30-001
 ```
 
@@ -583,8 +584,8 @@ Operator notes:
 
 - the small DAG makes it a good bounded smoke target for workflow control-plane
   validation;
-- use a non-default observability backend port when another local BioETL HTTP
-  backend already occupies `8081`.
+- prefer a long-lived `bioetl health server --port 8000` for Grafana Ops HTTP;
+  use `--ensure-observability-backend` only as a short-lived opt-in helper.
 
 ### 3. Canonical ChemblBaseline Workflow
 

--- a/docs/04-reference/cli.md
+++ b/docs/04-reference/cli.md
@@ -104,8 +104,8 @@ bioetl workflow status <NAME> [OPTIONS]
 | `--force-steps a,b` | Явно форсировать указанные шаги при resume вместо обычного skip поведения |
 | `--repair-steps a,b` | Явно пометить шаги как repair path для destructive ambiguity recovery |
 | `--incremental` | Автоматически продвинуть `start_offset` от последнего успешного workflow execution; несовместим с resume selectors и явным `--start-offset` |
-| `--ensure-observability-backend/--no-ensure-observability-backend` | Legacy flag; default Docker main surface no longer auto-starts Quarantine Explorer (`:8081`). Identity panels use `bioetl health server` / BioETL Ops HTTP on `:8000` |
-| `--observability-backend-port` | Legacy port for detached observability helper (prefer health server `:8000` for Grafana identity) |
+| `--ensure-observability-backend/--no-ensure-observability-backend` | **Default off.** Opt-in auto-start of detached **BioETL Ops HTTP** backend (`bioetl health server`) for Grafana ID/detail panels. Does not start Quarantine Explorer / `:8081`. Prefer a long-lived `bioetl health server --port 8000`. |
+| `--observability-backend-port` | Port for the opt-in detached Ops HTTP / health server backend (**default 8000**) |
 
 **`workflow status` опции:**
 

--- a/docs/05-operations/runbooks/monitoring-surface-reduction-2026-07-23.md
+++ b/docs/05-operations/runbooks/monitoring-surface-reduction-2026-07-23.md
@@ -57,6 +57,14 @@ The old Quarantine Explorer port `:8081` is not published by default.
 
 `python -m scripts.ops ensure-quarantine-explorer` is a fail-closed stub (exit 2).
 
+### CLI alignment (follow-up)
+
+- `--ensure-observability-backend` defaults to **off**
+- default health / Ops HTTP port is **8000** (`DEFAULT_HEALTH_SERVER_PORT`)
+- when ensure is explicitly enabled, CLI starts **`bioetl health server`**, not
+  `quarantine serve`
+- Grafana audit cycle defaults match: no auto-ensure; app base URL `:8000`
+
 ## Residual volumes
 
 Legacy volumes `*-loki-data` / `*-tempo-data` may still exist on disk. Do **not**

--- a/docs/05-operations/runbooks/observability-checklist.md
+++ b/docs/05-operations/runbooks/observability-checklist.md
@@ -133,7 +133,7 @@ Service ownership for this section is `@bioetl-observability`.
   server `up{job="bioetl"}` and `GET http://127.0.0.1:8000/health/live` (Docker
   scrape target `bioetl:8000`). Until healthy, classify HTTP-backed identity and
   processed-record panels as backend unavailable rather than valid-empty.
-  Quarantine Explorer scrape/alert was removed 2026-07-23.
+  BioETL Ops HTTP scrape/alert was removed 2026-07-23.
 - `BioETLGrafanaRendererUnavailable`: verify
   `up{job="grafana-image-renderer"}`, Grafana `rendererAvailable`, and one
   server-side render probe. Until it clears, mark screenshot evidence as render

--- a/scripts/ops/observability/grafana/ensure_quarantine_explorer.py
+++ b/scripts/ops/observability/grafana/ensure_quarantine_explorer.py
@@ -20,6 +20,11 @@ def main(argv: list[str] | None = None) -> int:
         "Domain quarantine write-path is unchanged; only the operator Explorer/HTTP UI was deleted.",
         file=sys.stderr,
     )
+    print(
+        "For Grafana identity panels use: bioetl health server --port 8000 "
+        "(BioETL Ops HTTP).",
+        file=sys.stderr,
+    )
     return 2
 
 

--- a/scripts/ops/observability/grafana/run_grafana_dashboard_audit_cycle.py
+++ b/scripts/ops/observability/grafana/run_grafana_dashboard_audit_cycle.py
@@ -49,7 +49,7 @@ from bioetl.interfaces.cli.commands.domains.health.observability_backend_runtime
 
 DEFAULT_GRAFANA_BASE_URL = "http://localhost:3000"
 DEFAULT_PROMETHEUS_BASE_URL = "http://localhost:9090"
-DEFAULT_APP_BASE_URL = "http://localhost:8081"
+DEFAULT_APP_BASE_URL = "http://localhost:8000"
 DEFAULT_SCREENSHOT_DIR = Path("reports/observability/grafana/screenshots")
 DEFAULT_GATE_OUTPUT_PATH = Path(
     "reports/observability/grafana/dashboard-release-gates.json"
@@ -153,16 +153,19 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--ensure-observability-backend",
         action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Auto-start or reuse a detached Quarantine Explorer backend before audit.",
+        default=False,
+        help=(
+            "Opt-in: auto-start or reuse a detached BioETL Ops HTTP "
+            "(health server) backend before audit. Default off."
+        ),
     )
     parser.add_argument(
         "--refresh-observability-backend",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help=(
-            "Force-refresh the detached Quarantine Explorer backend before audit so "
-            "the cycle does not reuse stale route handlers from an older process."
+            "Force-refresh the detached BioETL Ops HTTP (health server) backend "
+            "before audit so the cycle does not reuse stale route handlers."
         ),
     )
     parser.add_argument(
@@ -178,7 +181,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--observability-backend-port",
         type=int,
         default=DEFAULT_HEALTH_SERVER_PORT,
-        help="Port for the detached Quarantine Explorer backend.",
+        help="Port for the detached BioETL Ops HTTP / health server backend.",
     )
     parser.add_argument("--pipeline", default=DEFAULT_PIPELINE)
     parser.add_argument("--run-type", default=DEFAULT_RUN_TYPE)

--- a/src/bioetl/interfaces/cli/commands/_workflow_command_options.py
+++ b/src/bioetl/interfaces/cli/commands/_workflow_command_options.py
@@ -96,7 +96,7 @@ class WorkflowCommandOptions:
             repair_steps=cast(str | None, raw.get("repair_steps")),
             incremental=bool(raw.get("incremental", False)),
             ensure_observability_backend=bool(
-                raw.get("ensure_observability_backend", True)
+                raw.get("ensure_observability_backend", False)
             ),
             observability_backend_port=int(
                 raw.get("observability_backend_port", DEFAULT_HEALTH_SERVER_PORT)

--- a/src/bioetl/interfaces/cli/commands/domains/health/_observability_backend_startup.py
+++ b/src/bioetl/interfaces/cli/commands/domains/health/_observability_backend_startup.py
@@ -51,7 +51,7 @@ def _reuse_observability_backend_if_ready[ResultT](
         warning_printer(
             "Observability backend: existing listener on port "
             f"{port} (pid={existing_pid}) is bound but health probes timeout; "
-            "restarting detached Quarantine Explorer backend."
+            "restarting detached BioETL Ops HTTP (health server) backend."
         )
         if drop_stale_backend_fn(port):
             return None
@@ -77,7 +77,8 @@ def _reuse_observability_backend_if_ready[ResultT](
         )
     warning_printer(
         "Observability backend: existing listener is reachable but missing "
-        "required audit capabilities; restarting detached Quarantine Explorer backend."
+        "required audit capabilities; restarting detached BioETL Ops HTTP "
+        "(health server) backend."
     )
     if drop_stale_backend_fn(port):
         return None
@@ -124,9 +125,9 @@ def _start_observability_backend_detached[ResultT](
     except OSError as exc:
         startup_detail = build_startup_failure_detail_fn(startup_log_path)  # type: ignore[operator]  # pyright: ignore[reportCallIssue]
         warning_printer(  # type: ignore[operator]  # pyright: ignore[reportCallIssue]
-            "Observability backend: failed to start detached Quarantine Explorer "
-            f"backend on port {port} ({exc}). {startup_detail} Grafana ID panels "
-            "may remain empty."
+            "Observability backend: failed to start detached BioETL Ops HTTP "
+            f"(health server) backend on port {port} ({exc}). {startup_detail} "
+            "Grafana ID panels may remain empty."
         )
         return result_factory(
             status="failed",
@@ -193,7 +194,7 @@ def _build_started_backend_result[ResultT](
         health_url=health_url,
         pid=getattr(process, "pid", None),
         command=command,
-        message=f"Started detached Quarantine Explorer backend at {health_url}.",
+        message=f"Started detached BioETL Ops HTTP (health server) at {health_url}.",
     )
 
 
@@ -229,8 +230,8 @@ def _build_backend_capability_failure_result[ResultT](
     )
     startup_detail = build_startup_failure_detail_fn(startup_log_path, process=process)
     warning_printer(
-        "Observability backend: detached Quarantine Explorer process did not "
-        "become ready with required audit capabilities at "
+        "Observability backend: detached BioETL Ops HTTP (health server) process "
+        "did not become ready with required audit capabilities at "
         f"{health_url}. {startup_detail} "
         f"{capability_failure_detail or ''} Grafana ID panels may remain empty."
     )

--- a/src/bioetl/interfaces/cli/commands/domains/health/observability_backend_process.py
+++ b/src/bioetl/interfaces/cli/commands/domains/health/observability_backend_process.py
@@ -232,11 +232,16 @@ def _build_detached_backend_env(
 
 
 def build_detached_backend_log_path(port: int) -> Path:
-    """Return the deterministic detached backend startup log path for one port."""
-    return Path(tempfile.gettempdir()) / f"bioetl-quarantine-backend-{port}.log"
+    """Return the deterministic detached Ops HTTP backend startup log path.
+
+    Uses ``bioetl-ops-http-backend-{port}.log``. A legacy
+    ``bioetl-quarantine-backend-{port}.log`` path is accepted as a read alias
+    only by failure-detail helpers when present.
+    """
+    return Path(tempfile.gettempdir()) / f"bioetl-ops-http-backend-{port}.log"
 
 
-def start_detached_quarantine_backend(
+def start_detached_ops_http_backend(
     *,
     bind_host: str = "0.0.0.0",
     port: int = DEFAULT_HEALTH_SERVER_PORT,
@@ -244,22 +249,24 @@ def start_detached_quarantine_backend(
     data_root: Path | None = None,
     popen_factory: Callable[..., subprocess.Popen[bytes]] = subprocess.Popen,
 ) -> subprocess.Popen[bytes]:
-    """Launch ``bioetl quarantine serve`` as a detached background process."""
+    """Launch ``bioetl health server`` as a detached Ops HTTP backend process.
+
+    This is the shipping identity surface for Grafana BioETL Ops HTTP panels.
+    ``data_root`` is accepted for call-site compatibility but is not used by
+    the health-server command line.
+    """
+    del data_root  # health server discovers control-plane roots from runtime config
     command = [
         python_executable or sys.executable,
         "-m",
         "bioetl",
-        "quarantine",
-        "serve",
+        "health",
+        "server",
         "--host",
         bind_host,
         "--port",
         str(port),
     ]
-    if data_root is not None:
-        if not data_root.is_absolute():
-            raise ValueError("data_root must be an absolute path")
-        command.extend(("--data-root", str(data_root.resolve(strict=True))))
     kwargs = _build_detached_backend_popen_kwargs()
     kwargs.pop("stdout", None)
     kwargs.pop("stderr", None)
@@ -277,6 +284,28 @@ def start_detached_quarantine_backend(
         )
 
 
+def start_detached_quarantine_backend(
+    *,
+    bind_host: str = "0.0.0.0",
+    port: int = DEFAULT_HEALTH_SERVER_PORT,
+    python_executable: str | None = None,
+    data_root: Path | None = None,
+    popen_factory: Callable[..., subprocess.Popen[bytes]] = subprocess.Popen,
+) -> subprocess.Popen[bytes]:
+    """Compatibility alias for :func:`start_detached_ops_http_backend`.
+
+    Historical name retained for tests and import paths. Does **not** start
+    ``quarantine serve``; the shipping backend is ``bioetl health server``.
+    """
+    return start_detached_ops_http_backend(
+        bind_host=bind_host,
+        port=port,
+        python_executable=python_executable,
+        data_root=data_root,
+        popen_factory=popen_factory,
+    )
+
+
 def python_executable_to_tuple(args: object) -> tuple[str, ...]:
     """Normalize subprocess ``args`` into a tuple for stable reporting/tests."""
     if isinstance(args, (list, tuple)):
@@ -289,5 +318,6 @@ __all__ = [
     "drop_listening_backend_on_port",
     "find_listening_backend_pid_by_port",
     "python_executable_to_tuple",
+    "start_detached_ops_http_backend",
     "start_detached_quarantine_backend",
 ]

--- a/src/bioetl/interfaces/cli/commands/domains/health/observability_backend_runtime.py
+++ b/src/bioetl/interfaces/cli/commands/domains/health/observability_backend_runtime.py
@@ -121,7 +121,7 @@ def resolve_observability_backend_cli_options(
     ):
         raise TypeError("observability_backend_port must be a numeric CLI value")
     return (
-        bool(options.get("ensure_observability_backend", True)),
+        bool(options.get("ensure_observability_backend", False)),
         int(raw_port),
     )
 

--- a/src/bioetl/interfaces/cli/commands/domains/health/server_integration_lifecycle.py
+++ b/src/bioetl/interfaces/cli/commands/domains/health/server_integration_lifecycle.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from bioetl.interfaces.http.health_server import HealthServer
 
-DEFAULT_HEALTH_SERVER_PORT = 8081
+DEFAULT_HEALTH_SERVER_PORT = 8000
 
 _HEALTH_SERVER_DOMAIN_ERROR_TITLE = "Health server failed with domain error"
 _HEALTH_SERVER_UNEXPECTED_ERROR_TITLE = "Unexpected error in health server command"

--- a/src/bioetl/interfaces/cli/commands/domains/run/command_policy.py
+++ b/src/bioetl/interfaces/cli/commands/domains/run/command_policy.py
@@ -107,8 +107,8 @@ class RunCommandInput:
     resume_manifest_id: str | None = None
     exact_replay: bool = False
     required_persistence_profile: str | None = None
-    ensure_observability_backend: bool = True
-    observability_backend_port: int = 8081
+    ensure_observability_backend: bool = False
+    observability_backend_port: int = 8000
 
 
 def prepare_run_request(

--- a/src/bioetl/interfaces/cli/commands/domains/run_all/command_policy.py
+++ b/src/bioetl/interfaces/cli/commands/domains/run_all/command_policy.py
@@ -110,8 +110,8 @@ class RunAllCommandInput:
     debug: bool
     health_server: bool
     health_port: int
-    ensure_observability_backend: bool = True
-    observability_backend_port: int = 8081
+    ensure_observability_backend: bool = False
+    observability_backend_port: int = 8000
 
 
 def exit_with_code(code: int | str | None = None) -> NoReturn:
@@ -130,8 +130,8 @@ def build_run_all_command_input(
     debug: bool,
     health_server: bool,
     health_port: int,
-    ensure_observability_backend: bool = True,
-    observability_backend_port: int = 8081,
+    ensure_observability_backend: bool = False,
+    observability_backend_port: int = 8000,
 ) -> RunAllCommandInput:
     """Build normalized CLI input payload for run_all_command_flow."""
     return RunAllCommandInput(

--- a/src/bioetl/interfaces/cli/commands/domains/shared/click_options.py
+++ b/src/bioetl/interfaces/cli/commands/domains/shared/click_options.py
@@ -241,8 +241,8 @@ def with_observability_backend_options[**CommandParams, CommandReturn](
                 type=int,
                 default=default_backend_port,
                 help=(
-                    "Port for the detached Quarantine Explorer backend used by "
-                    "Grafana ID/detail panels."
+                    "Port for the detached BioETL Ops HTTP / health server "
+                    "backend used by Grafana ID/detail panels (default 8000)."
                 ),
                 show_default=True,
             )(func)
@@ -251,10 +251,11 @@ def with_observability_backend_options[**CommandParams, CommandReturn](
             click.option(
                 "--ensure-observability-backend/--no-ensure-observability-backend",
                 "ensure_observability_backend",
-                default=True,
+                default=False,
                 help=(
-                    "Auto-start a detached Quarantine Explorer backend for "
-                    "Grafana ID/detail panels."
+                    "Opt-in: auto-start a detached BioETL Ops HTTP backend "
+                    "(bioetl health server) for Grafana ID/detail panels. "
+                    "Default off."
                 ),
                 show_default=True,
             )(func)

--- a/src/bioetl/interfaces/cli/commands/health.py
+++ b/src/bioetl/interfaces/cli/commands/health.py
@@ -194,7 +194,7 @@ def health_server_command(host: str, port: int) -> None:
     - GET /ops/quarantine/filter-options - Explorer variable options
 
     Example:
-        bioetl health server --port 8081
+        bioetl health server --port 8000
 
     Args:
         host: IP address to bind the server to (e.g., '127.0.0.1' or '0.0.0.0').

--- a/src/bioetl/interfaces/cli/commands/quarantine.py
+++ b/src/bioetl/interfaces/cli/commands/quarantine.py
@@ -75,7 +75,10 @@ def quarantine() -> None:
 @typed_click_option(
     "--host",
     default="0.0.0.0",
-    help="Host to bind the Quarantine Explorer backend to.",
+    help=(
+        "Host to bind the legacy quarantine serve backend to. "
+        "Prefer `bioetl health server` on :8000 for Grafana Ops HTTP."
+    ),
     show_default=True,
 )
 @typed_click_option(
@@ -83,7 +86,10 @@ def quarantine() -> None:
     "-p",
     default=DEFAULT_QUARANTINE_SERVER_PORT,
     type=int,
-    help="Port for the long-lived Quarantine Explorer backend.",
+    help=(
+        "Port for the legacy quarantine serve backend (not the shipping "
+        "Grafana Ops HTTP surface; use health server :8000)."
+    ),
     show_default=True,
 )
 @typed_click_option(
@@ -95,7 +101,11 @@ def quarantine() -> None:
     ),
 )
 def quarantine_serve(host: str, port: int, data_root: Path | None) -> None:
-    """Start the backend used by Grafana Silver structural Reject Explorer."""
+    """Legacy long-lived HTTP helper (retired Grafana Explorer path).
+
+    Shipping Grafana identity panels use ``bioetl health server`` / BioETL Ops
+    HTTP on :8000. Domain quarantine inspect/replay/purge remain supported.
+    """
     if data_root is not None and not data_root.is_absolute():
         raise click.BadParameter(
             "must be an absolute directory path",

--- a/src/bioetl/interfaces/cli/commands/run_composite.py
+++ b/src/bioetl/interfaces/cli/commands/run_composite.py
@@ -277,15 +277,21 @@ def _exit_with_composite_result(success: bool, error_message: str | None) -> Non
 @typed_click_option(
     "--ensure-observability-backend/--no-ensure-observability-backend",
     "ensure_observability_backend",
-    default=True,
-    help="Auto-start a detached Quarantine Explorer backend for Grafana ID/detail panels.",
+    default=False,
+    help=(
+        "Opt-in: auto-start a detached BioETL Ops HTTP backend "
+        "(bioetl health server) for Grafana ID/detail panels. Default off."
+    ),
     show_default=True,
 )
 @typed_click_option(
     "--observability-backend-port",
     type=int,
     default=DEFAULT_HEALTH_SERVER_PORT,
-    help="Port for the detached Quarantine Explorer backend used by Grafana ID/detail panels.",
+    help=(
+        "Port for the detached BioETL Ops HTTP / health server backend "
+        "used by Grafana ID/detail panels (default 8000)."
+    ),
     show_default=True,
 )
 def run_composite(**options: object) -> None:

--- a/src/bioetl/interfaces/cli/commands/workflow.py
+++ b/src/bioetl/interfaces/cli/commands/workflow.py
@@ -241,15 +241,22 @@ def workflow() -> None:
 @typed_click_option(
     "--ensure-observability-backend/--no-ensure-observability-backend",
     "ensure_observability_backend",
-    default=True,
-    help="Auto-start a detached Quarantine Explorer backend for Grafana ID/detail panels.",
+    default=False,
+    help=(
+        "Opt-in: auto-start a detached BioETL Ops HTTP backend "
+        "(bioetl health server) for Grafana ID/detail panels. "
+        "Default off; prefer a long-lived health server on :8000."
+    ),
     show_default=True,
 )
 @typed_click_option(
     "--observability-backend-port",
     type=int,
     default=DEFAULT_HEALTH_SERVER_PORT,
-    help="Port for the detached Quarantine Explorer backend used by Grafana ID/detail panels.",
+    help=(
+        "Port for the detached BioETL Ops HTTP / health server backend "
+        "used by Grafana ID/detail panels (default 8000)."
+    ),
     show_default=True,
 )
 @typed_pass_obj

--- a/src/bioetl/interfaces/http/health_server.py
+++ b/src/bioetl/interfaces/http/health_server.py
@@ -75,7 +75,7 @@ class HealthServer(
     def __init__(
         self,
         host: str = "127.0.0.1",
-        port: int = 8081,
+        port: int = 8000,
         control_plane: HealthServerControlPlaneDeps | None = None,
         prometheus_base_url: str | None = None,
         logger: LoggerPort | None = None,
@@ -212,7 +212,7 @@ class HealthServer(
 
 async def run_health_server(
     host: str = "0.0.0.0",
-    port: int = 8081,
+    port: int = 8000,
     health_monitor: HealthMonitorPort | None = None,
     quarantine_service: QuarantineService | None = None,
     checkpoint_port: CheckpointPort | None = None,
@@ -230,7 +230,7 @@ async def run_health_server(
 
     Args:
         host: IP address to bind to. Defaults to all interfaces (0.0.0.0).
-        port: TCP port to listen on. Defaults to 8081.
+        port: TCP port to listen on. Defaults to 8000.
         health_monitor: Optional monitor providing provider health states.
             Health endpoints report no provider data when None.
         quarantine_service: Optional read-only quarantine explorer service.

--- a/tests/unit/interfaces/cli/commands/test_cli_coverage_boost_helpers.py
+++ b/tests/unit/interfaces/cli/commands/test_cli_coverage_boost_helpers.py
@@ -913,11 +913,12 @@ def test_backend_process_helpers_cover_listener_parsing_and_detached_start(
     )
 
     assert result == "process-sentinel"
-    assert captured["command"][:4] == [
+    assert captured["command"][:5] == [
         "python-custom",
         "-m",
         "bioetl",
-        "quarantine",
+        "health",
+        "server",
     ]
     assert captured["kwargs"]["env"] == {"PYTHONPATH": "src"}
     assert log_path.exists()

--- a/tests/unit/interfaces/cli/commands/test_health.py
+++ b/tests/unit/interfaces/cli/commands/test_health.py
@@ -78,7 +78,7 @@ class TestHealthServerCommand:
         assert "--host" in result.output
         assert "--port" in result.output
         assert "127.0.0.1" in result.output  # default host (localhost for security)
-        assert "8081" in result.output  # default port
+        assert "8000" in result.output  # default port
 
     @patch("bioetl.interfaces.http.health_server.HealthServer")
     @patch(
@@ -109,7 +109,7 @@ class TestHealthServerCommand:
             result = cli_runner.invoke(cli, ["health", "server"])
 
         # Verify output
-        assert "Starting health server on http://127.0.0.1:8081" in result.output
+        assert "Starting health server on http://127.0.0.1:8000" in result.output
         assert "/health" in result.output
         assert "/health/live" in result.output
         assert "/health/ready" in result.output
@@ -829,7 +829,7 @@ class TestHealthServerAsyncExecution:
         # Verify HealthServer was called with default options
         mock_server_cls.assert_called_once_with(
             host="127.0.0.1",
-            port=8081,
+            port=8000,
             control_plane=HealthServerControlPlaneDeps(
                 health_monitor=mock_deps.health_monitor,
                 quarantine_service=None,

--- a/tests/unit/interfaces/cli/commands/test_health_server_integration.py
+++ b/tests/unit/interfaces/cli/commands/test_health_server_integration.py
@@ -102,7 +102,7 @@ class TestHealthServerContext:
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
 
-        async with health_server_context(enabled=True, port=8081) as server:
+        async with health_server_context(enabled=True, port=8000) as server:
             assert server is mock_server
             mock_server.start.assert_called_once()
 
@@ -207,7 +207,7 @@ class TestHealthServerContext:
         mock_server_cls.return_value = mock_server
 
         async with health_server_context(
-            enabled=True, host="127.0.0.1", port=8081
+            enabled=True, host="127.0.0.1", port=8000
         ) as server:
             assert server is None
 
@@ -225,18 +225,18 @@ class TestEchoHealthServerInfo:
         # Use click's echo with standalone mode to capture output
         @click.command()
         def test_cmd() -> None:
-            echo_health_server_info(True, 8081)
+            echo_health_server_info(True, 8000)
 
         runner = CliRunner()
         result = runner.invoke(test_cmd)
-        assert "Health server: http://127.0.0.1:8081/health" in result.output
+        assert "Health server: http://127.0.0.1:8000/health" in result.output
 
     def test_no_echo_when_disabled(self) -> None:
         """Test that nothing is echoed when health server is disabled."""
 
         @click.command()
         def test_cmd() -> None:
-            echo_health_server_info(False, 8081)
+            echo_health_server_info(False, 8000)
 
         runner = CliRunner()
         result = runner.invoke(test_cmd)
@@ -268,7 +268,7 @@ class TestRunCommandHealthServerOptions:
         assert "--ensure-observability-backend" in result.output
         assert "--no-ensure-observability-backend" in result.output
         assert "--observability-backend-port" in result.output
-        assert "8081" in result.output  # default port
+        assert "8000" in result.output  # default port
 
 
 class TestRunAllCommandHealthServerOptions:
@@ -322,9 +322,9 @@ class TestWorkflowCommandObservabilityOptions:
 class TestDefaultHealthServerPort:
     """Test the default health server port constant."""
 
-    def test_default_port_is_8081(self) -> None:
-        """Test that default health server port is 8081."""
-        assert DEFAULT_HEALTH_SERVER_PORT == 8081
+    def test_default_port_is_8000(self) -> None:
+        """Test that default health server port is 8000."""
+        assert DEFAULT_HEALTH_SERVER_PORT == 8000
 
 
 class TestAddHealthServerOptions:

--- a/tests/unit/interfaces/cli/commands/test_observability_backend_runtime.py
+++ b/tests/unit/interfaces/cli/commands/test_observability_backend_runtime.py
@@ -269,8 +269,8 @@ def test_ensure_backend_restarts_bound_but_unresponsive_listener() -> None:
     )
 
     assert result.status == "started"
-    listener_pid.assert_called_once_with(8081)
-    drop.assert_called_once_with(8081)
+    listener_pid.assert_called_once_with(8000)
+    drop.assert_called_once_with(8000)
     start.assert_called_once()
     assert "health probes timeout" in warning.call_args.args[0]
 
@@ -315,7 +315,7 @@ def test_ensure_backend_restarts_stale_backend_missing_required_paths() -> None:
 
     assert result.status == "started"
     required_probe.assert_called_once()
-    drop.assert_called_once_with(8081)
+    drop.assert_called_once_with(8000)
     start.assert_called_once()
     wait.assert_called_once()
     wait_required.assert_called_once()
@@ -434,7 +434,7 @@ def test_ensure_backend_reuse_uses_required_probe_timeout() -> None:
 
     assert result.status == "reused"
     required_probe.assert_called_once_with(
-        "http://127.0.0.1:8081/health",
+        "http://127.0.0.1:8000/health",
         required_probe_paths=("/ops/control-plane/checkpoint-freshness?pipeline=x",),
         timeout_seconds=9.0,
     )
@@ -488,7 +488,7 @@ def test_ensure_backend_failed_startup_appends_process_diagnostics_to_log(
         MagicMock(return_value="Capability probe failed: timeout."),
     )
     probe = MagicMock(return_value=False)
-    process = MagicMock(pid=654, args=["python", "-m", "bioetl", "quarantine", "serve"])
+    process = MagicMock(pid=654, args=["python", "-m", "bioetl", "health", "server"])
     process.poll.return_value = None
 
     result = ensure_observability_backend_started(
@@ -505,7 +505,7 @@ def test_ensure_backend_failed_startup_appends_process_diagnostics_to_log(
     log_text = log_path.read_text(encoding="utf-8")
     assert "BioETL detached backend diagnostics" in log_text
     assert "child_pid=654" in log_text
-    assert "command=python -m bioetl quarantine serve" in log_text
+    assert "command=python -m bioetl health server" in log_text
     assert "Capability probe failed: timeout." in log_text
 
 
@@ -681,7 +681,7 @@ def test_start_detached_quarantine_backend_sets_repo_cwd_and_env() -> None:
 
     start_detached_quarantine_backend(
         bind_host="0.0.0.0",
-        port=8081,
+        port=8000,
         python_executable="python",
         popen_factory=fake_popen,
     )
@@ -691,12 +691,12 @@ def test_start_detached_quarantine_backend_sets_repo_cwd_and_env() -> None:
         "python",
         "-m",
         "bioetl",
-        "quarantine",
-        "serve",
+        "health",
+        "server",
         "--host",
         "0.0.0.0",
         "--port",
-        "8081",
+        "8000",
     ]
     assert isinstance(kwargs, dict)
     backend_cwd = Path(str(kwargs["cwd"]))
@@ -710,7 +710,7 @@ def test_start_detached_quarantine_backend_sets_repo_cwd_and_env() -> None:
     assert "PYTHONPATH" in env
 
 
-def test_start_detached_quarantine_backend_injects_absolute_data_root(
+def test_start_detached_quarantine_backend_ignores_data_root_for_health_server(
     tmp_path: Path,
 ) -> None:
     captured: dict[str, object] = {}
@@ -727,13 +727,15 @@ def test_start_detached_quarantine_backend_injects_absolute_data_root(
         popen_factory=fake_popen,
     )
 
-    assert captured["command"][-2:] == ["--data-root", str(tmp_path.resolve())]
+    # Shipping Ops HTTP backend is health server; data_root is not forwarded.
+    assert "--data-root" not in captured["command"]
+    assert captured["command"][2:5] == ["bioetl", "health", "server"]
 
 
 def test_build_detached_backend_log_path_uses_tempdir_and_port() -> None:
-    path = build_detached_backend_log_path(8081)
+    path = build_detached_backend_log_path(8000)
 
-    assert path.name == "bioetl-quarantine-backend-8081.log"
+    assert path.name == "bioetl-ops-http-backend-8000.log"
     assert path.parent.exists()
 
 

--- a/tests/unit/interfaces/cli/test_cli_commands_basic.py
+++ b/tests/unit/interfaces/cli/test_cli_commands_basic.py
@@ -74,7 +74,7 @@ def ensure_registration():
             "bioetl.interfaces.cli.commands.run.ensure_observability_backend_started",
             return_value=ObservabilityBackendEnsureResult(
                 status="failed",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
             ),
         ),
         patch(

--- a/tests/unit/interfaces/cli/test_cli_helpers.py
+++ b/tests/unit/interfaces/cli/test_cli_helpers.py
@@ -66,7 +66,7 @@ def patch_observability_backend_ensure() -> None:
             "bioetl.interfaces.cli.commands.run.ensure_observability_backend_started",
             return_value=ObservabilityBackendEnsureResult(
                 status="failed",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
             ),
         ),
         patch(

--- a/tests/unit/interfaces/cli/test_cli_run_all_vacuum_formatters.py
+++ b/tests/unit/interfaces/cli/test_cli_run_all_vacuum_formatters.py
@@ -110,7 +110,7 @@ def mock_run_all_observability_backend():
             "bioetl.interfaces.cli.commands.run_all.ensure_observability_backend_started",
             return_value=ObservabilityBackendEnsureResult(
                 status="disabled",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
             ),
         ),
         patch(

--- a/tests/unit/interfaces/cli/test_cli_run_commands.py
+++ b/tests/unit/interfaces/cli/test_cli_run_commands.py
@@ -172,7 +172,7 @@ def test_run_prepared_request_async_uses_compat_runtime_path():
         pipeline="chembl_activity",
         options=options,
         health_server=False,
-        health_port=8081,
+        health_port=8000,
     )
     expected = RunResult(
         status=PipelineRunResult.SUCCESS,
@@ -195,7 +195,7 @@ def test_run_prepared_request_async_uses_compat_runtime_path():
         "chembl_activity",
         options,
         health_server_enabled=False,
-        health_port=8081,
+        health_port=8000,
         registry=registry,
     )
 
@@ -337,7 +337,7 @@ def test_run_command_with_cli_policy_wires_registry_and_cli_seams() -> None:
         vacuum_retention_days=None,
         debug=False,
         health_server=True,
-        health_port=8081,
+        health_port=8000,
         enable_tracing=True,
         use_cached_bronze=False,
         cached_bronze_date=None,
@@ -365,8 +365,8 @@ def test_run_command_with_cli_policy_wires_registry_and_cli_seams() -> None:
 
     mock_resolve_registry.assert_called_once_with(ctx)
     mock_ensure_backend.assert_called_once_with(
-        enabled=True,
-        port=8081,
+        enabled=False,
+        port=8000,
         required_probe_paths=("/ops/control-plane/ready",),
     )
     mock_disable_transient.assert_called_once()
@@ -414,15 +414,17 @@ def test_run_command_with_cli_policy_disables_transient_health_server_on_live_ba
         vacuum_retention_days=None,
         debug=False,
         health_server=True,
-        health_port=8081,
+        health_port=8000,
         enable_tracing=True,
         use_cached_bronze=False,
         cached_bronze_date=None,
         cached_bronze_path=None,
+        ensure_observability_backend=True,
+        observability_backend_port=8000,
     )
     backend_result = ObservabilityBackendEnsureResult(
         status="reused",
-        health_url="http://127.0.0.1:8081/health",
+        health_url="http://127.0.0.1:8000/health",
     )
 
     with (
@@ -447,13 +449,13 @@ def test_run_command_with_cli_policy_disables_transient_health_server_on_live_ba
 
     mock_ensure_backend.assert_called_once_with(
         enabled=True,
-        port=8081,
+        port=8000,
         required_probe_paths=("/ops/control-plane/ready",),
     )
     mock_disable_transient.assert_called_once_with(
         health_server_enabled=True,
-        health_port=8081,
-        observability_backend_port=8081,
+        health_port=8000,
+        observability_backend_port=8000,
         backend_result=backend_result,
     )
     kwargs = mock_run_command_flow.call_args.kwargs
@@ -500,7 +502,7 @@ def test_run_callback_delegates_to_input_builder_and_cli_policy() -> None:
             vacuum_retention_days=None,
             debug=False,
             health_server=True,
-            health_port=8081,
+            health_port=8000,
             enable_tracing=True,
             use_cached_bronze=False,
             cached_bronze_date=None,
@@ -530,7 +532,7 @@ def test_run_callback_delegates_to_input_builder_and_cli_policy() -> None:
             vacuum_retention_days=None,
             debug=False,
             health_server=True,
-            health_port=8081,
+            health_port=8000,
             enable_tracing=True,
             use_cached_bronze=False,
             cached_bronze_date=None,
@@ -569,7 +571,7 @@ def test_run_all_with_cli_policy_wires_registry_and_cli_seams() -> None:
         list_only=False,
         debug=False,
         health_server=True,
-        health_port=8081,
+        health_port=8000,
     )
 
     with (
@@ -622,11 +624,13 @@ def test_run_all_callback_ensures_observability_backend_with_catalog_probe() -> 
         list_only=False,
         debug=False,
         health_server=True,
-        health_port=8081,
+        health_port=8000,
+        ensure_observability_backend=True,
+        observability_backend_port=8000,
     )
     backend_result = ObservabilityBackendEnsureResult(
         status="reused",
-        health_url="http://127.0.0.1:8081/health",
+        health_url="http://127.0.0.1:8000/health",
     )
 
     with (
@@ -659,20 +663,20 @@ def test_run_all_callback_ensures_observability_backend_with_catalog_probe() -> 
             list_only=False,
             debug=False,
             health_server=True,
-            health_port=8081,
+            health_port=8000,
             ensure_observability_backend=True,
-            observability_backend_port=8081,
+            observability_backend_port=8000,
         )
 
     mock_ensure_backend.assert_called_once_with(
         enabled=True,
-        port=8081,
+        port=8000,
         required_probe_paths=("/ops/control-plane/ready",),
     )
     mock_disable_transient.assert_called_once_with(
         health_server_enabled=True,
-        health_port=8081,
-        observability_backend_port=8081,
+        health_port=8000,
+        observability_backend_port=8000,
         backend_result=backend_result,
     )
     mock_dispatch.assert_called_once()

--- a/tests/unit/interfaces/cli/test_run_all_command.py
+++ b/tests/unit/interfaces/cli/test_run_all_command.py
@@ -100,7 +100,7 @@ def mock_run_all_observability_backend():
             "bioetl.interfaces.cli.commands.run_all.ensure_observability_backend_started",
             return_value=ObservabilityBackendEnsureResult(
                 status="disabled",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
             ),
         ) as mock_ensure_backend,
         patch(

--- a/tests/unit/interfaces/cli/test_run_all_service_mock.py
+++ b/tests/unit/interfaces/cli/test_run_all_service_mock.py
@@ -112,7 +112,7 @@ def mock_run_all_runtime_boundaries():
             "bioetl.interfaces.cli.commands.run_all.ensure_observability_backend_started",
             return_value=ObservabilityBackendEnsureResult(
                 status="disabled",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
             ),
         ),
         patch(

--- a/tests/unit/interfaces/cli/test_workflow_cli.py
+++ b/tests/unit/interfaces/cli/test_workflow_cli.py
@@ -142,7 +142,7 @@ def _mock_workflow_observability_backend(monkeypatch: Any) -> None:
         "ensure_observability_backend_started",
         lambda **_: ObservabilityBackendEnsureResult(
             status="started",
-            health_url="http://127.0.0.1:8081/health",
+            health_url="http://127.0.0.1:8000/health",
         ),
         raising=True,
     )

--- a/tests/unit/scripts/ops/observability/test_grafana_dashboard_audit_cycle.py
+++ b/tests/unit/scripts/ops/observability/test_grafana_dashboard_audit_cycle.py
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.unit
 def _backend_result(
     *,
     backend_available: bool,
-    health_url: str = "http://127.0.0.1:8081/health",
+    health_url: str = "http://127.0.0.1:8000/health",
     message: str = "ok",
     status: str = "started",
 ) -> SimpleNamespace:
@@ -224,8 +224,8 @@ def test_grafana_audit_cycle_parser_exposes_backend_boolean_flag() -> None:
         ]
     )
 
-    assert default_args.ensure_observability_backend is True
-    assert default_args.refresh_observability_backend is True
+    assert default_args.ensure_observability_backend is False
+    assert default_args.refresh_observability_backend is False
     assert default_args.render_filled_only is True
     assert disabled_args.ensure_observability_backend is False
     assert disabled_args.refresh_observability_backend is False
@@ -450,7 +450,7 @@ def test_grafana_audit_preflight_run_checks_collects_ok_results(
     monkeypatch.setattr(
         audit_subject,
         "_resolve_app_base_url",
-        lambda *_args, **_kwargs: "http://localhost:8081",
+        lambda *_args, **_kwargs: "http://localhost:8000",
     )
     monkeypatch.setattr(
         preflight_subject,
@@ -465,7 +465,7 @@ def test_grafana_audit_preflight_run_checks_collects_ok_results(
     checks = preflight_subject.run_checks(
         grafana_base_url="http://localhost:3000",
         prometheus_base_url="http://localhost:9090",
-        app_base_url="http://localhost:8081",
+        app_base_url="http://localhost:8000",
         grafana_username="admin",
         grafana_password="changeme",
         timeout_seconds=5.0,
@@ -519,7 +519,7 @@ def test_grafana_audit_preflight_can_skip_screenshot_check(
     monkeypatch.setattr(
         audit_subject,
         "_resolve_app_base_url",
-        lambda *_args, **_kwargs: "http://localhost:8081",
+        lambda *_args, **_kwargs: "http://localhost:8000",
     )
     called = False
 
@@ -543,7 +543,7 @@ def test_grafana_audit_preflight_can_skip_screenshot_check(
     checks = preflight_subject.run_checks(
         grafana_base_url="http://localhost:3000",
         prometheus_base_url="http://localhost:9090",
-        app_base_url="http://localhost:8081",
+        app_base_url="http://localhost:8000",
         grafana_username="admin",
         grafana_password="changeme",
         timeout_seconds=5.0,
@@ -585,13 +585,13 @@ def test_grafana_audit_preflight_can_run_semantic_checks_without_render_runtime(
     monkeypatch.setattr(
         audit_subject,
         "_resolve_app_base_url",
-        lambda *_args, **_kwargs: "http://localhost:8081",
+        lambda *_args, **_kwargs: "http://localhost:8000",
     )
 
     checks = preflight_subject.run_checks(
         grafana_base_url="http://localhost:3000",
         prometheus_base_url="http://localhost:9090",
-        app_base_url="http://localhost:8081",
+        app_base_url="http://localhost:8000",
         grafana_username="admin",
         grafana_password="changeme",
         timeout_seconds=5.0,
@@ -649,7 +649,7 @@ def test_preflight_can_run_render_checks_without_semantic_checks(
     checks = preflight_subject.run_checks(
         grafana_base_url="http://localhost:3000",
         prometheus_base_url="http://localhost:9090",
-        app_base_url="http://localhost:8081",
+        app_base_url="http://localhost:8000",
         grafana_username="admin",
         grafana_password="changeme",
         timeout_seconds=5.0,
@@ -880,9 +880,9 @@ def test_grafana_audit_cycle_runs_preflight_rerender_and_live_audit(
     assert any("render-api" in item for item in calls[2][1])
     assert str(tmp_path) in calls[3][1]
     assert "--screenshot-uids" in calls[4][1]
-    assert "http://127.0.0.1:8081" in calls[0][1]
-    assert "http://127.0.0.1:8081" in calls[1][1]
-    assert "http://127.0.0.1:8081" in calls[4][1]
+    assert "http://127.0.0.1:8000" in calls[0][1]
+    assert "http://127.0.0.1:8000" in calls[1][1]
+    assert "http://127.0.0.1:8000" in calls[4][1]
 
 
 def test_grafana_audit_cycle_exit_code_uses_validated_release_result(
@@ -1045,7 +1045,12 @@ def test_grafana_audit_cycle_skips_semantic_network_when_backend_is_unavailable(
     )
 
     result = cycle_subject.main(
-        ["--screenshot-dir", str(tmp_path), "--no-refresh-observability-backend"]
+        [
+            "--screenshot-dir",
+            str(tmp_path),
+            "--ensure-observability-backend",
+            "--no-refresh-observability-backend",
+        ]
     )
 
     assert result == 1
@@ -1267,11 +1272,16 @@ def test_grafana_audit_cycle_retries_backend_on_fallback_port(
     )
 
     result = cycle_subject.main(
-        ["--screenshot-dir", str(tmp_path), "--no-refresh-observability-backend"]
+        [
+            "--screenshot-dir",
+            str(tmp_path),
+            "--ensure-observability-backend",
+            "--no-refresh-observability-backend",
+        ]
     )
 
     assert result == 0
-    assert ensured_ports == [8081, 18081]
+    assert ensured_ports == [8000, 18081]
     assert "http://127.0.0.1:18081" in calls[0][1]
     assert "http://127.0.0.1:18081" in calls[1][1]
     assert "http://127.0.0.1:18081" in calls[4][1]
@@ -1328,7 +1338,11 @@ def test_grafana_audit_cycle_reuses_existing_backend_when_fallback_start_fails(
         lambda argv: calls.append(("audit", list(argv))) or 0,
     )
 
-    result = cycle_subject.main(["--screenshot-dir", str(tmp_path)])
+    result = cycle_subject.main([
+        "--screenshot-dir", str(tmp_path),
+        "--ensure-observability-backend",
+        "--no-refresh-observability-backend",
+    ])
 
     assert result == 0
     assert [name for name, _argv in calls] == [
@@ -1338,9 +1352,9 @@ def test_grafana_audit_cycle_reuses_existing_backend_when_fallback_start_fails(
         "rerender",
         "preflight",
     ]
-    assert "http://127.0.0.1:8081" in calls[0][1]
-    assert "http://127.0.0.1:8081" in calls[1][1]
-    assert "http://127.0.0.1:8081" in calls[4][1]
+    assert "http://127.0.0.1:8000" in calls[0][1]
+    assert "http://127.0.0.1:8000" in calls[1][1]
+    assert "http://127.0.0.1:8000" in calls[4][1]
 
 
 @pytest.mark.usefixtures("matching_gate_sources")
@@ -1357,7 +1371,7 @@ def test_grafana_audit_cycle_uses_managed_backend_when_detached_backend_fails(
         "ensure_observability_backend_started",
         lambda **_kwargs: _backend_result(
             backend_available=False,
-            health_url="http://127.0.0.1:8081/health",
+            health_url="http://127.0.0.1:8000/health",
             message="Detached backend did not become ready",
             status="failed",
         ),
@@ -1374,7 +1388,7 @@ def test_grafana_audit_cycle_uses_managed_backend_when_detached_backend_fails(
         lambda **_kwargs: cycle_subject.BackendEnsureOutcome(
             result=cycle_subject.ObservabilityBackendEnsureResult(
                 status="started",
-                health_url="http://127.0.0.1:8081/health",
+                health_url="http://127.0.0.1:8000/health",
                 message="Managed backend started.",
             ),
             managed_process=MagicMock(poll=lambda: 0),
@@ -1401,7 +1415,11 @@ def test_grafana_audit_cycle_uses_managed_backend_when_detached_backend_fails(
         lambda argv: calls.append(("audit", list(argv))) or 0,
     )
 
-    result = cycle_subject.main(["--screenshot-dir", str(tmp_path)])
+    result = cycle_subject.main([
+        "--screenshot-dir", str(tmp_path),
+        "--ensure-observability-backend",
+        "--no-refresh-observability-backend",
+    ])
 
     assert result == 0
     assert [name for name, _argv in calls] == [
@@ -1411,7 +1429,7 @@ def test_grafana_audit_cycle_uses_managed_backend_when_detached_backend_fails(
         "rerender",
         "preflight",
     ]
-    assert "http://127.0.0.1:8081" in calls[0][1]
+    assert "http://127.0.0.1:8000" in calls[0][1]
 
 
 @pytest.mark.usefixtures("matching_gate_sources")
@@ -1425,7 +1443,7 @@ def test_grafana_audit_cycle_can_disable_backend_refresh(
         "ensure_observability_backend_started",
         lambda **_kwargs: _backend_result(
             backend_available=True,
-            health_url="http://127.0.0.1:8081/health",
+            health_url="http://127.0.0.1:8000/health",
             message="ok",
             status="reused",
         ),
@@ -1462,7 +1480,7 @@ def test_live_audit_writes_report(
     output_path = tmp_path / "live-panel-audit.json"
     config = audit_subject.AuditConfig(
         prometheus_base_url="http://localhost:9090",
-        app_base_url="http://localhost:8081",
+        app_base_url="http://localhost:8000",
         loki_base_url="http://localhost:3100",
         tempo_base_url="http://localhost:3200",
         grafana_base_url="http://localhost:3000",


### PR DESCRIPTION
## Summary

Closes the observability CLI/docs drift epic so local `workflow run` no longer auto-starts retired Quarantine Explorer on `:8081`.

- **Phase A (#7564):** `--ensure-observability-backend` defaults **off**; `DEFAULT_HEALTH_SERVER_PORT` / health server default **8000**
- **Phase B (#7565):** opt-in ensure starts **`bioetl health server`** (BioETL Ops HTTP), not `quarantine serve`
- **Phase C (#7563):** operator docs, panel guides, and grafana-dashboard-render skills aligned to Ops HTTP `:8000`

## Validation

Focused unit tests green:
- `test_observability_backend_runtime`
- `test_health_server_integration` / `test_health`
- `test_workflow_cli` / `test_cli_run_commands`
- `test_grafana_dashboard_audit_cycle`

## Operator impact

```powershell
# default: no Explorer / no ensure noise
bioetl workflow run chembl_baseline --limit 1000 --required-persistence-profile degraded_observable

# optional identity backend for Grafana ID panels
bioetl health server --port 8000
# or: --ensure-observability-backend  (starts health server on :8000)
```

Prometheus metrics flush path unchanged. Loki/Tempo/Explorer remain out of shipping Docker surface.

Closes #7562
Closes #7563
Closes #7564
Closes #7565
