### PR TITLE
fix(ci): LF restamp inventory and dep-map (#7517 #7519)

### DIFF
--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-05T05:21:46.056109+00:00",
+  "generated_at": "2026-08-05T05:46:30.654383+00:00",
   "summary": {
     "total_scripts": 575,
     "status_counts": {
@@ -4584,7 +4584,7 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 14,
+      "reference_count": 15,
       "references": [
         {
           "path": "Makefile",
@@ -5022,7 +5022,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 429,
+          "line": 430,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/data_quality/run_silver_gold_filter_parity.py --check"
         },
@@ -5780,10 +5780,16 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 11,
+      "reference_count": 12,
       "references": [
         {
           "path": "Makefile",
+          "line": 257,
+          "source_group": "build",
+          "text": "$(RUN) python scripts/diagrams/generate_all_bundles.py"
+        },
+        {
+          "path": "makefile",
           "line": 257,
           "source_group": "build",
           "text": "$(RUN) python scripts/diagrams/generate_all_bundles.py"
@@ -5823,12 +5829,6 @@
           "line": 92,
           "source_group": "scripts",
           "text": "\"generate_all_bundles.py\", \"--collection\", \"architecture\""
-        },
-        {
-          "path": "scripts/diagrams/__main__.py",
-          "line": 96,
-          "source_group": "scripts",
-          "text": "\"render-views\": python_command(\"generate_all_bundles.py\", \"--collection\", \"views\"),"
         }
       ]
     },
@@ -6437,7 +6437,7 @@
       "agent_usage": [
         "py-doc-bot"
       ],
-      "reference_count": 25,
+      "reference_count": 26,
       "references": [
         {
           "path": ".codex/agents/py-doc-bot.md",
@@ -8901,17 +8901,17 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 26,
+      "reference_count": 27,
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 392,
+          "line": 393,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.ci neo4j-memory"
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 553,
+          "line": 554,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.ci neo4j-memory-live"
         },
@@ -9335,7 +9335,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 1039,
+          "line": 1040,
           "source_group": "ci",
           "text": "scripts/engineering/ci/run_pytest_resilient.py \\"
         },
@@ -10363,7 +10363,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 21,
+      "reference_count": 22,
       "references": [
         {
           "path": "Makefile",
@@ -11187,7 +11187,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 17,
+      "reference_count": 20,
       "references": [
         {
           "path": ".github/workflows/root-hygiene.yml",
@@ -11902,7 +11902,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 435,
+          "line": 436,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.qa check-naming-pkg --check"
         },
@@ -12271,7 +12271,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 376,
+          "line": 377,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/engineering/qa/check_test_audit_preflight.py --strict"
         },
@@ -12962,7 +12962,7 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 602,
+          "line": 603,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python scripts/engineering/qa/generate_architecture_dependency_map.py --check"
         },
@@ -13844,7 +13844,7 @@
         },
         {
           "path": "docs/00-project/ai/skills/local/grafana-dashboard-render/SKILL.md",
-          "line": 103,
+          "line": 96,
           "source_group": "docs",
           "text": "uv run python scripts/engineering/qa/report_dashboard_inventory.py --json"
         },
@@ -15377,7 +15377,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 85,
+      "reference_count": 88,
       "references": [
         {
           "path": ".github/ISSUES/TDX-AUDIT-016-Enforce-Zero-Reference-Script-Governance.md",
@@ -15784,7 +15784,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 373,
+          "line": 374,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.engineering.repo check-catalog --catalog scripts/engineering/repo/catalog.yaml"
         },
@@ -15841,7 +15841,7 @@
       "references": [
         {
           "path": ".github/workflows/tests.yml",
-          "line": 365,
+          "line": 366,
           "source_group": "ci",
           "text": "uv run --frozen --no-build python -m scripts.engineering.repo check-inventory \\"
         },
@@ -16993,7 +16993,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 35,
+      "reference_count": 45,
       "references": [
         {
           "path": "Makefile",
@@ -17356,7 +17356,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 17,
+      "reference_count": 18,
       "references": [
         {
           "path": "Makefile",
@@ -17375,6 +17375,12 @@
           "line": 308,
           "source_group": "docs",
           "text": "`scripts/ops/launchers/codex/setup_plugins.sh --pytest-only` перед запуском pytest."
+        },
+        {
+          "path": "makefile",
+          "line": 204,
+          "source_group": "build",
+          "text": "bash scripts/ops/launchers/codex/setup_plugins.sh --hooks-only"
         },
         {
           "path": "scripts/engineering/dev/README.md",
@@ -17399,12 +17405,6 @@
           "line": 570,
           "source_group": "scripts",
           "text": "# setup_plugins.sh may provision a temporary pytest runtime under /tmp when"
-        },
-        {
-          "path": "scripts/engineering/repo/generate_scripts_wrapper_caller_matrix.py",
-          "line": 107,
-          "source_group": "scripts",
-          "text": "Candidate(\"scripts/ops/launchers/codex/setup_plugins.sh\", BOOTSTRAP_HELPER_ROLE),"
         }
       ]
     },
@@ -19185,7 +19185,7 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 62,
+      "reference_count": 63,
       "references": [
         {
           "path": "Makefile",
@@ -20025,7 +20025,7 @@
         },
         {
           "path": "docs/00-project/ai/skills/local/grafana-dashboard-render/SKILL.md",
-          "line": 259,
+          "line": 252,
           "source_group": "docs",
           "text": "- Repo env bootstrap: `scripts/ops/support/load_repo_env.sh`"
         },
@@ -20277,7 +20277,7 @@
         },
         {
           "path": ".github/workflows/tests.yml",
-          "line": 426,
+          "line": 427,
           "source_group": "ci",
           "text": "run: uv run --frozen --no-build python -m scripts.schema generate-config-matrix --check"
         }

--- a/docs/02-architecture/generated/module-dependency-map.json
+++ b/docs/02-architecture/generated/module-dependency-map.json
@@ -6,7 +6,7 @@
     "cross_layer_group_edges": 55,
     "cross_layer_group_edges_total": 310,
     "violations": 0,
-    "source_fingerprint": "effb241806b8f59e75e522e5584f4292ba3bd4c3210c4660c3d500b20e30643e"
+    "source_fingerprint": "83e8a96d7df190e2f325892a9c93f2a020b7fc30764fed55d3c8083fff082af7"
   },
   "layer_edges": [
     {

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140"
+    "test_governance_source_tree_sha256": "d909d5ec7a8ad19ae658cd302158eba993d805f2e87e5801d391e8ae8db8cdd8"
   },
   "summary": {
     "by_alert_level": {
@@ -74,9 +74,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 2,
-    "test_governance_source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140",
+    "test_governance_source_tree_sha256": "d909d5ec7a8ad19ae658cd302158eba993d805f2e87e5801d391e8ae8db8cdd8",
     "total_flaky": 0,
     "total_test_files": 2178,
-    "total_tests_analyzed": 23291
+    "total_tests_analyzed": 23292
   }
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2362,12 +2362,12 @@
     },
     "top_duplicate_test_names": [],
     "total_test_files": 2178,
-    "total_test_functions": 23291,
+    "total_test_functions": 23292,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "73ed117744da637e6a8a04d1785265bde2d70d2670dc3d075b85b1ffea9d5140",
+  "source_tree_sha256": "d909d5ec7a8ad19ae658cd302158eba993d805f2e87e5801d391e8ae8db8cdd8",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,
@@ -2431,7 +2431,7 @@
   },
   "top_duplicate_test_names": [],
   "total_test_files": 2178,
-  "total_test_functions": 23291,
+  "total_test_functions": 23292,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }


### PR DESCRIPTION
Restamp scripts inventory from git-archive LF tree, rebind module-dependency-map fingerprint, and refresh test-governance/flaky burndown so governance-preflight and config-schema-preflight go green for CI-C1 closeout.