### PR TITLE
fix(ci): ruff format + inventory/lifecycle for #7515 #7519

### DIFF
--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-05T06:09:58.309802+00:00",
+  "generated_at": "2026-08-05T06:29:32.504574+00:00",
   "summary": {
-    "total_scripts": 576,
+    "total_scripts": 578,
     "status_counts": {
       "active": 341,
-      "supporting": 230,
+      "supporting": 232,
       "temporary_diagnostic": 5
     },
     "reference_group_coverage": {
@@ -4584,7 +4584,7 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 15,
+      "reference_count": 14,
       "references": [
         {
           "path": "Makefile",
@@ -5762,16 +5762,10 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 12,
+      "reference_count": 11,
       "references": [
         {
           "path": "Makefile",
-          "line": 257,
-          "source_group": "build",
-          "text": "$(RUN) python scripts/diagrams/generate_all_bundles.py"
-        },
-        {
-          "path": "makefile",
           "line": 257,
           "source_group": "build",
           "text": "$(RUN) python scripts/diagrams/generate_all_bundles.py"
@@ -5811,6 +5805,12 @@
           "line": 92,
           "source_group": "scripts",
           "text": "\"generate_all_bundles.py\", \"--collection\", \"architecture\""
+        },
+        {
+          "path": "scripts/diagrams/__main__.py",
+          "line": 96,
+          "source_group": "scripts",
+          "text": "\"render-views\": python_command(\"generate_all_bundles.py\", \"--collection\", \"views\"),"
         }
       ]
     },
@@ -6419,7 +6419,7 @@
       "agent_usage": [
         "py-doc-bot"
       ],
-      "reference_count": 26,
+      "reference_count": 25,
       "references": [
         {
           "path": ".codex/agents/py-doc-bot.md",
@@ -8883,7 +8883,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 27,
+      "reference_count": 26,
       "references": [
         {
           "path": ".github/workflows/tests.yml",
@@ -10345,7 +10345,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 22,
+      "reference_count": 21,
       "references": [
         {
           "path": "Makefile",
@@ -11169,7 +11169,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 20,
+      "reference_count": 17,
       "references": [
         {
           "path": ".github/workflows/root-hygiene.yml",
@@ -15359,7 +15359,7 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 88,
+      "reference_count": 85,
       "references": [
         {
           "path": ".github/ISSUES/TDX-AUDIT-016-Enforce-Zero-Reference-Script-Governance.md",
@@ -16963,7 +16963,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 45,
+      "reference_count": 35,
       "references": [
         {
           "path": "Makefile",
@@ -17326,7 +17326,7 @@
       "type": "sh",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 18,
+      "reference_count": 17,
       "references": [
         {
           "path": "Makefile",
@@ -17345,12 +17345,6 @@
           "line": 308,
           "source_group": "docs",
           "text": "`scripts/ops/launchers/codex/setup_plugins.sh --pytest-only` перед запуском pytest."
-        },
-        {
-          "path": "makefile",
-          "line": 204,
-          "source_group": "build",
-          "text": "bash scripts/ops/launchers/codex/setup_plugins.sh --hooks-only"
         },
         {
           "path": "scripts/engineering/dev/README.md",
@@ -17375,6 +17369,12 @@
           "line": 570,
           "source_group": "scripts",
           "text": "# setup_plugins.sh may provision a temporary pytest runtime under /tmp when"
+        },
+        {
+          "path": "scripts/engineering/repo/generate_scripts_wrapper_caller_matrix.py",
+          "line": 107,
+          "source_group": "scripts",
+          "text": "Candidate(\"scripts/ops/launchers/codex/setup_plugins.sh\", BOOTSTRAP_HELPER_ROLE),"
         }
       ]
     },
@@ -18120,6 +18120,30 @@
       "lifecycle_decision": "compatibility_wrapper",
       "review_by": "2026-09-30",
       "next_step": "Retain only as the fail-closed compatibility stub for the removed Quarantine Explorer command; keep it supporting while documented legacy invocations must receive the explicit exit-2 retirement message."
+    },
+    {
+      "path": "scripts/ops/observability/grafana/fix_gra_3c_i1.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1.py)."
+    },
+    {
+      "path": "scripts/ops/observability/grafana/fix_gra_3c_i1b.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1b.py)."
     },
     {
       "path": "scripts/ops/observability/grafana/generate_dux4_issue_pack.py",

--- a/configs/quality/scripts_lifecycle_registry.json
+++ b/configs/quality/scripts_lifecycle_registry.json
@@ -1086,7 +1086,7 @@
       "owner": "@bioetl-platform",
       "decision": "legacy_manual_utility",
       "review_by": "2026-09-30",
-      "next_step": "Retain only as the one-off RFA-00 Review First Action dashboard mutator for auditability; retire it after the dashboard migration is verified and the generated dashboard/contracts become the durable record."
+      "next_step": "Retain only as a one-off Review First Action (RFA-00) panel mutator for auditability; retire it after the RFA panel migration is verified and the shipped dashboard JSON becomes the durable record."
     },
     "scripts/ops/observability/grafana/run_grafana_render_matrix.py": {
       "owner": "@bioetl-platform",
@@ -1376,12 +1376,6 @@
       "review_by": "2026-09-30",
       "next_step": "Retain only as the bounded DUX7 live residual review runner for auditability; retire it after the review protocol is complete and the generated evidence becomes the durable record."
     },
-    "scripts/ops/observability/grafana/rfa_first_action_mutator.py": {
-      "owner": "@bioetl-platform",
-      "decision": "legacy_manual_utility",
-      "review_by": "2026-09-30",
-      "next_step": "Retain only as a one-off Review First Action (RFA-00) panel mutator for auditability; retire it after the RFA panel migration is verified and the shipped dashboard JSON becomes the durable record."
-    },
     "scripts/ops/_build_arch_review_report.py": {
       "owner": "@bioetl-platform",
       "decision": "shared_helper_module",
@@ -1417,6 +1411,18 @@
       "decision": "shared_helper_module",
       "review_by": "2026-07-15",
       "next_step": "Retain as the context-aware Neo4j audit connection helper while deployment and live-audit runbooks still reference src/tools/neo4j_audit.py; fold it into a broader canonical ops helper surface only if the audit workflow is consolidated."
+    },
+    "scripts/ops/observability/grafana/fix_gra_3c_i1.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1.py)."
+    },
+    "scripts/ops/observability/grafana/fix_gra_3c_i1b.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1b.py)."
     }
   }
 }

--- a/scripts/ops/observability/grafana/fix_gra_3c_i1b.py
+++ b/scripts/ops/observability/grafana/fix_gra_3c_i1b.py
@@ -56,7 +56,10 @@ def fix_value_align() -> None:
                 if override.get("matcher", {}).get("options") != "value":
                     continue
                 for prop in override.get("properties") or []:
-                    if prop.get("id") == "custom.align" and prop.get("value") != "right":
+                    if (
+                        prop.get("id") == "custom.align"
+                        and prop.get("value") != "right"
+                    ):
                         print(path.name, "align", prop.get("value"), "-> right")
                         prop["value"] = "right"
                         changed = True

--- a/tests/architecture/conftest.py
+++ b/tests/architecture/conftest.py
@@ -684,7 +684,11 @@ def _subprocess_cache_dependency_paths(
             path
             for path in (
                 repo_root / "docs" / "04-reference" / "config_comparison_matrix.csv",
-                repo_root / "docs" / "reports" / "generated" / "config-discrepancies-report.md",
+                repo_root
+                / "docs"
+                / "reports"
+                / "generated"
+                / "config-discrepancies-report.md",
                 repo_root / "reports" / "quality" / "config-discrepancy-baseline.json",
             )
             if path.exists()

--- a/tests/architecture/test_config_discrepancy_report_semantics.py
+++ b/tests/architecture/test_config_discrepancy_report_semantics.py
@@ -20,9 +20,7 @@ from pathlib import Path
 pytestmark = pytest.mark.architecture
 
 ROOT = Path(__file__).resolve().parents[2]
-REPORT_PATH = (
-    ROOT / "docs" / "reports" / "generated" / "config-discrepancies-report.md"
-)
+REPORT_PATH = ROOT / "docs" / "reports" / "generated" / "config-discrepancies-report.md"
 BASELINE_PATH = ROOT / "reports" / "quality" / "config-discrepancy-baseline.json"
 
 


### PR DESCRIPTION
## Summary
- clear residual `ruff format` drift on architecture helpers and GRA mutator (#7515)
- restamp scripts inventory and register lifecycle for `fix_gra_3c_i1` / `fix_gra_3c_i1b` so governance-preflight inventory step goes green (#7519)
- no technical-debt budget increases

## Test plan
- [x] `ruff format --check src tests scripts`
- [x] `ruff check src tests`
- [x] scripts inventory + lifecycle `--check`
- [ ] CI: lint, quality-and-architecture, governance-preflight green on head

Closes #7515
Closes #7519