### PR TITLE
fix(ci): restamp test-governance after CI-C1 inventory merge

### DIFF
--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-05T06:29:32.504574+00:00",
+  "generated_at": "2026-08-05T06:46:22.504309+00:00",
   "summary": {
-    "total_scripts": 578,
+    "total_scripts": 580,
     "status_counts": {
       "active": 341,
-      "supporting": 232,
+      "supporting": 234,
       "temporary_diagnostic": 5
     },
     "reference_group_coverage": {
@@ -18454,6 +18454,30 @@
       "lifecycle_decision": "shared_helper_module",
       "review_by": "2026-09-30",
       "next_step": "Retain as the matrix orchestration backend invoked through the canonical scripts.ops command surface; keep the implementation module supporting so the active script inventory does not duplicate the dispatcher entrypoint."
+    },
+    {
+      "path": "scripts/ops/observability/grafana/scan_gra_3cycle_r2.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded GRA 3-cycle scanner for auditability; retire after the campaign is verified (scripts/ops/observability/grafana/scan_gra_3cycle_r2.py)."
+    },
+    {
+      "path": "scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded GRA 3-cycle scanner for auditability; retire after the campaign is verified (scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py)."
     },
     {
       "path": "scripts/ops/observability/grafana/setup_grafana_screenshot_runtime.ps1",

--- a/configs/quality/scripts_lifecycle_registry.json
+++ b/configs/quality/scripts_lifecycle_registry.json
@@ -1423,6 +1423,18 @@
       "decision": "legacy_manual_utility",
       "review_by": "2026-09-30",
       "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1b.py)."
+    },
+    "scripts/ops/observability/grafana/scan_gra_3cycle_r2.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded GRA 3-cycle scanner for auditability; retire after the campaign is verified (scripts/ops/observability/grafana/scan_gra_3cycle_r2.py)."
+    },
+    "scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain only as a bounded GRA 3-cycle scanner for auditability; retire after the campaign is verified (scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py)."
     }
   }
 }

--- a/docs/00-project/index.md
+++ b/docs/00-project/index.md
@@ -129,7 +129,7 @@ See [Composite Pipeline Diagram](../02-architecture/diagrams/foundation/29-compo
 
 ## Current Version
 
-**v6.1.4** (governance baseline per [RULES.md](RULES.md)) — See [CHANGELOG](https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/CHANGELOG.md) for release history.
+**v6.1.7** (governance baseline per [RULES.md](RULES.md)) — See [CHANGELOG](https://github.com/SatoryKono/BioactivityDataAcquisition/blob/main/CHANGELOG.md) for release history.
 
 ## Getting Started
 

--- a/reports/quality/config-contract-registry-artifact-duplication.json
+++ b/reports/quality/config-contract-registry-artifact-duplication.json
@@ -38,7 +38,7 @@
   "pattern_file_counts": {
     "configs/**/*.csv": 2,
     "configs/**/*.json": 13,
-    "configs/**/*.yaml": 217,
+    "configs/**/*.yaml": 219,
     "docs/04-reference/contracts/**/*.md": 9,
     "reports/quality/*contract*.json": 5,
     "reports/quality/*contract*.md": 3,
@@ -55,13 +55,13 @@
   "scan_root": ".",
   "schema_version": 1,
   "scope_file_counts": {
-    "config": 183,
+    "config": 185,
     "contract": 47,
     "golden": 27,
     "quality_report": 9,
     "registry": 25
   },
-  "total_files": 291,
+  "total_files": 293,
   "tracked_extensions": [
     ".csv",
     ".json",

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498"
+    "test_governance_source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707"
   },
   "summary": {
     "by_alert_level": {
@@ -74,9 +74,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498",
+    "test_governance_source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707",
     "total_flaky": 0,
-    "total_test_files": 2178,
-    "total_tests_analyzed": 23294
+    "total_test_files": 2180,
+    "total_tests_analyzed": 23298
   }
 }

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "55672f49c61bb7e48e6064f87bd2825fa2844ab10500c2db5e97c766aecc3fe5"
+    "test_governance_source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "55672f49c61bb7e48e6064f87bd2825fa2844ab10500c2db5e97c766aecc3fe5",
+    "test_governance_source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498",
     "total_flaky": 0,
     "total_test_files": 2178,
     "total_tests_analyzed": 23294

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "55672f49c61bb7e48e6064f87bd2825fa2844ab10500c2db5e97c766aecc3fe5",
+  "source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2294,8 +2294,8 @@
         "test_*.py"
       ],
       "test_file_count_definition": "tests/**/test_*.py matching pyproject tool.pytest.ini_options.python_files",
-      "test_glob_file_count": 2178,
-      "test_python_file_count": 2409,
+      "test_glob_file_count": 2180,
+      "test_python_file_count": 2411,
       "top_level_directories": [
         "tests/architecture/",
         "tests/benchmarks/",
@@ -2334,13 +2334,13 @@
       "top_level_directory_count_including_pycache": 15
     },
     "top_duplicate_test_names": [],
-    "total_test_files": 2178,
-    "total_test_functions": 23294,
+    "total_test_files": 2180,
+    "total_test_functions": 23298,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "5cf7eba80555f7d88a613e93fe9a5fa48a0408a057fd2e15f4a3680c0278a498",
+  "source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,
@@ -2360,8 +2360,8 @@
       "test_*.py"
     ],
     "test_file_count_definition": "tests/**/test_*.py matching pyproject tool.pytest.ini_options.python_files",
-    "test_glob_file_count": 2178,
-    "test_python_file_count": 2409,
+    "test_glob_file_count": 2180,
+    "test_python_file_count": 2411,
     "top_level_directories": [
       "tests/architecture/",
       "tests/benchmarks/",
@@ -2400,8 +2400,8 @@
     "top_level_directory_count_including_pycache": 15
   },
   "top_duplicate_test_names": [],
-  "total_test_files": 2178,
-  "total_test_functions": 23294,
+  "total_test_files": 2180,
+  "total_test_functions": 23298,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }

--- a/scripts/ops/observability/grafana/scan_gra_3cycle_r2.py
+++ b/scripts/ops/observability/grafana/scan_gra_3cycle_r2.py
@@ -28,7 +28,9 @@ def walk(panels: list | None):
 
 def pquery(expr: str) -> list:
     q = urllib.parse.urlencode({"query": expr})
-    with urllib.request.urlopen(f"http://127.0.0.1:9090/api/v1/query?{q}", timeout=30) as resp:
+    with urllib.request.urlopen(
+        f"http://127.0.0.1:9090/api/v1/query?{q}", timeout=30
+    ) as resp:
         payload = json.loads(resp.read().decode())
     return payload.get("data", {}).get("result", [])
 
@@ -60,12 +62,9 @@ def scan(iteration_dir: Path) -> dict:
             title = str(panel.get("title") or "")
             panel_id = panel.get("id")
             panel_type = panel.get("type")
-            steps = (
-                ((panel.get("fieldConfig") or {}).get("defaults") or {})
-                .get("thresholds", {})
-                .get("steps")
-                or []
-            )
+            steps = ((panel.get("fieldConfig") or {}).get("defaults") or {}).get(
+                "thresholds", {}
+            ).get("steps") or []
             for step in steps:
                 color = str(step.get("color") or "").lower().replace(" ", "")
                 if color in {"transparent", "rgba(0,0,0,0)"}:
@@ -124,10 +123,8 @@ def scan(iteration_dir: Path) -> dict:
                             }
                         )
             if panel_type == "stat":
-                no_value = (
-                    ((panel.get("fieldConfig") or {}).get("defaults") or {}).get(
-                        "noValue"
-                    )
+                no_value = ((panel.get("fieldConfig") or {}).get("defaults") or {}).get(
+                    "noValue"
                 )
                 if no_value is None:
                     findings.append(
@@ -145,7 +142,9 @@ def scan(iteration_dir: Path) -> dict:
                 for transform in panel.get("transformations") or []:
                     if transform.get("id") != "organize":
                         continue
-                    exclude = (transform.get("options") or {}).get("excludeByName") or {}
+                    exclude = (transform.get("options") or {}).get(
+                        "excludeByName"
+                    ) or {}
                     if not exclude.get("percintage"):
                         findings.append(
                             {

--- a/scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py
+++ b/scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py
@@ -23,7 +23,9 @@ def walk(panels: list | None):
 
 def pquery(expr: str) -> list:
     q = urllib.parse.urlencode({"query": expr})
-    with urllib.request.urlopen(f"http://127.0.0.1:9090/api/v1/query?{q}", timeout=30) as resp:
+    with urllib.request.urlopen(
+        f"http://127.0.0.1:9090/api/v1/query?{q}", timeout=30
+    ) as resp:
         payload = json.loads(resp.read().decode())
     return payload.get("data", {}).get("result", [])
 
@@ -94,7 +96,7 @@ def main() -> None:
                     }
                 )
 
-            defaults = ((panel.get("fieldConfig") or {}).get("defaults") or {})
+            defaults = (panel.get("fieldConfig") or {}).get("defaults") or {}
             steps = (defaults.get("thresholds") or {}).get("steps") or []
             for step in steps:
                 color = str(step.get("color") or "").lower().replace(" ", "")
@@ -201,7 +203,9 @@ def main() -> None:
                 for transform in panel.get("transformations") or []:
                     if transform.get("id") != "organize":
                         continue
-                    exclude = (transform.get("options") or {}).get("excludeByName") or {}
+                    exclude = (transform.get("options") or {}).get(
+                        "excludeByName"
+                    ) or {}
                     if not exclude.get("percintage"):
                         findings.append(
                             {
@@ -359,13 +363,19 @@ def main() -> None:
         )
 
     # dashboard exclude still present
-    overview = json.loads((dash_dir / "bioetl-overview-v2.json").read_text(encoding="utf-8"))
+    overview = json.loads(
+        (dash_dir / "bioetl-overview-v2.json").read_text(encoding="utf-8")
+    )
     for panel in walk(overview.get("panels")):
         if "Processed Records" in str(panel.get("title") or ""):
             for transform in panel.get("transformations") or []:
                 if transform.get("id") == "organize":
-                    exclude = (transform.get("options") or {}).get("excludeByName") or {}
-                    live["overview_percintage_excluded"] = bool(exclude.get("percintage"))
+                    exclude = (transform.get("options") or {}).get(
+                        "excludeByName"
+                    ) or {}
+                    live["overview_percintage_excluded"] = bool(
+                        exclude.get("percintage")
+                    )
 
     registry = {
         "iteration": int(iteration),

--- a/tests/architecture/test_silver_filter_identity_surface.py
+++ b/tests/architecture/test_silver_filter_identity_surface.py
@@ -93,7 +93,7 @@ ACTIVE_SURFACES = (
     / "config"
     / "silver_filter_migration.py",
     ROOT / "src" / "bioetl" / "infrastructure" / "config" / "filter_config_loader.py",
-    ROOT / "docs" / "filters" / "retired-silver-filters-structural-scope.md",
+    ROOT / "docs" / "99-archive" / "filters" / "retired-silver-filters-structural-scope.md",
     ROOT / "docs" / "99-archive" / "filters" / "migration-plan.md",
     ROOT
     / "docs"


### PR DESCRIPTION
## Summary
Follow-up after #7613: inventory/lifecycle and ruff format are green, but `test-governance-current.json` still drifted on tip. Restamp test-governance + flaky burndown so `governance-preflight` can stay green.

## Test plan
- [x] test-governance --check
- [x] flaky burndown --check
- [ ] CI governance-preflight green