### PR TITLE
fix(obs): GRA-3C-r2 closed-loop Grafana cycle (Run Explorer report shell + recon table)

### DIFF
--- a/grafana/dashboards/bioetl-run-explorer-v1.json
+++ b/grafana/dashboards/bioetl-run-explorer-v1.json
@@ -757,7 +757,7 @@
           "id": 3015,
           "type": "table",
           "title": "Inspect Reconciliation",
-          "description": "Reconciliation block from pipeline_run_report_v1 (object may need backend table shape). An empty result is VALID EMPTY when reconciliation evidence is absent. UNRESOLVED_SCOPE when run_id is not selected; an unexpected empty may mean backend unavailable, so verify /health/live",
+          "description": "Reconciliation metrics from pipeline_run_report_v1 as parameter/value rows. An empty result is VALID EMPTY when reconciliation evidence is absent or run_id is unresolved. An unexpected empty may mean backend unavailable — verify /health/live.",
           "gridPos": {
             "h": 5,
             "w": 24,

--- a/src/bioetl/interfaces/http/_health_server_observability_routing.py
+++ b/src/bioetl/interfaces/http/_health_server_observability_routing.py
@@ -61,10 +61,29 @@ def _unresolved_pipeline_run_report_shell(
         # Match pipeline_run_report_v1 keys used by Run Explorer panels.
         "funnel": [],
         "reasons_top_n": [],
-        "reconciliation": {},
+        "reconciliation": [],
         "artifacts": [],
         "schema_version": "pipeline_run_report_v1",
     }
+
+
+def _table_shape_pipeline_run_report(
+    payload: dict[str, object],
+) -> dict[str, object]:
+    """Normalize nested report sections for Grafana Infinity table selectors.
+
+    ``reconciliation`` is stored as an object in pipeline_run_report_v1 files.
+    Run Explorer panel 3015 uses root_selector=reconciliation on a table panel,
+    so the HTTP surface exposes a list of {parameter, value} rows.
+    """
+    recon = payload.get("reconciliation")
+    if not isinstance(recon, dict):
+        return payload
+    shaped = dict(payload)
+    shaped["reconciliation"] = [
+        {"parameter": str(key), "value": value} for key, value in recon.items()
+    ]
+    return shaped
 
 
 class _HealthResponseSupport(Protocol):
@@ -182,7 +201,11 @@ async def handle_pipeline_run_report(
             },
         )
         return
-    await host._send_payload_response(writer, 200, payload)
+    await host._send_payload_response(
+        writer,
+        200,
+        _table_shape_pipeline_run_report(payload),
+    )
 
 
 async def handle_workflow_run_report(

--- a/tests/unit/interfaces/http/test_run_report_ops.py
+++ b/tests/unit/interfaces/http/test_run_report_ops.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 from bioetl.interfaces.http._health_server_observability_routing import (
     _is_unresolved_run_scope,
+    _table_shape_pipeline_run_report,
     _unresolved_pipeline_run_report_shell,
 )
 from bioetl.interfaces.http.run_report_ops import (
@@ -87,7 +88,25 @@ def test_unresolved_run_id_sentinel_shell_for_grafana() -> None:
     assert shell["funnel"] == []
     assert shell["reasons_top_n"] == []
     assert shell["artifacts"] == []
-    assert shell["reconciliation"] == {}
+    assert shell["reconciliation"] == []
+
+
+def test_table_shape_pipeline_run_report_reconciliation_rows() -> None:
+    shaped = _table_shape_pipeline_run_report(
+        {
+            "schema_version": "pipeline_run_report_v1",
+            "reconciliation": {
+                "silver_accounted": 10,
+                "gold_delta": 0,
+            },
+            "funnel": [{"stage": "bronze"}],
+        }
+    )
+    assert shaped["reconciliation"] == [
+        {"parameter": "silver_accounted", "value": 10},
+        {"parameter": "gold_delta", "value": 0},
+    ]
+    assert shaped["funnel"] == [{"stage": "bronze"}]
 
 
 def test_load_requires_explicit_owner_selector(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closed-loop Grafana 3-cycle audit (r2) for the seven operator boards with full Review → Issues → Fix → Verify → Close per iteration.

### Iteration highlights

- **I1 / #7616**: live Ops HTTP legacy percintage cleared on host runtime (source already correct; container modules refreshed).
- **I1 / #7617**: percentage left-align retained — required by metric semantics contract (closed not planned).
- **I2 / #7618**: pipeline-run-report returns HTTP 200 empty shell for unresolved run_id sentinels so Run Explorer detail panels no longer QUERY_ERROR on default dash.
- **I3 / #7620**: reconciliation table-shaped as parameter/value rows for Run Explorer panel 3015.

### Code

- `src/bioetl/interfaces/http/_health_server_observability_routing.py` — unresolved scope shell + reconciliation table shape
- `grafana/dashboards/bioetl-run-explorer-v1.json` — panel 3015 description
- unit coverage in `tests/unit/interfaces/http/test_run_report_ops.py`

### Evidence

- Residual scanners: 0 after each fix verification
- Ops HTTP panel probe: 23/23 OK
- Renders: 7/7 at 1920x1080 each iteration (pre + postfix)
- Contract tests: visual + metric semantics + run_report_ops pass

## Test plan

- [x] pytest tests/unit/interfaces/http/test_run_report_ops.py
- [x] pytest tests/integration/test_dashboard_visual_semantics.py tests/integration/test_grafana_dashboard_metric_semantics.py
- [x] Live Ops probes for processed-records + pipeline-run-report
- [x] python -m scripts.ops rerender-grafana --fallback none 1920x1080 x 3 iterations
- [ ] CI green on PR
