### PR TITLE
Agent/ci c1 gov restamp final

### DIFF
--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,15 +1,15 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-05T06:46:22.504309+00:00",
+  "generated_at": "2026-08-05T07:10:59.672083+00:00",
   "summary": {
-    "total_scripts": 580,
+    "total_scripts": 582,
     "status_counts": {
       "active": 341,
-      "supporting": 234,
+      "supporting": 236,
       "temporary_diagnostic": 5
     },
     "reference_group_coverage": {
-      "agents": 11,
+      "agents": 12,
       "build": 12,
       "ci": 77,
       "docs": 235,
@@ -15948,8 +15948,14 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 5,
+      "reference_count": 6,
       "references": [
+        {
+          "path": "AGENTS.md",
+          "line": 77,
+          "source_group": "agents",
+          "text": "`scripts/engineering/repo/cleanup_root_local_clutter.py`. See"
+        },
         {
           "path": "docs/05-operations/verification/root-hygiene-refactoring-plan-2026-07-08.md",
           "line": 61,
@@ -18146,6 +18152,18 @@
       "next_step": "Retain only as a bounded one-off utility for auditability; classify or retire after the owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_i1b.py)."
     },
     {
+      "path": "scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain as bounded one-off utility for auditability; retire after owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py)."
+    },
+    {
       "path": "scripts/ops/observability/grafana/generate_dux4_issue_pack.py",
       "type": "py",
       "status": "supporting",
@@ -18201,6 +18219,18 @@
       "lifecycle_decision": "legacy_manual_utility",
       "review_by": "2026-09-30",
       "next_step": "Retain only as a bounded DUX6 issue-pack generator for auditability; retire it after the issue campaign is published and the generated pack becomes the durable record."
+    },
+    {
+      "path": "scripts/ops/observability/grafana/probe_ops_http_panels.py",
+      "type": "py",
+      "status": "supporting",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": [],
+      "owner": "@bioetl-platform",
+      "lifecycle_decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain as bounded one-off utility for auditability; retire after owning workflow is verified (scripts/ops/observability/grafana/probe_ops_http_panels.py)."
     },
     {
       "path": "scripts/ops/observability/grafana/render_all_grafana_screenshots.ps1",

--- a/configs/quality/scripts_lifecycle_registry.json
+++ b/configs/quality/scripts_lifecycle_registry.json
@@ -1435,6 +1435,18 @@
       "decision": "legacy_manual_utility",
       "review_by": "2026-09-30",
       "next_step": "Retain only as a bounded GRA 3-cycle scanner for auditability; retire after the campaign is verified (scripts/ops/observability/grafana/scan_gra_3cycle_r2_deep.py)."
+    },
+    "scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain as bounded one-off utility for auditability; retire after owning workflow is verified (scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py)."
+    },
+    "scripts/ops/observability/grafana/probe_ops_http_panels.py": {
+      "owner": "@bioetl-platform",
+      "decision": "legacy_manual_utility",
+      "review_by": "2026-09-30",
+      "next_step": "Retain as bounded one-off utility for auditability; retire after owning workflow is verified (scripts/ops/observability/grafana/probe_ops_http_panels.py)."
     }
   }
 }

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643"
+    "test_governance_source_tree_sha256": "7cc38dd19192028c7f9e00e4ff32982e7d17954031031e1b4777be1a075f0394"
   },
   "summary": {
     "by_alert_level": {
@@ -74,7 +74,7 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643",
+    "test_governance_source_tree_sha256": "7cc38dd19192028c7f9e00e4ff32982e7d17954031031e1b4777be1a075f0394",
     "total_flaky": 0,
     "total_test_files": 2180,
     "total_tests_analyzed": 23299

--- a/reports/quality/flaky-test-burndown-review.json
+++ b/reports/quality/flaky-test-burndown-review.json
@@ -40,7 +40,7 @@
   ],
   "source_fingerprints": {
     "curated_inventory_sha256": "fcc0223fda92af30984526c1ed95253c46c20b031234f0240a698b6484e3b651",
-    "test_governance_source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707"
+    "test_governance_source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643"
   },
   "summary": {
     "by_alert_level": {
@@ -74,9 +74,9 @@
       "quarantined": 0
     },
     "test_governance_budget_violation_count": 0,
-    "test_governance_source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707",
+    "test_governance_source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643",
     "total_flaky": 0,
     "total_test_files": 2180,
-    "total_tests_analyzed": 23298
+    "total_tests_analyzed": 23299
   }
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2314,6 +2314,7 @@
         "tests/unit/"
       ],
       "top_level_directories_including_pycache": [
+        "tests/__pycache__/",
         "tests/architecture/",
         "tests/benchmarks/",
         "tests/contract/",
@@ -2331,16 +2332,16 @@
         "tests/unit/"
       ],
       "top_level_directory_count": 15,
-      "top_level_directory_count_including_pycache": 15
+      "top_level_directory_count_including_pycache": 16
     },
     "top_duplicate_test_names": [],
     "total_test_files": 2180,
-    "total_test_functions": 23298,
+    "total_test_functions": 23299,
     "unreviewed_assertion_bypass_count": 0,
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "e2b04d3af183d5a3beb85fc02f078435f617b0a9abed171544a58cec5fc0f707",
+  "source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,
@@ -2380,6 +2381,7 @@
       "tests/unit/"
     ],
     "top_level_directories_including_pycache": [
+      "tests/__pycache__/",
       "tests/architecture/",
       "tests/benchmarks/",
       "tests/contract/",
@@ -2397,11 +2399,11 @@
       "tests/unit/"
     ],
     "top_level_directory_count": 15,
-    "top_level_directory_count_including_pycache": 15
+    "top_level_directory_count_including_pycache": 16
   },
   "top_duplicate_test_names": [],
   "total_test_files": 2180,
-  "total_test_functions": 23298,
+  "total_test_functions": 23299,
   "unreviewed_assertion_bypass_count": 0,
   "uuid4_call_sites": 0
 }

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2341,7 +2341,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "81440bee3350e3273a7e16a3efbdd246cd25356334f01b4e421e0bd267e24643",
+  "source_tree_sha256": "7cc38dd19192028c7f9e00e4ff32982e7d17954031031e1b4777be1a075f0394",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py
+++ b/scripts/ops/observability/grafana/fix_gra_3c_r2_i1.py
@@ -31,7 +31,10 @@ def fix_percentage_align() -> list[dict]:
                 if override.get("matcher", {}).get("options") != "percentage":
                     continue
                 for prop in override.get("properties") or []:
-                    if prop.get("id") == "custom.align" and prop.get("value") != "right":
+                    if (
+                        prop.get("id") == "custom.align"
+                        and prop.get("value") != "right"
+                    ):
                         old = prop.get("value")
                         prop["value"] = "right"
                         dirty = True

--- a/scripts/ops/observability/grafana/probe_ops_http_panels.py
+++ b/scripts/ops/observability/grafana/probe_ops_http_panels.py
@@ -70,7 +70,14 @@ def main() -> None:
                 }
                 results.append(item)
                 flag = "OK" if status in (200, 204) else "BAD"
-                print(flag, path.name, panel.get("id"), panel.get("title"), status, resolve(url)[:100])
+                print(
+                    flag,
+                    path.name,
+                    panel.get("id"),
+                    panel.get("title"),
+                    status,
+                    resolve(url)[:100],
+                )
 
     bad = [r for r in results if r["status"] not in (200, 204)]
     out = (

--- a/tests/architecture/test_silver_filter_identity_surface.py
+++ b/tests/architecture/test_silver_filter_identity_surface.py
@@ -93,7 +93,11 @@ ACTIVE_SURFACES = (
     / "config"
     / "silver_filter_migration.py",
     ROOT / "src" / "bioetl" / "infrastructure" / "config" / "filter_config_loader.py",
-    ROOT / "docs" / "99-archive" / "filters" / "retired-silver-filters-structural-scope.md",
+    ROOT
+    / "docs"
+    / "99-archive"
+    / "filters"
+    / "retired-silver-filters-structural-scope.md",
     ROOT / "docs" / "99-archive" / "filters" / "migration-plan.md",
     ROOT
     / "docs"


### PR DESCRIPTION
## Summary

<!-- Brief description of changes (1-3 sentences) -->

## Changes

-

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Config / pipeline change
- [ ] Documentation
- [ ] CI / infrastructure

## Affected layers

- [ ] Domain
- [ ] Application
- [ ] Infrastructure
- [ ] Composition
- [ ] Interfaces
- [ ] Configs

## Test plan

- [ ] Unit tests pass (`pytest tests/unit/`)
- [ ] Architecture tests pass (`pytest tests/architecture/`)
- [ ] Type check passes (`mypy --strict src/bioetl/`)
- [ ] Manual verification (describe below if applicable)

## Architecture verification evidence

<!-- Required for architecture/debt/gate/refactor changes. -->

<!-- Record concrete before/after values and the exact gates you ran. -->

- Before metrics:
- After metrics:
- Gates / verification:
- Outcome: `improved` / `unchanged` / `worsened`
- Justification (required for `unchanged` or `worsened`):

## Compatibility / tech-debt prevention (TD-10)

Keep twin / transition / expired compatibility metrics at zero:

- [ ] No new transition shims, twin modules, or package-root compatibility facades
      without inventory updates and owner review
- [ ] No first-party `src` imports of `bioetl.infrastructure.config` package root
      (see `docs/02-architecture/compatibility/infrastructure-config-package-root-sunset.md`)
- [ ] No debt budget / threshold / exemption growth (shrink-only scorecard)
- [ ] Permanent public CLI/composition entrypoints stay inventory-listed (not “dead code”)

## Checklist

- [ ] No new import boundary violations (ARCH-001)
- [ ] No hardcoded secrets (AP-005)
- [ ] Type annotations on all public functions (TYPE-001)
- [ ] Tests added/updated for new code (TEST-002)
- [ ] If `checks-complete` fails, I first triage `lint` → `c901-governance` →
      `arch-tests` and do not debug `checks-complete` separately

- [ ] If many jobs fail quickly, I inspected `dependency-preflight` first (`reports/ci/dependency-preflight.log`)
