### PR TITLE
fix(obs): close Grafana issues #7564 #7552 #6574 #6573 #6360

### DIFF
--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -836,7 +836,7 @@
       },
       "targets": [
         {
-          "expr": "topk(4, bioetl_l0_next_action_route{pipeline=~\"$pipeline\",run_type=~\"$run_type\"} or label_replace(label_replace(label_replace(vector(0), \"action_target\", \"no_route\", \"\", \"\"), \"action_reason\", \"selected_scope_not_present\", \"\", \"\"), \"action_dashboard_uid\", \"bioetl-overview-v2\", \"\", \"\"))",
+          "expr": "topk(4, bioetl_l0_next_action_route{pipeline=~\"$pipeline\",run_type=~\"$run_type\"} or bioetl_l0_next_action_no_route)",
           "refId": "A",
           "format": "table",
           "instant": true

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -955,7 +955,8 @@
               "mode": "multi",
               "sort": "desc"
             }
-          }
+          },
+          "maxDataPoints": 400
         },
         {
           "datasource": {

--- a/grafana/prometheus-rules/bioetl_observability.yml
+++ b/grafana/prometheus-rules/bioetl_observability.yml
@@ -376,6 +376,14 @@ groups:
           action_reason: no_recent_activity_or_unknown_state
           action_dashboard_uid: bioetl-overview-v2
         expr: bioetl_overview_pipeline_run_type_universe * 5
+      # Compact NO_ROUTE fallback for Overview First Action (#6574) — keeps
+      # first-screen PromQL under the 200-char diet without multi-label_replace.
+      - record: bioetl_l0_next_action_no_route
+        labels:
+          action_target: no_route
+          action_reason: selected_scope_not_present
+          action_dashboard_uid: bioetl-overview-v2
+        expr: vector(0)
       - record: bioetl_l1_runtime_blocker_status
         expr: bioetl_l0_input_status_selected{input="runtime"}
       - record: bioetl_l1_dq_status

--- a/src/bioetl/interfaces/cli/commands/domains/composite/command_input.py
+++ b/src/bioetl/interfaces/cli/commands/domains/composite/command_input.py
@@ -25,7 +25,8 @@ class CompositeRunCommandInput:
     debug: bool = False
     health_server: bool = True
     health_port: int = DEFAULT_HEALTH_SERVER_PORT
-    ensure_observability_backend: bool = True
+    # Align with workflow/run Click defaults (#7564): opt-in Ops HTTP backend.
+    ensure_observability_backend: bool = False
     observability_backend_port: int = DEFAULT_HEALTH_SERVER_PORT
 
 
@@ -59,7 +60,7 @@ def build_composite_run_command_input(
         health_port=cast(int, options.get("health_port", DEFAULT_HEALTH_SERVER_PORT)),
         ensure_observability_backend=cast(
             bool,
-            options.get("ensure_observability_backend", True),
+            options.get("ensure_observability_backend", False),
         ),
         observability_backend_port=cast(
             int,

--- a/tests/integration/test_grafana_overview_config.py
+++ b/tests/integration/test_grafana_overview_config.py
@@ -191,9 +191,12 @@ def test_status_and_next_action_preserve_current_status_semantics() -> None:
     assert 'run_type=~"$run_type"' in next_action_expr
     assert "$__range" not in next_action_expr
     assert "NO_ROUTE" in description or "no_route" in next_action_expr
-    assert "selected_scope_not_present" in next_action_expr
-    # Allow NO_ROUTE label_replace fallback in expr (RFA-P0).
-    assert len(next_action_expr) <= 320
+    # #6574: compact recording-rule fallback (preferred) or legacy label_replace.
+    assert (
+        "bioetl_l0_next_action_no_route" in next_action_expr
+        or "selected_scope_not_present" in next_action_expr
+    )
+    assert len(next_action_expr) <= 200
 
     # Priority column uses text color; Action carries row-aware board link.
     overrides = next_action.get("fieldConfig", {}).get("overrides", [])
@@ -297,8 +300,8 @@ def test_selected_scope_cards_normalize_workflow_pipeline_aliases() -> None:
     ):
         expr = _panel_expr(_panels_by_title()[title])
         assert 'pipeline=~"$pipeline"' in expr
-        # Review First Action may include compact NO_ROUTE label_replace fallback (RFA-P0).
-        max_len = 320 if title == "Review First Action" else 200
+        # Review First Action uses recording-rule NO_ROUTE fallback (#6574 diet).
+        max_len = 200
         assert len(expr) <= max_len, f"{title} expr length {len(expr)} > {max_len}"
         assert "$__range" not in expr
 

--- a/tests/unit/interfaces/cli/commands/test_run_composite.py
+++ b/tests/unit/interfaces/cli/commands/test_run_composite.py
@@ -417,9 +417,10 @@ class TestRunCompositeCommand:
     def test_run_composite_ensures_observability_backend_with_catalog_probe(
         self, cli_runner: CliRunner
     ) -> None:
+        """#7564: ensure backend defaults off; default Ops HTTP port 8000."""
         backend_result = ObservabilityBackendEnsureResult(
             status="reused",
-            health_url="http://127.0.0.1:8081/health",
+            health_url="http://127.0.0.1:8000/health",
         )
         with (
             patch(
@@ -438,8 +439,8 @@ class TestRunCompositeCommand:
 
         assert result.exit_code == ExitCode.OK.value
         mock_ensure_backend.assert_called_once_with(
-            enabled=True,
-            port=8081,
+            enabled=False,
+            port=8000,
             required_probe_paths=("/ops/control-plane/ready",),
         )
 

--- a/tests/unit/interfaces/http/test_control_plane_selector_filters.py
+++ b/tests/unit/interfaces/http/test_control_plane_selector_filters.py
@@ -134,6 +134,50 @@ def test_filter_records_requires_all_selected_dimensions_to_match() -> None:
     ) == (first,)
 
 
+def test_run_id_options_order_by_started_at_desc_independent_of_input_order() -> None:
+    """#7552: filter-options run_id list is newest-start-first, not catalog order."""
+    from bioetl.interfaces.http._control_plane_selector_payloads import (
+        RUN_ID_NO_SELECTION,
+        defaults_payload,
+        options_payload,
+    )
+
+    older = _record(
+        "older",
+        workflow_candidates=("wf-a",),
+        pipeline="chembl_activity",
+        run_type="backfill",
+        run_status="success",
+        completed_offset=1,
+    )
+    newer = _record(
+        "newer",
+        workflow_candidates=("wf-a",),
+        pipeline="chembl_activity",
+        run_type="backfill",
+        run_status="success",
+        completed_offset=10,
+    )
+    middle = _record(
+        "middle",
+        workflow_candidates=("wf-a",),
+        pipeline="chembl_activity",
+        run_type="incremental",
+        run_status="success",
+        completed_offset=5,
+    )
+
+    # Deliberately reverse catalog encounter order.
+    options = options_payload((older, newer, middle))
+    assert options["run_id"] == ["run-newer", "run-middle", "run-older"]
+
+    defaults = defaults_payload()
+    assert defaults["policy"] == "last_run_truthful"
+    assert defaults["run_type_fallback"] == "backfill"
+    assert defaults["run_id_list_order"] == "started_at_desc"
+    assert RUN_ID_NO_SELECTION == "-"
+
+
 def test_latest_record_uses_completed_at_then_manifest_id_tie_breaker() -> None:
     older = _record(
         "a",


### PR DESCRIPTION
## Summary

Closeout for open Observability/Grafana backlog:

| Issue | Result |
| --- | --- |
| #7564 | Composite ensure-backend default off; port 8000 alignment residual fixed |
| #7552 | Selector started_at sort + defaults verified; unit coverage added |
| #6574 | First Action PromQL 285→115 via `bioetl_l0_next_action_no_route`; maxDataPoints residual |
| #6573 | Lazy Run context verified (collapsed on primary boards); docs already document policy |
| #6360 | Exact within-dashboard PromQL dups = 0 (verified) |

## Changes

- `command_input.py`: ensure_observability_backend default False
- `bioetl_observability.yml`: recording rule `bioetl_l0_next_action_no_route`
- Overview First Action: thin topk + recording fallback
- Runtime Track Stage Lag: maxDataPoints 400
- Unit/integration tests updated

## Test plan

- [x] pytest overview_config, selector filters, run_composite, visual semantics, prometheus rules config
- [ ] CI green
