### PR TITLE
chore(governance): pin final issue 4343 tree

### DIFF
--- a/configs/quality/technical_debt_audit_registry.yaml
+++ b/configs/quality/technical_debt_audit_registry.yaml
@@ -5,7 +5,7 @@ audits:
   status: current
   report_path: reports/quality/total-tech-debt-audit-main-current.md
   audited_commit_sha: 14bcbfbd8054292fff9f55837da508a80ceaaeea
-  evidence_surface_sha256: d7cdb0410953cb4a7958ddc552cc354e4696735c2f476c5690aabff7b887b810
+  evidence_surface_sha256: 825d7820aa0c2e71299be8239c3217c8e049fa551ad752ff5b529530c69607e5
   evidence_paths:
   - configs/quality/compatibility_facade_inventory.yaml
   - configs/quality/constructor_waivers.yaml

--- a/configs/quality/test_telemetry_baseline.yaml
+++ b/configs/quality/test_telemetry_baseline.yaml
@@ -2,11 +2,11 @@ version: 1
 policy_scope: test_telemetry_baseline
 workflow_path: .github/workflows/tests.yml
 source_branch: main
-refreshed_at_utc: '2026-08-05T11:07:06.501447+00:00'
+refreshed_at_utc: '2026-08-05T11:11:28.065043+00:00'
 refresh_status: captured
 source_commit: 5271c40811c2420da5ae82fa233f56dfc02f25af
 source_run_id: github-30999069843-1
-source_tree_sha256: 671ec7f5d8eb2568fd50ae738a716f1c7825f6af5f78db1acf8c9936992f8ef9
+source_tree_sha256: 2b5a1f47d2da4ebaec0e5d14b93c98ed549dfb823fc74dbee319c83d7ae60555
 freshness_guard:
   timestamp_field: refreshed_at_utc
   max_age_days: 45

--- a/docs/05-engineering/test-telemetry-baseline.md
+++ b/docs/05-engineering/test-telemetry-baseline.md
@@ -30,9 +30,9 @@ trend evidence only.
 - Source branch: `main`
 - Source commit: `5271c40811c2420da5ae82fa233f56dfc02f25af`
 - Source run id: `github-30999069843-1`
-- Source tree sha256: `671ec7f5d8eb2568fd50ae738a716f1c7825f6af5f78db1acf8c9936992f8ef9`
+- Source tree sha256: `2b5a1f47d2da4ebaec0e5d14b93c98ed549dfb823fc74dbee319c83d7ae60555`
 - Refresh status: `captured`
-- Refreshed at (UTC): `2026-08-05T11:07:06.501447+00:00`
+- Refreshed at (UTC): `2026-08-05T11:11:28.065043+00:00`
 
 ## Branch-accurate provenance (#5729)
 

--- a/reports/quality/test-governance-current.json
+++ b/reports/quality/test-governance-current.json
@@ -2340,7 +2340,7 @@
     "uuid4_call_sites": 0
   },
   "root": ".",
-  "source_tree_sha256": "0030d149fde3b30bf3276fba7e85527df21b2399c063d6d579e7755cf4eaa4b5",
+  "source_tree_sha256": "8f2d8dbc7ded90ba37ed4b1b625e5c58f5c0257f21703e249badf0f2a6bd9422",
   "summary": {
     "assertion_branch_reachability_percent": 100.0,
     "assertless_total_candidates": 105,

--- a/reports/quality/total-tech-debt-audit-main-current.md
+++ b/reports/quality/total-tech-debt-audit-main-current.md
@@ -10,7 +10,7 @@ Audited branch: main
 
 Audited commit SHA: `14bcbfbd8054292fff9f55837da508a80ceaaeea`
 
-Evidence surface SHA-256: `d7cdb0410953cb4a7958ddc552cc354e4696735c2f476c5690aabff7b887b810`
+Evidence surface SHA-256: `825d7820aa0c2e71299be8239c3217c8e049fa551ad752ff5b529530c69607e5`
 
 Registry: configs/quality/technical_debt_audit_registry.yaml
 
@@ -18,7 +18,7 @@ Registry: configs/quality/technical_debt_audit_registry.yaml
 {
   "audit_id": "total-tech-debt-main-2026-07-27-r1",
   "audited_commit_sha": "14bcbfbd8054292fff9f55837da508a80ceaaeea",
-  "evidence_surface_sha256": "d7cdb0410953cb4a7958ddc552cc354e4696735c2f476c5690aabff7b887b810",
+  "evidence_surface_sha256": "825d7820aa0c2e71299be8239c3217c8e049fa551ad752ff5b529530c69607e5",
   "metrics": {
     "architecture_integral_score": 9.41,
     "architecture_interpretation": "good_targeted_improvements",

--- a/reports/test-telemetry/coverage-summary.json
+++ b/reports/test-telemetry/coverage-summary.json
@@ -2,8 +2,8 @@
   "source_branch": "main",
   "source_commit": "5271c40811c2420da5ae82fa233f56dfc02f25af",
   "source_run_id": "github-30999069843-1",
-  "source_tree_sha256": "671ec7f5d8eb2568fd50ae738a716f1c7825f6af5f78db1acf8c9936992f8ef9",
-  "refreshed_at_utc": "2026-08-05T11:07:06.501447+00:00",
+  "source_tree_sha256": "2b5a1f47d2da4ebaec0e5d14b93c98ed549dfb823fc74dbee319c83d7ae60555",
+  "refreshed_at_utc": "2026-08-05T11:11:28.065043+00:00",
   "refresh_status": "captured",
   "coverage_percent": 92.44,
   "coverage": {

--- a/reports/test-telemetry/slowest-tests.json
+++ b/reports/test-telemetry/slowest-tests.json
@@ -2,8 +2,8 @@
   "source_branch": "main",
   "source_commit": "5271c40811c2420da5ae82fa233f56dfc02f25af",
   "source_run_id": "github-30999069843-1",
-  "source_tree_sha256": "671ec7f5d8eb2568fd50ae738a716f1c7825f6af5f78db1acf8c9936992f8ef9",
-  "refreshed_at_utc": "2026-08-05T11:07:06.501447+00:00",
+  "source_tree_sha256": "2b5a1f47d2da4ebaec0e5d14b93c98ed549dfb823fc74dbee319c83d7ae60555",
+  "refreshed_at_utc": "2026-08-05T11:11:28.065043+00:00",
   "refresh_status": "captured",
   "total_cases": 46742,
   "top_slowest": [


### PR DESCRIPTION
## Результат

Завершает governance-closeout после уже влитого source-изменения для #4343.

- публичный source importer `bioetl.domain.composite.config`: **1 → 0**;
- split-module source importer baseline остаётся **7** (без роста долга);
- dependency edges: **7218 → 7216**, architecture violations: **0**;
- API/class identity сохранена, package-level `__getattr__` не возвращён;
- test-governance и telemetry provenance закреплены на финальном дереве;
- technical-debt audit evidence hash обновлён без увеличения budget/waiver/skip/xfail.

## Проверки

- composite/domain/CLI/bootstrap unit suites;
- facade/import-boundary architecture category;
- compatibility importer census + facade snapshot + dependency map drift;
- test-governance + telemetry governance;
- debt audit + debt gates + scorecard closeouts;
- Ruff, mypy, import-linter (6/6 contracts).

Closes #4343