### PR TITLE
style(ci): apply ruff format to four drifted modules

### DIFF
--- a/src/bioetl/interfaces/http/_health_server_observability_routing.py
+++ b/src/bioetl/interfaces/http/_health_server_observability_routing.py
@@ -83,8 +83,7 @@ def _table_shape_pipeline_run_report(
         return payload
     shaped = dict(payload)
     shaped["reconciliation"] = [
-        {"parameter": str(key), "value": str(value)}
-        for key, value in recon.items()
+        {"parameter": str(key), "value": str(value)} for key, value in recon.items()
     ]
     return shaped
 

--- a/tests/integration/test_dashboard_variable_dependencies.py
+++ b/tests/integration/test_dashboard_variable_dependencies.py
@@ -21,9 +21,7 @@ pytestmark = pytest.mark.integration
 
 def _templating_map(path: str) -> dict[str, dict]:
     dashboard = load_dashboard(Path(path))
-    return {
-        v.get("name"): v for v in dashboard.get("templating", {}).get("list", [])
-    }
+    return {v.get("name"): v for v in dashboard.get("templating", {}).get("list", [])}
 
 
 def test_runtime_variable_dependencies():

--- a/tests/integration/test_grafana_render_first_remediation.py
+++ b/tests/integration/test_grafana_render_first_remediation.py
@@ -443,7 +443,15 @@ def test_incident_ranked_suspects_hides_merged_activation_fields() -> None:
     exclude = organize.get("options", {}).get("excludeByName", {})
 
     assert len(suspects.get("targets", [])) == 3
-    for field in ("Time", "Time 1", "Time 2", "Value", "Value #A", "Value #B", "Value #C"):
+    for field in (
+        "Time",
+        "Time 1",
+        "Time 2",
+        "Value",
+        "Value #A",
+        "Value #B",
+        "Value #C",
+    ):
         assert exclude.get(field) is True
     assert not {
         value
@@ -470,8 +478,7 @@ def test_incident_alert_history_has_readable_full_width_layout() -> None:
     assert "ALERTS" in str(history.get("targets", [{}])[0].get("expr", ""))
     color_overrides = {
         override.get("matcher", {}).get("options"): {
-            prop.get("id"): prop.get("value")
-            for prop in override.get("properties", [])
+            prop.get("id"): prop.get("value") for prop in override.get("properties", [])
         }
         for override in history.get("fieldConfig", {}).get("overrides", [])
     }
@@ -495,9 +502,7 @@ def test_runtime_multi_query_tables_expose_semantic_fields_only() -> None:
         for transform in blocker_detail.get("transformations", [])
         if transform.get("id") == "organize"
     )
-    blocker_exclude = blocker_organize.get("options", {}).get(
-        "excludeByName", {}
-    )
+    blocker_exclude = blocker_organize.get("options", {}).get("excludeByName", {})
     for ref_id in {target.get("refId") for target in blocker_detail.get("targets", [])}:
         assert blocker_exclude.get(f"Value #{ref_id}") is True
     assert blocker_exclude.get("Value") is True

--- a/tests/unit/application/core/test_record_normalization_profiles.py
+++ b/tests/unit/application/core/test_record_normalization_profiles.py
@@ -321,7 +321,11 @@ def test_finalize_pre_silver_projects_malformed_json_findings_to_dq_warning() ->
             "publication_type": "PUBLICATION",
             "affiliation_list": "not-json",
         },
-        build_silver_record=lambda _context, entity_id, content_hash, _index, business: {
+        build_silver_record=lambda _context,
+        entity_id,
+        content_hash,
+        _index,
+        business: {
             "entity_id": entity_id,
             "content_hash": content_hash,
             **business,


### PR DESCRIPTION
## Summary

Close **#7515** / audit finding `F-C1-002`: ruff format drift on main tip.

## Files

- `src/bioetl/interfaces/http/_health_server_observability_routing.py`
- `tests/integration/test_dashboard_variable_dependencies.py`
- `tests/integration/test_grafana_render_first_remediation.py`
- `tests/unit/application/core/test_record_normalization_profiles.py`

## Verification

- `ruff format --check .` → all formatted
- `ruff check .` → All checks passed

Closes #7515