### PR TITLE
docs(grafana): align operator bus 0..6 to Incident + Run Explorer

### DIFF
--- a/docs/03-guides/dashboards/README.md
+++ b/docs/03-guides/dashboards/README.md
@@ -148,8 +148,7 @@ shadow review. The seven JSON UIDs remain authoritative and reachable. See
 
 Текущая навигационная модель:
 
-- `0. Control Plane`, `1. Overview`, `2. Runtime`, `3. Provider Health`,
-  `4. Data Quality`, `5. Workflow`, `6. Alerts & SLO` образуют единую
+- `0. Trust`, `1. Overview`, `2. Pipeline Diagnostics`, `3. Provider Health`, `4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer` образуют единую
   numbered top-level шину `0..6`.
 - На всех восьми shipped dashboards navigation panel `id=1000` визуально
   показывает bus `0..6`, затем `Silver Reject Explorer`, `Explore Logs` и
@@ -189,7 +188,7 @@ shadow review. The seven JSON UIDs remain authoritative and reachable. See
   parameters; primary dashboard links preserve the shared
   `workflow/pipeline/run_type` shell and primary `run_id` only between
   dashboards that expose that selector.
-- `bioetl-workflow-overview` additionally ships hidden exact-run handoff vars
+- ~~`bioetl-workflow-overview`~~ (**retired**) historically shipped hidden exact-run handoff vars
   (`workflow_context`, `pipeline_context_exact`, `run_type_context_exact`,
   `provider_context_exact`) so selected `run_id` can narrow downstream links
   without changing the visible selector shell on the same dashboard.
@@ -301,7 +300,7 @@ secondary mirrors только как локальный контекст. Mirro
 | Inputs | `1. Overview` | `2. Runtime`, `4. Data Quality`, `0. Control Plane` |
 | Data Validation | `1. Overview` | `2. Runtime`, `0. Control Plane` |
 | Provider | `1. Overview` | `3. Provider Health` |
-| Workflow | `1. Overview` | `5. Workflow` |
+| Workflow evidence | `1. Overview` | `2. Pipeline Diagnostics` (workflow band) |
 | Replay Safety State | `0. Control Plane` | `1. Overview`, `2. Runtime` |
 | Checkpoint Freshness Lag | `0. Control Plane` | `2. Runtime` |
 | Ledger/Manifest Consistency | `0. Control Plane` | `2. Runtime` |

--- a/docs/03-guides/dashboards/dashboard-extension-human.md
+++ b/docs/03-guides/dashboards/dashboard-extension-human.md
@@ -54,9 +54,7 @@ Dashboard System 2.0 checklist: [operator-ux-v2.md](operator-ux-v2.md).
 
 ### Навигация
 
-- Top-level шина: `0. Control Plane` / `1. Overview` / `2. Runtime` /
-  `3. Provider Health` / `4. Data Quality` / `5. Workflow` /
-  `6. Alerts & SLO`.
+- Top-level шина: `0. Trust` / `1. Overview` / `2. Pipeline Diagnostics` / `3. Provider Health` / `4. Data Quality` / `5. Incident Workspace` / `6. Run Explorer`.
 - На текущей странице текущий dashboard остаётся видимым в navigation panel
   `id=1000` как disabled theme-safe item; machine-readable `panel.links`
   по-прежнему не содержат self-link. Полная навигация читаема в dark/light

--- a/docs/03-guides/dashboards/dashboard-extension-llm.md
+++ b/docs/03-guides/dashboards/dashboard-extension-llm.md
@@ -38,8 +38,7 @@ Grafana dashboards в BioETL.
 
 ## 2. Текущая модель shipped dashboards
 
-- `0. Control Plane`, `1. Overview`, `2. Runtime`, `3. Provider Health`,
-  `4. Data Quality`, `5. Workflow`, `6. Alerts & SLO` — единая top-level
+- `0. Trust`, `1. Overview`, `2. Pipeline Diagnostics`, `3. Provider Health`, `4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer` — единая top-level
   шина.
 - На каждой из восьми shipped страниц navigation panel `id=1000` визуально
   показывает полный bus `0..6`; текущий dashboard рендерится как disabled

--- a/docs/03-guides/dashboards/dashboard-v2-usage.md
+++ b/docs/03-guides/dashboards/dashboard-v2-usage.md
@@ -32,7 +32,7 @@ or query semantics. See [Optional Scenes dual path](scenes-dual-path.md).
 > [monitoring-surface-reduction](../../05-operations/runbooks/monitoring-surface-reduction-2026-07-23.md).
 
 Shipped inventory (**7 dashboards**): Control Plane, Overview, Runtime, Provider
-Health, Data Quality, Workflow, Alerts & SLO. Primary `0..6` refresh is `60s`.
+Provider Health, Data Quality, Incident Workspace, Run Explorer. Primary `0..6` refresh is `60s`.
 Generic primary handoffs preserve HTTP `$run_id` for identity panels only
 (not Prometheus labels).
 
@@ -103,7 +103,7 @@ mention `6. Alerts & SLO` / Explore Logs / Explore Traces as removed surfaces.
 - `bioetl-dq-v2`: `$workflow`, `$pipeline`, `$run_type`, `$run_id`, `$stage`
 - `bioetl-provider-health-v2`: `$workflow`, `$pipeline`, `$run_type`,
   `$run_id`, `$provider`, hidden `$pipeline_context`, `$adapter`
-- `bioetl-workflow-overview`: `$workflow`, `$pipeline`, `$run_type`,
+- ~~`bioetl-workflow-overview`~~ (**retired**): was `$workflow`, `$pipeline`, `$run_type`,
   `$run_id`, `$status`, `$step_status`, `$step_kind`, hidden
   `$workflow_context`, `$pipeline_context`, `$pipeline_context_exact`,
   `$run_type_context`, `$run_type_context_exact`, `$provider_context`,
@@ -111,7 +111,7 @@ mention `6. Alerts & SLO` / Explore Logs / Explore Traces as removed surfaces.
 - `CLI quarantine inspect`: bounded forensic `$pipeline`, `$run_type`,
   `$reason_code`, `$field`, `$quarantine_run_id`, `$payload_hash`; it does not
   own the shared `$workflow` / `$run_id` shell
-- `bioetl-alerts-slo`: `$workflow`, `$pipeline`, `$run_type`
+- ~~`bioetl-alerts-slo`~~ (**retired**): was `$workflow`, `$pipeline`, `$run_type`
 - `bioetl-overview-v2` intentionally ships with `Workflow=All`,
   `Pipeline=All`, `Run Type=All`, and `Run ID=-` as fleet L0 entry scope (SEL-P0 O2).
 - Non-Overview primary boards default `Run Type=backfill` (majority operator case)
@@ -347,7 +347,7 @@ Explorer health probe and monitoring setup docs for that reason.
 
 В `2. Pipeline Diagnostics` cross-dashboard routing выполняется через полный top-level bus:
 `0. Trust`, `1. Overview`, `2. Pipeline Diagnostics`, `3. Provider Health`,
-`4. Data Quality`, `5. Workflow`, `6. Alerts & SLO`, затем
+`4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer`, затем
 `0..6` bus only (adjuncts removed); текущий Runtime item
 остаётся видимым disabled.
 
@@ -457,7 +457,7 @@ Primary dashboards MUST follow the canonical navigation contract in
 
 The top-level dashboard bus is:
 `0. Trust`, `1. Overview`, `2. Pipeline Diagnostics`, `3. Provider Health`,
-`4. Data Quality`, `5. Workflow`, `6. Alerts & SLO`. Each page renders the full
+`4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer`. Each page renders the full
 visual bus in navigation panel `id=1000`; the current dashboard stays visible
 as a disabled high-contrast item, while machine-readable `panel.links` still
 omit self-links.
@@ -525,11 +525,11 @@ Variable handoff policy for dashboard links remains strict and bounded:
 ## First 2 clicks scenario (operator)
 
 1. **Click #1:** открыть `bioetl-overview-v2`, прочитать `Status` + `First Action`.
-2. **Click #2:** открыть рекомендуемый dashboard из top-level bus (`0. Trust`, `2. Pipeline Diagnostics`, `3. Provider Health`, `4. Data Quality`, `5. Workflow`, `6. Alerts & SLO`).
+2. **Click #2:** открыть рекомендуемый dashboard из top-level bus (`0. Trust`, `2. Pipeline Diagnostics`, `3. Provider Health`, `4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer`).
 
 Цель сценария: root-cause направление должно быть определено максимум за 2 клика без обязательной прокрутки по нечастым CTA.
 - `bioetl-runtime`: top-level links `0. Trust`, `1. Overview`,
-  `3. Provider Health`, `4. Data Quality`, `5. Workflow`, `6. Alerts & SLO`,
+  `3. Provider Health`, `4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer`,
   `0..6` bus only (adjuncts removed) дают явный
   routing path из L2 runtime triage. Cross-dashboard handoffs передают только
   target-scoped variables; forensic IDs в runtime dashboard запрещены.
@@ -559,7 +559,7 @@ Variable handoff policy for dashboard links remains strict and bounded:
   `bioetl_control_plane_read_duration_seconds_bucket` глобальны по
   `store/operation/status`.
 - `bioetl-provider-health-v2`: dashboard links `0. Trust`,
-  `1. Overview`, `2. Pipeline Diagnostics`, `4. Data Quality`, `5. Workflow` дают быстрый
+  `1. Overview`, `2. Pipeline Diagnostics`, `4. Data Quality`, `5. Incident Workspace` дают быстрый
   переход из provider health surface без дублирования Runtime variants.
   Panel `id=114` (`Review Raw Provider Health Enum`) показывает явный enum
   raw-source mapping `0=UNHEALTHY`, `1=DEGRADED`, `2=HEALTHY` as below-fold
@@ -578,7 +578,7 @@ Variable handoff policy for dashboard links remains strict and bounded:
   2. Click #2: перейти в `2. Pipeline Diagnostics` при active degradation/failure trend или
      в `0. Trust` при симптомах retry exhaustion/state inconsistency.
 - `bioetl-dq-v2`: dashboard links `0. Trust`, `1. Overview`,
-  `2. Pipeline Diagnostics`, `3. Provider Health`, `5. Workflow`, `Silver Reject Explorer`,
+  `2. Pipeline Diagnostics`, `3. Provider Health`, `5. Incident Workspace` (CLI `bioetl quarantine inspect` for forensics; Silver Reject Explorer retired),
   `Explore Logs`, `Explore Traces` дают переходы для DQ incidents и freshness
   investigation. `Explore Traces` здесь остаётся traced-run-only adjunct;
   включайте tracing через `--tracing` или

--- a/docs/03-guides/dashboards/design-system.md
+++ b/docs/03-guides/dashboards/design-system.md
@@ -229,12 +229,12 @@ Normative rules:
 
 The shared shell is derived from `1. Overview` and applies to primary
 dashboards `0. Control Plane`, `2. Runtime`, `3. Provider Health`,
-`4. Data Quality`, and `5. Workflow`.
+`4. Data Quality`, `5. Incident Workspace`, and `6. Run Explorer`.
 
 | Panel | Canonical ID | Role | Data contract |
 | --- | ---:| --- | --- |
 | `Inspect Scope & Evidence` | `9400` | Question and evidence-scope banner | Visible text contains the primary dashboard question and short plain-language definitions of the evidence scopes used on the page. Selector values and datasource details stay in the panel tooltip/description. |
-| `Status` | `9401` | Compact dashboard verdict | Prometheus status for the dashboard role; no `$run_id` Prometheus filtering. `5. Workflow` is selected-range evidence and must say so. |
+| `Status` | `9401` | Compact dashboard verdict | Prometheus status for the dashboard role; no `$run_id` Prometheus filtering. Workflow band on `2. Pipeline Diagnostics` is selected-range evidence and must say so. |
 | `ID` | `9402` | Local control-plane identity | HTTP/Infinity `BioETL Ops HTTP` table from `/ops/control-plane/identity-table`; exact `run_id` is preserved HTTP identity context across primary dashboards. The two visible columns are `parameter` and `value`; rows cover run/manifest IDs, Provider.Entity version, contract schema, execution flags, replay capability/mode, checkpoint anchors, optional composite run, and identity health. |
 | `Processed Records` | `9403` | Current stage/outcome accounting evidence | HTTP/Infinity table from `/ops/observability/processed-records`, backed by compact `bioetl_processed_records_*` recording rules and canonical `bioetl_stage_records_total` outcomes. It shows non-zero Bronze, Silver outcome, and Gold outcome rows only. `Inspect Processed Records` displays `parameter` and `value`; `Review Processed Records` also displays the canonical formatted `percentage`. Internal `row_status` is hidden. `value` uses a space as the thousands separator, is left-padded to the displayed `bronze [total]` width, and is right-aligned in the table. Bronze is `100%`; `silver [valid]` and `gold [valid]` use one decimal; secondary outcomes use up to three decimals with trailing zeroes trimmed. Silver and Gold percentages use Bronze total. Status, accounted subtotal, and delta rows stay out of the compact table. Missing accounting series are no-data/instrumentation gaps, not OK. |
 
@@ -279,7 +279,7 @@ same answer-first reading order.
 | --- | --- | --- | --- |
 | L0 answer-first hub | `bioetl-overview-v2` | current answer, next route, bounded mirrors | historical context, routing aids, collapsed-by-default diagnostics |
 | L1/L2 triage | `bioetl-runtime`, `bioetl-control-plane-v1`, `bioetl-provider-health-v2`, `bioetl-dq-v2` | current verdict, first action, causes, trust markers | selected-range evidence, collapsed-by-default diagnostics |
-| Selected-range operational evidence | `bioetl-workflow-overview` | selected-range operational verdict and immediate fallout | lower evidence bands, optional collapsed-by-default diagnostics |
+| Selected-range operational evidence | `bioetl-runtime` workflow band (retired: `bioetl-workflow-overview`) | selected-range operational verdict and immediate fallout | lower evidence bands, optional collapsed-by-default diagnostics |
 | Forensic explorer | `bioetl-silver-reject-explorer` | scope semantics, no-data guidance, bounded summary | row-level browsing, record details, forensic tables |
 
 Normative rules:
@@ -506,7 +506,7 @@ Implementation guardrails:
 Источник фиксированного словаря для `links[].title`: `docs/03-guides/dashboards/navigation-contract.md`.
 
 Правила:
-- Названия top-level ссылок MUST совпадать с каноническими строками из navigation contract (например: `0. Control Plane`, `1. Overview`, `2. Runtime`, `3. Provider Health`, `4. Data Quality`, `5. Workflow`, `6. Alerts & SLO`, `Silver Reject Explorer`).
+- Названия top-level ссылок MUST совпадать с каноническими строками из navigation contract (например: `0. Trust`, `1. Overview`, `2. Pipeline Diagnostics`, `3. Provider Health`, `4. Data Quality`, `5. Incident Workspace`, `6. Run Explorer`, `Silver Reject Explorer`).
 - Explore-ссылки MUST использовать короткие названия: `Explore Logs` и `Explore Traces`.
 - Формулировки вида `Back to Overview`, `5. Control Plane`, `6. Workflow Overview`, `Explore Logs (Loki, tracing profile)`, `Explore Traces (Tempo, tracing profile)`, `Next Recommended Drilldown` считаются legacy-лексикой и не допускаются в shipped top navigation.
 
@@ -557,7 +557,7 @@ allowed.
 - `bioetl-overview-v2` является dashboard-routing-first surface. Panel-level
   CTA здесь MAY оставаться dashboard-only и по умолчанию не требует прямых
   runbook links.
-- `bioetl-workflow-overview` является selected-range evidence surface. Его
+- ~~`bioetl-workflow-overview`~~ (**retired**; evidence lives in Runtime workflow band). Исторически это был selected-range evidence surface. Его
   четыре summary counters selected-range evidence не требуют panel-level
   runbook links; shipped `First Action` остаётся единственным
   оправданным dashboard-handoff CTA exception на этой странице.


### PR DESCRIPTION
## Summary
Docs audit cycle 2: fix primary dashboard guides that still listed retired bus entries `5. Workflow` / `6. Alerts & SLO`.

## Changes
- README, dashboard-v2-usage, design-system, extension human/llm guides
- Explicit retired markers for workflow-overview / alerts-slo selector inventories

## Issue
Closes #7653

## Verification
- `python -m scripts.docs check-links --links` (run locally)