### PR TITLE
fix(cli): default quarantine serve port to 8000

### DIFF
--- a/src/bioetl/interfaces/cli/commands/domains/quarantine/server_backend.py
+++ b/src/bioetl/interfaces/cli/commands/domains/quarantine/server_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-DEFAULT_QUARANTINE_SERVER_PORT = 8081
+DEFAULT_QUARANTINE_SERVER_PORT = 8000
 
 __all__ = [
     "DEFAULT_QUARANTINE_SERVER_PORT",

--- a/tests/unit/interfaces/cli/commands/test_quarantine.py
+++ b/tests/unit/interfaces/cli/commands/test_quarantine.py
@@ -101,7 +101,7 @@ class TestQuarantineGroup:
         assert "--port" in result.output
         assert "--data-root" in result.output
         assert "0.0.0.0" in result.output
-        assert "8081" in result.output
+        assert "8000" in result.output
 
     @patch(
         "bioetl.interfaces.cli.commands.quarantine.run_long_lived_quarantine_backend_command"
@@ -140,7 +140,7 @@ class TestQuarantineGroup:
         assert result.exit_code == ExitCode.OK.value
         mock_run_quarantine_backend_command.assert_called_once_with(
             host="0.0.0.0",
-            port=8081,
+            port=8000,
             data_root=tmp_path.resolve(),
         )
 


### PR DESCRIPTION
## Summary

Close **#7564** residual: `DEFAULT_QUARANTINE_SERVER_PORT` was still **8081**.

## Changes

- `DEFAULT_QUARANTINE_SERVER_PORT = 8000` in `server_backend.py`
- unit tests expect default **8000**

Already true on tip before this PR: `DEFAULT_HEALTH_SERVER_PORT = 8000`, `ensure_observability_backend` default **False**.

## Verification

- `pytest tests/unit/interfaces/cli/commands/test_quarantine.py -q`
- `ruff check` on touched files

Closes #7564