### PR TITLE
fix(grafana): right-align Processed Records percentage columns

### DIFF
--- a/grafana/dashboards/bioetl-control-plane-v1.json
+++ b/grafana/dashboards/bioetl-control-plane-v1.json
@@ -4312,7 +4312,7 @@
             "properties": [
               {
                 "id": "custom.align",
-                "value": "left"
+                "value": "right"
               },
               {
                 "id": "custom.cellOptions",

--- a/grafana/dashboards/bioetl-dq-v2.json
+++ b/grafana/dashboards/bioetl-dq-v2.json
@@ -2688,7 +2688,7 @@
             "properties": [
               {
                 "id": "custom.align",
-                "value": "left"
+                "value": "right"
               },
               {
                 "id": "custom.cellOptions",

--- a/grafana/dashboards/bioetl-overview-v2.json
+++ b/grafana/dashboards/bioetl-overview-v2.json
@@ -3318,7 +3318,7 @@
             "properties": [
               {
                 "id": "custom.align",
-                "value": "left"
+                "value": "right"
               },
               {
                 "id": "custom.cellOptions",

--- a/grafana/dashboards/bioetl-provider-health-v2.json
+++ b/grafana/dashboards/bioetl-provider-health-v2.json
@@ -2622,7 +2622,7 @@
             "properties": [
               {
                 "id": "custom.align",
-                "value": "left"
+                "value": "right"
               },
               {
                 "id": "custom.cellOptions",

--- a/grafana/dashboards/bioetl-run-explorer-v1.json
+++ b/grafana/dashboards/bioetl-run-explorer-v1.json
@@ -497,7 +497,7 @@
             "properties": [
               {
                 "id": "custom.align",
-                "value": "left"
+                "value": "right"
               },
               {
                 "id": "custom.cellOptions",

--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -3004,7 +3004,7 @@
                 "properties": [
                   {
                     "id": "custom.align",
-                    "value": "left"
+                    "value": "right"
                   },
                   {
                     "id": "custom.cellOptions",


### PR DESCRIPTION
## Summary

Close **#7617**: Processed Records `percentage` column was left-aligned.

## Changes

`custom.align: right` for matcher `percentage` on panels:

| Dashboard | Panel id |
|-----------|----------|
| control-plane-v1 | 9403 |
| overview-v2 | 9301 |
| runtime | 9403 |
| provider-health-v2 | 9403 |
| dq-v2 | 9403 |
| run-explorer-v1 | 9403 |

Closes #7617