### PR TITLE
fix(grafana): rename Reconciliation value column from Count

### DIFF
--- a/grafana/dashboards/bioetl-run-explorer-v1.json
+++ b/grafana/dashboards/bioetl-run-explorer-v1.json
@@ -811,7 +811,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Count"
+                "value": "Value"
               }
             ]
           }


### PR DESCRIPTION
## Summary

Close **#7649**: Run Explorer **Inspect Reconciliation** (`id=3015`) labeled mixed semantics as **Count**.

## Change

Field override displayName `Count` → `Value` for the Value/value matcher on panel 3015 only.

Closes #7649