### PR TITLE
fix(grafana): show Processed Records percentage on Runtime

### DIFF
--- a/grafana/dashboards/bioetl-runtime.json
+++ b/grafana/dashboards/bioetl-runtime.json
@@ -3111,25 +3111,25 @@
               "id": "organize",
               "options": {
                 "excludeByName": {
-                  "percentage": true,
                   "row_status": true,
                   "percintage": true
                 },
                 "indexByName": {
                   "parameter": 0,
                   "value": 1,
-                  "row_status": 3,
-                  "percentage": 2
+                  "count": 1,
+                  "percentage": 2,
+                  "row_status": 3
                 },
                 "renameByName": {
                   "parameter": "parameter",
-                  "value": "value",
+                  "value": "count",
+                  "percentage": "percentage",
                   "row_status": "",
                   "Value": "count",
                   "Value #A": "Series A",
                   "Value #B": "Series B",
-                  "Value #C": "Series C",
-                  "percentage": "percentage"
+                  "Value #C": "Series C"
                 }
               }
             }

--- a/tests/integration/test_grafana_dashboard_metric_semantics.py
+++ b/tests/integration/test_grafana_dashboard_metric_semantics.py
@@ -1970,7 +1970,7 @@ def test_processed_records_parameter_rows_sort_and_display_cleanly(
         prop.get("id"): prop.get("value")
         for prop in percentage_overrides[0].get("properties", [])
     }
-    assert percentage_properties["custom.align"] == "left"
+    assert percentage_properties["custom.align"] == "right"
     assert percentage_properties["custom.cellOptions"] == {"type": "color-text"}
     # PFILL-01: plain percentage text — no pipe-token regex mappings required.
     assert percentage_properties.get("mappings", []) == []


### PR DESCRIPTION
## Summary

Close **#7540**: Runtime Processed Records (`id=9403`) excluded `percentage`.

Also:
- rename API `value` → operator `count` (match Overview/Provider)
- test expects percentage `custom.align=right` after #7617

## Verification

- `pytest tests/integration/test_grafana_dashboard_metric_semantics.py -k processed_records_parameter -q`

Closes #7540