### PR TITLE
fix(grafana): show alert occurrence as Count not Severity

### DIFF
--- a/grafana/dashboards/bioetl-incident-v1.json
+++ b/grafana/dashboards/bioetl-incident-v1.json
@@ -495,42 +495,10 @@
               "options": "^(Value|#Value|Value \\(.*\\)|value)$"
             },
             "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background",
-                  "mode": "basic"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "orange",
-                      "value": 1
-                    },
-                    {
-                      "color": "red",
-                      "value": 2
-                    }
-                  ]
-                }
-              },
+              {"id": "custom.cellOptions", "value": {"type": "auto"}},
               {
                 "id": "displayName",
-                "value": "Severity"
+                "value": "Count"
               }
             ]
           }


### PR DESCRIPTION
## Summary

Close **#7661**: panel `Monitor Current Alerts` (`id=2005`) used `count by (alertname, alertstate)` but labeled the metric **Severity** with orange/red thresholds on occurrence count.

## Changes

- `displayName`: Severity → **Count**
- cell type: color-background → **auto**
- remove count-based severity thresholds/color mode

Closes #7661