### PR TITLE
fix(grafana): give DQ suspects reason column room

### DIFF
--- a/grafana/dashboards/bioetl-incident-v1.json
+++ b/grafana/dashboards/bioetl-incident-v1.json
@@ -813,6 +813,45 @@
                 "value": "Signal"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": true,
+                  "legend": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 220
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
## Summary

Close **#7662**: Incident **Inspect DQ Suspects** (`id=2004`) truncated `reason`.

## Changes

- Hide `Time` (instant-query noise)
- `reason` width 220 + wrapText

Closes #7662