### PR TITLE
fix(grafana): apply reason-width layout to Inspect DQ Suspects

### DIFF
--- a/grafana/dashboards/bioetl-incident-v1.json
+++ b/grafana/dashboards/bioetl-incident-v1.json
@@ -1098,6 +1098,45 @@
                 "value": "Signal"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": true,
+                  "legend": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 220
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
## Summary

Correct follow-up for **#7662**: overrides landed on panel **2002** in #7685; this applies Time hide + reason width/wrap to **Inspect DQ Suspects** (`id=2004`).

Panel 2002 keeps the same beneficial layout for runtime reasons.

Closes #7662