### PR TITLE
test(grafana): reject collapsed rows that lose nested panels

### DIFF
--- a/tests/integration/test_grafana_render_first_remediation.py
+++ b/tests/integration/test_grafana_render_first_remediation.py
@@ -502,6 +502,37 @@ def test_rf006_progressive_disclosure_reduces_first_path() -> None:
         assert len(row.get("panels") or []) > 0
 
 
+def test_collapsed_rows_never_ship_empty_nested_panels() -> None:
+    """Collapsed progressive-disclosure rows must retain nested panel payload.
+
+    Host-side expand/collapse WIP previously emptied Runtime nested rows
+    (collapsed=false + panels=[]). Guard all seven operator boards (#7829).
+    """
+    operator_files = (
+        "bioetl-control-plane-v1.json",
+        "bioetl-overview-v2.json",
+        "bioetl-runtime.json",
+        "bioetl-provider-health-v2.json",
+        "bioetl-dq-v2.json",
+        "bioetl-incident-v1.json",
+        "bioetl-run-explorer-v1.json",
+    )
+    for name in operator_files:
+        dashboard = _load(name)
+        empty: list[tuple[object, object]] = []
+        for panel in _iter_panels(dashboard.get("panels") or []):
+            if panel.get("type") != "row":
+                continue
+            if panel.get("collapsed") is not True:
+                continue
+            nested = panel.get("panels") or []
+            if len(nested) == 0:
+                empty.append((panel.get("id"), panel.get("title")))
+        assert not empty, (
+            f"{name}: collapsed rows must keep nested panels; empty nests={empty}"
+        )
+
+
 def test_rf007_counts_and_dense_legends_are_bounded() -> None:
     runtime = _load("bioetl-runtime.json")
     for panel_id in (240, 241):


### PR DESCRIPTION
## Summary
Grafana 3-cycle r7: integrity test so progressive-disclosure rows cannot ship with empty nested panels.

## Issues
Closes #7829  

## Verification
- [x] Render 7/7 × 3 iterations
- [x] `test_collapsed_rows_never_ship_empty_nested_panels` + RF-006
- [ ] full make lint/test

## Artifacts
`reports/observability/grafana-3cycle-20260805-r7/CONSOLIDATED_REPORT.md`