### PR TITLE
docs(cr-full): publish #7696 FINDINGS triage and de-dupe pack

### DIFF
--- a/.github/ISSUES/CODERABBIT-FULL-2026-08-FINDINGS-PACK.md
+++ b/.github/ISSUES/CODERABBIT-FULL-2026-08-FINDINGS-PACK.md
@@ -15,32 +15,18 @@
 | trivial | 457 |
 | **total** | **1468** |
 
-## Path-cluster issue inventory
+## Path-cluster inventory (after de-dupe)
 
 | Metric | Count |
 | --- | ---: |
-| Open residual clusters before de-dupe | 268 |
-| Canonical kept | 220 |
-| Duplicates identified | 48 |
-| Duplicates closed this run | 0 |
-| Canonical critical (P0) | 12 |
-| Canonical major (P1) | 208 |
-| Canonical minor (P2) | 0 |
-| Canonical trivial | 0 |
+| Canonical open residual issues | 220 |
+| Duplicates closed | 48 |
+| P0 critical | 12 |
+| P1 major | 208 |
+| P2 minor | 0 |
+| trivial open | 0 |
 
-## Campaign parent issues
-
-| Code | Issue | Status note |
-| --- | ---: | --- |
-| meta | #7688 | open |
-| CR-FULL-00 | #7689 | preflight done |
-| Wave A–D | #7690–#7693 | closed after residual CLI |
-| Wave E/F | #7694–#7695 | open blocked #8031/#8032 |
-| FINDINGS | #7696 | this pack |
-| Closeout | #7697 | after implement |
-| Secret | #7698 | owner |
-
-## Canonical P0 critical issues
+## Canonical P0 critical
 
 - [#7738](https://github.com/SatoryKono/BioactivityDataAcquisition/issues/7738) — `src/bioetl/composition/bootstrap/runtime` (34 findings, Wave A)
 - [#7750](https://github.com/SatoryKono/BioactivityDataAcquisition/issues/7750) — `src/bioetl/application/services/control_plane` (73 findings, Wave A)
@@ -57,20 +43,27 @@
 
 ## De-dupe policy
 
-1. One open issue per residual path (normalized).
-2. Prefer Wave A over Wave B when same path (fixes mid-campaign filter mis-tag).
-3. Prefer lower issue number / higher severity when still tied.
-4. Implement only against canonical issue; closed dupes link back.
-5. Do **not** grow tech-debt / quality budgets.
+1. One open issue per residual path.
+2. Prefer Wave A over later waves for same path.
+3. Prefer higher severity, then lower issue number.
+4. Implement only canonical issues.
+5. No tech-debt budget growth.
 
-## Related artifacts
+## Files
 
 - `reports/quality/coderabbit/20260806/FINDINGS.md`
 - `reports/quality/coderabbit/20260806/TRIAGE.md`
 - `reports/quality/coderabbit/20260806/DE_DUPE_MAP.json`
-- Wave raw: `reports/quality/coderabbit/20260805/` (or local `/tmp/bioetl-cr-artifacts/20260805/`)
 
-## Errors during close
+## Campaign parents
 
-- none
+| Issue | Note |
+| ---: | --- |
+| #7688 | epic open |
+| #7690–#7693 | Wave A–D closed after residual CLI |
+| #7694–#7695 | E/F blocked #8031/#8032 |
+| #7696 | this pack (complete) |
+| #7697 | FINAL after implement |
+| #7698 | CI secret owner |
+| #7946 | domain rate-limit retry |
 

--- a/.github/ISSUES/CODERABBIT-FULL-2026-08-ISSUE-PACK.md
+++ b/.github/ISSUES/CODERABBIT-FULL-2026-08-ISSUE-PACK.md
@@ -104,3 +104,13 @@ reports/quality/coderabbit/YYYYMMDD/
 `priority:high` / `priority:medium`, `audit-tooling`, `testing`,
 `architecture-tests`, `documentation`, `docs-drift`, `observability`,
 `data-quality`, `reproducibility`, `security`, `ci`
+
+
+## Residual FINDINGS pack (#7696)
+
+Post-campaign de-dupe pack: [CODERABBIT-FULL-2026-08-FINDINGS-PACK.md](CODERABBIT-FULL-2026-08-FINDINGS-PACK.md)
+
+- Artifacts: `reports/quality/coderabbit/20260806/` (`FINDINGS.md`, `TRIAGE.md`, `DE_DUPE_MAP.json`)
+- Canonical open residual path-cluster issues after de-dupe: see findings pack
+- Duplicates closed (Wave B mis-tags / path twins) mapped in DE_DUPE_MAP.json
+

--- a/reports/quality/coderabbit/20260806/CODERABBIT-FULL-2026-08-FINDINGS-PACK.md
+++ b/reports/quality/coderabbit/20260806/CODERABBIT-FULL-2026-08-FINDINGS-PACK.md
@@ -15,32 +15,18 @@
 | trivial | 457 |
 | **total** | **1468** |
 
-## Path-cluster issue inventory
+## Path-cluster inventory (after de-dupe)
 
 | Metric | Count |
 | --- | ---: |
-| Open residual clusters before de-dupe | 268 |
-| Canonical kept | 220 |
-| Duplicates identified | 48 |
-| Duplicates closed this run | 0 |
-| Canonical critical (P0) | 12 |
-| Canonical major (P1) | 208 |
-| Canonical minor (P2) | 0 |
-| Canonical trivial | 0 |
+| Canonical open residual issues | 220 |
+| Duplicates closed | 48 |
+| P0 critical | 12 |
+| P1 major | 208 |
+| P2 minor | 0 |
+| trivial open | 0 |
 
-## Campaign parent issues
-
-| Code | Issue | Status note |
-| --- | ---: | --- |
-| meta | #7688 | open |
-| CR-FULL-00 | #7689 | preflight done |
-| Wave A–D | #7690–#7693 | closed after residual CLI |
-| Wave E/F | #7694–#7695 | open blocked #8031/#8032 |
-| FINDINGS | #7696 | this pack |
-| Closeout | #7697 | after implement |
-| Secret | #7698 | owner |
-
-## Canonical P0 critical issues
+## Canonical P0 critical
 
 - [#7738](https://github.com/SatoryKono/BioactivityDataAcquisition/issues/7738) — `src/bioetl/composition/bootstrap/runtime` (34 findings, Wave A)
 - [#7750](https://github.com/SatoryKono/BioactivityDataAcquisition/issues/7750) — `src/bioetl/application/services/control_plane` (73 findings, Wave A)
@@ -57,20 +43,27 @@
 
 ## De-dupe policy
 
-1. One open issue per residual path (normalized).
-2. Prefer Wave A over Wave B when same path (fixes mid-campaign filter mis-tag).
-3. Prefer lower issue number / higher severity when still tied.
-4. Implement only against canonical issue; closed dupes link back.
-5. Do **not** grow tech-debt / quality budgets.
+1. One open issue per residual path.
+2. Prefer Wave A over later waves for same path.
+3. Prefer higher severity, then lower issue number.
+4. Implement only canonical issues.
+5. No tech-debt budget growth.
 
-## Related artifacts
+## Files
 
 - `reports/quality/coderabbit/20260806/FINDINGS.md`
 - `reports/quality/coderabbit/20260806/TRIAGE.md`
 - `reports/quality/coderabbit/20260806/DE_DUPE_MAP.json`
-- Wave raw: `reports/quality/coderabbit/20260805/` (or local `/tmp/bioetl-cr-artifacts/20260805/`)
 
-## Errors during close
+## Campaign parents
 
-- none
+| Issue | Note |
+| ---: | --- |
+| #7688 | epic open |
+| #7690–#7693 | Wave A–D closed after residual CLI |
+| #7694–#7695 | E/F blocked #8031/#8032 |
+| #7696 | this pack (complete) |
+| #7697 | FINAL after implement |
+| #7698 | CI secret owner |
+| #7946 | domain rate-limit retry |
 

--- a/reports/quality/coderabbit/20260806/DE_DUPE_MAP.json
+++ b/reports/quality/coderabbit/20260806/DE_DUPE_MAP.json
@@ -1,143 +1,14 @@
 [
   {
-    "duplicate": 7919,
-    "canonical": 7911,
-    "path": "src/bioetl/domain/ports/runtime",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/runtime` (sev major/A \u2192 canonical #7911 major/A)"
-  },
-  {
-    "duplicate": 7921,
-    "canonical": 7912,
-    "path": "src/bioetl/domain/ports/noop",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/noop` (sev major/A \u2192 canonical #7912 major/A)"
-  },
-  {
-    "duplicate": 7923,
-    "canonical": 7913,
-    "path": "src/bioetl/domain/ports/quality",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/quality` (sev major/A \u2192 canonical #7913 major/A)"
-  },
-  {
-    "duplicate": 7924,
-    "canonical": 7914,
-    "path": "src/bioetl/domain/ports/storage",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/storage` (sev major/A \u2192 canonical #7914 major/A)"
-  },
-  {
-    "duplicate": 7925,
-    "canonical": 7915,
-    "path": "src/bioetl/domain/ports/storage_maintenance.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/storage_maintenance.py` (sev major/A \u2192 canonical #7915 major/A)"
-  },
-  {
-    "duplicate": 7926,
-    "canonical": 7916,
-    "path": "src/bioetl/domain/ports/workflow_foreign_key_reconciliation.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/workflow_foreign_key_reconciliation.py` (sev major/A \u2192 canonical #7916 major/A)"
-  },
-  {
-    "duplicate": 7927,
-    "canonical": 7917,
-    "path": "src/bioetl/domain/ports/__init__.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/__init__.py` (sev major/A \u2192 canonical #7917 major/A)"
-  },
-  {
-    "duplicate": 7928,
-    "canonical": 7918,
-    "path": "src/bioetl/domain/ports/adr.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/adr.py` (sev major/A \u2192 canonical #7918 major/A)"
-  },
-  {
-    "duplicate": 7936,
-    "canonical": 7779,
-    "path": "src/bioetl/application/core/batch_checkpoint_recovery_service.py",
-    "dupe_wave": "A",
-    "dupe_sev": "critical",
-    "canon_wave": "A",
-    "canon_sev": "critical",
-    "reason": "same path `src/bioetl/application/core/batch_checkpoint_recovery_service.py` (sev critical/A \u2192 canonical #7779 critical/A)"
-  },
-  {
-    "duplicate": 7937,
-    "canonical": 7748,
-    "path": "src/bioetl/composition/runtime_builders/_run_manifest_creation_support.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/runtime_builders/_run_manifest_creation_support.py` (sev major/A \u2192 canonical #7748 major/A)"
-  },
-  {
-    "duplicate": 7938,
-    "canonical": 7749,
-    "path": "src/bioetl/composition/runtime_builders/_run_manifest_data_roots.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/runtime_builders/_run_manifest_data_roots.py` (sev major/A \u2192 canonical #7749 major/A)"
-  },
-  {
-    "duplicate": 7939,
-    "canonical": 7751,
-    "path": "src/bioetl/composition/runtime_builders/_snapshot_mapping_support.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/runtime_builders/_snapshot_mapping_support.py` (sev major/A \u2192 canonical #7751 major/A)"
-  },
-  {
-    "duplicate": 7940,
-    "canonical": 7895,
-    "path": "src/bioetl/interfaces/http/_health_server_identity_routing_support.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/interfaces/http/_health_server_identity_routing_support.py` (sev major/A \u2192 canonical #7895 major/A)"
-  },
-  {
     "duplicate": 7941,
     "canonical": 7761,
     "path": "src/bioetl/application/core/_batch_write_support.py",
     "dupe_wave": "A",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/_batch_write_support.py` (sev major/A \u2192 canonical #7761 major/A)"
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7942,
@@ -145,9 +16,10 @@
     "path": "src/bioetl/application/core/_batch_writer_gold_support.py",
     "dupe_wave": "A",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/_batch_writer_gold_support.py` (sev major/A \u2192 canonical #7771 major/A)"
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7943,
@@ -155,9 +27,10 @@
     "path": "src/bioetl/application/core/_quarantine_metrics_support.py",
     "dupe_wave": "A",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/_quarantine_metrics_support.py` (sev major/A \u2192 canonical #7772 major/A)"
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7944,
@@ -165,219 +38,10 @@
     "path": "src/bioetl/application/core/_record_normalization_mapping.py",
     "dupe_wave": "A",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/_record_normalization_mapping.py` (sev major/A \u2192 canonical #7773 major/A)"
-  },
-  {
-    "duplicate": 7945,
-    "canonical": 7774,
-    "path": "src/bioetl/application/core/batch_executor_dq_helpers.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_executor_dq_helpers.py` (sev major/A \u2192 canonical #7774 major/A)"
-  },
-  {
-    "duplicate": 7947,
-    "canonical": 7775,
-    "path": "src/bioetl/application/core/batch_executor_dq_mixin.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_executor_dq_mixin.py` (sev major/A \u2192 canonical #7775 major/A)"
-  },
-  {
-    "duplicate": 7948,
-    "canonical": 7776,
-    "path": "src/bioetl/application/core/batch_executor_helpers.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_executor_helpers.py` (sev major/A \u2192 canonical #7776 major/A)"
-  },
-  {
-    "duplicate": 7949,
-    "canonical": 7780,
-    "path": "src/bioetl/application/core/batch_writer_columns_mixin.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_writer_columns_mixin.py` (sev major/A \u2192 canonical #7780 major/A)"
-  },
-  {
-    "duplicate": 7950,
-    "canonical": 7781,
-    "path": "src/bioetl/application/core/batch_writer_io_mixin.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_writer_io_mixin.py` (sev major/A \u2192 canonical #7781 major/A)"
-  },
-  {
-    "duplicate": 7951,
-    "canonical": 7782,
-    "path": "src/bioetl/application/core/batch_writer_tracing_mixin.py",
-    "dupe_wave": "A",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_writer_tracing_mixin.py` (sev major/A \u2192 canonical #7782 major/A)"
-  },
-  {
-    "duplicate": 7952,
-    "canonical": 7750,
-    "path": "src/bioetl/application/services/control_plane",
-    "dupe_wave": "B",
-    "dupe_sev": "critical",
-    "canon_wave": "A",
-    "canon_sev": "critical",
-    "reason": "same path `src/bioetl/application/services/control_plane` (sev critical/B \u2192 canonical #7750 critical/A)"
-  },
-  {
-    "duplicate": 7953,
-    "canonical": 7738,
-    "path": "src/bioetl/composition/bootstrap/runtime",
-    "dupe_wave": "B",
-    "dupe_sev": "critical",
-    "canon_wave": "A",
-    "canon_sev": "critical",
-    "reason": "same path `src/bioetl/composition/bootstrap/runtime` (sev critical/B \u2192 canonical #7738 critical/A)"
-  },
-  {
-    "duplicate": 7954,
-    "canonical": 7852,
-    "path": "src/bioetl/interfaces/cli/commands",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/interfaces/cli/commands` (sev major/B \u2192 canonical #7852 major/A)"
-  },
-  {
-    "duplicate": 7955,
-    "canonical": 7739,
-    "path": "src/bioetl/composition/factories/pipeline",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/factories/pipeline` (sev major/B \u2192 canonical #7739 major/A)"
-  },
-  {
-    "duplicate": 7956,
-    "canonical": 7740,
-    "path": "src/bioetl/composition/factories/services",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/factories/services` (sev major/B \u2192 canonical #7740 major/A)"
-  },
-  {
-    "duplicate": 7957,
-    "canonical": 7741,
-    "path": "src/bioetl/composition/factories/storage",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/factories/storage` (sev major/B \u2192 canonical #7741 major/A)"
-  },
-  {
-    "duplicate": 7958,
-    "canonical": 7821,
-    "path": "src/bioetl/infrastructure/adapters/crossref",
-    "dupe_wave": "B",
-    "dupe_sev": "critical",
-    "canon_wave": "A",
-    "canon_sev": "critical",
-    "reason": "same path `src/bioetl/infrastructure/adapters/crossref` (sev critical/B \u2192 canonical #7821 critical/A)"
-  },
-  {
-    "duplicate": 7959,
-    "canonical": 7810,
-    "path": "src/bioetl/infrastructure/adapters/openalex",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/openalex` (sev major/B \u2192 canonical #7810 major/A)"
-  },
-  {
-    "duplicate": 7960,
-    "canonical": 7805,
-    "path": "src/bioetl/infrastructure/adapters/uniprot",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/uniprot` (sev major/B \u2192 canonical #7805 major/A)"
-  },
-  {
-    "duplicate": 7961,
-    "canonical": 7822,
-    "path": "src/bioetl/infrastructure/adapters/common",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/common` (sev major/B \u2192 canonical #7822 major/A)"
-  },
-  {
-    "duplicate": 7963,
-    "canonical": 7742,
-    "path": "src/bioetl/composition/factories/pipeline_support",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/factories/pipeline_support` (sev major/B \u2192 canonical #7742 major/A)"
-  },
-  {
-    "duplicate": 7964,
-    "canonical": 7929,
-    "path": "src/bioetl/domain/contracts/gold",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/contracts/gold` (sev major/B \u2192 canonical #7929 major/A)"
-  },
-  {
-    "duplicate": 7965,
-    "canonical": 7824,
-    "path": "src/bioetl/infrastructure/adapters/pubchem",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/pubchem` (sev major/B \u2192 canonical #7824 major/A)"
-  },
-  {
-    "duplicate": 7966,
-    "canonical": 7823,
-    "path": "src/bioetl/infrastructure/adapters/decorators",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/decorators` (sev major/B \u2192 canonical #7823 major/A)"
-  },
-  {
-    "duplicate": 7967,
-    "canonical": 7809,
-    "path": "src/bioetl/infrastructure/adapters/http",
-    "dupe_wave": "B",
-    "dupe_sev": "critical",
-    "canon_wave": "A",
-    "canon_sev": "critical",
-    "reason": "same path `src/bioetl/infrastructure/adapters/http` (sev critical/B \u2192 canonical #7809 critical/A)"
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7968,
@@ -385,49 +49,21 @@
     "path": "src/bioetl/application/core/base_transformer",
     "dupe_wave": "B",
     "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "critical",
-    "reason": "same path `src/bioetl/application/core/base_transformer` (sev critical/B \u2192 canonical #7770 critical/A)"
+    "canon_state": "OPEN"
   },
   {
-    "duplicate": 7969,
-    "canonical": 7760,
-    "path": "src/bioetl/application/core/postrun",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
+    "duplicate": 7936,
+    "canonical": 7779,
+    "path": "src/bioetl/application/core/batch_checkpoint_recovery_service.py",
+    "dupe_wave": "A",
+    "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/postrun` (sev major/B \u2192 canonical #7760 major/A)"
-  },
-  {
-    "duplicate": 7970,
-    "canonical": 7743,
-    "path": "src/bioetl/composition/bootstrap/cli",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/bootstrap/cli` (sev major/B \u2192 canonical #7743 major/A)"
-  },
-  {
-    "duplicate": 7971,
-    "canonical": 7744,
-    "path": "src/bioetl/composition/factories/datasource",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/factories/datasource` (sev major/B \u2192 canonical #7744 major/A)"
-  },
-  {
-    "duplicate": 7976,
-    "canonical": 7825,
-    "path": "src/bioetl/infrastructure/adapters/chembl",
-    "dupe_wave": "B",
-    "dupe_sev": "major",
-    "canon_wave": "A",
-    "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/chembl` (sev major/B \u2192 canonical #7825 major/A)"
+    "canon_sev": "critical",
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7977,
@@ -435,9 +71,76 @@
     "path": "src/bioetl/application/core/batch_execution",
     "dupe_wave": "B",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/batch_execution` (sev major/B \u2192 canonical #7778 major/A)"
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7945,
+    "canonical": 7774,
+    "path": "src/bioetl/application/core/batch_executor_dq_helpers.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7947,
+    "canonical": 7775,
+    "path": "src/bioetl/application/core/batch_executor_dq_mixin.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7948,
+    "canonical": 7776,
+    "path": "src/bioetl/application/core/batch_executor_helpers.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7949,
+    "canonical": 7780,
+    "path": "src/bioetl/application/core/batch_writer_columns_mixin.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7950,
+    "canonical": 7781,
+    "path": "src/bioetl/application/core/batch_writer_io_mixin.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7951,
+    "canonical": 7782,
+    "path": "src/bioetl/application/core/batch_writer_tracing_mixin.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7978,
@@ -445,9 +148,32 @@
     "path": "src/bioetl/application/core/lifecycle",
     "dupe_wave": "B",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/application/core/lifecycle` (sev major/B \u2192 canonical #7783 major/A)"
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7969,
+    "canonical": 7760,
+    "path": "src/bioetl/application/core/postrun",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7952,
+    "canonical": 7750,
+    "path": "src/bioetl/application/services/control_plane",
+    "dupe_wave": "B",
+    "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "critical",
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7979,
@@ -455,19 +181,153 @@
     "path": "src/bioetl/composition/bootstrap/assembly",
     "dupe_wave": "B",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/composition/bootstrap/assembly` (sev major/B \u2192 canonical #7745 major/A)"
+    "canon_state": "OPEN"
   },
   {
-    "duplicate": 7980,
-    "canonical": 7826,
-    "path": "src/bioetl/infrastructure/adapters/pubmed",
+    "duplicate": 7970,
+    "canonical": 7743,
+    "path": "src/bioetl/composition/bootstrap/cli",
     "dupe_wave": "B",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/infrastructure/adapters/pubmed` (sev major/B \u2192 canonical #7826 major/A)"
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7953,
+    "canonical": 7738,
+    "path": "src/bioetl/composition/bootstrap/runtime",
+    "dupe_wave": "B",
+    "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "critical",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7971,
+    "canonical": 7744,
+    "path": "src/bioetl/composition/factories/datasource",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7955,
+    "canonical": 7739,
+    "path": "src/bioetl/composition/factories/pipeline",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7963,
+    "canonical": 7742,
+    "path": "src/bioetl/composition/factories/pipeline_support",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7956,
+    "canonical": 7740,
+    "path": "src/bioetl/composition/factories/services",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7957,
+    "canonical": 7741,
+    "path": "src/bioetl/composition/factories/storage",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7937,
+    "canonical": 7748,
+    "path": "src/bioetl/composition/runtime_builders/_run_manifest_creation_support.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7938,
+    "canonical": 7749,
+    "path": "src/bioetl/composition/runtime_builders/_run_manifest_data_roots.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7939,
+    "canonical": 7751,
+    "path": "src/bioetl/composition/runtime_builders/_snapshot_mapping_support.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7964,
+    "canonical": 7929,
+    "path": "src/bioetl/domain/contracts/gold",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7927,
+    "canonical": 7917,
+    "path": "src/bioetl/domain/ports/__init__.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7928,
+    "canonical": 7918,
+    "path": "src/bioetl/domain/ports/adr.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
   },
   {
     "duplicate": 7981,
@@ -475,8 +335,196 @@
     "path": "src/bioetl/domain/ports/control_plane",
     "dupe_wave": "B",
     "dupe_sev": "major",
+    "dupe_state": "CLOSED",
     "canon_wave": "A",
     "canon_sev": "major",
-    "reason": "same path `src/bioetl/domain/ports/control_plane` (sev major/B \u2192 canonical #7904 major/A)"
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7921,
+    "canonical": 7912,
+    "path": "src/bioetl/domain/ports/noop",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7923,
+    "canonical": 7913,
+    "path": "src/bioetl/domain/ports/quality",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7919,
+    "canonical": 7911,
+    "path": "src/bioetl/domain/ports/runtime",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7924,
+    "canonical": 7914,
+    "path": "src/bioetl/domain/ports/storage",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7925,
+    "canonical": 7915,
+    "path": "src/bioetl/domain/ports/storage_maintenance.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7926,
+    "canonical": 7916,
+    "path": "src/bioetl/domain/ports/workflow_foreign_key_reconciliation.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7976,
+    "canonical": 7825,
+    "path": "src/bioetl/infrastructure/adapters/chembl",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7961,
+    "canonical": 7822,
+    "path": "src/bioetl/infrastructure/adapters/common",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7958,
+    "canonical": 7821,
+    "path": "src/bioetl/infrastructure/adapters/crossref",
+    "dupe_wave": "B",
+    "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "critical",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7966,
+    "canonical": 7823,
+    "path": "src/bioetl/infrastructure/adapters/decorators",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7967,
+    "canonical": 7809,
+    "path": "src/bioetl/infrastructure/adapters/http",
+    "dupe_wave": "B",
+    "dupe_sev": "critical",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "critical",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7959,
+    "canonical": 7810,
+    "path": "src/bioetl/infrastructure/adapters/openalex",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7965,
+    "canonical": 7824,
+    "path": "src/bioetl/infrastructure/adapters/pubchem",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7980,
+    "canonical": 7826,
+    "path": "src/bioetl/infrastructure/adapters/pubmed",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7960,
+    "canonical": 7805,
+    "path": "src/bioetl/infrastructure/adapters/uniprot",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7954,
+    "canonical": 7852,
+    "path": "src/bioetl/interfaces/cli/commands",
+    "dupe_wave": "B",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
+  },
+  {
+    "duplicate": 7940,
+    "canonical": 7895,
+    "path": "src/bioetl/interfaces/http/_health_server_identity_routing_support.py",
+    "dupe_wave": "A",
+    "dupe_sev": "major",
+    "dupe_state": "CLOSED",
+    "canon_wave": "A",
+    "canon_sev": "major",
+    "canon_state": "OPEN"
   }
 ]

--- a/reports/quality/coderabbit/20260806/FINDINGS.md
+++ b/reports/quality/coderabbit/20260806/FINDINGS.md
@@ -1,13 +1,10 @@
 # FINDINGS — CR-FULL residual (de-duped)
 
-- Generated: 2026-08-06T07:40Z
+- Generated: 2026-08-06T07:45Z
 - Epic: #7688 · Task: #7696
-- Open residual clusters before de-dupe: 268
-- Canonical kept: 220
-- Duplicates closed/identified: 48 (dry-run)
-- Agent NDJSON severity totals A–D: {'major': 736, 'trivial': 457, 'minor': 253, 'critical': 22} (sum=1468)
-
-## Columns
+- Canonical open path-clusters: **220**
+- Duplicates closed (recorded): **48**
+- Agent NDJSON severity totals: `{'major': 736, 'trivial': 457, 'minor': 253, 'critical': 22}` (sum=1468)
 
 | id | sev | wave | path | findings | action | issue |
 | --- | --- | --- | --- | ---: | --- | ---: |
@@ -232,9 +229,9 @@
 | CR-C-8028 | major | C | `src/bioetl/infrastructure/observability/server.py` | 1 | P1 | #8028 |
 | CR-C-8029 | major | C | `src/bioetl/infrastructure/observability/unified_logger.py` | 1 | P1 | #8029 |
 
-## Duplicates (closed → canonical)
+## Duplicates closed → canonical
 
-| duplicate | canonical | path | reason |
+| duplicate | canonical | path | waves |
 | ---: | ---: | --- | --- |
 | #7919 | #7911 | `src/bioetl/domain/ports/runtime` | A/major → A/major |
 | #7921 | #7912 | `src/bioetl/domain/ports/noop` | A/major → A/major |

--- a/reports/quality/coderabbit/20260806/TRIAGE.md
+++ b/reports/quality/coderabbit/20260806/TRIAGE.md
@@ -1,19 +1,21 @@
 # TRIAGE — CR-FULL #7696
 
-- Generated: 2026-08-06T07:40Z
+- Generated: 2026-08-06T07:45Z
 - Policy: code wins; no tech-debt budget growth
-- De-dupe: one open issue per residual path (prefer earlier Wave A, lower number)
+- De-dupe: one open issue per residual path (prefer Wave A / lower number / higher sev)
 
-## Severity → action
+## Counts
 
-| Sev | Action | Count (canonical) |
-| --- | --- | ---: |
-| critical | P0 implement | 12 |
-| major | P1 path issue | 208 |
-| minor | P2 backlog | 0 |
-| trivial | reject/style drop unless correctness | 0 |
+| Bucket | Count |
+| --- | ---: |
+| Canonical open | 220 |
+| P0 critical | 12 |
+| P1 major | 208 |
+| P2 minor | 0 |
+| trivial open | 0 |
+| Duplicates closed | 48 |
 
-## Agent NDJSON totals (raw, pre-cluster)
+## Agent NDJSON (raw)
 
 | Wave | critical | major | minor | trivial | total |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -23,7 +25,7 @@
 | D | 1 | 4 | 1 | 5 | 11 |
 | **ALL** | 22 | 736 | 253 | 457 | 1468 |
 
-## P0 critical (canonical)
+## P0 critical (canonical open)
 
 - #7738 `src/bioetl/composition/bootstrap/runtime` (34 findings, Wave A)
 - #7750 `src/bioetl/application/services/control_plane` (73 findings, Wave A)
@@ -38,7 +40,7 @@
 - #7993 `src/bioetl/infrastructure/storage/metadata` (3 findings, Wave B)
 - #8030 `tests/security` (5 findings, Wave D)
 
-## P1 major — top by finding_count
+## P1 major — top 30 by findings
 
 - #7739 `src/bioetl/composition/factories/pipeline` (17, Wave A)
 - #7740 `src/bioetl/composition/factories/services` (16, Wave A)
@@ -70,38 +72,29 @@
 - #7760 `src/bioetl/application/core/postrun` (3, Wave A)
 - #7827 `src/bioetl/infrastructure/adapters/semanticscholar` (3, Wave A)
 - #7911 `src/bioetl/domain/ports/runtime` (3, Wave A)
-- #7982 `src/bioetl/application/pipelines/pubchem` (3, Wave B)
-- #7983 `src/bioetl/application/pipelines/semanticscholar` (3, Wave B)
-- #7987 `src/bioetl/infrastructure/storage/support` (3, Wave B)
-- #8012 `src/bioetl/infrastructure/observability/anomaly` (3, Wave C)
-- #7753 `src/bioetl/composition/_workflow_services.py` (2, Wave A)
-- #7754 `src/bioetl/composition/builders.py` (2, Wave A)
-- #7755 `src/bioetl/composition/factories/_observability_wiring.py` (2, Wave A)
-- #7757 `src/bioetl/composition/providers/_config_helpers.py` (2, Wave A)
-- #7758 `src/bioetl/composition/providers/_registration_contracts.py` (2, Wave A)
-- #7759 `src/bioetl/composition/providers/registration.py` (2, Wave A)
-- … +168 more major (see FINDINGS.md)
+- … +178 more in FINDINGS.md
 
-## Reject rules applied
+## Parallel streams
 
-- trivial severity clusters: keep closed only if opened; prefer drop on implement pass
-- style/types-only without basedpyright gate: reject at implement time
-- Wave B mis-tags of Wave A paths: closed as dupes of Wave A canonical
-- E/F residual CLI blocked: #8031 #8032 (not path-cluster residuals)
-- Domain rate-limit backlog: #7946
+| Stream | Paths |
+| --- | --- |
+| 1 Edge | interfaces/http, interfaces/cli, adapters, pipelines, configs/quality |
+| 2 Core | composition, application/core, domain, storage, observability |
 
-## Stream split (for parallel implement)
+## Reject / hold
 
-- Stream 1 edge: interfaces/http|cli, adapters, pipelines, configs/quality
-- Stream 2 core: composition, application/core, domain, storage, observability
-- See major_streams_split.txt / critical stream plan in campaign notes
+- trivial: drop unless correctness risk at implement
+- types-only without basedpyright: reject
+- style without correctness: reject
+- E/F CLI blocked: #8031 #8032
+- Domain rate-limit residual: #7946
 
-## Acceptance (#7696)
+## Acceptance #7696
 
-- [x] FINDINGS.md (de-duped)
+- [x] FINDINGS.md de-duped
 - [x] TRIAGE.md
 - [x] DE_DUPE_MAP.json
-- [ ] Duplicate issues closed on GitHub
+- [x] Duplicate path-cluster issues closed (48)
 - [x] Severity counts
-- [x] Issue pack residual section
+- [x] Findings pack published
 


### PR DESCRIPTION
## Summary

Complete **#7696** residual FINDINGS normalization:

- De-dupe path-cluster issues (one open issue per residual path)
- Closed Wave B mis-tags / path twins against Wave A (or earlier) canonicals
- Publish FINDINGS.md, TRIAGE.md, DE_DUPE_MAP.json, findings pack

## Results

| Metric | Value |
| --- | ---: |
| Agent findings (raw) | 1468 (critical 22 / major 736) |
| Canonical open residual issues | 220 |
| Duplicates closed | 48 |
| P0 critical | 12 |
| P1 major | 208 |

## Files

- reports/quality/coderabbit/20260806/*
- .github/ISSUES/CODERABBIT-FULL-2026-08-FINDINGS-PACK.md
- pointer in CODERABBIT-FULL-2026-08-ISSUE-PACK.md

## Notes

- No tech-debt budget growth
- E/F residual still blocked (#8031/#8032)
- Domain rate-limit backlog #7946

Closes #7696
