### PR TITLE
fix(domain): S4 CR majors — gold contracts + ports

### DIFF
--- a/src/bioetl/composition/factories/pipeline/transformer_dependencies.py
+++ b/src/bioetl/composition/factories/pipeline/transformer_dependencies.py
@@ -25,6 +25,7 @@ from bioetl.domain.ports import (
     TracingPort,
 )
 from bioetl.domain.ports.noop import NoOpPiiHasher
+from bioetl.infrastructure.security.pii_hasher import Sha256PiiHasher
 
 
 class ContractPolicyLoader(Protocol):
@@ -34,6 +35,20 @@ class ContractPolicyLoader(Protocol):
         """Load contract policy for provider/entity."""
         ...
 
+
+
+
+def _default_pii_hasher() -> PiiHasherPort:
+    """Prefer salted SHA-256 hasher; fall back to NoOp only when salt is unset.
+
+    Production deployments MUST set BIOETL_PII_SALT_CURRENT (or inject
+    Sha256PiiHasher via composition). Unit tests without salt still construct
+    transformers safely.
+    """
+    try:
+        return Sha256PiiHasher.from_env()
+    except ValueError:
+        return NoOpPiiHasher()
 
 def build_transformer_dependencies(
     *,
@@ -75,7 +90,7 @@ def build_transformer_dependencies(
         tracer=resolve_tracing_port(tracer=tracer),
         metrics=resolve_metrics_port(metrics=metrics),
         identity_service=resolved_identity_service,
-        pii_hasher=pii_hasher if pii_hasher is not None else NoOpPiiHasher(),
+        pii_hasher=pii_hasher if pii_hasher is not None else _default_pii_hasher(),
         data_normalizer=(
             data_normalizer if data_normalizer is not None else DefaultDataNormalizer()
         ),

--- a/src/bioetl/composition/factories/transformer_dependencies.py
+++ b/src/bioetl/composition/factories/transformer_dependencies.py
@@ -21,9 +21,24 @@ from bioetl.domain.ports import (
     TracingPort,
 )
 from bioetl.domain.ports.noop import NoOpPiiHasher
+from bioetl.infrastructure.security.pii_hasher import Sha256PiiHasher
 
 __all__ = ["build_transformer_dependencies"]
 
+
+
+
+def _default_pii_hasher() -> PiiHasherPort:
+    """Prefer salted SHA-256 hasher; fall back to NoOp only when salt is unset.
+
+    Production deployments MUST set BIOETL_PII_SALT_CURRENT (or inject
+    Sha256PiiHasher via composition). Unit tests without salt still construct
+    transformers safely.
+    """
+    try:
+        return Sha256PiiHasher.from_env()
+    except ValueError:
+        return NoOpPiiHasher()
 
 def build_transformer_dependencies(
     *,
@@ -44,7 +59,7 @@ def build_transformer_dependencies(
             if identity_service is not None
             else EntityIdentityGenerator()
         ),
-        pii_hasher=pii_hasher if pii_hasher is not None else NoOpPiiHasher(),
+        pii_hasher=pii_hasher if pii_hasher is not None else _default_pii_hasher(),
         data_normalizer=(
             data_normalizer if data_normalizer is not None else DefaultDataNormalizer()
         ),

--- a/src/bioetl/domain/contracts/gold/_chembl_activity_assay_schemas.py
+++ b/src/bioetl/domain/contracts/gold/_chembl_activity_assay_schemas.py
@@ -7,6 +7,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 
@@ -16,7 +17,10 @@ class ChEMBLActivityGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary identifier
     activity_id: Series[str] = pa.Field(nullable=False)
@@ -126,7 +130,10 @@ class ChEMBLAssayGoldSchema(StrictGoldContractSchema):
     """Schema for ChEMBL Assay in Gold layer."""
 
     entity_id: Series[str] = pa.Field(nullable=False, str_matches=r"^.+$")
-    content_hash: Series[str] = pa.Field(nullable=False, str_matches=r"^[a-f0-9]{64}$")
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     assay_id: Series[str] = pa.Field(nullable=False, str_matches=r"^.+$")
     target_id: Series[str] = pa.Field(nullable=True)
     publication_id: Series[str] = pa.Field(nullable=True)
@@ -174,7 +181,10 @@ class ChEMBLAssayParametersGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary identifier (surrogate)
     assay_param_id: Series[float] = pa.Field(

--- a/src/bioetl/domain/contracts/gold/_chembl_molecule_protein_schemas.py
+++ b/src/bioetl/domain/contracts/gold/_chembl_molecule_protein_schemas.py
@@ -7,6 +7,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 
@@ -15,7 +16,10 @@ class ChEMBLMoleculeGoldSchema(StrictGoldContractSchema):
     """Schema for ChEMBL Molecule in Gold layer."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     molecule_id: Series[str] = pa.Field(nullable=False)
     pref_name: Series[str] = pa.Field(nullable=True)
     molecule_type: Series[str] = pa.Field(nullable=True)
@@ -31,15 +35,15 @@ class ChEMBLMoleculeGoldSchema(StrictGoldContractSchema):
     usan_year: Series[float] = pa.Field(nullable=True, coerce=True)  # int64
     helm_notation: Series[str] = pa.Field(nullable=True)
     molecule_species: Series[str] = pa.Field(nullable=True)
-    oral: Series[bool] = pa.Field(nullable=True)
-    parenteral: Series[bool] = pa.Field(nullable=True)
-    topical: Series[bool] = pa.Field(nullable=True)
+    oral: Series[bool] = pa.Field(nullable=True, coerce=True)
+    parenteral: Series[bool] = pa.Field(nullable=True, coerce=True)
+    topical: Series[bool] = pa.Field(nullable=True, coerce=True)
     black_box_warning: Series[float] = pa.Field(nullable=True, coerce=True)
     natural_product: Series[float] = pa.Field(nullable=True, coerce=True)
     first_in_class: Series[float] = pa.Field(nullable=True, coerce=True)
     prodrug: Series[float] = pa.Field(nullable=True, coerce=True)
-    therapeutic_flag: Series[bool] = pa.Field(nullable=True)
-    withdrawn_flag: Series[bool] = pa.Field(nullable=True)
+    therapeutic_flag: Series[bool] = pa.Field(nullable=True, coerce=True)
+    withdrawn_flag: Series[bool] = pa.Field(nullable=True, coerce=True)
     inorganic_flag: Series[float] = pa.Field(nullable=True, coerce=True)
     polymer_flag: Series[float] = pa.Field(nullable=True, coerce=True)
     molecule_hierarchy: Series[str] = pa.Field(nullable=True)
@@ -80,7 +84,10 @@ class ChEMBLProteinClassGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary identifier
     protein_class_id: Series[float] = pa.Field(nullable=False, ge=1, coerce=True)

--- a/src/bioetl/domain/contracts/gold/_chembl_reference_publication_schemas.py
+++ b/src/bioetl/domain/contracts/gold/_chembl_reference_publication_schemas.py
@@ -7,8 +7,10 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
+from bioetl.domain.schemas.common.publication_base import LOOKUP_METHODS
 
 
 class ChEMBLCellLineGoldSchema(StrictGoldContractSchema):
@@ -16,7 +18,10 @@ class ChEMBLCellLineGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary identifier
     cell_id: Series[str] = pa.Field(nullable=False)
@@ -45,7 +50,10 @@ class ChEMBLCompoundRecordGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary identifier
     record_id: Series[float] = pa.Field(nullable=False, coerce=True)  # int64 in Silver
@@ -67,7 +75,10 @@ class ChEMBLPublicationGoldSchema(StrictGoldContractSchema):
     """Schema for ChEMBL Document in Gold layer."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     publication_id: Series[str] = pa.Field(nullable=False)
     # Cross-reference IDs (prefixed, for linking publications across providers)
     publication_doi: Series[str] = pa.Field(nullable=True)
@@ -99,10 +110,12 @@ class ChEMBLPublicationGoldSchema(StrictGoldContractSchema):
     # System field (per SYSTEM_FIELDS_PREFIX)
     source: Series[str] = pa.Field(nullable=True, alias="_source")
 
-    # Lookup metadata
-    # _lookup_method: "direct" | "doi" | "pmid" | "title_fallback" | "unknown"
-    # _original_id: Original identifier used for lookup (publication_id for direct)
-    lookup_method: Series[str] = pa.Field(nullable=True, alias="_lookup_method")
+    # Lookup metadata (aligned with PublicationGoldCommonSchema)
+    lookup_method: Series[str] = pa.Field(
+        nullable=False,
+        alias="_lookup_method",
+        isin=LOOKUP_METHODS,
+    )
     original_id: Series[str] = pa.Field(nullable=True, alias="_original_id")
 
 
@@ -114,7 +127,10 @@ class ChEMBLPublicationSimilarityGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary key
     sim_id: Series[float] = pa.Field(nullable=False, coerce=True)  # int64 in Silver
@@ -145,7 +161,10 @@ class ChEMBLPublicationTermGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Composite key fields
     publication_id: Series[str] = pa.Field(nullable=False)

--- a/src/bioetl/domain/contracts/gold/_chembl_target_lookup_schemas.py
+++ b/src/bioetl/domain/contracts/gold/_chembl_target_lookup_schemas.py
@@ -7,6 +7,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 
@@ -15,7 +16,10 @@ class ChEMBLTargetGoldSchema(StrictGoldContractSchema):
     """Schema for ChEMBL Target in Gold layer."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     target_id: Series[str] = pa.Field(nullable=False)
     target_type: Series[str] = pa.Field(nullable=True)
     pref_name: Series[str] = pa.Field(nullable=True)
@@ -53,7 +57,10 @@ class ChEMBLTargetComponentGoldSchema(StrictGoldContractSchema):
     """Schema for ChEMBL Target Component in Gold layer."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     primary_component_id: Series[float] = pa.Field(
         nullable=False, coerce=True, alias="component_id"
     )  # int64
@@ -77,7 +84,10 @@ class ChEMBLTargetProteinClassificationGoldSchema(StrictGoldContractSchema):
     """Gold schema for ChEMBL target protein classification relation rows."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     target_id: Series[str] = pa.Field(nullable=False)
     classification_status: Series[str] = pa.Field(
         nullable=False,
@@ -146,7 +156,10 @@ class ChEMBLTissueGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary key (transformer maps tissue_chembl_id → tissue_id)
     tissue_id: Series[str] = pa.Field(
@@ -163,10 +176,11 @@ class ChEMBLTissueGoldSchema(StrictGoldContractSchema):
     )
 
     # Ontology identifiers (optional)
+    # Underscore form matches domain tissue normalization (colon → underscore).
     bto_id: Series[str] = pa.Field(
         nullable=True,
         str_matches=r"^BTO_\d{7}$",
-        description="BRENDA Tissue Ontology ID",
+        description="BRENDA Tissue Ontology ID (underscore form, e.g. BTO_0000001)",
     )
     caloha_id: Series[str] = pa.Field(
         nullable=True,
@@ -176,12 +190,12 @@ class ChEMBLTissueGoldSchema(StrictGoldContractSchema):
     efo_id: Series[str] = pa.Field(
         nullable=True,
         str_matches=r"^EFO_\d{7}$",
-        description="Experimental Factor Ontology ID",
+        description="Experimental Factor Ontology ID (underscore form)",
     )
     uberon_id: Series[str] = pa.Field(
         nullable=True,
         str_matches=r"^UBERON_\d{7}$",
-        description="Uberon Ontology ID",
+        description="Uberon Ontology ID (underscore form)",
     )
 
 
@@ -200,7 +214,10 @@ class ChEMBLSubcellularFractionGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary key (normalized subcellular fraction name)
     subcellular_fraction: Series[str] = pa.Field(

--- a/src/bioetl/domain/contracts/gold/_publication_common_schema.py
+++ b/src/bioetl/domain/contracts/gold/_publication_common_schema.py
@@ -9,6 +9,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 from bioetl.domain.mapping.publication_type_classification import (
@@ -25,7 +26,8 @@ def _check_classification_values(
 ) -> Series[bool]:
     allowed = publication_classification_values(field_name)
     if not allowed:
-        return cast(Series[bool], series.isna() | series.notna())
+        # Fail closed: empty taxonomy must not accept non-null values.
+        return cast(Series[bool], series.isna())
     return cast(Series[bool], series.isna() | series.isin(allowed))
 
 
@@ -33,7 +35,10 @@ class PublicationGoldCommonSchema(StrictGoldContractSchema):
     """Common contract fields shared by provider-specific Gold publication schemas."""
 
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
     doi: Series[str] = pa.Field(nullable=True, str_matches=DOI_REGEX_PATTERN)
     pmid: Series[str] = pa.Field(nullable=True)
     pmc_id: Series[str] = pa.Field(nullable=True)

--- a/src/bioetl/domain/contracts/gold/_strict_gold_contract_schema.py
+++ b/src/bioetl/domain/contracts/gold/_strict_gold_contract_schema.py
@@ -7,8 +7,16 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 
+# Universal content_hash invariant for Gold entity rows: SHA-256 lowercase hex.
+CONTENT_HASH_HEX64_PATTERN = r"^[0-9a-f]{64}$"
+
+
 class StrictGoldContractSchema(pa.DataFrameModel):
-    """Common strict metadata and DQ fields for Gold contracts."""
+    """Common strict metadata and DQ fields for Gold contracts.
+
+    Entity schemas that carry ``content_hash`` SHOULD constrain it with
+    ``CONTENT_HASH_HEX64_PATTERN`` (64-char lowercase hex SHA-256).
+    """
 
     dq_warn: Series[bool] = pa.Field(
         nullable=False,
@@ -30,4 +38,4 @@ class StrictGoldContractSchema(pa.DataFrameModel):
         strict = True
 
 
-__all__ = ["StrictGoldContractSchema"]
+__all__ = ["CONTENT_HASH_HEX64_PATTERN", "StrictGoldContractSchema"]

--- a/src/bioetl/domain/contracts/gold/composite_bioassay.py
+++ b/src/bioetl/domain/contracts/gold/composite_bioassay.py
@@ -30,20 +30,23 @@ class CompositeActivityGoldSchema(CompositeLookupLineageSchema):
         nullable=True,
         description="ChEMBL target identifier used as activity-to-target lineage anchor.",
     )
-    taxonomy_id: Series[int] = pa.Field(
+    taxonomy_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="NCBI taxonomy identifier retained as inherited target lineage metadata.",
     )
     publication_id: Series[str] = pa.Field(
         nullable=True,
         description="ChEMBL publication identifier used as activity-to-publication lineage anchor.",
     )
-    record_id: Series[int] = pa.Field(
+    record_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="ChEMBL compound record identifier retained as source-scoped lineage.",
     )
-    src_id: Series[int] = pa.Field(
+    src_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="Provider source identifier retained as source-scoped lineage metadata.",
     )
     canonical_smiles: Series[str] = pa.Field(
@@ -79,8 +82,9 @@ class CompositeAssayGoldSchema(CompositeLookupLineageSchema):
         nullable=True,
         description="ChEMBL publication identifier used as assay-to-publication lineage anchor.",
     )
-    src_id: Series[int] = pa.Field(
+    src_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="Provider source identifier retained as source-scoped lineage metadata.",
     )
     description: Series[str] = pa.Field(
@@ -115,8 +119,9 @@ class CompositeTargetGoldSchema(CompositeLookupLineageSchema):
         nullable=True,
         description="UniProt accession retained as partial cross-source protein lineage anchor.",
     )
-    taxonomy_id: Series[int] = pa.Field(
+    taxonomy_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="NCBI taxonomy identifier retained as organism lineage metadata.",
     )
     description: Series[str] = pa.Field(

--- a/src/bioetl/domain/contracts/gold/composite_publication.py
+++ b/src/bioetl/domain/contracts/gold/composite_publication.py
@@ -39,7 +39,8 @@ class CompositePublicationGoldSchema(CompositeLookupLineageSchema):
         nullable=False,
         description="Canonical-cleaned publication title retained as fallback join evidence.",
     )
-    src_id: Series[int] = pa.Field(
+    src_id: Series[float] = pa.Field(
         nullable=True,
+        coerce=True,
         description="Provider source identifier retained as source-scoped lineage metadata.",
     )

--- a/src/bioetl/domain/contracts/gold/pubchem.py
+++ b/src/bioetl/domain/contracts/gold/pubchem.py
@@ -16,6 +16,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 
@@ -54,7 +55,10 @@ class PubChemCompoundGoldSchema(StrictGoldContractSchema):
         nullable=True, coerce=True, alias="tpsa"
     )
     iupac_name: Series[str] = pa.Field(nullable=True)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # 3D molecular descriptors
     complexity: Series[float] = pa.Field(nullable=True, coerce=True)

--- a/src/bioetl/domain/contracts/gold/publications_pubmed.py
+++ b/src/bioetl/domain/contracts/gold/publications_pubmed.py
@@ -16,7 +16,7 @@ class PubMedPublicationGoldSchema(PublicationGoldCommonSchema):
 
     pmid: Series[str] = pa.Field(nullable=False)
     title: Series[str] = pa.Field(nullable=False)
-    abstract_structured: Series[bool] = pa.Field(nullable=True)
+    abstract_structured: Series[bool] = pa.Field(nullable=True, coerce=True)
     journal_name_short: Series[str] = pa.Field(nullable=True)
     journal_iso_abbrev: Series[str] = pa.Field(nullable=True)
     journal_issn_type: Series[str] = pa.Field(nullable=True)

--- a/src/bioetl/domain/contracts/gold/publications_semanticscholar.py
+++ b/src/bioetl/domain/contracts/gold/publications_semanticscholar.py
@@ -19,7 +19,8 @@ class SemanticScholarPublicationGoldSchema(PublicationGoldCommonSchema):
 
     paper_id: Series[str] = pa.Field(nullable=False)
     title: Series[str] = pa.Field(nullable=False)
-    corpus_id: Series[float] = pa.Field(nullable=True, coerce=True)
+    # Preserve exact corpus identifier without float coercion loss.
+    corpus_id: Series[str] = pa.Field(nullable=True)
     tldr: Series[str] = pa.Field(nullable=True)
     page_range: Series[str] = pa.Field(nullable=True)
     citations_received: Series[float] = pa.Field(nullable=True, ge=0, coerce=True)

--- a/src/bioetl/domain/contracts/gold/uniprot.py
+++ b/src/bioetl/domain/contracts/gold/uniprot.py
@@ -17,6 +17,7 @@ import pandera.pandas as pa
 from pandera.typing import Series
 
 from bioetl.domain.contracts.gold._strict_gold_contract_schema import (
+    CONTENT_HASH_HEX64_PATTERN,
     StrictGoldContractSchema,
 )
 
@@ -32,7 +33,10 @@ class UniProtProteinGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Core identifiers
     accession: Series[str] = pa.Field(nullable=False)
@@ -156,7 +160,10 @@ class UniProtIDMappingGoldSchema(StrictGoldContractSchema):
 
     # System fields
     entity_id: Series[str] = pa.Field(nullable=False)
-    content_hash: Series[str] = pa.Field(nullable=False)
+    content_hash: Series[str] = pa.Field(
+        nullable=False,
+        str_matches=CONTENT_HASH_HEX64_PATTERN,
+    )
 
     # Primary key (source identifier)
     target_id: Series[str] = pa.Field(nullable=False)

--- a/src/bioetl/domain/ports/__init__.py
+++ b/src/bioetl/domain/ports/__init__.py
@@ -15,6 +15,7 @@ _EXPORT_GROUPS: dict[str, tuple[str, ...]] = {
         "AdrDocument",
         "AdrInfo",
         "AdrServicePort",
+        "AdrIssueSeverity",
         "AdrValidationIssue",
         "AdrValidationReport",
     ),
@@ -164,6 +165,7 @@ _EXPORT_GROUPS: dict[str, tuple[str, ...]] = {
         "coerce_silver_write_request",
     ),
     "bioetl.domain.ports.workflow_foreign_key_reconciliation": (
+        "ForeignKeyReconciliationAction",
         "ForeignKeyReconciliationLayer",
         "ForeignKeyReconciliationMutationMode",
         "ForeignKeyReconciliationPort",
@@ -184,11 +186,24 @@ _EXPORT_GROUPS: dict[str, tuple[str, ...]] = {
     ),
 }
 
-_EXPORT_MODULES = {
-    export_name: module_name
-    for module_name, export_names in _EXPORT_GROUPS.items()
-    for export_name in export_names
-}
+def _build_export_modules(
+    export_groups: dict[str, tuple[str, ...]],
+) -> dict[str, str]:
+    """Map export names to modules with fail-fast collision detection."""
+    export_modules: dict[str, str] = {}
+    for module_name, export_names in export_groups.items():
+        for export_name in export_names:
+            existing = export_modules.get(export_name)
+            if existing is not None and existing != module_name:
+                raise RuntimeError(
+                    f"duplicate ports export {export_name!r}: "
+                    f"{existing!r} and {module_name!r}"
+                )
+            export_modules[export_name] = module_name
+    return export_modules
+
+
+_EXPORT_MODULES = _build_export_modules(_EXPORT_GROUPS)
 
 __all__ = [*_EXPORT_MODULES]
 

--- a/src/bioetl/domain/ports/adr.py
+++ b/src/bioetl/domain/ports/adr.py
@@ -11,6 +11,7 @@ and are wired in the Composition layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
 
@@ -35,6 +36,14 @@ class AdrDocument:
     date: str | None = None
 
 
+class AdrIssueSeverity(StrEnum):
+    """Severity levels for ADR validation issues."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
 @dataclass(frozen=True, slots=True)
 class AdrValidationIssue:
     """Single validation issue for an ADR document."""
@@ -42,7 +51,7 @@ class AdrValidationIssue:
     number: int | None
     path: str
     message: str
-    severity: str = "error"  # one of: error, warning, info
+    severity: AdrIssueSeverity = AdrIssueSeverity.ERROR
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,7 +62,7 @@ class AdrValidationReport:
     total: int
     errors: int
     warnings: int
-    issues: list[AdrValidationIssue]
+    issues: tuple[AdrValidationIssue, ...]
 
 
 @runtime_checkable

--- a/src/bioetl/domain/ports/data_source.py
+++ b/src/bioetl/domain/ports/data_source.py
@@ -217,7 +217,7 @@ class DataSourceFactoryPort(Protocol):
     def create(
         self,
         provider: str,
-    ) -> Any:  # Any: returns different adapter types per provider
+    ) -> DataSourcePort:
         """Create a data source adapter for the given provider.
 
         Args:

--- a/src/bioetl/domain/ports/delta_reader.py
+++ b/src/bioetl/domain/ports/delta_reader.py
@@ -38,10 +38,13 @@ class DeltaReaderPort(Protocol):
             columns: Optional list of columns to read (projection pushdown).
                     If None, reads all columns.
             limit: Optional maximum number of rows to read.
-                  If None, reads all rows.
+                  If None, reads all rows. Result row order is **unspecified**;
+                  callers that need a deterministic subset must sort after read
+                  (or use a higher-level query contract that defines order).
 
         Returns:
-            Opaque table payload with the requested data.
+            Opaque table payload with the requested data. Ordering of rows is
+            not part of this port contract.
 
         Raises:
             An adapter-defined read error when the table reference is invalid or

--- a/src/bioetl/domain/ports/export.py
+++ b/src/bioetl/domain/ports/export.py
@@ -53,6 +53,17 @@ class ExportFileFingerprint:
     size_bytes: int
     sha256: str
 
+    def __post_init__(self) -> None:
+        if self.size_bytes < 0:
+            raise ValueError(f"size_bytes must be non-negative, got {self.size_bytes!r}")
+        digest = self.sha256.strip().lower()
+        if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+            raise ValueError(
+                f"sha256 must be a 64-character lowercase hex digest, got {self.sha256!r}"
+            )
+        if digest != self.sha256:
+            object.__setattr__(self, "sha256", digest)
+
 
 @runtime_checkable
 class ExportCatalogPort(Protocol):

--- a/src/bioetl/domain/ports/health_check.py
+++ b/src/bioetl/domain/ports/health_check.py
@@ -8,6 +8,8 @@ with detailed health status information including latency and error tracking.
 
 from __future__ import annotations
 
+import math
+
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -61,6 +63,16 @@ class HealthCheckResult:
     last_error: str | None = None
     consecutive_failures: int = 0
     checked_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.latency_ms) or self.latency_ms < 0:
+            raise ValueError(
+                f"latency_ms must be finite and non-negative, got {self.latency_ms!r}"
+            )
+        if self.consecutive_failures < 0:
+            raise ValueError(
+                f"consecutive_failures must be non-negative, got {self.consecutive_failures!r}"
+            )
 
     @property
     def is_healthy(self) -> bool:

--- a/src/bioetl/domain/ports/noop/_debug.py
+++ b/src/bioetl/domain/ports/noop/_debug.py
@@ -18,13 +18,16 @@ class NoOpDebug:
     Used in production mode where no interactive debugging is needed.
     """
 
-    def is_breakpoint_enabled(self, _breakpoint: StageBreakpoint) -> bool:
+    def is_breakpoint_enabled(self, breakpoint: StageBreakpoint) -> bool:
         """Always returns False — no breakpoints in production."""
+        _ = breakpoint
         return False
 
-    def on_breakpoint(self, _hit: BreakpointHit) -> DebugAction:
+    def on_breakpoint(self, hit: BreakpointHit) -> DebugAction:
         """Always continues — no pausing in production."""
+        _ = hit
         return DebugAction.CONTINUE
 
     def on_snapshot(self, snapshot: PipelineSnapshot) -> None:
         """No-op — snapshots discarded in production."""
+        _ = snapshot

--- a/src/bioetl/domain/ports/noop/_memory_metadata.py
+++ b/src/bioetl/domain/ports/noop/_memory_metadata.py
@@ -64,15 +64,16 @@ class NoOpMemoryMonitor:
         overhead_factor = 2.5
         return (record_count * avg_record_size_bytes * overhead_factor) / (1024 * 1024)
 
-    def calculate_max_batch_size(self, _avg_record_size_bytes: int = 1024) -> int:
+    def calculate_max_batch_size(self, avg_record_size_bytes: int = 1024) -> int:
         """Return a fixed maximum batch size of 10000 records.
 
         Args:
-            _avg_record_size_bytes: Average record size in bytes (ignored).
+            avg_record_size_bytes: Average record size in bytes (ignored by NoOp).
 
         Returns:
             Fixed maximum batch size.
         """
+        _ = avg_record_size_bytes
         return 10000
 
 

--- a/src/bioetl/domain/ports/noop/_tracing.py
+++ b/src/bioetl/domain/ports/noop/_tracing.py
@@ -33,15 +33,16 @@ class _NoOpSpan:
 
     def set_attribute(
         self,
-        _key: str,
-        _value: object,
+        key: str,
+        value: object,
     ) -> None:
         """No-op implementation — discards the span attribute.
 
         Args:
-            _key: Attribute name (ignored).
-            _value: Attribute value (ignored).
+            key: Attribute name (ignored).
+            value: Attribute value (ignored).
         """
+        _ = key, value
         return None
 
     def set_status(self, _status: object) -> None:
@@ -54,24 +55,25 @@ class _NoOpSpan:
 
     def add_event(
         self,
-        _name: str,
+        name: str,
         attributes: Mapping[str, object] | None = None,
     ) -> None:
         """No-op implementation — discards span events.
 
         Args:
-            _name: Event name (ignored).
+            name: Event name (ignored).
             attributes: Optional event attributes (ignored).
         """
-        _ = attributes
+        _ = name, attributes
         return None
 
-    def record_exception(self, _exception: Exception) -> None:
+    def record_exception(self, exception: BaseException) -> None:
         """No-op implementation — discards the recorded exception.
 
         Args:
-            _exception: Exception to record (ignored).
+            exception: Exception to record (ignored).
         """
+        _ = exception
         return None
 
 

--- a/src/bioetl/domain/ports/observability/dq_monitor.py
+++ b/src/bioetl/domain/ports/observability/dq_monitor.py
@@ -33,14 +33,15 @@ class DQMonitorPort(Protocol):
     def check_quality(
         self,
         metrics: dict[str, float],
-        timestamp: datetime | None = None,
+        timestamp: datetime,
     ) -> list[DQAnomaly]:
         """Evaluate metrics against baselines and return detected anomalies.
 
         Args:
             metrics: Mapping of metric name to current observed value.
-            timestamp: Canonical application-owned timestamp for anomaly
-                evaluation and emitted anomaly records.
+            timestamp: Mandatory caller-owned timestamp for anomaly
+                evaluation and emitted anomaly records. Adapters must not
+                synthesize wall-clock time when the caller omits it.
 
         Returns:
             List of domain anomaly DTOs for metrics that deviate from baseline.
@@ -50,14 +51,14 @@ class DQMonitorPort(Protocol):
     def update_baseline_from_metrics(
         self,
         metrics: dict[str, float],
-        timestamp: datetime | None = None,
+        timestamp: datetime,
     ) -> None:
         """Update stored baselines by incorporating new observed metric values.
 
         Args:
             metrics: Mapping of metric name to newly observed value.
-            timestamp: Canonical application-owned timestamp associated with
-                this baseline update decision.
+            timestamp: Mandatory caller-owned timestamp associated with
+                this baseline update decision. Adapters must not invent time.
         """
         ...
 

--- a/src/bioetl/domain/ports/observability/tracing.py
+++ b/src/bioetl/domain/ports/observability/tracing.py
@@ -2,7 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from types import TracebackType
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SpanHandle(Protocol):
+    """Minimal context-managed span surface required by BioETL callers."""
+
+    def __enter__(self) -> SpanHandle: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None: ...
+
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def add_event(self, name: str, attributes: dict[str, object] | None = None) -> None: ...
+
+    def record_exception(self, exception: BaseException) -> None: ...
+
+
+@runtime_checkable
+class TracerHandle(Protocol):
+    """Minimal tracer surface returned by TracingPort.get_tracer."""
+
+    def start_as_current_span(self, name: str) -> SpanHandle: ...
 
 
 @runtime_checkable
@@ -12,17 +40,16 @@ class TracingPort(Protocol):
     def get_tracer(
         self,
         name: str,
-    ) -> Any:  # Any: OTel Tracer-compatible object
+    ) -> TracerHandle:
         """Return OpenTelemetry-compatible tracer instance.
 
         Args:
             name: Tracer name, typically the instrumented module or component name.
 
         Returns:
-            OTel-compatible Tracer object for creating spans. Context-managed
-            spans returned by the tracer must expose ``set_attribute()``,
-            ``add_event()``, and ``record_exception()`` so NoOp and concrete
-            adapters remain behaviorally interchangeable.
+            Tracer handle that yields context-managed span handles exposing
+            ``set_attribute()``, ``add_event()``, and ``record_exception()`` so
+            NoOp and concrete adapters remain behaviorally interchangeable.
         """
         ...
 

--- a/src/bioetl/domain/ports/quality/silver_dq_request.py
+++ b/src/bioetl/domain/ports/quality/silver_dq_request.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from dataclasses import MISSING, dataclass, fields
+from typing import TYPE_CHECKING, Any, Final
 
 from bioetl.domain.types import JsonDict
 
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from bioetl.domain.ports.quality.dq_config import SilverDQConfigPort
 
 DataContainer = Any
+
+# Sentinel distinguishes omitted request from explicit None.
+_REQUEST_OMITTED: Final[object] = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,47 +40,31 @@ class SilverDQAnalyzeRequest:
     key_nullability_rules: list[JsonDict] | None = None
 
 
-_SILVER_DQ_ANALYZE_POSITIONAL_FIELDS = (
-    "data",
-    "run_id",
-    "pipeline",
-    "target_table",
-    "source_batch_ids",
-    "config",
-    "timestamp",
-    "primary_keys",
-    "soft_fail_threshold",
-    "hard_fail_threshold",
-    "input_record_count",
-    "quarantined_count",
-    "previous_schema",
-    "key_nullability_rules",
-)
-_SILVER_DQ_ANALYZE_REQUIRED_FIELDS = (
-    "data",
-    "run_id",
-    "pipeline",
-    "target_table",
-    "source_batch_ids",
-    "config",
-    "timestamp",
-    "primary_keys",
-)
-_SILVER_DQ_ANALYZE_DEFAULTS: dict[str, object] = {
-    "soft_fail_threshold": 0.05,
-    "hard_fail_threshold": 0.20,
-    "input_record_count": None,
-    "quarantined_count": 0,
-    "previous_schema": None,
-    "key_nullability_rules": None,
-}
-_SILVER_DQ_ANALYZE_ALLOWED_FIELDS = frozenset(
-    {*_SILVER_DQ_ANALYZE_POSITIONAL_FIELDS, *tuple(_SILVER_DQ_ANALYZE_DEFAULTS)}
-)
+def _silver_dq_field_meta() -> tuple[tuple[str, ...], tuple[str, ...], dict[str, object], frozenset[str]]:
+    positional: list[str] = []
+    required: list[str] = []
+    defaults: dict[str, object] = {}
+    for field in fields(SilverDQAnalyzeRequest):
+        positional.append(field.name)
+        if field.default is MISSING and field.default_factory is MISSING:
+            required.append(field.name)
+        elif field.default is not MISSING:
+            defaults[field.name] = field.default
+        else:
+            defaults[field.name] = field.default_factory()  # type: ignore[misc]
+    return tuple(positional), tuple(required), defaults, frozenset(positional)
+
+
+(
+    _SILVER_DQ_ANALYZE_POSITIONAL_FIELDS,
+    _SILVER_DQ_ANALYZE_REQUIRED_FIELDS,
+    _SILVER_DQ_ANALYZE_DEFAULTS,
+    _SILVER_DQ_ANALYZE_ALLOWED_FIELDS,
+) = _silver_dq_field_meta()
 
 
 def coerce_silver_dq_analyze_request(
-    request: SilverDQAnalyzeRequest | DataContainer | None = None,
+    request: SilverDQAnalyzeRequest | DataContainer | None | object = _REQUEST_OMITTED,
     *,
     args: tuple[object, ...] = (),
     kwargs: Mapping[str, object] | None = None,
@@ -114,12 +101,16 @@ def coerce_silver_dq_analyze_request(
 
 def _resolve_silver_dq_analyze_kwargs(
     *,
-    request: SilverDQAnalyzeRequest | DataContainer | None,
+    request: SilverDQAnalyzeRequest | DataContainer | None | object,
     args: tuple[object, ...],
     kwargs: Mapping[str, object] | None,
 ) -> dict[str, object]:
     resolved_kwargs = dict(kwargs or {})
-    legacy_values = list(args) if request is None else [request, *args]
+    if request is _REQUEST_OMITTED:
+        legacy_values: list[object] = list(args)
+    else:
+        # Explicit None is preserved as the first positional (data) slot.
+        legacy_values = [request, *args]
     _merge_silver_dq_analyze_legacy_values(resolved_kwargs, legacy_values)
     _raise_on_unexpected_silver_dq_fields(resolved_kwargs)
     _raise_on_missing_silver_dq_fields(resolved_kwargs)

--- a/src/bioetl/domain/ports/runtime/composite_checkpoint.py
+++ b/src/bioetl/domain/ports/runtime/composite_checkpoint.py
@@ -58,7 +58,9 @@ class CompositeCheckpointPort(Protocol):
             pattern: Glob pattern (e.g. ``composite_publication_*.json``).
 
         Returns:
-            List of matching relative paths, sorted by modification time descending.
+            List of matching relative paths, ordered deterministically by
+            **lexical descending** filename (checkpoint filenames encode run
+            identity). Callers must not rely on filesystem mtime ordering.
         """
         ...
 

--- a/src/bioetl/domain/ports/runtime/locking.py
+++ b/src/bioetl/domain/ports/runtime/locking.py
@@ -43,7 +43,11 @@ class LockPort(Protocol):
         Args:
             key: The unique key for the lock.
             owner_id: The ID of the run attempting to acquire the lock.
-            ttl: Time-to-live for the lock in seconds.
+            ttl: Time-to-live for the lock in seconds. When ``ttl`` is ``None``,
+                the adapter does not schedule TTL expiry (lock held until
+                explicit release or process teardown). When ``ttl`` is a positive
+                int, adapters that support TTL expire the lock after that many
+                seconds of wall time.
             wait: If True, wait for the lock to be released if it's already held.
             wait_timeout: Maximum time to wait for the lock in seconds.
             exclusive: If True, acquire an exclusive lock.

--- a/src/bioetl/domain/ports/storage/bronze_port.py
+++ b/src/bioetl/domain/ports/storage/bronze_port.py
@@ -37,7 +37,9 @@ class BronzeStoragePort(Protocol):
         """Write raw records to the Bronze layer.
 
         Args:
-            records: An iterable of byte strings, where each string is a raw record.
+            records: A single-pass iterator of raw record byte strings. Callers
+                that may retry write_bronze after failure must re-create the
+                iterator; the port does not buffer or re-materialize records.
             provider: The name of the data provider.
             entity: The type of entity being written.
             date: The datetime for the data partition.

--- a/src/bioetl/domain/ports/storage/silver_port.py
+++ b/src/bioetl/domain/ports/storage/silver_port.py
@@ -201,7 +201,14 @@ class SilverStoragePort(Protocol):
         *args: object,
         **kwargs: object,
     ) -> SilverWriteResult | None:
-        """Write transformed records to the Silver layer."""
+        """Write transformed records to the Silver layer.
+
+        Canonical path: pass a ``SilverWriteRequest`` as ``request``.
+        Legacy compatibility: ``request`` may be a table name string with
+        remaining fields supplied via ``*args``/``**kwargs`` (see
+        ``coerce_silver_write_request``). New callers must not invent additional
+        keyword-only shapes; prefer the typed request object.
+        """
         ...
 
     async def read_silver(

--- a/src/bioetl/domain/ports/storage_maintenance.py
+++ b/src/bioetl/domain/ports/storage_maintenance.py
@@ -104,6 +104,11 @@ class StorageMaintenancePort(Protocol):
         Collapses exact duplicates by content identity and keeps one deterministic
         winner per primary key group without relying on runtime ingestion timestamps.
 
+        Deterministic winner rule: within each primary-key group, retain the row
+        with the **lowest** content-hash identity (lexicographic ascending after
+        total-order ranking of primary-key components). Remaining rows in the
+        group are removed as duplicates.
+
         Args:
             table_name: Logical Silver table name.
             primary_keys: Business key columns for deduplication.

--- a/src/bioetl/domain/ports/workflow_foreign_key_reconciliation.py
+++ b/src/bioetl/domain/ports/workflow_foreign_key_reconciliation.py
@@ -6,6 +6,7 @@ from dataclasses import KW_ONLY, dataclass
 from typing import Literal, Protocol, cast, runtime_checkable
 
 __all__ = [
+    "ForeignKeyReconciliationAction",
     "ForeignKeyReconciliationLayer",
     "ForeignKeyReconciliationMutationMode",
     "ForeignKeyReconciliationPort",
@@ -14,11 +15,19 @@ __all__ = [
 ]
 
 ForeignKeyReconciliationLayer = Literal["silver", "gold"]
+ForeignKeyReconciliationAction = Literal["delete_orphans"]
 ForeignKeyReconciliationMutationMode = Literal[
     "unknown",
     "delete_orphans",
     "dry_run",
     "blocked",
+    "no_op",
+    "missing_source",
+    "dry_run_preview",
+    "quarantine_skipped",
+    "gold_scd2_expiry",
+    "silver_rewrite",
+    "quarantine_written",
 ]
 
 
@@ -123,7 +132,7 @@ class ForeignKeyReconciliationRequest:
     source_key: str
     reference_key: str
     primary_keys: tuple[str, ...]
-    action: Literal["delete_orphans"] = "delete_orphans"
+    action: ForeignKeyReconciliationAction = "delete_orphans"
     source_keys: tuple[str, ...] | None = None
     reference_keys: tuple[str, ...] | None = None
     nulls_equal: bool = False
@@ -205,38 +214,56 @@ class ForeignKeyReconciliationResult:
     reference_table: str
     source_key: str
     reference_key: str
-    action: str
+    action: ForeignKeyReconciliationAction
     scanned_rows: int
     retained_rows: int
     orphan_rows_deleted: int
     mutated: bool
     dry_run: bool = False
     would_mutate: bool = False
-    mutation_mode: ForeignKeyReconciliationMutationMode | str = "unknown"
+    mutation_mode: ForeignKeyReconciliationMutationMode = "unknown"
     quarantine_batch_id: str | None = None
     quarantine_rows_written: int = 0
     quarantine_error_code: str | None = None
     _: KW_ONLY
     source_layer: ForeignKeyReconciliationLayer = "silver"
     reference_layer: ForeignKeyReconciliationLayer = "silver"
-    mutation_layer: ForeignKeyReconciliationLayer = "silver"
+    mutation_layer: ForeignKeyReconciliationLayer | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "source_layer",
-            _normalize_layer(self.source_layer, "source_layer"),
+        allowed_actions: frozenset[str] = frozenset({"delete_orphans"})
+        if self.action not in allowed_actions:
+            raise ValueError(
+                f"action must be one of {sorted(allowed_actions)}, got {self.action!r}"
+            )
+        allowed_modes: frozenset[str] = frozenset(
+            {
+                "unknown",
+                "delete_orphans",
+                "dry_run",
+                "blocked",
+                "no_op",
+                "missing_source",
+                "dry_run_preview",
+                "quarantine_skipped",
+                "gold_scd2_expiry",
+                "silver_rewrite",
+                "quarantine_written",
+            }
         )
-        object.__setattr__(
-            self,
-            "reference_layer",
-            _normalize_layer(self.reference_layer, "reference_layer"),
-        )
-        object.__setattr__(
-            self,
+        if self.mutation_mode not in allowed_modes:
+            raise ValueError(
+                f"mutation_mode must be one of {sorted(allowed_modes)}, got {self.mutation_mode!r}"
+            )
+        source_layer = _normalize_layer(self.source_layer, "source_layer")
+        reference_layer = _normalize_layer(self.reference_layer, "reference_layer")
+        mutation_layer = _normalize_layer(
+            self.mutation_layer if self.mutation_layer is not None else source_layer,
             "mutation_layer",
-            _normalize_layer(self.mutation_layer, "mutation_layer"),
         )
+        object.__setattr__(self, "source_layer", source_layer)
+        object.__setattr__(self, "reference_layer", reference_layer)
+        object.__setattr__(self, "mutation_layer", mutation_layer)
 
 
 @runtime_checkable

--- a/src/bioetl/infrastructure/adr/_adr_validators.py
+++ b/src/bioetl/infrastructure/adr/_adr_validators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from bioetl.domain.ports import AdrValidationIssue
+from bioetl.domain.ports import AdrIssueSeverity, AdrValidationIssue
 
 from ._adr_file_utils import ADR_FILENAME_RE
 from ._adr_metadata_extractors import extract_meta, parse_h1_title
@@ -31,7 +31,7 @@ def validate_filename(
                 number=None,
                 path=str(p),
                 message="Filename does not match ADR-XXX-title.md",
-                severity="error",
+                severity=AdrIssueSeverity.ERROR,
             )
         )
     return m
@@ -57,7 +57,7 @@ def validate_duplicate_number(
                 number=number,
                 path=str(p),
                 message="Duplicate ADR number",
-                severity="error",
+                severity=AdrIssueSeverity.ERROR,
             )
         )
     else:
@@ -90,7 +90,7 @@ def read_adr_text(
                 number=number,
                 path=str(p),
                 message=f"Cannot read file: {exc}",
-                severity="error",
+                severity=AdrIssueSeverity.ERROR,
             )
         )
         return None
@@ -117,7 +117,7 @@ def validate_title(
                 number=number,
                 path=str(p),
                 message="Missing H1 title ('# ...')",
-                severity="error",
+                severity=AdrIssueSeverity.ERROR,
             )
         )
     else:
@@ -128,7 +128,7 @@ def validate_title(
                     number=number,
                     path=str(p),
                     message="ADR number mismatch between filename and H1",
-                    severity="warning",
+                    severity=AdrIssueSeverity.WARNING,
                 )
             )
 
@@ -154,6 +154,6 @@ def validate_status(
                 number=number,
                 path=str(p),
                 message="Missing status metadata (Status/Статус)",
-                severity="warning",
+                severity=AdrIssueSeverity.WARNING,
             )
         )

--- a/src/bioetl/infrastructure/adr/fs_adr_service.py
+++ b/src/bioetl/infrastructure/adr/fs_adr_service.py
@@ -14,6 +14,7 @@ from bioetl.domain.ports import (
     AdrDocument,
     AdrInfo,
     AdrServicePort,
+    AdrIssueSeverity,
     AdrValidationIssue,
     AdrValidationReport,
 )
@@ -115,14 +116,14 @@ class FilesystemAdrCatalog(AdrServicePort):
         issues: list[AdrValidationIssue],
     ) -> AdrValidationReport:
         """Build aggregate validation report from discovered files and issues."""
-        errors = sum(1 for issue in issues if issue.severity == "error")
-        warnings = sum(1 for issue in issues if issue.severity == "warning")
+        errors = sum(1 for issue in issues if issue.severity == AdrIssueSeverity.ERROR)
+        warnings = sum(1 for issue in issues if issue.severity == AdrIssueSeverity.WARNING)
         return AdrValidationReport(
             valid=errors == 0,
             total=len(files),
             errors=errors,
             warnings=warnings,
-            issues=issues,
+            issues=tuple(issues),
         )
 
     def validate(self) -> AdrValidationReport:
@@ -140,7 +141,7 @@ class FilesystemAdrCatalog(AdrServicePort):
 
         return self._build_validation_report(
             files=files,
-            issues=issues,
+            issues=tuple(issues),
         )
 
 

--- a/src/bioetl/infrastructure/observability/anomaly/monitor.py
+++ b/src/bioetl/infrastructure/observability/anomaly/monitor.py
@@ -87,7 +87,7 @@ class DataQualityMonitor:
             self.detector.set_threshold(metric_name, min_threshold, max_threshold)
 
     def check_quality(
-        self, metrics: dict[str, float], timestamp: datetime | None = None
+        self, metrics: dict[str, float], timestamp: datetime
     ) -> list[DQAnomaly]:
         """Check metrics for quality issues.
 
@@ -108,7 +108,7 @@ class DataQualityMonitor:
         return anomalies
 
     def update_baseline_from_metrics(
-        self, metrics: dict[str, float], timestamp: datetime | None = None
+        self, metrics: dict[str, float], timestamp: datetime
     ) -> None:
         """Update baseline with current metrics (if no anomalies).
 

--- a/src/bioetl/infrastructure/storage/support/checkpoint_writer.py
+++ b/src/bioetl/infrastructure/storage/support/checkpoint_writer.py
@@ -51,11 +51,11 @@ class FileCompositeCheckpointWriter:
         return False
 
     def list_glob(self, pattern: str) -> list[str]:
-        """List files matching glob, sorted by mtime descending."""
+        """List files matching glob, lexical descending by filename."""
         if not self._checkpoint_dir.exists():
             return []
         matches = list(self._checkpoint_dir.glob(pattern))
-        matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        matches.sort(key=lambda p: p.name, reverse=True)  # deterministic lexical, not mtime
         return [p.name for p in matches]
 
     def exists(self, path: str) -> bool:

--- a/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_support.py
+++ b/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_support.py
@@ -6,6 +6,7 @@ from math import isnan
 from typing import Protocol
 
 from bioetl.domain.ports import (
+    ForeignKeyReconciliationMutationMode,
     ForeignKeyReconciliationRequest,
     ForeignKeyReconciliationResult,
 )
@@ -27,7 +28,7 @@ def build_reconciliation_result(
     orphan_rows_deleted: int,
     mutated: bool,
     would_mutate: bool,
-    mutation_mode: str = "unknown",
+    mutation_mode: ForeignKeyReconciliationMutationMode = "unknown",
     quarantine_batch_id: str | None = None,
     quarantine_rows_written: int = 0,
     quarantine_error_code: str | None = None,

--- a/tests/unit/domain/contracts/gold/test_publication_common_schema.py
+++ b/tests/unit/domain/contracts/gold/test_publication_common_schema.py
@@ -46,7 +46,7 @@ pytestmark = pytest.mark.unit
 def _publication_gold_frame(**overrides: object) -> pd.DataFrame:
     record: dict[str, object] = {
         "entity_id": "publication:1",
-        "content_hash": "hash",
+        "content_hash": "a" * 64,
         "doi": "10.1000/example",
         "pmid": None,
         "pmc_id": None,
@@ -131,7 +131,7 @@ def test_publication_gold_contract_rejects_invalid_field_constraints(
         PublicationGoldCommonSchema.validate(_publication_gold_frame(**overrides))
 
 
-def test_publication_gold_contract_allows_any_taxonomy_value_when_not_loaded(
+def test_publication_gold_contract_fails_closed_when_taxonomy_not_loaded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -140,14 +140,22 @@ def test_publication_gold_contract_allows_any_taxonomy_value_when_not_loaded(
         lambda field_name: frozenset(),
     )
 
+    # Empty taxonomy must not accept non-null classification values (fail closed).
+    with pytest.raises(pa.errors.SchemaError):
+        PublicationGoldCommonSchema.validate(
+            _publication_gold_frame(
+                publication_type_unified="custom-type",
+                publication_subclass="custom-subclass",
+                publication_class="custom-class",
+            )
+        )
+
+    # Null classification fields remain valid when taxonomy is empty.
     validated = PublicationGoldCommonSchema.validate(
         _publication_gold_frame(
-            publication_type_unified="custom-type",
-            publication_subclass="custom-subclass",
-            publication_class="custom-class",
+            publication_type_unified=None,
+            publication_subclass=None,
+            publication_class=None,
         )
     )
-
-    assert validated["publication_type_unified"].iloc[0] == "custom-type"
-    assert validated["publication_subclass"].iloc[0] == "custom-subclass"
-    assert validated["publication_class"].iloc[0] == "custom-class"
+    assert validated["publication_type_unified"].isna().iloc[0]

--- a/tests/unit/infrastructure/storage/support/test_checkpoint_writer.py
+++ b/tests/unit/infrastructure/storage/support/test_checkpoint_writer.py
@@ -57,19 +57,20 @@ def test_checkpoint_writer_read_delete_exists_and_missing_paths(tmp_path: Path) 
     assert writer.read("state.json") is None
 
 
-def test_checkpoint_writer_list_glob_returns_newest_first(tmp_path: Path) -> None:
+def test_checkpoint_writer_list_glob_returns_lexical_descending(tmp_path: Path) -> None:
     writer = FileCompositeCheckpointWriter(tmp_path)
 
     assert writer.list_glob("*.json") == []
 
-    older = tmp_path / "older.json"
-    newer = tmp_path / "newer.json"
-    older.write_text("older", encoding="utf-8")
-    newer.write_text("newer", encoding="utf-8")
-    os.utime(older, (1, 1))
-    os.utime(newer, (2, 2))
+    # Ordering is lexical descending by filename (not mtime).
+    first = tmp_path / "run_001.json"
+    second = tmp_path / "run_002.json"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    os.utime(first, (2, 2))
+    os.utime(second, (1, 1))
 
-    assert writer.list_glob("*.json") == ["newer.json", "older.json"]
+    assert writer.list_glob("*.json") == ["run_002.json", "run_001.json"]
 
 
 def test_checkpoint_writer_write_atomic_removes_temp_on_failure(


### PR DESCRIPTION
## Summary

Closes Stream S4 domain residual majors from the CodeRabbit full pack (#7688 Wave A).

### Gold contracts (#7929)
- Universal CONTENT_HASH_HEX64_PATTERN on Gold entity content_hash fields
- Nullable bool coerce alignment (molecule, pubmed)
- ChEMBL publication LOOKUP_METHODS + tissue ontology docs
- Fail-closed empty taxonomy classification checks
- Composite lineage int-to-float coerce; Semantic Scholar corpus_id as str

### Runtime / ports
- #7911: lexical checkpoint list_glob, lock TTL docs, NoOp/debug param parity
- #7903: mandatory DQ timestamps; structural TracerHandle/SpanHandle
- #7912: NoOp memory param rename; PII defaults prefer Sha256PiiHasher.from_env() with NoOp fallback when salt unset
- #7913: silver DQ request metadata from dataclasses.fields + omitted sentinel
- #7914/#7915: bronze/silver write + dedupe winner docs (async mass-migration deferred)
- #7916: FK action/mode Literals + validation; mutation_layer defaults to source_layer
- #7905-#7907, #7917-#7918, #7922: delta limit ordering, export/health validation, export collision detection, ADR StrEnum/tuple issues, DataSourceFactory return type

### Explicitly deferred / reject
- #7904 control-plane release-artifact process noise (out of residual fix scope)
- #7915 async rewrite of preview_cleanup / table probes (wide blast radius; docs-only for winner rule)
- #7920 async AuditPort.log_event (wide caller blast radius; separate PR)

## Test plan
- [x] pytest tests/unit/domain/contracts/gold/ tests/unit/domain/ports/ tests/unit/infrastructure/adr/
- [x] checkpoint writer list_glob test updated for lexical order
- [x] publication common schema fail-closed taxonomy test

Closes #7929
Closes #7911
Closes #7903
Closes #7912
Closes #7913
Closes #7914
Closes #7915
Closes #7916
Closes #7905
Closes #7906
Closes #7907
Closes #7917
Closes #7918
Closes #7922