### PR TITLE
fix(storage): harden FK reconciliation (#7992 #7996)

### DIFF
--- a/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_quarantine.py
+++ b/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_quarantine.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import re
 from dataclasses import dataclass
 from datetime import date, datetime
 from math import isnan
@@ -18,13 +19,14 @@ from bioetl.domain.ports import (
     QuarantinePort,
     QuarantineWriteRequest,
 )
-from bioetl.domain.types import BatchID, BronzeRecord, MetaDict
+from bioetl.domain.types import BatchID, BronzeRecord, MetaDict, RunID
 from bioetl.infrastructure.storage.gold.io_delta_protocols import (
     GoldWriteRetryModuleProtocol,
 )
 from bioetl.infrastructure.storage.gold.io_delta_runtime import (
     _run_gold_write_with_retry,
 )
+from bioetl.infrastructure.storage.delta.schema_ops import delta_schema_to_pyarrow
 from bioetl.infrastructure.storage.gold.io_helpers import load_gold_writer_module
 from bioetl.infrastructure.time.system_clock import current_utc_time
 
@@ -37,6 +39,7 @@ FOREIGN_KEY_ORPHAN_QUARANTINE_CATEGORY = "foreign_key_reconciliation"
 FOREIGN_KEY_ORPHAN_PIPELINE_DEFAULT = "workflow_transforms"
 _CURRENT_FLAG_COLUMNS = ("_is_current", "is_current")
 _VALID_TO_COLUMNS = ("_valid_to", "valid_to")
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,7 +134,8 @@ async def apply_reconciliation_mutation(
             quarantine_error_code=quarantine_summary.quarantine_error_code,
         )
 
-    host.silver_writer.clear(request.source_table, dry_run=False)
+    # Atomic Silver rewrite: single overwrite write when retained rows remain.
+    # Avoid clear-then-write so a failed write cannot leave an empty table.
     if retained_rows:
         source_schema = pa.Table.from_pylist(retained_rows).schema
         await host.silver_writer.write_silver(
@@ -139,8 +143,10 @@ async def apply_reconciliation_mutation(
             records=retained_rows,
             primary_keys=list(request.primary_keys),
             schema=source_schema,
-            mode="merge",
+            mode="delete",  # SilverWriteMode.DELETE => overwrite table atomically
         )
+    else:
+        host.silver_writer.clear(request.source_table, dry_run=False)
 
     return ReconciliationMutationSummary(
         mutation_mode="silver_rewrite",
@@ -160,16 +166,34 @@ async def expire_gold_orphan_rows(
     if not orphan_rows:
         return
     gold_writer = _require_gold_writer(host)
-    current_flag_col = _resolve_present_column(orphan_rows, _CURRENT_FLAG_COLUMNS)
-    valid_to_col = _resolve_present_column(orphan_rows, _VALID_TO_COLUMNS)
-    key_rows = _build_gold_orphan_key_rows(orphan_rows, request.primary_keys)
+    module = load_gold_writer_module()
+    table_path = gold_writer._resolve_table_path(request.source_table)
+    table_columns = _delta_table_column_names(module, table_path)
+    primary_keys = tuple(
+        _require_sql_identifier(key, "primary_keys") for key in request.primary_keys
+    )
+    current_flag_col = _require_sql_identifier(
+        _resolve_present_column(
+            orphan_rows,
+            _CURRENT_FLAG_COLUMNS,
+            table_columns=table_columns,
+        ),
+        "current_flag_column",
+    )
+    valid_to_col = _require_sql_identifier(
+        _resolve_present_column(
+            orphan_rows,
+            _VALID_TO_COLUMNS,
+            table_columns=table_columns,
+        ),
+        "valid_to_column",
+    )
+    key_rows = _build_gold_orphan_key_rows(orphan_rows, primary_keys)
     if not key_rows:
         return
 
-    module = load_gold_writer_module()
-    table_path = gold_writer._resolve_table_path(request.source_table)
     merge_condition = " AND ".join(
-        f"target.{key} = source.{key}" for key in request.primary_keys
+        f"target.{key} = source.{key}" for key in primary_keys
     )
     merge_condition += f" AND target.{current_flag_col} = true"
     ts_iso = current_utc_time().isoformat()
@@ -241,10 +265,46 @@ def _expire_gold_orphan_rows_once(
     )
 
 
+def _require_sql_identifier(name: str, field_name: str) -> str:
+    """Reject identifiers that are unsafe to interpolate into Delta merge SQL."""
+    if not _SQL_IDENTIFIER_RE.fullmatch(name):
+        raise ValueError(
+            f"{field_name} is not a safe SQL identifier: {name!r}"
+        )
+    return name
+
+
+def _delta_table_column_names(
+    module: Any,  # Any: gold writer module providing DeltaTable
+    table_path: str,
+) -> frozenset[str] | None:
+    """Return Gold table column names from Delta schema when available."""
+    try:
+        delta_table = module.DeltaTable(table_path)
+        schema = delta_table.schema()
+        arrow_schema = delta_schema_to_pyarrow(schema)
+        return frozenset(arrow_schema.names)
+    except Exception:
+        # Fall back to orphan-row inspection when schema cannot be loaded
+        # (unit fakes, missing tables, schema API variance).
+        return None
+
+
 def _resolve_present_column(
     rows: list[dict[str, object]],
     candidates: tuple[str, ...],
+    *,
+    table_columns: frozenset[str] | None = None,
 ) -> str:
+    """Pick the first SCD2 metadata column present on the Gold table schema.
+
+    Prefer the live Delta schema. Fall back to orphan-row keys only when the
+    schema cannot be inspected, so unit fakes and partial environments still work.
+    """
+    if table_columns is not None:
+        for candidate in candidates:
+            if candidate in table_columns:
+                return candidate
     for candidate in candidates:
         if any(candidate in row for row in rows):
             return candidate
@@ -312,7 +372,7 @@ async def quarantine_orphan_rows(
                 "error_code": error_code,
                 "payload": cast("BronzeRecord", row),
                 "bronze_batch_id": batch_id,
-                "run_id": None,
+                "run_id": _coerce_optional_run_id(request.workflow_run_id),
                 "metadata": cast(
                     "MetaDict",
                     {
@@ -324,6 +384,11 @@ async def quarantine_orphan_rows(
                         "source_layer": request.source_layer,
                         "reference_layer": request.reference_layer,
                         "mutation_layer": request.effective_mutation_layer,
+                        "workflow_run_id": request.workflow_run_id,
+                        "workflow_name": request.workflow_name,
+                        "manifest_id": request.manifest_id,
+                        "step_id": request.step_id,
+                        "transform_name": request.transform_name,
                     },
                 ),
                 "ingestion_ts": current_utc_time(),
@@ -337,6 +402,16 @@ async def quarantine_orphan_rows(
         quarantine_rows_written=len(quarantine_rows),
         quarantine_error_code=error_code,
     )
+
+
+def _coerce_optional_run_id(workflow_run_id: str | None) -> RunID | None:
+    """Map request workflow_run_id to typed RunID when it is a UUID."""
+    if workflow_run_id is None:
+        return None
+    try:
+        return RunID(UUID(str(workflow_run_id)))
+    except (TypeError, ValueError, AttributeError):
+        return None
 
 
 def _orphan_error_code(request: ForeignKeyReconciliationRequest) -> str:

--- a/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_support.py
+++ b/src/bioetl/infrastructure/storage/workflow_foreign_key_reconciliation_support.py
@@ -81,18 +81,26 @@ def partition_source_rows(
     source_rows: list[dict[str, object]],
     reference_values: set[tuple[object, ...]],
 ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
-    """Partition source rows into retained and orphan rows."""
+    """Partition source rows into retained and orphan rows.
+
+    Rows with any NULL / blank / NaN foreign-key component are always retained.
+    SQL-style foreign-key checks do not treat NULL as a missing parent, so
+    ``delete_orphans`` must never classify incomplete FK rows as orphans.
+    """
     retained_rows: list[dict[str, object]] = []
     orphan_rows: list[dict[str, object]] = []
+    source_keys = request.effective_source_keys
     for row in source_rows:
+        if row_has_null_foreign_key(row, source_keys):
+            retained_rows.append(row)
+            continue
         source_key = normalize_row_key(
             row,
-            request.effective_source_keys,
+            source_keys,
             nulls_equal=request.nulls_equal,
         )
         if source_key is None:
-            # nulls_equal=False and incomplete FK: SQL-like NULL does not fail the
-            # foreign-key check, so retain the row instead of treating it as orphan.
+            # Defensive: incomplete keys after null-component check still retain.
             retained_rows.append(row)
             continue
         if source_key in reference_values:
@@ -172,6 +180,14 @@ def complete_dry_run(
     )
 
 
+def row_has_null_foreign_key(
+    row: dict[str, object],
+    keys: tuple[str, ...],
+) -> bool:
+    """Return True when any foreign-key component is null, blank, or NaN."""
+    return any(normalize_value(row.get(key)) is None for key in keys)
+
+
 def normalize_row_key(
     row: dict[str, object],
     keys: tuple[str, ...],
@@ -192,27 +208,45 @@ def normalize_row_key(
     return tuple(normalized)
 
 
-def normalize_value(value: object) -> str | None:
-    """Normalize one foreign-key value for comparison."""
+def normalize_value(value: object) -> object | None:
+    """Normalize one foreign-key value for comparison.
+
+    Invariants:
+    - ``None``, blank strings, and NaN are null (``None``).
+    - Strings stay distinct from numeric values (``"5"`` != ``5``).
+    - Integral numbers that differ only by float form match (``5`` == ``5.0``).
+    - Booleans are not collapsed into integers.
+    """
     if value is None:
         return None
-    if isinstance(value, float) and isnan(value):
-        return None
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, float):
+        if isnan(value):
+            return None
+        if value.is_integer():
+            return ("int", int(value))
+        return ("float", value)
+    if isinstance(value, int):
+        return ("int", value)
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
             return None
-        return stripped
+        return ("str", stripped)
     rendered = str(value).strip()
     if not rendered:
         return None
-    return rendered
+    return ("other", type(value).__name__, rendered)
 
 
 __all__ = [
     "build_reconciliation_result",
     "complete_dry_run",
     "complete_without_mutation",
+    "normalize_row_key",
+    "normalize_value",
     "partition_source_rows",
     "reference_value_set",
+    "row_has_null_foreign_key",
 ]

--- a/tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation.py
+++ b/tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation.py
@@ -247,7 +247,9 @@ async def test_gold_expiry_retries_commit_conflict(
     )
 
     assert writer.merge_attempts == 2
+    # One schema inspection open + two merge retry attempts.
     assert fake_module.table_paths == [
+        "/tmp/chembl/assay",
         "/tmp/chembl/assay",
         "/tmp/chembl/assay",
     ]

--- a/tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation_support.py
+++ b/tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation_support.py
@@ -1,0 +1,86 @@
+# pyright: reportArgumentType=false
+"""Unit tests for FK reconciliation support helpers (#7996)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from bioetl.domain.ports.workflow_foreign_key_reconciliation import (
+    ForeignKeyReconciliationRequest,
+)
+from bioetl.infrastructure.storage.workflow_foreign_key_reconciliation_support import (
+    normalize_value,
+    partition_source_rows,
+    reference_value_set,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _request(**overrides: object) -> ForeignKeyReconciliationRequest:
+    payload: dict[str, object] = {
+        "source_table": "silver.activity",
+        "reference_table": "silver.assay",
+        "source_key": "assay_id",
+        "reference_key": "assay_id",
+        "primary_keys": ("activity_id",),
+        "nulls_equal": False,
+    }
+    payload.update(overrides)
+    return ForeignKeyReconciliationRequest(**payload)  # type: ignore[arg-type]
+
+
+def test_normalize_value_keeps_string_and_number_distinct() -> None:
+    assert normalize_value(5) == normalize_value(5.0)
+    assert normalize_value("5") != normalize_value(5)
+    assert normalize_value(True) != normalize_value(1)
+    assert normalize_value(None) is None
+    assert normalize_value(float("nan")) is None
+    assert normalize_value("  ") is None
+    assert normalize_value(math.nan) is None
+
+
+def test_partition_retains_null_foreign_keys_even_when_nulls_equal() -> None:
+    request = _request(nulls_equal=True)
+    source_rows = [
+        {"activity_id": "a1", "assay_id": None},
+        {"activity_id": "a2", "assay_id": ""},
+        {"activity_id": "a3", "assay_id": "missing"},
+        {"activity_id": "a4", "assay_id": "ok"},
+    ]
+    reference_values = reference_value_set(
+        request,
+        [{"assay_id": "ok"}],
+    )
+    retained, orphans = partition_source_rows(
+        request,
+        source_rows=source_rows,
+        reference_values=reference_values,
+    )
+    retained_ids = {row["activity_id"] for row in retained}
+    orphan_ids = {row["activity_id"] for row in orphans}
+    assert retained_ids == {"a1", "a2", "a4"}
+    assert orphan_ids == {"a3"}
+
+
+def test_partition_matches_integral_float_keys() -> None:
+    request = _request(source_key="target_id", reference_key="target_id")
+    source_rows = [
+        {"activity_id": "a1", "target_id": 5},
+        {"activity_id": "a2", "target_id": 5.0},
+        {"activity_id": "a3", "target_id": "5"},
+    ]
+    reference_values = reference_value_set(
+        request,
+        [{"target_id": 5.0}],
+    )
+    retained, orphans = partition_source_rows(
+        request,
+        source_rows=source_rows,
+        reference_values=reference_values,
+    )
+    assert {row["activity_id"] for row in retained} == {"a1", "a2"}
+    assert {row["activity_id"] for row in orphans} == {"a3"}


### PR DESCRIPTION
## Summary

Closes CodeRabbit residual findings for workflow foreign-key reconciliation storage helpers.

### #7992 quarantine
- Atomic Silver rewrite via single overwrite write (mode=delete) instead of clear-then-merge
- Validate primary_keys and SCD2 column names before SQL merge interpolation
- Resolve SCD2 metadata columns from live Delta table schema (fallback to orphan rows)
- Thread request.workflow_run_id into quarantine write run_id + metadata

### #7996 support
- Rows with any NULL/blank/NaN foreign-key component are never classified as orphans
- normalize_value keeps strings distinct from numbers while matching 5 and 5.0

## Test plan
- [x] pytest tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation_support.py
- [x] pytest tests/unit/infrastructure/storage/test_workflow_foreign_key_reconciliation.py
- [x] pytest tests/unit/application/workflow/test_reconcile_foreign_keys.py

Closes #7992
Closes #7996

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/satorykono/bioactivitydataacquisition/pull/8039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->