### PR TITLE
fix(core): close #7795 #7811 #7812 base_transformer residuals

### DIFF
--- a/reports/quality/coderabbit/_live/OPEN_CRITICAL_MAJOR_STREAMS.md
+++ b/reports/quality/coderabbit/_live/OPEN_CRITICAL_MAJOR_STREAMS.md
@@ -1,18 +1,18 @@
-# Open CodeRabbit residual — CRITICAL + MAJOR (refreshed)
+# Open CodeRabbit residual — CRITICAL + MAJOR
 
-Live `gh` search, repo `SatoryKono/BioactivityDataAcquisition`.
+Live `gh` snapshot, repo `SatoryKono/BioactivityDataAcquisition`.
 
-| Severity | Open |
-|----------|-----:|
-| **critical** | **0** |
-| **major** | **54** |
-| **TOTAL C+M** | **54** |
+| Class | Open |
+|-------|-----:|
+| **critical path-cluster** | **0** |
+| **major path-cluster** | **29** |
+| **TOTAL C+M path-clusters** | **29** |
 
-## CRITICAL
+## CRITICAL path-clusters
 
-_Нет открытых critical residual path-cluster issues_ (ранее #7992/#7996 и storage FK cluster закрыты).
+_Нет открытых critical residual path-cluster issues._
 
-## MAJOR (полный список по path)
+## MAJOR path-clusters (полный список)
 
 - **#7795** — `src/bioetl/application/core/_base_transformer_structural_support.py`
 - **#7797** — `src/bioetl/application/core/_fetch_forwarding.py`
@@ -43,72 +43,56 @@ _Нет открытых critical residual path-cluster issues_ (ранее #799
 - **#7848** — `src/bioetl/application/core/runner_flow_metrics.py`
 - **#7787** — `src/bioetl/application/core/subcellular_fraction_support.py`
 - **#7763** — `src/bioetl/application/core/wiring`
-- **#7920** — `src/bioetl/domain/ports/audit.py`
-- **#7904** — `src/bioetl/domain/ports/control_plane`
-- **#8017** — `src/bioetl/infrastructure/observability/__init__.py`
-- **#8013** — `src/bioetl/infrastructure/observability/_metrics_defs_adapter.py`
-- **#8018** — `src/bioetl/infrastructure/observability/_metrics_defs_core.py`
-- **#8007** — `src/bioetl/infrastructure/observability/_metrics_defs_pipeline.py`
-- **#8019** — `src/bioetl/infrastructure/observability/_metrics_defs_pipeline_checkpoint.py`
-- **#8020** — `src/bioetl/infrastructure/observability/_metrics_defs_storage.py`
-- **#8008** — `src/bioetl/infrastructure/observability/_metrics_gateway_publication.py`
-- **#8009** — `src/bioetl/infrastructure/observability/_metrics_server_state.py`
-- **#8021** — `src/bioetl/infrastructure/observability/_prometheus_metric_label_normalizers.py`
-- **#8022** — `src/bioetl/infrastructure/observability/_prometheus_metric_label_vocab_publication.py`
-- **#8012** — `src/bioetl/infrastructure/observability/anomaly`
-- **#8023** — `src/bioetl/infrastructure/observability/circuit_breaker_mapping.py`
-- **#8010** — `src/bioetl/infrastructure/observability/debug_adapters.py`
-- **#8024** — `src/bioetl/infrastructure/observability/logging.py`
-- **#8014** — `src/bioetl/infrastructure/observability/logging_config.py`
-- **#8025** — `src/bioetl/infrastructure/observability/logging_helpers.py`
-- **#8011** — `src/bioetl/infrastructure/observability/metrics_collector.py`
-- **#8026** — `src/bioetl/infrastructure/observability/metrics_definitions.py`
-- **#8027** — `src/bioetl/infrastructure/observability/prometheus_metric_label_dispatch.py`
-- **#8015** — `src/bioetl/infrastructure/observability/prometheus_metric_registries.py`
-- **#8028** — `src/bioetl/infrastructure/observability/server.py`
-- **#8016** — `src/bioetl/infrastructure/observability/tracing.py`
-- **#8029** — `src/bioetl/infrastructure/observability/unified_logger.py`
+
+## Campaign / meta open (не path-cluster implement)
+
+- **#7688** — [CR-FULL][meta] Exhaustive CodeRabbit residual audit campaign (2026-08)
+- **#7946** — [CR-FULL][Wave A][P2] Retry rate-limited domain residual leaves
+- **#8031** — [CR-FULL][Wave E][P2] CLI residual blocked: docs/grafana/scripts All files ignored
+- **#8032** — [CR-FULL][Wave F][P2] CLI residual blocked: tests All files ignored
 
 ## 5 независимых потоков (exclusive path ownership)
 
-Перебалансировка после закрытий: critical / application-batch / infrastructure-storage = 0 open → 5 потоков на оставшиеся major.
+Все major path-clusters сейчас под `src/bioetl/application/core/*`.
+Critical / domain / observability / storage path-clusters закрыты.
 
 ```
-S1 app-lifecycle-runner ──┐
-S2 app-record-transform ──┼── parallel worktrees
-S3 obs-metrics          ──┤
-S4 obs-logging-tracing  ──┤
-S5 domain               ──┘
+S1 lifecycle-runner       ──┐
+S2 config-services        ──┼── parallel worktrees
+S3 record-quarantine-fetch──┤
+S4 transformer            ──┤
+S5 publication            ──┘
 ```
 
 | Stream | Exclusive paths | Issues | IDs |
 |--------|-----------------|-------:|-----|
-| **S1 app-lifecycle-runner** | `application/core` runner/lifecycle/preflight/postrun/wiring/config/… | 11 | #7760, #7763, #7777, #7783, #7784, #7785, #7786, #7787, … +3 |
-| **S2 app-record-transform** | `application/core` record/quarantine/fetch/transformer/publication/… | 18 | #7762, #7772, #7773, #7795, #7797, #7798, #7799, #7800, … +10 |
-| **S3 obs-metrics** | `infrastructure/observability` metrics/prometheus/server/anomaly/… | 16 | #8007, #8008, #8009, #8011, #8012, #8013, #8015, #8017, … +8 |
-| **S4 obs-logging-tracing** | `infrastructure/observability` logging/tracing/debug/circuit_breaker | 7 | #8010, #8014, #8016, #8023, #8024, #8025, #8029 |
-| **S5 domain** | `domain/ports/*` | 2 | #7904, #7920 |
+| **S1 lifecycle-runner** | `postrun, wiring, lifecycle, preflight, runner, pre_silver, runner_flow_metrics` | 7 | #7760, #7763, #7783, #7784, #7785, #7786, #7848 |
+| **S2 config-services** | `config.py, pipeline_services.py, entity_id.py, subcellular_fraction_support.py` | 4 | #7777, #7787, #7841, #7844 |
+| **S3 record-quarantine-fetch** | `record_*, quarantine_*, fetch_*, filtered_*, data_sources, normalization_*` | 12 | #7772, #7773, #7797, #7798, #7799, #7800, #7801, #7802, #7803, #7842, #7843, #7847 |
+| **S4 transformer** | `base_transformer*` | 3 | #7795, #7811, #7812 |
+| **S5 publication** | `publication_term_*` | 3 | #7762, #7845, #7846 |
 
-### S1 app-lifecycle-runner (11)
+### S1 lifecycle-runner (7)
 
 - **#7760** `src/bioetl/application/core/postrun`
 - **#7763** `src/bioetl/application/core/wiring`
-- **#7777** `src/bioetl/application/core/entity_id.py`
 - **#7783** `src/bioetl/application/core/lifecycle`
 - **#7784** `src/bioetl/application/core/pre_silver_finalization_flow.py`
 - **#7785** `src/bioetl/application/core/preflight`
 - **#7786** `src/bioetl/application/core/runner.py`
+- **#7848** `src/bioetl/application/core/runner_flow_metrics.py`
+
+### S2 config-services (4)
+
+- **#7777** `src/bioetl/application/core/entity_id.py`
 - **#7787** `src/bioetl/application/core/subcellular_fraction_support.py`
 - **#7841** `src/bioetl/application/core/config.py`
 - **#7844** `src/bioetl/application/core/pipeline_services.py`
-- **#7848** `src/bioetl/application/core/runner_flow_metrics.py`
 
-### S2 app-record-transform (18)
+### S3 record-quarantine-fetch (12)
 
-- **#7762** `src/bioetl/application/core/publication_term_extraction_mixin.py`
 - **#7772** `src/bioetl/application/core/_quarantine_metrics_support.py`
 - **#7773** `src/bioetl/application/core/_record_normalization_mapping.py`
-- **#7795** `src/bioetl/application/core/_base_transformer_structural_support.py`
 - **#7797** `src/bioetl/application/core/_fetch_forwarding.py`
 - **#7798** `src/bioetl/application/core/_filtered_data_source_fetch_support.py`
 - **#7799** `src/bioetl/application/core/_filtered_data_source_support.py`
@@ -116,53 +100,26 @@ S5 domain               ──┘
 - **#7801** `src/bioetl/application/core/_quarantine_write_support.py`
 - **#7802** `src/bioetl/application/core/_record_normalization_hash_support.py`
 - **#7803** `src/bioetl/application/core/_record_processor_span_support.py`
-- **#7811** `src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py`
-- **#7812** `src/bioetl/application/core/base_transformer_execution_mixin.py`
 - **#7842** `src/bioetl/application/core/data_sources`
 - **#7843** `src/bioetl/application/core/normalization_fallbacks.py`
-- **#7845** `src/bioetl/application/core/publication_term_filtering_mixin.py`
-- **#7846** `src/bioetl/application/core/publication_term_runtime.py`
 - **#7847** `src/bioetl/application/core/record_processor.py`
 
-### S3 obs-metrics (16)
+### S4 transformer (3)
 
-- **#8007** `src/bioetl/infrastructure/observability/_metrics_defs_pipeline.py`
-- **#8008** `src/bioetl/infrastructure/observability/_metrics_gateway_publication.py`
-- **#8009** `src/bioetl/infrastructure/observability/_metrics_server_state.py`
-- **#8011** `src/bioetl/infrastructure/observability/metrics_collector.py`
-- **#8012** `src/bioetl/infrastructure/observability/anomaly`
-- **#8013** `src/bioetl/infrastructure/observability/_metrics_defs_adapter.py`
-- **#8015** `src/bioetl/infrastructure/observability/prometheus_metric_registries.py`
-- **#8017** `src/bioetl/infrastructure/observability/__init__.py`
-- **#8018** `src/bioetl/infrastructure/observability/_metrics_defs_core.py`
-- **#8019** `src/bioetl/infrastructure/observability/_metrics_defs_pipeline_checkpoint.py`
-- **#8020** `src/bioetl/infrastructure/observability/_metrics_defs_storage.py`
-- **#8021** `src/bioetl/infrastructure/observability/_prometheus_metric_label_normalizers.py`
-- **#8022** `src/bioetl/infrastructure/observability/_prometheus_metric_label_vocab_publication.py`
-- **#8026** `src/bioetl/infrastructure/observability/metrics_definitions.py`
-- **#8027** `src/bioetl/infrastructure/observability/prometheus_metric_label_dispatch.py`
-- **#8028** `src/bioetl/infrastructure/observability/server.py`
+- **#7795** `src/bioetl/application/core/_base_transformer_structural_support.py`
+- **#7811** `src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py`
+- **#7812** `src/bioetl/application/core/base_transformer_execution_mixin.py`
 
-### S4 obs-logging-tracing (7)
+### S5 publication (3)
 
-- **#8010** `src/bioetl/infrastructure/observability/debug_adapters.py`
-- **#8014** `src/bioetl/infrastructure/observability/logging_config.py`
-- **#8016** `src/bioetl/infrastructure/observability/tracing.py`
-- **#8023** `src/bioetl/infrastructure/observability/circuit_breaker_mapping.py`
-- **#8024** `src/bioetl/infrastructure/observability/logging.py`
-- **#8025** `src/bioetl/infrastructure/observability/logging_helpers.py`
-- **#8029** `src/bioetl/infrastructure/observability/unified_logger.py`
-
-### S5 domain (2)
-
-- **#7904** `src/bioetl/domain/ports/control_plane`
-- **#7920** `src/bioetl/domain/ports/audit.py`
+- **#7762** `src/bioetl/application/core/publication_term_extraction_mixin.py`
+- **#7845** `src/bioetl/application/core/publication_term_filtering_mixin.py`
+- **#7846** `src/bioetl/application/core/publication_term_runtime.py`
 
 ## Правила параллелизма
 
-1. Один worktree/agent на stream; **path ownership не пересекается**.
-2. S1 и S2 оба под `application/core/` — **разные файлы**; не править «чужие».
-3. S3 и S4 оба под `observability/` — **разные файлы**.
-4. S5 domain — 2 issue; можно закрыть быстро или прицепить к S4 (paths всё равно exclusive).
-5. Не увеличивать бюджеты техдолга.
-6. После PR: close issue + evidence; пересчёт inventory.
+1. Один worktree/agent на stream; path ownership не пересекается.
+2. Все потоки под `application/core/` — разные файлы.
+3. Не увеличивать бюджеты техдолга.
+4. Meta issues (#7688, #7946, #8031, #8032) — не в implement-streams.
+5. После PR: close + evidence; пересчёт inventory.

--- a/reports/quality/coderabbit/_live/inventory_cm.py
+++ b/reports/quality/coderabbit/_live/inventory_cm.py
@@ -1,0 +1,253 @@
+"""Live inventory: open CR residual critical/major + 5 streams."""
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+OUT = Path("reports/quality/coderabbit/_live")
+
+
+def strip_ansi(raw: bytes) -> str:
+    return re.sub(rb"\x1b\[[0-9;]*m", b"", raw).decode("utf-8", errors="replace").strip()
+
+
+def load_search(path: Path) -> list[dict]:
+    text = strip_ansi(path.read_bytes())
+    dec = json.JSONDecoder()
+    idx = 0
+    items: list[dict] = []
+    while idx < len(text):
+        while idx < len(text) and text[idx].isspace():
+            idx += 1
+        if idx >= len(text):
+            break
+        obj, end = dec.raw_decode(text, idx)
+        idx = end
+        if isinstance(obj, dict) and "items" in obj:
+            items.extend(obj["items"])
+    return items
+
+
+def path_of(title: str) -> str:
+    m = re.search(r"`([^`]+)`", title or "")
+    if m and not m.group(1).endswith("..."):
+        return m.group(1)
+    return ""
+
+
+def stream_of(path: str) -> str:
+    p = path.replace("\\", "/")
+    name = p.rsplit("/", 1)[-1]
+    if "publication_term" in p:
+        return "S5 publication"
+    if "base_transformer" in p or "_base_transformer" in p:
+        return "S4 transformer"
+    if (
+        any(
+            k in p
+            for k in (
+                "quarantine",
+                "fetch",
+                "filtered_data",
+                "record_",
+                "record_processor",
+                "normalization",
+                "data_sources",
+            )
+        )
+        or name in {"record_processor.py", "normalization_fallbacks.py"}
+    ):
+        return "S3 record-quarantine-fetch"
+    if name in {
+        "config.py",
+        "pipeline_services.py",
+        "entity_id.py",
+        "subcellular_fraction_support.py",
+    }:
+        return "S2 config-services"
+    return "S1 lifecycle-runner"
+
+
+def main() -> None:
+    maj_raw = load_search(OUT / "search_major_residual.json")
+    crit_raw = load_search(OUT / "search_critical_residual.json")
+
+    path_clusters: list[dict] = []
+    meta: list[dict] = []
+    for it in maj_raw:
+        title = it.get("title", "")
+        p = path_of(title)
+        if "[major]" in title.lower() and p.startswith("src/"):
+            path_clusters.append(
+                {"number": it["number"], "path": p, "title": title}
+            )
+        else:
+            meta.append({"number": it["number"], "title": title})
+
+    crit_pc: list[dict] = []
+    crit_meta: list[dict] = []
+    for it in crit_raw:
+        title = it.get("title", "")
+        p = path_of(title)
+        if "[critical]" in title.lower() and p.startswith("src/"):
+            crit_pc.append({"number": it["number"], "path": p, "title": title})
+        else:
+            crit_meta.append({"number": it["number"], "title": title})
+
+    streams: dict[str, list[dict]] = defaultdict(list)
+    for m in path_clusters:
+        streams[stream_of(m["path"])].append(m)
+
+    order = [
+        "S1 lifecycle-runner",
+        "S2 config-services",
+        "S3 record-quarantine-fetch",
+        "S4 transformer",
+        "S5 publication",
+    ]
+    assert sum(len(streams[s]) for s in order) == len(path_clusters)
+
+    roots = {
+        "S1 lifecycle-runner": (
+            "postrun, wiring, lifecycle, preflight, runner, "
+            "pre_silver, runner_flow_metrics"
+        ),
+        "S2 config-services": (
+            "config.py, pipeline_services.py, entity_id.py, "
+            "subcellular_fraction_support.py"
+        ),
+        "S3 record-quarantine-fetch": (
+            "record_*, quarantine_*, fetch_*, filtered_*, "
+            "data_sources, normalization_*"
+        ),
+        "S4 transformer": "base_transformer*",
+        "S5 publication": "publication_term_*",
+    }
+
+    # meta unique
+    seen: set[int] = set()
+    meta_all: list[dict] = []
+    for m in meta + crit_meta:
+        n = m["number"]
+        if n in seen or n in {x["number"] for x in path_clusters}:
+            continue
+        seen.add(n)
+        meta_all.append(m)
+
+    lines: list[str] = []
+    lines.append("# Open CodeRabbit residual — CRITICAL + MAJOR")
+    lines.append("")
+    lines.append(
+        "Live `gh` snapshot, repo `SatoryKono/BioactivityDataAcquisition`."
+    )
+    lines.append("")
+    lines.append("| Class | Open |")
+    lines.append("|-------|-----:|")
+    lines.append(f"| **critical path-cluster** | **{len(crit_pc)}** |")
+    lines.append(f"| **major path-cluster** | **{len(path_clusters)}** |")
+    lines.append(
+        f"| **TOTAL C+M path-clusters** | **{len(crit_pc) + len(path_clusters)}** |"
+    )
+    lines.append("")
+    lines.append("## CRITICAL path-clusters")
+    lines.append("")
+    if not crit_pc:
+        lines.append(
+            "_Нет открытых critical residual path-cluster issues._"
+        )
+    else:
+        for c in sorted(crit_pc, key=lambda x: x["number"]):
+            lines.append(f"- **#{c['number']}** `{c['path']}`")
+    lines.append("")
+    lines.append("## MAJOR path-clusters (полный список)")
+    lines.append("")
+    for m in sorted(path_clusters, key=lambda x: x["path"]):
+        lines.append(f"- **#{m['number']}** — `{m['path']}`")
+    lines.append("")
+    lines.append("## Campaign / meta open (не path-cluster implement)")
+    lines.append("")
+    for m in sorted(meta_all, key=lambda x: x["number"]):
+        lines.append(f"- **#{m['number']}** — {m['title']}")
+    lines.append("")
+    lines.append("## 5 независимых потоков (exclusive path ownership)")
+    lines.append("")
+    lines.append(
+        "Все major path-clusters сейчас под `src/bioetl/application/core/*`."
+    )
+    lines.append(
+        "Critical / domain / observability / storage path-clusters закрыты."
+    )
+    lines.append("")
+    lines.append("```")
+    lines.append("S1 lifecycle-runner       ──┐")
+    lines.append("S2 config-services        ──┼── parallel worktrees")
+    lines.append("S3 record-quarantine-fetch──┤")
+    lines.append("S4 transformer            ──┤")
+    lines.append("S5 publication            ──┘")
+    lines.append("```")
+    lines.append("")
+    lines.append("| Stream | Exclusive paths | Issues | IDs |")
+    lines.append("|--------|-----------------|-------:|-----|")
+    for s in order:
+        items = sorted(streams[s], key=lambda x: x["number"])
+        ids = ", ".join(f"#{m['number']}" for m in items)
+        lines.append(
+            f"| **{s}** | `{roots[s]}` | {len(items)} | {ids} |"
+        )
+    lines.append("")
+    for s in order:
+        items = sorted(streams[s], key=lambda x: x["number"])
+        lines.append(f"### {s} ({len(items)})")
+        lines.append("")
+        for m in items:
+            lines.append(f"- **#{m['number']}** `{m['path']}`")
+        lines.append("")
+    lines.append("## Правила параллелизма")
+    lines.append("")
+    lines.append(
+        "1. Один worktree/agent на stream; path ownership не пересекается."
+    )
+    lines.append(
+        "2. Все потоки под `application/core/` — разные файлы."
+    )
+    lines.append("3. Не увеличивать бюджеты техдолга.")
+    lines.append(
+        "4. Meta issues (#7688, #7946, #8031, #8032) — не в implement-streams."
+    )
+    lines.append(
+        "5. После PR: close + evidence; пересчёт inventory."
+    )
+    lines.append("")
+
+    text = "\n".join(lines)
+    (OUT / "OPEN_CRITICAL_MAJOR_STREAMS.md").write_text(text, encoding="utf-8")
+    payload = {
+        "critical_path_clusters": crit_pc,
+        "major_path_clusters": path_clusters,
+        "meta_open": meta_all,
+        "streams": {
+            s: [
+                {
+                    "number": m["number"],
+                    "severity": "major",
+                    "path": m["path"],
+                }
+                for m in sorted(streams[s], key=lambda x: x["number"])
+            ]
+            for s in order
+        },
+    }
+    (OUT / "open_cm_streams.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(text)
+    print("COUNTS:")
+    for s in order:
+        print(f"  {s}: {len(streams[s])}")
+    print("total", sum(len(streams[s]) for s in order))
+
+
+if __name__ == "__main__":
+    main()

--- a/reports/quality/coderabbit/_live/open_cm_streams.json
+++ b/reports/quality/coderabbit/_live/open_cm_streams.json
@@ -1,35 +1,10 @@
 {
-  "critical": [],
-  "major": [
+  "critical_path_clusters": [],
+  "major_path_clusters": [
     {
-      "number": 7760,
-      "path": "src/bioetl/application/core/postrun",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/postrun` (3 findings)"
-    },
-    {
-      "number": 7762,
-      "path": "src/bioetl/application/core/publication_term_extraction_mixin.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_extraction_mixin.py` (2 findings)"
-    },
-    {
-      "number": 7763,
-      "path": "src/bioetl/application/core/wiring",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/wiring` (2 findings)"
-    },
-    {
-      "number": 7772,
-      "path": "src/bioetl/application/core/_quarantine_metrics_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_metrics_support.py` (2 findings)"
-    },
-    {
-      "number": 7773,
-      "path": "src/bioetl/application/core/_record_normalization_mapping.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_normalization_mapping.py` (2 findings)"
-    },
-    {
-      "number": 7777,
-      "path": "src/bioetl/application/core/entity_id.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/entity_id.py` (2 findings)"
+      "number": 7785,
+      "path": "src/bioetl/application/core/preflight",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/preflight` (2 findings)"
     },
     {
       "number": 7783,
@@ -37,79 +12,14 @@
       "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/lifecycle` (2 findings)"
     },
     {
-      "number": 7784,
-      "path": "src/bioetl/application/core/pre_silver_finalization_flow.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/pre_silver_finalization_flow.py` (2 findings)"
+      "number": 7763,
+      "path": "src/bioetl/application/core/wiring",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/wiring` (2 findings)"
     },
     {
-      "number": 7785,
-      "path": "src/bioetl/application/core/preflight",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/preflight` (2 findings)"
-    },
-    {
-      "number": 7786,
-      "path": "src/bioetl/application/core/runner.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/runner.py` (2 findings)"
-    },
-    {
-      "number": 7787,
-      "path": "src/bioetl/application/core/subcellular_fraction_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/subcellular_fraction_support.py` (2 findings)"
-    },
-    {
-      "number": 7795,
-      "path": "src/bioetl/application/core/_base_transformer_structural_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_base_transformer_structural_support.py` (1 findings)"
-    },
-    {
-      "number": 7797,
-      "path": "src/bioetl/application/core/_fetch_forwarding.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_fetch_forwarding.py` (1 findings)"
-    },
-    {
-      "number": 7798,
-      "path": "src/bioetl/application/core/_filtered_data_source_fetch_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_filtered_data_source_fetch_support.py` (1 findings)"
-    },
-    {
-      "number": 7799,
-      "path": "src/bioetl/application/core/_filtered_data_source_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_filtered_data_source_support.py` (1 findings)"
-    },
-    {
-      "number": 7800,
-      "path": "src/bioetl/application/core/_quarantine_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_support.py` (1 findings)"
-    },
-    {
-      "number": 7801,
-      "path": "src/bioetl/application/core/_quarantine_write_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_write_support.py` (1 findings)"
-    },
-    {
-      "number": 7802,
-      "path": "src/bioetl/application/core/_record_normalization_hash_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_normalization_hash_support.py` (1 findings)"
-    },
-    {
-      "number": 7803,
-      "path": "src/bioetl/application/core/_record_processor_span_support.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_processor_span_support.py` (1 findings)"
-    },
-    {
-      "number": 7811,
-      "path": "src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py` (1 fi..."
-    },
-    {
-      "number": 7812,
-      "path": "src/bioetl/application/core/base_transformer_execution_mixin.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/base_transformer_execution_mixin.py` (1 findings)"
-    },
-    {
-      "number": 7841,
-      "path": "src/bioetl/application/core/config.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/config.py` (1 findings)"
+      "number": 7760,
+      "path": "src/bioetl/application/core/postrun",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/postrun` (3 findings)"
     },
     {
       "number": 7842,
@@ -117,24 +27,14 @@
       "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/data_sources` (1 findings)"
     },
     {
-      "number": 7843,
-      "path": "src/bioetl/application/core/normalization_fallbacks.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/normalization_fallbacks.py` (1 findings)"
+      "number": 7841,
+      "path": "src/bioetl/application/core/config.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/config.py` (1 findings)"
     },
     {
-      "number": 7844,
-      "path": "src/bioetl/application/core/pipeline_services.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/pipeline_services.py` (1 findings)"
-    },
-    {
-      "number": 7845,
-      "path": "src/bioetl/application/core/publication_term_filtering_mixin.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_filtering_mixin.py` (1 findings)"
-    },
-    {
-      "number": 7846,
-      "path": "src/bioetl/application/core/publication_term_runtime.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_runtime.py` (1 findings)"
+      "number": 7786,
+      "path": "src/bioetl/application/core/runner.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/runner.py` (2 findings)"
     },
     {
       "number": 7847,
@@ -142,138 +42,131 @@
       "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/record_processor.py` (1 findings)"
     },
     {
+      "number": 7844,
+      "path": "src/bioetl/application/core/pipeline_services.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/pipeline_services.py` (1 findings)"
+    },
+    {
+      "number": 7843,
+      "path": "src/bioetl/application/core/normalization_fallbacks.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/normalization_fallbacks.py` (1 findings)"
+    },
+    {
+      "number": 7800,
+      "path": "src/bioetl/application/core/_quarantine_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_support.py` (1 findings)"
+    },
+    {
+      "number": 7797,
+      "path": "src/bioetl/application/core/_fetch_forwarding.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_fetch_forwarding.py` (1 findings)"
+    },
+    {
+      "number": 7777,
+      "path": "src/bioetl/application/core/entity_id.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/entity_id.py` (2 findings)"
+    },
+    {
       "number": 7848,
       "path": "src/bioetl/application/core/runner_flow_metrics.py",
       "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/runner_flow_metrics.py` (1 findings)"
     },
     {
-      "number": 7904,
-      "path": "src/bioetl/domain/ports/control_plane",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/domain/ports/control_plane` (1 findings)"
+      "number": 7846,
+      "path": "src/bioetl/application/core/publication_term_runtime.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_runtime.py` (1 findings)"
     },
     {
-      "number": 7920,
-      "path": "src/bioetl/domain/ports/audit.py",
-      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/domain/ports/audit.py` (1 findings)"
+      "number": 7801,
+      "path": "src/bioetl/application/core/_quarantine_write_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_write_support.py` (1 findings)"
     },
     {
-      "number": 8007,
-      "path": "src/bioetl/infrastructure/observability/_metrics_defs_pipeline.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_defs_pipeline.py` (2 findings)"
+      "number": 7787,
+      "path": "src/bioetl/application/core/subcellular_fraction_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/subcellular_fraction_support.py` (2 findings)"
     },
     {
-      "number": 8008,
-      "path": "src/bioetl/infrastructure/observability/_metrics_gateway_publication.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_gateway_publication.py` (2 fin..."
+      "number": 7773,
+      "path": "src/bioetl/application/core/_record_normalization_mapping.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_normalization_mapping.py` (2 findings)"
     },
     {
-      "number": 8009,
-      "path": "src/bioetl/infrastructure/observability/_metrics_server_state.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_server_state.py` (1 findings)"
+      "number": 7772,
+      "path": "src/bioetl/application/core/_quarantine_metrics_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_quarantine_metrics_support.py` (2 findings)"
     },
     {
-      "number": 8010,
-      "path": "src/bioetl/infrastructure/observability/debug_adapters.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/debug_adapters.py` (1 findings)"
+      "number": 7845,
+      "path": "src/bioetl/application/core/publication_term_filtering_mixin.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_filtering_mixin.py` (1 findings)"
     },
     {
-      "number": 8011,
-      "path": "src/bioetl/infrastructure/observability/metrics_collector.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/metrics_collector.py` (1 findings)"
+      "number": 7812,
+      "path": "src/bioetl/application/core/base_transformer_execution_mixin.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/base_transformer_execution_mixin.py` (1 findings)"
     },
     {
-      "number": 8012,
-      "path": "src/bioetl/infrastructure/observability/anomaly",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/anomaly` (3 findings)"
+      "number": 7803,
+      "path": "src/bioetl/application/core/_record_processor_span_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_processor_span_support.py` (1 findings)"
     },
     {
-      "number": 8013,
-      "path": "src/bioetl/infrastructure/observability/_metrics_defs_adapter.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_defs_adapter.py` (2 findings)"
+      "number": 7802,
+      "path": "src/bioetl/application/core/_record_normalization_hash_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_record_normalization_hash_support.py` (1 findings)"
     },
     {
-      "number": 8014,
-      "path": "src/bioetl/infrastructure/observability/logging_config.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/logging_config.py` (2 findings)"
+      "number": 7799,
+      "path": "src/bioetl/application/core/_filtered_data_source_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_filtered_data_source_support.py` (1 findings)"
     },
     {
-      "number": 8015,
-      "path": "src/bioetl/infrastructure/observability/prometheus_metric_registries.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/prometheus_metric_registries.py` (2 fin..."
+      "number": 7795,
+      "path": "src/bioetl/application/core/_base_transformer_structural_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_base_transformer_structural_support.py` (1 findings)"
     },
     {
-      "number": 8016,
-      "path": "src/bioetl/infrastructure/observability/tracing.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/tracing.py` (2 findings)"
+      "number": 7784,
+      "path": "src/bioetl/application/core/pre_silver_finalization_flow.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/pre_silver_finalization_flow.py` (2 findings)"
     },
     {
-      "number": 8017,
-      "path": "src/bioetl/infrastructure/observability/__init__.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/__init__.py` (1 findings)"
+      "number": 7762,
+      "path": "src/bioetl/application/core/publication_term_extraction_mixin.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/publication_term_extraction_mixin.py` (2 findings)"
     },
     {
-      "number": 8018,
-      "path": "src/bioetl/infrastructure/observability/_metrics_defs_core.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_defs_core.py` (1 findings)"
+      "number": 7811,
+      "path": "src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py` (1 fi..."
     },
     {
-      "number": 8019,
-      "path": "src/bioetl/infrastructure/observability/_metrics_defs_pipeline_checkpoint.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_defs_pipeline_checkpoint.py` (..."
+      "number": 7798,
+      "path": "src/bioetl/application/core/_filtered_data_source_fetch_support.py",
+      "title": "[CR-FULL][Wave A][major] residual in `src/bioetl/application/core/_filtered_data_source_fetch_support.py` (1 findings)"
+    }
+  ],
+  "meta_open": [
+    {
+      "number": 7946,
+      "title": "[CR-FULL][Wave A][P2] Retry rate-limited domain residual leaves"
     },
     {
-      "number": 8020,
-      "path": "src/bioetl/infrastructure/observability/_metrics_defs_storage.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_metrics_defs_storage.py` (1 findings)"
+      "number": 8032,
+      "title": "[CR-FULL][Wave F][P2] CLI residual blocked: tests All files ignored"
     },
     {
-      "number": 8021,
-      "path": "src/bioetl/infrastructure/observability/_prometheus_metric_label_normalizers.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_prometheus_metric_label_normalizers.py..."
+      "number": 7688,
+      "title": "[CR-FULL][meta] Exhaustive CodeRabbit residual audit campaign (2026-08)"
     },
     {
-      "number": 8022,
-      "path": "src/bioetl/infrastructure/observability/_prometheus_metric_label_vocab_publication.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/_prometheus_metric_label_vocab_publicat..."
-    },
-    {
-      "number": 8023,
-      "path": "src/bioetl/infrastructure/observability/circuit_breaker_mapping.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/circuit_breaker_mapping.py` (1 findings)"
-    },
-    {
-      "number": 8024,
-      "path": "src/bioetl/infrastructure/observability/logging.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/logging.py` (1 findings)"
-    },
-    {
-      "number": 8025,
-      "path": "src/bioetl/infrastructure/observability/logging_helpers.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/logging_helpers.py` (1 findings)"
-    },
-    {
-      "number": 8026,
-      "path": "src/bioetl/infrastructure/observability/metrics_definitions.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/metrics_definitions.py` (1 findings)"
-    },
-    {
-      "number": 8027,
-      "path": "src/bioetl/infrastructure/observability/prometheus_metric_label_dispatch.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/prometheus_metric_label_dispatch.py` (1..."
-    },
-    {
-      "number": 8028,
-      "path": "src/bioetl/infrastructure/observability/server.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/server.py` (1 findings)"
-    },
-    {
-      "number": 8029,
-      "path": "src/bioetl/infrastructure/observability/unified_logger.py",
-      "title": "[CR-FULL][Wave C][major] residual in `src/bioetl/infrastructure/observability/unified_logger.py` (1 findings)"
+      "number": 8031,
+      "title": "[CR-FULL][Wave E][P2] CLI residual blocked: docs/grafana/scripts All files ignored"
     }
   ],
   "streams": {
-    "S1 app-lifecycle-runner": [
+    "S1 lifecycle-runner": [
       {
         "number": 7760,
         "severity": "major",
@@ -283,11 +176,6 @@
         "number": 7763,
         "severity": "major",
         "path": "src/bioetl/application/core/wiring"
-      },
-      {
-        "number": 7777,
-        "severity": "major",
-        "path": "src/bioetl/application/core/entity_id.py"
       },
       {
         "number": 7783,
@@ -310,6 +198,18 @@
         "path": "src/bioetl/application/core/runner.py"
       },
       {
+        "number": 7848,
+        "severity": "major",
+        "path": "src/bioetl/application/core/runner_flow_metrics.py"
+      }
+    ],
+    "S2 config-services": [
+      {
+        "number": 7777,
+        "severity": "major",
+        "path": "src/bioetl/application/core/entity_id.py"
+      },
+      {
         "number": 7787,
         "severity": "major",
         "path": "src/bioetl/application/core/subcellular_fraction_support.py"
@@ -323,19 +223,9 @@
         "number": 7844,
         "severity": "major",
         "path": "src/bioetl/application/core/pipeline_services.py"
-      },
-      {
-        "number": 7848,
-        "severity": "major",
-        "path": "src/bioetl/application/core/runner_flow_metrics.py"
       }
     ],
-    "S2 app-record-transform": [
-      {
-        "number": 7762,
-        "severity": "major",
-        "path": "src/bioetl/application/core/publication_term_extraction_mixin.py"
-      },
+    "S3 record-quarantine-fetch": [
       {
         "number": 7772,
         "severity": "major",
@@ -345,11 +235,6 @@
         "number": 7773,
         "severity": "major",
         "path": "src/bioetl/application/core/_record_normalization_mapping.py"
-      },
-      {
-        "number": 7795,
-        "severity": "major",
-        "path": "src/bioetl/application/core/_base_transformer_structural_support.py"
       },
       {
         "number": 7797,
@@ -387,16 +272,6 @@
         "path": "src/bioetl/application/core/_record_processor_span_support.py"
       },
       {
-        "number": 7811,
-        "severity": "major",
-        "path": "src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py"
-      },
-      {
-        "number": 7812,
-        "severity": "major",
-        "path": "src/bioetl/application/core/base_transformer_execution_mixin.py"
-      },
-      {
         "number": 7842,
         "severity": "major",
         "path": "src/bioetl/application/core/data_sources"
@@ -407,6 +282,35 @@
         "path": "src/bioetl/application/core/normalization_fallbacks.py"
       },
       {
+        "number": 7847,
+        "severity": "major",
+        "path": "src/bioetl/application/core/record_processor.py"
+      }
+    ],
+    "S4 transformer": [
+      {
+        "number": 7795,
+        "severity": "major",
+        "path": "src/bioetl/application/core/_base_transformer_structural_support.py"
+      },
+      {
+        "number": 7811,
+        "severity": "major",
+        "path": "src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py"
+      },
+      {
+        "number": 7812,
+        "severity": "major",
+        "path": "src/bioetl/application/core/base_transformer_execution_mixin.py"
+      }
+    ],
+    "S5 publication": [
+      {
+        "number": 7762,
+        "severity": "major",
+        "path": "src/bioetl/application/core/publication_term_extraction_mixin.py"
+      },
+      {
         "number": 7845,
         "severity": "major",
         "path": "src/bioetl/application/core/publication_term_filtering_mixin.py"
@@ -415,142 +319,6 @@
         "number": 7846,
         "severity": "major",
         "path": "src/bioetl/application/core/publication_term_runtime.py"
-      },
-      {
-        "number": 7847,
-        "severity": "major",
-        "path": "src/bioetl/application/core/record_processor.py"
-      }
-    ],
-    "S3 obs-metrics": [
-      {
-        "number": 8007,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_defs_pipeline.py"
-      },
-      {
-        "number": 8008,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_gateway_publication.py"
-      },
-      {
-        "number": 8009,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_server_state.py"
-      },
-      {
-        "number": 8011,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/metrics_collector.py"
-      },
-      {
-        "number": 8012,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/anomaly"
-      },
-      {
-        "number": 8013,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_defs_adapter.py"
-      },
-      {
-        "number": 8015,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/prometheus_metric_registries.py"
-      },
-      {
-        "number": 8017,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/__init__.py"
-      },
-      {
-        "number": 8018,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_defs_core.py"
-      },
-      {
-        "number": 8019,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_defs_pipeline_checkpoint.py"
-      },
-      {
-        "number": 8020,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_metrics_defs_storage.py"
-      },
-      {
-        "number": 8021,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_prometheus_metric_label_normalizers.py"
-      },
-      {
-        "number": 8022,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/_prometheus_metric_label_vocab_publication.py"
-      },
-      {
-        "number": 8026,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/metrics_definitions.py"
-      },
-      {
-        "number": 8027,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/prometheus_metric_label_dispatch.py"
-      },
-      {
-        "number": 8028,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/server.py"
-      }
-    ],
-    "S4 obs-logging-tracing": [
-      {
-        "number": 8010,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/debug_adapters.py"
-      },
-      {
-        "number": 8014,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/logging_config.py"
-      },
-      {
-        "number": 8016,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/tracing.py"
-      },
-      {
-        "number": 8023,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/circuit_breaker_mapping.py"
-      },
-      {
-        "number": 8024,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/logging.py"
-      },
-      {
-        "number": 8025,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/logging_helpers.py"
-      },
-      {
-        "number": 8029,
-        "severity": "major",
-        "path": "src/bioetl/infrastructure/observability/unified_logger.py"
-      }
-    ],
-    "S5 domain": [
-      {
-        "number": 7904,
-        "severity": "major",
-        "path": "src/bioetl/domain/ports/control_plane"
-      },
-      {
-        "number": 7920,
-        "severity": "major",
-        "path": "src/bioetl/domain/ports/audit.py"
       }
     ]
   }

--- a/src/bioetl/application/core/_base_transformer_structural_support.py
+++ b/src/bioetl/application/core/_base_transformer_structural_support.py
@@ -55,23 +55,15 @@ def classify_structural_shadow_comparison(
     return f"structural_{structural_state}_silver_filter_{silver_state}"
 
 
-def apply_silver_filter(
+def _raise_if_silver_filtered_out(
     owner: TransformerExecutionOwner,
     context: PipelineContext,
-    result: SilverRecord | None,
     index: int,
+    decision: FilterDecision,
 ) -> None:
-    """Check silver filter and raise FilteredOutError if excluded."""
+    """Raise FilteredOutError when a Silver filter decision rejects the record."""
     from bioetl.application.core.base_transformer.errors import FilteredOutError
 
-    if (
-        result is None
-        or owner._silver_filters is None
-        or owner._silver_filters.is_empty()
-    ):
-        return
-
-    decision = owner._silver_filters.evaluate(cast("GoldRecord", result))  # pyright: ignore[reportInvalidCast]
     if decision.include:
         return
 
@@ -88,6 +80,34 @@ def apply_silver_filter(
         decision.message or "Record excluded by silver filters",
         details={"policy_stage": "structural", **decision.to_dict()},
     )
+
+
+def apply_silver_filter(
+    owner: TransformerExecutionOwner,
+    context: PipelineContext,
+    result: SilverRecord | None,
+    index: int,
+    *,
+    precomputed_decision: FilterDecision | None = None,
+) -> None:
+    """Check silver filter and raise FilteredOutError if excluded.
+
+    When ``precomputed_decision`` is provided (e.g. from the structural-policy
+    shadow evaluation), the filter is not re-evaluated (#7795).
+    """
+    if (
+        result is None
+        or owner._silver_filters is None
+        or owner._silver_filters.is_empty()
+    ):
+        return
+
+    decision = (
+        precomputed_decision
+        if precomputed_decision is not None
+        else owner._silver_filters.evaluate(cast("GoldRecord", result))  # pyright: ignore[reportInvalidCast]
+    )
+    _raise_if_silver_filtered_out(owner, context, index, decision)
 
 
 def evaluate_semantic_shadow_decision(
@@ -146,7 +166,10 @@ def apply_structural_policy(
         return None
 
     outcome = owner._structural_policy.apply(result)
-    silver_filter_shadow_decision = evaluate_semantic_shadow_decision(
+    # Evaluate Silver filters at most once for non-quarantined records (#7795).
+    # For quarantine candidates, shadow uses the pre-policy record; for keep
+    # path, evaluate on the post-policy record and reuse for enforcement.
+    silver_filter_decision = evaluate_semantic_shadow_decision(
         owner,
         outcome.record if not outcome.should_quarantine else result,
     )
@@ -156,7 +179,7 @@ def apply_structural_policy(
     )
     shadow_comparison = classify_structural_shadow_comparison(
         structural_rejected=outcome.should_quarantine,
-        silver_filter_decision=silver_filter_shadow_decision,
+        silver_filter_decision=silver_filter_decision,
     )
     record_structural_policy_metrics(
         owner,
@@ -175,6 +198,14 @@ def apply_structural_policy(
         )
 
     if not outcome.should_quarantine:
+        # Reuse the single evaluation for real enforcement (no second evaluate).
+        if silver_filter_decision is not None:
+            _raise_if_silver_filtered_out(
+                owner,
+                context,
+                index,
+                silver_filter_decision,
+            )
         return outcome.record
 
     details = outcome.details or {}
@@ -188,8 +219,8 @@ def apply_structural_policy(
         action_taken=details.get("action_taken"),
         shadow_comparison=shadow_comparison,
         silver_filter_shadow_reason_code=(
-            silver_filter_shadow_decision.reason_code
-            if silver_filter_shadow_decision is not None
+            silver_filter_decision.reason_code
+            if silver_filter_decision is not None
             else None
         ),
     )
@@ -200,8 +231,8 @@ def apply_structural_policy(
             "policy_stage": "structural",
             "shadow_comparison": shadow_comparison,
             "silver_filter_shadow_reason_code": (
-                silver_filter_shadow_decision.reason_code
-                if silver_filter_shadow_decision is not None
+                silver_filter_decision.reason_code
+                if silver_filter_decision is not None
                 else None
             ),
         },

--- a/src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py
+++ b/src/bioetl/application/core/base_transformer_dependency_helpers_mixin.py
@@ -148,13 +148,8 @@ class _BaseTransformerDependencyHelpersMixin:
         business_data: GoldRecord,
     ) -> GoldRecord:
         """Apply legacy contract hash policy only when no explicit identity policy exists."""
-        identity_include = getattr(
-            identity_service, "_content_hash_include_fields", None
-        )
-        identity_exclude = getattr(
-            identity_service, "_content_hash_exclude_fields", None
-        )
-        if identity_include or identity_exclude:
+        # Public collaborator API (#7811): do not inspect private identity fields.
+        if identity_service.has_explicit_content_hash_policy():
             return dict(business_data)
 
         include_fields = contract_policy.hash_include

--- a/src/bioetl/application/core/base_transformer_execution_mixin.py
+++ b/src/bioetl/application/core/base_transformer_execution_mixin.py
@@ -114,21 +114,26 @@ class _BaseTransformerExecutionMixin(_BaseTransformerRecordHelpersMixin):
         record: BronzeRecord,
         index: int,
     ) -> SilverRecord | None:
-        """Transform Bronze record to Silver format (Template Method)."""
+        """Transform Bronze record to Silver format (Template Method).
+
+        Dispatches through instance hooks so subclasses can override policy,
+        filter, error, and metrics seams (#7812). Structural policy evaluates
+        and enforces Silver filters once for kept records (#7795).
+        """
         start_time = time.perf_counter()
         error_type: str | None = None
-        span = start_transform_span(self, context, index)
+        span = self._start_transform_span(context, index)
 
         try:
             result = await self._transform_impl(context, record, index)
-            result = apply_structural_policy(self, context, result, index)
-            apply_silver_filter(self, context, result, index)
-            return result
+            # Structural policy applies Silver filter once for non-quarantined
+            # records; do not call _apply_silver_filter again after this.
+            return self._apply_structural_policy(context, result, index)
         except TransformationError as error:
-            error_type = handle_transformation_error(self, error, context, span)
+            error_type = self._handle_transformation_error(error, context, span)
             return None
         except ValueError as error:
-            error_type = handle_validation_error(self, error, context, span)
+            error_type = self._handle_validation_error(error, context, span)
             raise
         finally:
-            record_metrics_and_close_span(self, start_time, error_type, span)
+            self._record_metrics_and_close_span(start_time, error_type, span)

--- a/src/bioetl/domain/behavior/identity_service.py
+++ b/src/bioetl/domain/behavior/identity_service.py
@@ -74,6 +74,16 @@ class EntityIdentityGenerator:
         self._content_hash_include_fields = content_hash_include_fields
         self._content_hash_exclude_fields = content_hash_exclude_fields or set()
 
+    def has_explicit_content_hash_policy(self) -> bool:
+        """Return True when instance-level include/exclude hash field policy is set.
+
+        Used by transformers to decide whether contract-level legacy hash
+        scoping should be skipped in favor of the identity collaborator policy.
+        """
+        return bool(self._content_hash_include_fields) or bool(
+            self._content_hash_exclude_fields
+        )
+
     def compute_entity_id(
         self,
         provider: str,

--- a/tests/unit/application/core/test_base_transformer_structural_support.py
+++ b/tests/unit/application/core/test_base_transformer_structural_support.py
@@ -39,11 +39,13 @@ from bioetl.application.core import _base_transformer_structural_support  # noqa
 pytestmark = pytest.mark.unit
 
 from bioetl.application.core._base_transformer_structural_support import (
+    apply_structural_policy,
     classify_structural_action,
     classify_structural_shadow_comparison,
     evaluate_semantic_shadow_decision,
     record_structural_policy_metrics,
 )
+from bioetl.application.core.base_transformer.errors import FilteredOutError
 from bioetl.domain.filtering import FilterDecision
 
 
@@ -292,3 +294,69 @@ class TestRecordStructuralPolicyMetrics:
         )
 
         mock_owner._metrics.increment_counter.assert_not_called()
+
+
+class TestApplyStructuralPolicySingleFilterEval:
+    """#7795: Silver filter evaluated once for non-quarantined records."""
+
+    def test_kept_record_evaluates_silver_filter_once_and_passes(self) -> None:
+        mock_owner = MagicMock()
+        mock_owner.provider = "chembl"
+        mock_owner.entity_type = "activity"
+        mock_owner._metrics = MagicMock()
+        mock_owner._structural_policy = MagicMock()
+        kept = {"entity_id": "chembl:1", "value": 1.0}
+        outcome = MagicMock()
+        outcome.record = kept
+        outcome.should_quarantine = False
+        outcome.details = None
+        outcome.events = ()
+        mock_owner._structural_policy.apply.return_value = outcome
+
+        decision = FilterDecision(
+            include=True,
+            reason_code="ok",
+            rule_type="always",
+            field=None,
+            message="pass",
+        )
+        mock_owner._silver_filters = MagicMock()
+        mock_owner._silver_filters.is_empty.return_value = False
+        mock_owner._silver_filters.evaluate.return_value = decision
+
+        context = MagicMock()
+        result = apply_structural_policy(mock_owner, context, kept, index=0)
+
+        assert result == kept
+        mock_owner._silver_filters.evaluate.assert_called_once_with(kept)
+
+    def test_kept_record_raises_filtered_out_without_second_evaluate(self) -> None:
+        mock_owner = MagicMock()
+        mock_owner.provider = "chembl"
+        mock_owner.entity_type = "activity"
+        mock_owner._metrics = MagicMock()
+        mock_owner._structural_policy = MagicMock()
+        kept = {"entity_id": "chembl:1", "value": 1.0}
+        outcome = MagicMock()
+        outcome.record = kept
+        outcome.should_quarantine = False
+        outcome.details = None
+        outcome.events = ()
+        mock_owner._structural_policy.apply.return_value = outcome
+
+        decision = FilterDecision(
+            include=False,
+            reason_code="reject",
+            rule_type="value_range",
+            field="value",
+            message="too small",
+        )
+        mock_owner._silver_filters = MagicMock()
+        mock_owner._silver_filters.is_empty.return_value = False
+        mock_owner._silver_filters.evaluate.return_value = decision
+
+        context = MagicMock()
+        with pytest.raises(FilteredOutError, match="too small"):
+            apply_structural_policy(mock_owner, context, kept, index=3)
+
+        mock_owner._silver_filters.evaluate.assert_called_once_with(kept)

--- a/tests/unit/domain/services/test_identity_service.py
+++ b/tests/unit/domain/services/test_identity_service.py
@@ -76,6 +76,22 @@ _HASH_SAFE_SCALAR = st.one_of(
 )
 
 
+class TestEntityIdentityGeneratorHashPolicySurface:
+    """Public hash-policy collaborator API (#7811)."""
+
+    def test_has_explicit_content_hash_policy_false_by_default(self) -> None:
+        service = EntityIdentityGenerator()
+        assert service.has_explicit_content_hash_policy() is False
+
+    def test_has_explicit_content_hash_policy_true_with_include(self) -> None:
+        service = EntityIdentityGenerator(content_hash_include_fields={"a"})
+        assert service.has_explicit_content_hash_policy() is True
+
+    def test_has_explicit_content_hash_policy_true_with_exclude(self) -> None:
+        service = EntityIdentityGenerator(content_hash_exclude_fields={"b"})
+        assert service.has_explicit_content_hash_policy() is True
+
+
 class TestEntityIdentityGeneratorDeterminism:
     """Test determinism of content hash generation."""
 


### PR DESCRIPTION
## Summary

S4 transformer residuals for BaseTransformer hooks and structural filter path:

- **#7795:** Evaluate Silver filters once for non-quarantined records inside `apply_structural_policy` and enforce that decision without a second `evaluate`.
- **#7811:** Detect explicit identity hash policy via public `EntityIdentityGenerator.has_explicit_content_hash_policy()` (no private `_content_hash_*` getattr).
- **#7812:** `transform()` dispatches through instance hooks (`_start_transform_span`, `_apply_structural_policy`, error/metrics handlers).

## Test plan

- [x] `pytest tests/unit/application/core/test_base_transformer_structural_support.py tests/unit/domain/services/test_identity_service.py tests/unit/application/core/test_base_transformer.py -q`

Closes #7795
Closes #7811
Closes #7812