### PR TITLE
fix(core): S5 publication_term residuals (#7762 #7845 #7846)

### DIFF
--- a/src/bioetl/application/core/publication_term_extraction_mixin.py
+++ b/src/bioetl/application/core/publication_term_extraction_mixin.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING, Protocol, cast
 
 from bioetl.application.core.publication_term_runtime import (
     compute_term_entity_id,
@@ -12,20 +13,69 @@ from bioetl.application.core.publication_term_runtime import (
 from bioetl.domain.types import BronzeRecord
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from bioetl.domain.ports import DataSourcePort, FilterableDataSourcePort
 
-    from bioetl.domain.ports import FilterableDataSourcePort
+
+def normalize_publication_term_limit(limit: int | None) -> int | None:
+    """Validate and normalize an optional term-record limit.
+
+    Returns:
+        ``None`` when unlimited, otherwise a non-negative integer.
+
+    Raises:
+        TypeError: If limit is not an int (bool rejected).
+        ValueError: If limit is negative.
+    """
+    if limit is None:
+        return None
+    if isinstance(limit, bool) or not isinstance(limit, int):
+        raise TypeError(f"limit must be int | None, got {type(limit).__name__}")
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    return limit
+
+
+class PublicationTermExtractionHost(Protocol):
+    """Structural host required by publication-term extraction mixins.
+
+    Composed adapters (e.g. ``PublicationTermDataSource``) provide these
+    attributes; mixin methods use the protocol instead of ``self: Any``.
+    """
+
+    SOURCE_ENTITY_TYPE: str
+    PUBLICATION_LIMIT_MULTIPLIER: int
+    _data_source: DataSourcePort
+
+    def _extract_terms_from_publication(
+        self,
+        record: BronzeRecord,
+        publication_id: str,
+    ) -> list[BronzeRecord]: ...
+
+    def _yield_terms_from_publications(
+        self,
+        publications: AsyncIterator[BronzeRecord],
+        limit: int | None,
+    ) -> AsyncIterator[BronzeRecord]: ...
 
 
 class PublicationTermExtractionMixin:
     """Shared publication->term extraction flow."""
 
     async def _yield_terms_from_publications(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         publications: AsyncIterator[BronzeRecord],
         limit: int | None,
     ) -> AsyncIterator[BronzeRecord]:
         """Expand a publication stream into term records with optional limit."""
+        normalized_limit = normalize_publication_term_limit(limit)
+        if normalized_limit == 0:
+            aclose = getattr(publications, "aclose", None)
+            if callable(aclose):
+                aclose_fn = cast(Callable[[], Awaitable[object]], aclose)
+                await aclose_fn()
+            return
+
         term_count = 0
         try:
             async for publication in publications:
@@ -35,80 +85,66 @@ class PublicationTermExtractionMixin:
                 if not publication_id:
                     continue
                 terms = self._extract_terms_from_publication(
-                    publication, publication_id
+                    publication, str(publication_id)
                 )
                 for term in terms:
                     yield term
                     term_count += 1
-                    if limit and term_count >= limit:
+                    if (
+                        normalized_limit is not None
+                        and term_count >= normalized_limit
+                    ):
                         return
         finally:
             aclose = getattr(publications, "aclose", None)
             if callable(aclose):
-                from collections.abc import Awaitable, Callable
-                from typing import cast
-
                 aclose_fn = cast(Callable[[], Awaitable[object]], aclose)
                 await aclose_fn()
 
     async def _fetch_publication_terms(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         limit: int | None,
         filter_ids: list[str] | None,
         filter_field: str | None,
     ) -> AsyncIterator[BronzeRecord]:
-        """Fetch publications from wrapped source and yield extracted terms.
-        Args:
-            limit: Optional maximum number of term records to yield. The upstream
-                publication fetch uses a multiplied limit to account for term expansion.
-            filter_ids: Optional list of identifier values to pass to the upstream fetch.
-                When None, no ID filter is applied.
-            filter_field: Optional field name on which to filter upstream publications.
-                When None, no field filter is applied.
-        """
-        publication_limit = limit * self.PUBLICATION_LIMIT_MULTIPLIER if limit else None
+        """Fetch publications from wrapped source and yield extracted terms."""
+        normalized_limit = normalize_publication_term_limit(limit)
+        if normalized_limit == 0:
+            return
+
+        publication_limit = (
+            normalized_limit * self.PUBLICATION_LIMIT_MULTIPLIER
+            if normalized_limit is not None
+            else None
+        )
         publications = self._data_source.fetch(
             entity_type=self.SOURCE_ENTITY_TYPE,
             limit=publication_limit,
             filter_ids=filter_ids,
             filter_field=filter_field,
         )
-        async for term in self._yield_terms_from_publications(publications, limit):
+        async for term in self._yield_terms_from_publications(
+            publications, normalized_limit
+        ):
             yield term
 
     def _extract_terms_from_publication(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         record: BronzeRecord,
         publication_id: str,
     ) -> list[BronzeRecord]:
-        """Extract and flatten all terms from a publication record.
-        Args:
-            record: Raw Bronze publication record containing ``mesh_terms`` and ``keywords`` fields.
-            publication_id: Identifier of the parent publication used to link each term record.
-        Returns:
-            List of Bronze term records, one per MeSH heading, MeSH qualifier, or keyword found.
-        """
+        """Extract and flatten all terms from a publication record."""
         return extract_terms_from_publication(record, publication_id)
 
     def _create_term_record(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         publication_id: str,
         term: str,
         term_type: str,
         mesh_id: str | None,
         qualifier: str | None,
     ) -> BronzeRecord:
-        """Create a single publication-term record.
-        Args:
-            publication_id: Identifier of the parent publication.
-            term: Text of the extracted term, stripped of surrounding whitespace.
-            term_type: Controlled vocabulary type (e.g., ``'MESH_HEADING'``, ``'KEYWORD'``).
-            mesh_id: Optional MeSH concept identifier associated with the term.
-            qualifier: Optional MeSH qualifier string. Pass None for non-qualified terms.
-        Returns:
-            Bronze record dict with ``entity_id``, ``publication_id``, ``term``,
-            ``term_type``, ``mesh_id``, and ``qualifier`` fields.
-        """
+        """Create a single publication-term record."""
         return create_term_record(
             publication_id=publication_id,
             term=term,
@@ -118,19 +154,12 @@ class PublicationTermExtractionMixin:
         )
 
     def _compute_entity_id(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         publication_id: str,
         term_type: str,
         term: str,
     ) -> str:
-        """Compute deterministic term entity ID.
-        Args:
-            publication_id: Identifier of the parent publication.
-            term_type: Controlled vocabulary type (e.g., ``'MESH_HEADING'``).
-            term: Normalized term text used as part of the hash input.
-        Returns:
-            Deterministic string entity ID derived from the composite key.
-        """
+        """Compute deterministic term entity ID."""
         return compute_term_entity_id(
             publication_id=publication_id,
             term_type=term_type,
@@ -138,26 +167,29 @@ class PublicationTermExtractionMixin:
         )
 
     async def _fetch_filtered_publication_terms(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermExtractionHost,
         filterable: FilterableDataSourcePort,
         filter_ids: list[str],
         filter_field: str,
         limit: int | None,
     ) -> AsyncIterator[BronzeRecord]:
-        """Fetch filtered publications and yield extracted terms.
-        Args:
-            filterable: Filterable data source port to delegate publication fetching to.
-            filter_ids: List of identifier values to filter upstream publications by.
-            filter_field: Field name on which to apply the filter.
-            limit: Optional maximum number of term records to yield. The upstream
-                publication fetch uses a multiplied limit to account for term expansion.
-        """
-        publication_limit = limit * self.PUBLICATION_LIMIT_MULTIPLIER if limit else None
+        """Fetch filtered publications and yield extracted terms."""
+        normalized_limit = normalize_publication_term_limit(limit)
+        if normalized_limit == 0:
+            return
+
+        publication_limit = (
+            normalized_limit * self.PUBLICATION_LIMIT_MULTIPLIER
+            if normalized_limit is not None
+            else None
+        )
         publications = filterable.fetch_filtered(
             entity_type=self.SOURCE_ENTITY_TYPE,
             filter_ids=filter_ids,
             filter_field=filter_field,
             limit=publication_limit,
         )
-        async for term in self._yield_terms_from_publications(publications, limit):
+        async for term in self._yield_terms_from_publications(
+            publications, normalized_limit
+        ):
             yield term

--- a/src/bioetl/application/core/publication_term_filtering_mixin.py
+++ b/src/bioetl/application/core/publication_term_filtering_mixin.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import AsyncIterator
+from typing import Protocol, cast
 
+from bioetl.application.core.publication_term_extraction_mixin import (
+    PublicationTermExtractionHost,
+    normalize_publication_term_limit,
+)
 from bioetl.application.core.target_data_source_mixins import (
     _FallbackFilterableTargetFetchMixin,
     _FilterableTargetDelegationMixin,
@@ -11,8 +16,17 @@ from bioetl.application.core.target_data_source_mixins import (
 from bioetl.domain.ports import FilterableDataSourcePort
 from bioetl.domain.types import BronzeRecord
 
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+
+class PublicationTermFilteringHost(PublicationTermExtractionHost, Protocol):
+    """Host surface for filterable publication-term delegation."""
+
+    def _fetch_filtered_publication_terms(
+        self,
+        filterable: FilterableDataSourcePort,
+        filter_ids: list[str],
+        filter_field: str,
+        limit: int | None,
+    ) -> AsyncIterator[BronzeRecord]: ...
 
 
 class PublicationTermFilteringMixin(
@@ -22,7 +36,7 @@ class PublicationTermFilteringMixin(
     """FilterableDataSourcePort-compatible delegation for term extraction wrapper."""
 
     async def _fetch_target_filtered_records(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermFilteringHost,
         filterable: FilterableDataSourcePort,
         filter_ids: list[str],
         filter_field: str,
@@ -35,37 +49,55 @@ class PublicationTermFilteringMixin(
             yield record
 
     async def _fetch_target_multi_filtered_records(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermFilteringHost,
         filterable: FilterableDataSourcePort,
         filters: dict[str, list[str]],
         limit: int | None = None,
     ) -> AsyncIterator[BronzeRecord]:
         """Yield publication-term records from multi-filtered upstream publications."""
-        publication_limit = limit * self.PUBLICATION_LIMIT_MULTIPLIER if limit else None
+        normalized_limit = normalize_publication_term_limit(limit)
+        if normalized_limit == 0:
+            return
+        # Treat limit=0 as a hard zero upstream budget (not "unlimited").
+        publication_limit = (
+            normalized_limit * self.PUBLICATION_LIMIT_MULTIPLIER
+            if normalized_limit is not None
+            else None
+        )
         async for record in self._yield_terms_from_publications(
             filterable.fetch_multi_filtered(
                 entity_type=self.SOURCE_ENTITY_TYPE,
                 filters=filters,
                 limit=publication_limit,
             ),
-            limit,
+            normalized_limit,
         ):
             yield record
 
     def _resolve_target_fallback_upstream_limit(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermFilteringHost,
         limit: int | None = None,
     ) -> int | None:
-        """Scale upstream publication fetches to account for term expansion."""
-        return limit * self.PUBLICATION_LIMIT_MULTIPLIER if limit else None
+        """Scale upstream publication fetches to account for term expansion.
+
+        ``limit=0`` remains zero (no upstream fetch), rather than being treated
+        as absent/unlimited via truthiness.
+        """
+        normalized_limit = normalize_publication_term_limit(limit)
+        if normalized_limit is None:
+            return None
+        return normalized_limit * self.PUBLICATION_LIMIT_MULTIPLIER
 
     def _yield_target_records_from_fallback_source_records(
-        self: Any,  # Any: mixin self type is provided structurally by composed adapter class
+        self: PublicationTermFilteringHost,
         source_records: AsyncIterator[object],
         limit: int | None,
     ) -> AsyncIterator[BronzeRecord]:
         """Transform fallback-fetched publications into publication-term records."""
         return cast(
             "AsyncIterator[BronzeRecord]",
-            self._yield_terms_from_publications(source_records, limit),
+            self._yield_terms_from_publications(
+                cast("AsyncIterator[BronzeRecord]", source_records),
+                limit,
+            ),
         )

--- a/src/bioetl/application/core/publication_term_runtime.py
+++ b/src/bioetl/application/core/publication_term_runtime.py
@@ -6,10 +6,23 @@ from bioetl.application.core.entity_id import compute_publication_term_entity_id
 from bioetl.domain.types import BronzeRecord
 
 
+def _as_nonempty_str(value: object) -> str | None:
+    """Return stripped non-empty string content, else None."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def extract_terms_from_publication(
     record: BronzeRecord, publication_id: str
 ) -> list[BronzeRecord]:
-    """Extract and flatten all terms from a publication record."""
+    """Extract and flatten all terms from a publication record.
+
+    MeSH branch validates ``mesh_heading``, ``mesh_qualifier``, and ``mesh_id``
+    as non-whitespace strings before record creation; non-string / blank values
+    are skipped rather than coerced.
+    """
     terms: list[BronzeRecord] = []
     raw_mesh_terms = record.get("mesh_terms")
     mesh_terms: list[object] = (
@@ -18,25 +31,26 @@ def extract_terms_from_publication(
     for mesh in mesh_terms:
         if not isinstance(mesh, dict):
             continue
-        mesh_heading = mesh.get("mesh_heading")
-        if mesh_heading:
+        mesh_heading = _as_nonempty_str(mesh.get("mesh_heading"))
+        mesh_qualifier = _as_nonempty_str(mesh.get("mesh_qualifier"))
+        mesh_id = _as_nonempty_str(mesh.get("mesh_id"))
+        if mesh_heading is not None:
             terms.append(
                 create_term_record(
                     publication_id=publication_id,
                     term=mesh_heading,
                     term_type="MESH_HEADING",
-                    mesh_id=mesh.get("mesh_id"),
-                    qualifier=mesh.get("mesh_qualifier"),
+                    mesh_id=mesh_id,
+                    qualifier=mesh_qualifier,
                 )
             )
-        mesh_qualifier = mesh.get("mesh_qualifier")
-        if mesh_qualifier:
+        if mesh_qualifier is not None:
             terms.append(
                 create_term_record(
                     publication_id=publication_id,
                     term=mesh_qualifier,
                     term_type="MESH_QUALIFIER",
-                    mesh_id=mesh.get("mesh_id"),
+                    mesh_id=mesh_id,
                     qualifier=None,
                 )
             )
@@ -68,6 +82,10 @@ def create_term_record(
 ) -> BronzeRecord:
     """Create a single publication-term record."""
     normalized_term = term.strip() if term else term
+    normalized_mesh_id = _as_nonempty_str(mesh_id) if mesh_id is not None else None
+    normalized_qualifier = (
+        _as_nonempty_str(qualifier) if qualifier is not None else None
+    )
     entity_id = compute_term_entity_id(
         publication_id=publication_id,
         term_type=term_type,
@@ -78,8 +96,8 @@ def create_term_record(
         "publication_id": publication_id,
         "term": normalized_term,
         "term_type": term_type,
-        "mesh_id": mesh_id,
-        "qualifier": qualifier,
+        "mesh_id": normalized_mesh_id,
+        "qualifier": normalized_qualifier,
     }
 
 

--- a/tests/unit/application/core/test_publication_term_runtime.py
+++ b/tests/unit/application/core/test_publication_term_runtime.py
@@ -92,3 +92,61 @@ def test_extract_terms_from_publication_preserves_mesh_shape_and_keyword_semanti
     assert terms[1]["qualifier"] is None
     assert terms[2]["term"] == "kinase"
     assert terms[3]["term"] == "inhibitor"
+
+
+def test_extract_mesh_rejects_non_string_and_blank_fields() -> None:
+    publication = {
+        "mesh_terms": [
+            {
+                "mesh_heading": "  ",
+                "mesh_id": "D1",
+                "mesh_qualifier": "use",
+            },
+            {
+                "mesh_heading": 123,
+                "mesh_id": "D2",
+                "mesh_qualifier": "x",
+            },
+            {
+                "mesh_heading": "valid heading",
+                "mesh_id": 999,
+                "mesh_qualifier": "  ",
+            },
+            {
+                "mesh_heading": "kinase",
+                "mesh_id": " D004791 ",
+                "mesh_qualifier": " therapeutic use ",
+            },
+        ],
+        "keywords": ["ok", "  ", 5, None],
+    }
+
+    terms = extract_terms_from_publication(publication, "CHEMBL9")
+
+    # blank heading skipped; non-str heading skipped; blank qualifier omitted;
+    # valid heading kept with non-str mesh_id -> None; last mesh has full fields
+    types = [t["term_type"] for t in terms]
+    assert "KEYWORD" in types
+    assert types.count("KEYWORD") == 1
+    assert terms[-1]["term"] == "ok" or any(t["term"] == "ok" for t in terms)
+
+    heading = next(t for t in terms if t["term"] == "kinase")
+    assert heading["term_type"] == "MESH_HEADING"
+    assert heading["mesh_id"] == "D004791"
+    assert heading["qualifier"] == "therapeutic use"
+
+    qualifier = next(t for t in terms if t["term"] == "therapeutic use")
+    assert qualifier["term_type"] == "MESH_QUALIFIER"
+    assert qualifier["mesh_id"] == "D004791"
+
+
+def test_create_term_record_normalizes_mesh_id_and_qualifier() -> None:
+    record = create_term_record(
+        publication_id="CHEMBL1",
+        term="enzyme",
+        term_type="MESH_HEADING",
+        mesh_id="  D1  ",
+        qualifier="  use  ",
+    )
+    assert record["mesh_id"] == "D1"
+    assert record["qualifier"] == "use"

--- a/tests/unit/application/core/test_publication_term_s5_residuals.py
+++ b/tests/unit/application/core/test_publication_term_s5_residuals.py
@@ -1,0 +1,106 @@
+# pyright: reportArgumentType=false
+"""S5 publication_term residual coverage for #7762 #7845 #7846."""
+
+from __future__ import annotations
+
+import pytest
+
+from bioetl.application.core.data_sources.publication_term import (
+    PublicationTermDataSource,
+)
+from bioetl.application.core.publication_term_extraction_mixin import (
+    normalize_publication_term_limit,
+)
+from bioetl.application.core.publication_term_runtime import (
+    create_term_record,
+    extract_terms_from_publication,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_normalize_publication_term_limit_accepts_zero_and_rejects_invalid() -> None:
+    assert normalize_publication_term_limit(None) is None
+    assert normalize_publication_term_limit(0) == 0
+    assert normalize_publication_term_limit(3) == 3
+    with pytest.raises(ValueError, match="limit must be >= 0"):
+        normalize_publication_term_limit(-1)
+    with pytest.raises(TypeError):
+        normalize_publication_term_limit(True)  # type: ignore[arg-type]
+
+
+def test_resolve_target_fallback_upstream_limit_treats_zero_as_zero() -> None:
+    class _Src:
+        async def fetch(self, **kwargs):  # type: ignore[no-untyped-def]
+            if False:
+                yield {}
+            raise AssertionError("upstream fetch must not run for pure limit math")
+
+    wrapper = PublicationTermDataSource(data_source=_Src())  # type: ignore[arg-type]
+    assert wrapper._resolve_target_fallback_upstream_limit(0) == 0
+    assert wrapper._resolve_target_fallback_upstream_limit(2) == (
+        2 * PublicationTermDataSource.PUBLICATION_LIMIT_MULTIPLIER
+    )
+    assert wrapper._resolve_target_fallback_upstream_limit(None) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_limit_zero_yields_empty_without_upstream_records() -> None:
+    class _Src:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def fetch(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            if False:
+                yield {}
+
+    source = _Src()
+    wrapper = PublicationTermDataSource(data_source=source)  # type: ignore[arg-type]
+    terms = [term async for term in wrapper.fetch("publication_term", limit=0)]
+    assert terms == []
+    assert source.calls == 0
+
+
+def test_extract_mesh_rejects_non_string_and_blank_fields() -> None:
+    publication = {
+        "mesh_terms": [
+            {
+                "mesh_heading": "  ",
+                "mesh_id": "D1",
+                "mesh_qualifier": "use",
+            },
+            {
+                "mesh_heading": 123,
+                "mesh_id": "D2",
+                "mesh_qualifier": "x",
+            },
+            {
+                "mesh_heading": "kinase",
+                "mesh_id": " D004791 ",
+                "mesh_qualifier": " therapeutic use ",
+            },
+        ],
+        "keywords": ["ok", "  ", 5, None],
+    }
+    terms = extract_terms_from_publication(publication, "CHEMBL9")
+    assert sum(1 for t in terms if t["term_type"] == "KEYWORD") == 1
+    heading = next(t for t in terms if t["term"] == "kinase")
+    assert heading["mesh_id"] == "D004791"
+    assert heading["qualifier"] == "therapeutic use"
+    qualifier = next(t for t in terms if t["term"] == "therapeutic use")
+    assert qualifier["term_type"] == "MESH_QUALIFIER"
+    # blank heading with qualifier still yields MESH_QUALIFIER only
+    assert any(t["term"] == "use" and t["term_type"] == "MESH_QUALIFIER" for t in terms)
+
+
+def test_create_term_record_normalizes_mesh_id_and_qualifier() -> None:
+    record = create_term_record(
+        publication_id="CHEMBL1",
+        term="enzyme",
+        term_type="MESH_HEADING",
+        mesh_id="  D1  ",
+        qualifier="  use  ",
+    )
+    assert record["mesh_id"] == "D1"
+    assert record["qualifier"] == "use"


### PR DESCRIPTION
## Summary

Closes S5 publication_term residual majors:

- #7762 `publication_term_extraction_mixin.py`
- #7845 `publication_term_filtering_mixin.py`
- #7846 `publication_term_runtime.py`

### Changes
- Replace `self: Any` with structural `PublicationTermExtractionHost` / `PublicationTermFilteringHost` protocols
- Validate/normalize term `limit` (`None` | `>=0` int); `limit=0` short-circuits without upstream fetch
- Treat `limit=0` as zero in fallback upstream limit scaling (`is not None`, not truthiness)
- MeSH extraction accepts only non-whitespace strings for heading/qualifier/id

### Tests
- Extended runtime contracts + `test_publication_term_s5_residuals.py`
- Full publication_term unit suite green

Closes #7762
Closes #7845
Closes #7846
