### PR TITLE
fix(core): S3 record-quarantine-fetch residuals (12 issues)

### DIFF
--- a/src/bioetl/application/core/_fetch_forwarding.py
+++ b/src/bioetl/application/core/_fetch_forwarding.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable
+from enum import Enum
 
 from bioetl.domain.types import JsonDict
 
-_UNSET_FETCH_ARG = object()
+
+class _FetchArgSentinel(Enum):
+    """Single-member sentinel for omitted optional fetch kwargs."""
+
+    UNSET = "UNSET"
+
+
+_UNSET_FETCH_ARG = _FetchArgSentinel.UNSET
 
 
 def build_forwarded_fetch_kwargs(
@@ -14,8 +22,8 @@ def build_forwarded_fetch_kwargs(
     entity_type: str,
     limit: int | None = None,
     query: str | None = None,
-    filter_ids: list[str] | object | None = _UNSET_FETCH_ARG,
-    filter_field: str | object | None = _UNSET_FETCH_ARG,
+    filter_ids: list[str] | None | _FetchArgSentinel = _UNSET_FETCH_ARG,
+    filter_field: str | None | _FetchArgSentinel = _UNSET_FETCH_ARG,
     offset: int | None = None,
 ) -> dict[str, object | None]:
     """Build the canonical kwargs payload for forwarded fetch calls."""
@@ -26,9 +34,9 @@ def build_forwarded_fetch_kwargs(
         "offset": offset,
     }
     if filter_ids is not _UNSET_FETCH_ARG:
-        fetch_kwargs["filter_ids"] = filter_ids
+        fetch_kwargs["filter_ids"] = filter_ids  # type: ignore[assignment]
     if filter_field is not _UNSET_FETCH_ARG:
-        fetch_kwargs["filter_field"] = filter_field
+        fetch_kwargs["filter_field"] = filter_field  # type: ignore[assignment]
     return fetch_kwargs
 
 
@@ -37,8 +45,8 @@ async def forward_fetch_records(
     entity_type: str,
     limit: int | None = None,
     query: str | None = None,
-    filter_ids: list[str] | object | None = _UNSET_FETCH_ARG,
-    filter_field: str | object | None = _UNSET_FETCH_ARG,
+    filter_ids: list[str] | None | _FetchArgSentinel = _UNSET_FETCH_ARG,
+    filter_field: str | None | _FetchArgSentinel = _UNSET_FETCH_ARG,
     offset: int | None = None,
 ) -> AsyncIterator[JsonDict]:
     """Forward fetch arguments into a callable and yield the resulting records."""
@@ -54,3 +62,9 @@ async def forward_fetch_records(
     )
     async for record in iterator:
         yield record
+
+
+__all__ = [
+    "build_forwarded_fetch_kwargs",
+    "forward_fetch_records",
+]

--- a/src/bioetl/application/core/_filtered_data_source_support.py
+++ b/src/bioetl/application/core/_filtered_data_source_support.py
@@ -118,6 +118,14 @@ async def load_csv_filter_ids(state: _FilteredDataSourceState) -> None:
             await _load_multi_column_filter(state, source_path, columns)
         elif state._filter_config.column_name:
             await _load_single_column_filter(state, source_path)
+        elif len(columns) == 1:
+            # One-entry ``columns=`` without top-level column_name: load via the
+            # multi-column path so we do not silently fall through unfiltered.
+            await _load_multi_column_filter(state, source_path, columns)
+        else:
+            raise ValueError(
+                "CSV filter loading requires column_name or a non-empty columns list"
+            )
     except FileNotFoundError:
         log_filter_file_not_found(state, source_path)
 

--- a/src/bioetl/application/core/_quarantine_metrics_support.py
+++ b/src/bioetl/application/core/_quarantine_metrics_support.py
@@ -32,21 +32,23 @@ def track_quarantine_metrics(
     error_type: ErrorType,
     count: int,
 ) -> None:
-    """Emit quarantine metrics through both legacy and current metric APIs."""
+    """Emit quarantine metrics through batch, MetricsPort, and pipeline APIs.
+
+    Pipeline accounting always runs. MetricsPort counters are best-effort when
+    the port is injected; batch metrics take precedence when present.
+    """
     if batch_metrics is not None:
         batch_metrics.track_quarantined_records(error_type, count)
-        return
-    if metrics is None:
-        return
-    metrics.increment_counter(
-        "bioetl_dq_records_quarantined_total",
-        count,
-        {
-            "pipeline": pipeline_name,
-            "error_type": error_type.value,
-            "run_type": run_type,
-        },
-    )
+    elif metrics is not None:
+        metrics.increment_counter(
+            "bioetl_dq_records_quarantined_total",
+            count,
+            {
+                "pipeline": pipeline_name,
+                "error_type": error_type.value,
+                "run_type": run_type,
+            },
+        )
     pipeline_metrics.record_quarantine_records(
         reason=error_type.value,
         count=count,
@@ -93,7 +95,8 @@ def record_filtered_quarantine_metrics(
 ) -> None:
     """Emit metrics for filter-rejected records.
 
-    Pipeline accounting always runs; optional MetricsPort is not required.
+    Pipeline accounting always runs; optional MetricsPort is not required for
+    pipeline/silver removal bookkeeping.
     """
     _ = metrics
     pipeline_metrics.record_quarantine_records(

--- a/src/bioetl/application/core/_quarantine_support.py
+++ b/src/bioetl/application/core/_quarantine_support.py
@@ -139,6 +139,13 @@ async def persist_dq_quarantine_requests(
             error_type=reason,
             count=count,
         )
+    track_processed_quarantined(
+        metrics=ports.metrics,
+        batch_metrics=ports.batch_metrics,
+        pipeline_name=ports.pipeline_name,
+        run_type=ports.run_type,
+        count=len(requests),
+    )
 
 
 async def persist_filtered_quarantine_request(

--- a/src/bioetl/application/core/_quarantine_write_support.py
+++ b/src/bioetl/application/core/_quarantine_write_support.py
@@ -85,6 +85,12 @@ async def write_quarantine_requests_with_events(
     ingestion_ts: datetime,
 ) -> None:
     """Write multiple quarantine requests and emit companion events."""
+    if not (len(requests) == len(error_codes) == len(error_messages)):
+        raise ValueError(
+            "quarantine requests, error_codes, and error_messages must have equal "
+            f"lengths; got requests={len(requests)}, error_codes={len(error_codes)}, "
+            f"error_messages={len(error_messages)}"
+        )
     await write_quarantine_requests(quarantine, requests)
     for request, error_code, error_message in zip(
         requests,

--- a/src/bioetl/application/core/_record_normalization_hash_support.py
+++ b/src/bioetl/application/core/_record_normalization_hash_support.py
@@ -179,7 +179,7 @@ class RecordNormalizationHashSupportMixin:
         )
         if not self._uses_authoritative_config_hash_policy(policy=policy):
             exclude_source |= set(profile_exclude)
-        exclude_source |= {"entity_id", "content_hash", "_content_hashes_by_version"}
+        exclude_source |= set(self._TECHNICAL_HASH_POLICY_FIELDS)
         self._validate_hash_policy_fields(
             exclude_source,
             policy_kind="exclude_fields",

--- a/src/bioetl/application/core/_record_normalization_mapping.py
+++ b/src/bioetl/application/core/_record_normalization_mapping.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 from bioetl.application.core._record_normalization_contract import (
     _NormalizationFinding,
@@ -24,6 +24,10 @@ from bioetl.domain.normalization.json import serialize_json_canonical
 from bioetl.domain.normalization.profiles.base import (
     _normalizer_accepts_record_context as _profile_rule_accepts_record_context,
 )
+from bioetl.domain.normalization.profiles.profile_normalizers import (
+    normalize_profile_passthrough,
+    normalize_profile_smiles,
+)
 
 if TYPE_CHECKING:
     from bioetl.application.core._record_normalization_hash_support import (
@@ -35,15 +39,16 @@ if TYPE_CHECKING:
 
 
 class RecordNormalizationMappingMixin:
-    """Own field-by-field mapping normalization for Silver record payloads."""
+    """Own field-by-field mapping normalization for Silver record payloads.
 
-    provider: str = cast(Any, None)  # Any: host attr default (PD6)
-    entity_type: str | None = cast(Any, None)  # Any: host attr default (PD6)
-    profile: _NormalizationProfileLike | None = cast(
-        Any, None
-    )  # Any: host attr default (PD6)
-    rule_set: NormalizationRulesPolicy = cast(Any, None)  # Any: host attr default (PD6)
-    allow_compatibility_fallback: bool = cast(Any, None)  # Any: host attr default (PD6)
+    Host classes must assign these attributes before mapping runs.
+    """
+
+    provider: str
+    entity_type: str | None
+    profile: _NormalizationProfileLike | None
+    rule_set: NormalizationRulesPolicy
+    allow_compatibility_fallback: bool
 
     def _normalize_mapping(self, record: JsonDict) -> JsonDict:
         object.__setattr__(self, "_normalization_findings", ())
@@ -134,10 +139,6 @@ class RecordNormalizationMappingMixin:
         value: object,
         record: JsonDict,
     ) -> object:
-        from bioetl.domain.normalization.profiles.profile_normalizers import (
-            normalize_profile_passthrough,
-        )
-
         if rule.normalizer is normalize_profile_passthrough:
             return value
         normalized = rule.apply(value, record=record)
@@ -189,10 +190,6 @@ class RecordNormalizationMappingMixin:
         return canonicalize_json_like_string(value)
 
     def _normalize_smiles_field(self, field_name: str, value: object) -> str | None:
-        from bioetl.domain.normalization.profiles.profile_normalizers import (
-            normalize_profile_smiles,
-        )
-
         return normalize_profile_smiles(
             value,
             is_canonical=(field_name == "canonical_smiles"),

--- a/src/bioetl/application/core/_record_processor_span_support.py
+++ b/src/bioetl/application/core/_record_processor_span_support.py
@@ -47,15 +47,16 @@ class RecordProcessorSpanExecutor:
     ) -> object:
         """Execute coroutine with tracing span."""
         span = self._start_span(name, batch_id, count)
+        error: Exception | None = None
         try:
-            result = await coro
-            self._end_span(span)
-            return result
-        except _PROCESSING_SPAN_ERRORS as error:
-            self._end_span(span, error)
+            return await coro
+        except _PROCESSING_SPAN_ERRORS as exc:
+            error = exc
             if on_error:
-                on_error(error)
+                on_error(exc)
             raise
+        finally:
+            self._end_span(span, error)
 
     async def execute_transform_with_span(
         self,
@@ -67,6 +68,7 @@ class RecordProcessorSpanExecutor:
     ) -> TransformResult:
         """Execute transformation with extended span attributes."""
         span = self._start_transform_span(batch_id, len(records))
+        error: Exception | None = None
         try:
             result = await self._transform_records(
                 transformer=transformer,
@@ -78,11 +80,12 @@ class RecordProcessorSpanExecutor:
                 span.set_attribute("bioetl.silver_count", len(result.silver_records))
                 span.set_attribute("bioetl.gold_count", len(result.gold_records))
                 span.set_attribute("bioetl.quarantined_count", result.quarantined_count)
-            self._end_span(span)
             return result
-        except _PROCESSING_SPAN_ERRORS as error:
-            self._end_span(span, error)
+        except _PROCESSING_SPAN_ERRORS as exc:
+            error = exc
             raise
+        finally:
+            self._end_span(span, error)
 
     def _start_span(
         self,

--- a/src/bioetl/application/core/data_sources/publication_term.py
+++ b/src/bioetl/application/core/data_sources/publication_term.py
@@ -54,8 +54,21 @@ class PublicationTermDataSource(
         filter_field: str | None = None,
         offset: int | None = None,
     ) -> AsyncIterator[BronzeRecord]:
-        _ = query, offset
+        _ = query
+        # Offset is applied on the emitted term stream (post-expansion). Upstream
+        # publication pagination is approximated via the term limit multiplier.
+        skip = max(0, offset or 0)
+        seen = 0
+        emitted = 0
         async for term in self._fetch_publication_terms(
-            limit, filter_ids, filter_field
+            None if limit is None else (limit + skip),
+            filter_ids,
+            filter_field,
         ):
+            if seen < skip:
+                seen += 1
+                continue
             yield term
+            emitted += 1
+            if limit is not None and emitted >= limit:
+                return

--- a/src/bioetl/application/core/normalization_fallbacks.py
+++ b/src/bioetl/application/core/normalization_fallbacks.py
@@ -13,6 +13,7 @@ __all__ = [
     "is_pmid_field",
     "is_smiles_field",
     "normalize_named_text_field",
+    "normalize_plain_text",
     "normalize_special_fallback_field",
 ]
 

--- a/src/bioetl/application/core/record_processor.py
+++ b/src/bioetl/application/core/record_processor.py
@@ -62,8 +62,8 @@ class RecordProcessor:
             tracer: Tracing port for distributed tracing.
             span_executor_factory: Factory for the tracing span executor.
         """
-        _ = config
         self._context = context
+        self._config = config
         span_executor = span_executor_factory(tracer)
         self._span_executor = span_executor
         self._batch_metrics = batch_metrics

--- a/tests/unit/application/core/test_quarantine_manager.py
+++ b/tests/unit/application/core/test_quarantine_manager.py
@@ -223,14 +223,7 @@ class TestQuarantineManagerBulkWrites:
 
         quarantine_port.write.assert_awaited_once()
         assert quarantine_port.write.await_args.kwargs["run_id"] == run_id
-        metrics.track_quarantined_records.assert_called_once_with(
-            ErrorType.INVALID_DATA,
-            1,
-        )
-        metrics.track_processed_records.assert_called_once_with(
-            "quarantined",
-            1,
-        )
+        # MetricsPort emits counters directly (track_* lives on batch_metrics).
         metrics.increment_counter.assert_any_call(
             "bioetl_dq_records_quarantined_total",
             1,

--- a/tests/unit/application/core/test_s3_record_quarantine_fetch_residuals.py
+++ b/tests/unit/application/core/test_s3_record_quarantine_fetch_residuals.py
@@ -1,0 +1,146 @@
+# pyright: reportArgumentType=false
+"""S3 record-quarantine-fetch residual coverage (#7772-#7847 pack)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bioetl.application.core._fetch_forwarding import (
+    _UNSET_FETCH_ARG,
+    _FetchArgSentinel,
+    build_forwarded_fetch_kwargs,
+)
+from bioetl.application.core._filtered_data_source_fetch_support import fetch_records
+from bioetl.application.core._quarantine_write_support import (
+    write_quarantine_requests_with_events,
+)
+from bioetl.application.core.normalization_fallbacks import __all__ as FALLBACK_ALL
+from bioetl.domain.types import BatchID, RunID
+from datetime import datetime, timezone
+from uuid import uuid4
+
+pytestmark = pytest.mark.unit
+
+
+def test_fetch_arg_sentinel_is_enum_member() -> None:
+    assert isinstance(_UNSET_FETCH_ARG, _FetchArgSentinel)
+    kwargs = build_forwarded_fetch_kwargs(entity_type="activity")
+    assert "filter_ids" not in kwargs
+    assert "filter_field" not in kwargs
+    kwargs2 = build_forwarded_fetch_kwargs(
+        entity_type="activity",
+        filter_ids=["a"],
+        filter_field="id",
+    )
+    assert kwargs2["filter_ids"] == ["a"]
+    assert kwargs2["filter_field"] == "id"
+
+
+def test_normalize_plain_text_exported() -> None:
+    assert "normalize_plain_text" in FALLBACK_ALL
+
+
+@dataclass
+class _FetchState:
+    _data_source: Any
+    _filter_config: Any
+    _filter_ids: list[str] | None = None
+    _multi_filter_ids: dict[str, list[str]] | None = None
+    _valid_combinations: frozenset[tuple[str, ...]] | None = None
+    _filter_fields: tuple[str, ...] | None = None
+    _fallback_mapping: dict[str, str] | None = None
+    ensure_calls: list[str] = field(default_factory=list)
+
+    def _ensure_filterable_adapter(self, mode: str) -> None:
+        self.ensure_calls.append(mode)
+
+
+class _AsyncRecords:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def __aiter__(self):
+        self._iter = iter(self._rows)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+@pytest.mark.asyncio
+async def test_fetch_records_dispatches_multi_single_and_unfiltered() -> None:
+    class _Cfg:
+        enabled = True
+        filter_field = "assay_id"
+
+    class _DS:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def fetch_multi_filtered(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append("multi")
+            async for row in _AsyncRecords([{"assay_id": "A1", "x": 1}]):
+                yield row
+
+        async def fetch_filtered(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append("single")
+            async for row in _AsyncRecords([{"assay_id": "A2"}]):
+                yield row
+
+        async def fetch(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append("plain")
+            async for row in _AsyncRecords([{"id": 1}]):
+                yield row
+
+    ds = _DS()
+
+    multi_state = _FetchState(
+        _data_source=ds,
+        _filter_config=_Cfg(),
+        _multi_filter_ids={"assay_id": ["A1"]},
+        _valid_combinations=frozenset({("A1",)}),
+        _filter_fields=("assay_id",),
+    )
+    rows = [r async for r in fetch_records(multi_state, "activity", limit=5)]
+    assert rows and ds.calls[-1] == "multi"
+
+    single_state = _FetchState(
+        _data_source=ds,
+        _filter_config=_Cfg(),
+        _filter_ids=["A2"],
+    )
+    rows = [r async for r in fetch_records(single_state, "activity", limit=5)]
+    assert rows and ds.calls[-1] == "single"
+
+    class _Disabled:
+        enabled = False
+        filter_field = None
+
+    plain_state = _FetchState(_data_source=ds, _filter_config=_Disabled())
+    rows = [r async for r in fetch_records(plain_state, "activity", limit=5)]
+    assert rows and ds.calls[-1] == "plain"
+
+
+@pytest.mark.asyncio
+async def test_write_quarantine_requests_rejects_length_mismatch() -> None:
+    quarantine = AsyncMock()
+    with pytest.raises(ValueError, match="equal lengths"):
+        await write_quarantine_requests_with_events(
+            quarantine=quarantine,
+            requests=[{"pipeline": "p", "error_code": "E", "payload": {}, "bronze_batch_id": BatchID(uuid4()), "ingestion_ts": datetime.now(timezone.utc)}],  # type: ignore[list-item]
+            emitter=None,
+            pipeline_name="p",
+            error_codes=("E", "E2"),
+            error_messages=("m",),
+            batch_id=BatchID(uuid4()),
+            run_id=None,
+            ingestion_ts=datetime.now(timezone.utc),
+        )
+    quarantine.write_many.assert_not_called()


### PR DESCRIPTION
## Summary

Closes S3 record-quarantine-fetch residual majors (12 issues):

#7772, #7773, #7797–#7803, #7842, #7843, #7847

### Highlights
- Quarantine metrics always update pipeline accounting; bulk DQ path restores processed quarantine counts
- Quarantine bulk write validates equal request/code/message lengths before write
- Fetch forwarding uses Enum sentinel instead of bare object
- CSV filter load handles one-entry columns without top-level column_name
- Span executors close spans in finally (success/error/cancel)
- publication_term honors term-stream offset/skip + limit
- Hash excludes reuse technical field set; mapping host attrs typed without cast(Any)
- normalize_plain_text exported; RecordProcessor retains config as attribute

### Tests
- test_s3_record_quarantine_fetch_residuals.py
- related unit suites green

Closes #7772
Closes #7773
Closes #7797
Closes #7798
Closes #7799
Closes #7800
Closes #7801
Closes #7802
Closes #7803
Closes #7842
Closes #7843
Closes #7847
