### PR TITLE
fix(core): close S2 runner-flow residuals #7784 #7786 #7848

### DIFF
--- a/src/bioetl/application/core/runner_flow_metrics.py
+++ b/src/bioetl/application/core/runner_flow_metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from bioetl.application.runtime_clock import current_utc_time
 
@@ -122,7 +122,7 @@ def record_flow_invariants(
 
 def _record_count_flow_invariants(
     *,
-    pipeline_metrics: object,
+    pipeline_metrics: PipelineMetricsRecorder,
     run_type: str,
     fetched: int,
     bronze: int,
@@ -133,8 +133,7 @@ def _record_count_flow_invariants(
     filtered_out: int,
 ) -> None:
     """Record record-count invariant results for one completed run."""
-    typed_pipeline_metrics = cast("PipelineMetricsRecorder", pipeline_metrics)
-    typed_pipeline_metrics.record_flow_invariant(
+    pipeline_metrics.record_flow_invariant(
         run_type=run_type,
         invariant="fetched_equals_bronze",
         status=_equality_invariant_status(
@@ -144,7 +143,7 @@ def _record_count_flow_invariants(
         ),
     )
     partition_total = silver + quarantined + filtered_out
-    typed_pipeline_metrics.record_flow_invariant(
+    pipeline_metrics.record_flow_invariant(
         run_type=run_type,
         invariant="bronze_partitioned",
         status=_equality_invariant_status(
@@ -153,7 +152,7 @@ def _record_count_flow_invariants(
             observed=bronze > 0 or partition_total > 0,
         ),
     )
-    typed_pipeline_metrics.record_flow_invariant(
+    pipeline_metrics.record_flow_invariant(
         run_type=run_type,
         invariant="silver_gold_monotonic",
         status=_monotonic_invariant_status(
@@ -163,7 +162,7 @@ def _record_count_flow_invariants(
         ),
     )
     gold_terminal = gold + gold_excluded_by_contract
-    typed_pipeline_metrics.record_flow_invariant(
+    pipeline_metrics.record_flow_invariant(
         run_type=run_type,
         invariant="silver_gold_terminal_accounted",
         status=_monotonic_invariant_status(
@@ -191,7 +190,7 @@ def _monotonic_invariant_status(*, upper: int, lower: int, observed: bool) -> st
 def _record_stage_lag_gauges(
     *,
     host: _PipelineRunnerFlowHostProtocol,
-    pipeline_metrics: object,
+    pipeline_metrics: PipelineMetricsRecorder,
     run_type: str,
     ingestion_backlog: int,
     validation_backlog: int,
@@ -204,18 +203,17 @@ def _record_stage_lag_gauges(
         lag_seconds = 0.0
     else:
         lag_seconds = max(0.0, (current_time_fn() - started_at).total_seconds())
-    typed_pipeline_metrics = cast("PipelineMetricsRecorder", pipeline_metrics)
-    typed_pipeline_metrics.record_stage_lag_seconds(
+    pipeline_metrics.record_stage_lag_seconds(
         run_type=run_type,
         stage="ingestion",
         seconds=lag_seconds if ingestion_backlog > 0 else 0.0,
     )
-    typed_pipeline_metrics.record_stage_lag_seconds(
+    pipeline_metrics.record_stage_lag_seconds(
         run_type=run_type,
         stage="validation",
         seconds=lag_seconds if validation_backlog > 0 else 0.0,
     )
-    typed_pipeline_metrics.record_stage_lag_seconds(
+    pipeline_metrics.record_stage_lag_seconds(
         run_type=run_type,
         stage="output",
         seconds=lag_seconds if output_backlog > 0 else 0.0,


### PR DESCRIPTION
## Summary

Closes CR-FULL Wave A major residuals for the S2 **runner-flow** slice:

- **#7848** — type `pipeline_metrics` as `PipelineMetricsRecorder` in `runner_flow_metrics` helpers and drop redundant `cast`/`object` seams.
- **#7784** — confirm already on `main`: pre-silver finalization shares normalize→hash→build→project via `_get_record_normalizer` / `_project_hashed_silver_record` / `_finalize_business_data_with_entity_id`.
- **#7786** — confirm already on `main`: terminal shutdown recorded only in outer `run()`, and finalize/cleanup are independently guarded.

## Changes

- `src/bioetl/application/core/runner_flow_metrics.py`: `PipelineMetricsRecorder` parameter types; remove local `cast` aliases.

## Evidence (code wins)

| Issue | Verdict | Anchor |
|-------|---------|--------|
| #7784 | already fixed on main | `_get_record_normalizer`, `_project_hashed_silver_record`, `_finalize_business_data_with_entity_id` in `pre_silver_finalization_flow.py` |
| #7786 | already fixed on main | outer-only `_record_terminal_shutdown` + dual try/except in `runner.run()` finally |
| #7848 | fixed in this PR | typed helpers, no `object`+`cast` |

## Checks

- [x] `pytest` unit: `test_runner.py`, `test_runner_flow.py`, `test_runner_execution_flow.py`, `test_pipeline_metrics.py` — green
- [ ] `make lint` / full architecture suite — skipped (typing-only + confirm-on-main)
- [x] No tech-debt budget growth
- [x] No hardcoded secrets

## Checklist

- [x] Conventional Commits title
- [x] Root-cause slice PR for three issues
- [x] Documentation N/A (typing / already-landed behavior)

Closes #7784
Closes #7786
Closes #7848