### PR TITLE
docs(ai): CYCLE-02 memory docs residual equal-peer anchors

### DIFF
--- a/docs/00-project/ai/agents/policy/AI_RUNTIME_MIRROR_OWNERSHIP.md
+++ b/docs/00-project/ai/agents/policy/AI_RUNTIME_MIRROR_OWNERSHIP.md
@@ -7,7 +7,7 @@ Owner: BioETL Team
 Reviewers:
 
 - BioETL Team
-  Last verified: '2026-04-26'
+  Last verified: '2026-08-06'
 
 ______________________________________________________________________
 

--- a/docs/00-project/ai/memory/README.md
+++ b/docs/00-project/ai/memory/README.md
@@ -43,8 +43,10 @@ profiles в BioETL.
 
 If a runtime profile is renamed or added, update this matrix and the matching
 tracked runtime profile anchors in the same change set. On the current `main`
-checkout that means `.codex/agents/*.md`; a Gemini agent tree is not tracked on
-`main` today.
+checkout that means equal-peer trees `.codex/agents/*.md` and
+`.junie/agents/*.md` (parity via `scripts/ai/junie/check_junie_mirror.sh`), plus
+`.devin/agents/**` for Devin-specific profiles. A Gemini agent tree
+(`.gemini/agents/**`) is not tracked on `main` today.
 - **Machine-readable memory artifact**:
   `mcp-memory.json`
   — служебный memory snapshot для tooling/integration сценариев, не human


### PR DESCRIPTION
## Summary
CYCLE-02 differential remediation for AI agent memory audit.

- Fix residual Codex-only profile anchor in `docs/00-project/ai/memory/README.md` (#8080)
- Refresh `AI_RUNTIME_MIRROR_OWNERSHIP.md` last verified date
- Architecturally closed #8051 (reject move of `src/memory` → `scripts/memory`)

## Verification
- Regression: MEM-JUNIE-RUNTIME present; MEMORY_USAGE equal-peer text intact
- No product code change this cycle

Closes #8080