### PR TITLE
fix(ai): CYCLE-03 skill entrypoints and AI memory issue closeout

### DIFF
--- a/.codex/skills/py-architecture-debt-bot/SKILL.md
+++ b/.codex/skills/py-architecture-debt-bot/SKILL.md
@@ -21,8 +21,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 

--- a/.junie/skills/py-architecture-debt-bot/SKILL.md
+++ b/.junie/skills/py-architecture-debt-bot/SKILL.md
@@ -21,8 +21,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 

--- a/configs/quality/scripts_inventory_manifest.json
+++ b/configs/quality/scripts_inventory_manifest.json
@@ -1,10 +1,11 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2026-08-06T09:17:05.817782+00:00",
+  "generated_at": "2026-08-06T14:42:08.128066+00:00",
   "summary": {
-    "total_scripts": 574,
+    "total_scripts": 581,
     "status_counts": {
-      "active": 341,
+      "active": 343,
+      "orphan": 5,
       "supporting": 228,
       "temporary_diagnostic": 5
     },
@@ -12,9 +13,9 @@
       "agents": 12,
       "build": 16,
       "ci": 77,
-      "docs": 232,
+      "docs": 233,
       "other": 81,
-      "scripts": 456,
+      "scripts": 458,
       "skills": 18,
       "tests": 366
     }
@@ -5891,8 +5892,14 @@
       "type": "py",
       "status": "active",
       "agent_usage": [],
-      "reference_count": 13,
+      "reference_count": 14,
       "references": [
+        {
+          "path": "docs/00-project/governance/documentation-update-plan.md",
+          "line": 34,
+          "source_group": "docs",
+          "text": "- Генератор: `scripts/diagrams/generate_pipeline_dataflows.py`"
+        },
         {
           "path": "docs/03-guides/pipeline-configuration.md",
           "line": 930,
@@ -5934,12 +5941,6 @@
           "line": 193,
           "source_group": "docs",
           "text": "python scripts/diagrams/generate_pipeline_dataflows.py --check-drift"
-        },
-        {
-          "path": "docs/03-guides/pipeline-dataflow-documentation.md",
-          "line": 263,
-          "source_group": "docs",
-          "text": "python scripts/diagrams/generate_pipeline_dataflows.py"
         }
       ]
     },
@@ -8835,6 +8836,22 @@
           "text": "from scripts.documentation_governance_check import DocumentationGovernanceChecker"
         }
       ]
+    },
+    {
+      "path": "scripts/engineering/apply_s1_c2_fixes.py",
+      "type": "py",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
+    },
+    {
+      "path": "scripts/engineering/apply_s1_c3c6_fixes.py",
+      "type": "py",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
     },
     {
       "path": "scripts/engineering/baselines/__main__.py",
@@ -12632,7 +12649,7 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 79,
+      "reference_count": 81,
       "references": [
         {
           "path": "docs/00-project/RULES.md",
@@ -16666,6 +16683,36 @@
       "next_step": "Retain only as the bounded resume helper for the current CodeRabbit architecture-review campaign; remove it after the remaining-layer review is complete rather than treating it as a public active script."
     },
     {
+      "path": "scripts/ops/coderabbit/build_matrix.py",
+      "type": "py",
+      "status": "active",
+      "agent_usage": [],
+      "reference_count": 1,
+      "references": [
+        {
+          "path": "scripts/ops/coderabbit/README.md",
+          "line": 7,
+          "source_group": "scripts",
+          "text": "| `build_matrix.py` | Build leaf scope matrix (writes under `reports/quality/coderabbit/`) |"
+        }
+      ]
+    },
+    {
+      "path": "scripts/ops/coderabbit/run_leaves.py",
+      "type": "py",
+      "status": "active",
+      "agent_usage": [],
+      "reference_count": 1,
+      "references": [
+        {
+          "path": "scripts/ops/coderabbit/README.md",
+          "line": 8,
+          "source_group": "scripts",
+          "text": "| `run_leaves.py` | Sequential leaf runner (logs under reports; requires API key) |"
+        }
+      ]
+    },
+    {
       "path": "scripts/ops/codex-exec.bat",
       "type": "bat",
       "status": "active",
@@ -18463,7 +18510,7 @@
         },
         {
           "path": "tests/unit/scripts/ops/observability/test_grafana_render_contract.py",
-          "line": 24,
+          "line": 25,
           "source_group": "tests",
           "text": "from scripts.ops.observability.grafana import ("
         }
@@ -18519,7 +18566,7 @@
         },
         {
           "path": "docs/03-guides/dashboards/README.md",
-          "line": 148,
+          "line": 153,
           "source_group": "docs",
           "text": "- On Linux, `setup_grafana_screenshot_runtime.sh` is the canonical bootstrap"
         },
@@ -18531,13 +18578,13 @@
         },
         {
           "path": "scripts/ops/observability/grafana/rerender_grafana_screenshots.py",
-          "line": 1075,
+          "line": 1237,
           "source_group": "scripts",
           "text": "\"setup_grafana_screenshot_runtime.sh` to install repo-local \""
         },
         {
           "path": "scripts/ops/observability/grafana/rerender_grafana_screenshots.py",
-          "line": 1162,
+          "line": 1324,
           "source_group": "scripts",
           "text": "\"setup_grafana_screenshot_runtime.sh` or \""
         },
@@ -19202,7 +19249,7 @@
       "type": "py",
       "status": "supporting",
       "agent_usage": [],
-      "reference_count": 68,
+      "reference_count": 66,
       "references": [
         {
           "path": "Makefile",
@@ -20072,7 +20119,7 @@
         },
         {
           "path": "scripts/ops/observability/grafana/rerender_grafana_screenshots.py",
-          "line": 183,
+          "line": 336,
           "source_group": "scripts",
           "text": "\"scripts/ops/support/load_repo_env.sh or pass --username/--password \""
         },
@@ -20257,6 +20304,30 @@
           "text": "\"2. Implement the optimized test runner: python3 scripts/optimized_test_runner.py --list\""
         }
       ]
+    },
+    {
+      "path": "scripts/quality/coderabbit/build_streams.py",
+      "type": "py",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
+    },
+    {
+      "path": "scripts/quality/coderabbit/inventory_cm.py",
+      "type": "py",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
+    },
+    {
+      "path": "scripts/quality/coderabbit/rebalance_streams.py",
+      "type": "py",
+      "status": "orphan",
+      "agent_usage": [],
+      "reference_count": 0,
+      "references": []
     },
     {
       "path": "scripts/schema/__main__.py",

--- a/docs/00-project/ai/agents/policy/AI_RUNTIME_MIRROR_OWNERSHIP.md
+++ b/docs/00-project/ai/agents/policy/AI_RUNTIME_MIRROR_OWNERSHIP.md
@@ -7,7 +7,7 @@ Owner: BioETL Team
 Reviewers:
 
 - BioETL Team
-  Last verified: '2026-04-26'
+  Last verified: '2026-08-06'
 
 ______________________________________________________________________
 

--- a/docs/00-project/ai/memory/README.md
+++ b/docs/00-project/ai/memory/README.md
@@ -43,8 +43,10 @@ profiles в BioETL.
 
 If a runtime profile is renamed or added, update this matrix and the matching
 tracked runtime profile anchors in the same change set. On the current `main`
-checkout that means `.codex/agents/*.md`; a Gemini agent tree is not tracked on
-`main` today.
+checkout that means equal-peer trees `.codex/agents/*.md` and
+`.junie/agents/*.md` (parity via `scripts/ai/junie/check_junie_mirror.sh`), plus
+`.devin/agents/**` for Devin-specific profiles. A Gemini agent tree
+(`.gemini/agents/**`) is not tracked on `main` today.
 - **Machine-readable memory artifact**:
   `mcp-memory.json`
   — служебный memory snapshot для tooling/integration сценариев, не human

--- a/docs/00-project/ai/skills/local/py-architecture-debt-bot/SKILL.md
+++ b/docs/00-project/ai/skills/local/py-architecture-debt-bot/SKILL.md
@@ -29,8 +29,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 

--- a/docs/00-project/governance/03-file-policy.md
+++ b/docs/00-project/governance/03-file-policy.md
@@ -44,6 +44,8 @@ generated output, `configs/quality/generated_artifact_routing.yaml`.
 | Forbidden root files/directories | tracked `.env*` except `.env.example`, generated diagnostics, root scratch scripts/tests, local cache/output directories, and ad-hoc root dumps | strict root audit and generated-artifact routing | delete, ignore as local-only where approved, or route retained evidence to `reports/**` |
 | Temporary compatibility surfaces | reviewed non-script exact-root compatibility entrypoints only | `configs/quality/root_hygiene_review_registry.yaml` owner lanes | root `.sh`, `.ps1`, `.py`, and `.bat` compatibility exceptions are closed and MUST NOT be restored |
 
+| Agent skills lockfile | `skills-lock.json` | root allowlist + `root_hygiene_review_registry.yaml` lane `root_tooling_transitions` | **MUST stay exact root** while skill installer / lock tooling emit the documented filename; do not rehome speculatively (RH5-06 / #7023 closed as retain) |
+
 Docker helper dispositions are resolved as follows and MUST stay aligned with
 `docs/05-operations/verification/docker-helper-root-relocation-audit.md`:
 


### PR DESCRIPTION
## Summary
CYCLE-03 AI agent memory / skills remediation.

- Fix outdated `python -m scripts.qa` → `python -m scripts.engineering.qa` in architecture-debt skill (#8073)
- Codex/Junie parity maintained (`check_junie_mirror.sh --check` OK)
- Close #8072: runtime mirror drift check reports no drift
- Close #8076: docs agent scripts still actively referenced — not obsolete

## Verification
- `bash scripts/ai/junie/check_junie_mirror.sh --check` — OK
- `python -m scripts.docs check-drift --runtime-mirrors --freshness` — no drift
- `git ls-files scripts/qa` — empty; real module is `scripts.engineering.qa`

Closes #8073
Closes #8072
Closes #8076