### PR TITLE
fix(ai): correct architecture-debt skill entrypoints (#8073)

### DIFF
--- a/.codex/skills/py-architecture-debt-bot/SKILL.md
+++ b/.codex/skills/py-architecture-debt-bot/SKILL.md
@@ -21,8 +21,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 

--- a/.junie/skills/py-architecture-debt-bot/SKILL.md
+++ b/.junie/skills/py-architecture-debt-bot/SKILL.md
@@ -21,8 +21,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 

--- a/docs/00-project/ai/skills/local/py-architecture-debt-bot/SKILL.md
+++ b/docs/00-project/ai/skills/local/py-architecture-debt-bot/SKILL.md
@@ -29,8 +29,8 @@ Run the role-specific workflow as defined in the py-architecture-debt-bot profil
 - Shared project context: `../../../docs/00-project/ai/memory/agent-memory.md`
 - Role-specific memory: `../../../docs/00-project/ai/memory/memory-py-architecture-debt-bot.md`
 - Deterministic helpers:
-  - `python -m scripts.qa generate-debt-tasks`
-  - `python -m scripts.qa reduce-architecture-debt`
+  - `python -m scripts.engineering.qa generate-debt-tasks`
+  - `python -m scripts.engineering.qa reduce-architecture-debt`
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
CYCLE-03 remediation (clean branch from current main).

- `python -m scripts.qa …` → `python -m scripts.engineering.qa …` in Codex/Junie/docs skill mirrors for py-architecture-debt-bot
- Junie mirror parity OK

Also closes verified findings without product change:
- #8072 — `check-drift --runtime-mirrors --freshness` reports no drift
- #8076 — `docs/00-project/ai/agents/scripts/**` still actively referenced by runtime/orchestration docs; not obsolete

Closes #8073
Closes #8072
Closes #8076