### PR TITLE
feat(tooling): Zed LSP + architecture-safe BioETL snippets

### DIFF
--- a/.zed/README.md
+++ b/.zed/README.md
@@ -37,7 +37,7 @@ That does **not** imply WSL task parity; WSL development stays on repository she
 | `tasks.json` | Quality/test tasks via `.venv-win` (+ doctor-guarded launcher) |
 | `mcp.json` | Optional workspace MCP inventory (prefer shared HTTP plane; not attached to Agent profiles) |
 | `USER_SETTINGS_NO_AGENT_MCP.overlay.json` | Snippet for user-level Zed settings (disable extension MCP + thrash agents) |
-| `snippets/` | Optional copy-into-user snippets (not auto-loaded) |
+| `snippets/` | Canonical bioetl-* snippets (repo SSOT; user mirror may be needed) |
 | `README.md` | This guide |
 
 Zed loads `.zed/settings.json` and `.zed/tasks.json` from the worktree root automatically.
@@ -346,3 +346,49 @@ Scan exclusions include local venvs/caches (`.venv-win`, `.venv-wsl`, `.cache`,
 - `scripts/engineering/dev/run_pytest.ps1` / `run_pytest.sh`
 - https://zed.dev/docs/tasks
 - https://zed.dev/docs/languages/python
+
+## Canonical LSP stack (project)
+
+| Language | Server | Role | CI gate |
+|----------|--------|------|---------|
+| Python | **basedpyright** | semantic/types/navigation | IDE; product gate remains **mypy** |
+| Python | **ruff** | lint + format + organize imports | pre-commit + CI |
+| YAML | default YAML language server | schema/diagnostics | — |
+| JSON/JSONC | default JSON language server | format/diagnostics | — |
+| Docker Compose | docker-compose | compose diagnostics | — |
+
+**Not active in project Python `language_servers`:** `pylsp`, legacy `ruff-lsp` (native `ruff` server), `ty`, second pyright flavor.
+
+Do not enable multiple Python semantic servers together.
+
+## Snippets (`bioetl-*`)
+
+Tracked under `.zed/snippets/`. In current Zed builds, project snippets may need to be
+mirrored into user snippet config depending on version; the tracked files remain the
+**repo source of truth** and are guarded by `test_zed_workspace_config.py`.
+
+### Required Python prefixes
+
+| Prefix | Layer |
+|--------|--------|
+| `bioetl-vo` | domain |
+| `bioetl-port` | domain |
+| `bioetl-impl` | infrastructure |
+| `bioetl-config` | domain/config |
+| `bioetl-factory` | composition |
+| `bioetl-error` | domain |
+| `bioetl-test-unit` / `bioetl-test-async` / `bioetl-test-arch` | tests |
+| `bioetl-extract` / `bioetl-transform` / `bioetl-validate` / `bioetl-export` | pipelines |
+| `bioetl-log` | application via LoggerPort |
+| `bioetl-event` | domain events |
+
+### Required YAML prefixes
+
+| Prefix | Source shape |
+|--------|----------------|
+| `bioetl-pipeline-config` | `configs/entities/*` |
+| `bioetl-dq-rule` | entity quality ranges/required_fields |
+| `bioetl-retry-policy` / `bioetl-rate-limit` | `configs/providers/*` |
+| `bioetl-composite-enricher` / `bioetl-field-priority` | ADR-026 composites |
+
+Snippets must not invent retired paths (`bioetl.pipelines`, `data/silver`, parquet sinks) or use `print()`.

--- a/.zed/snippets/python.json
+++ b/.zed/snippets/python.json
@@ -1,53 +1,311 @@
 {
-  "BioETL Pipeline Import": {
-    "prefix": "bioetl-pipeline",
-    "description": "Import BioETL pipeline components",
+  "BioETL Value Object": {
+    "prefix": "bioetl-vo",
+    "description": "Domain value object (frozen dataclass, no I/O)",
     "body": [
       "from __future__ import annotations",
       "",
-      "from bioetl.application.${1:pipeline_name} import ${2:PipelineName}",
-      "from bioetl.domain.schemas import ${3:SchemaName}",
-      "from bioetl.infrastructure.config import load_config"
+      "from dataclasses import dataclass",
+      "",
+      "",
+      "@dataclass(frozen=True, slots=True)",
+      "class ${1:ExampleValue}:",
+      "    \"\"\"${2:Immutable domain value object}.\"\"\"",
+      "",
+      "    ${3:field_name}: ${4:str}",
+      "",
+      "    def __post_init__(self) -> None:",
+      "        \"\"\"Validate invariants without I/O.\"\"\"",
+      "        ${5:pass}"
     ]
   },
-  "BioETL Schema Import": {
-    "prefix": "bioetl-schema",
-    "description": "Import BioETL domain schema",
+  "BioETL Domain Port": {
+    "prefix": "bioetl-port",
+    "description": "Domain Protocol port (no concrete implementation)",
     "body": [
       "from __future__ import annotations",
       "",
-      "from bioetl.domain.schemas.${1:module} import ${2:SchemaName}"
+      "from typing import Protocol, runtime_checkable",
+      "",
+      "",
+      "@runtime_checkable",
+      "class ${1:ExamplePort}(Protocol):",
+      "    \"\"\"${2:Cross-cutting domain port}.\"\"\"",
+      "",
+      "    def ${3:operation}(self, ${4:arg}: ${5:str}) -> ${6:None}:",
+      "        \"\"\"${7:Port method contract}.\"\"\"",
+      "        ..."
     ]
   },
-  "BioETL Logger": {
-    "prefix": "bioetl-logger",
-    "description": "Import and setup BioETL structured logger",
+  "BioETL Infrastructure Implementation": {
+    "prefix": "bioetl-impl",
+    "description": "Infrastructure adapter implementing a domain port",
     "body": [
       "from __future__ import annotations",
       "",
-      "import structlog",
+      "from bioetl.domain.ports.${1:module} import ${2:ExamplePort}",
       "",
-      "logger = structlog.get_logger(__name__)"
+      "",
+      "class ${2:ExamplePort}Impl:",
+      "    \"\"\"Infrastructure implementation of ${2:ExamplePort}.\"\"\"",
+      "",
+      "    def ${3:operation}(self, ${4:arg}: ${5:str}) -> ${6:None}:",
+      "        \"\"\"${7:Adapter behavior (I/O lives here)}.\"\"\"",
+      "        ${8:raise NotImplementedError}"
     ]
   },
-  "BioETL Pipeline Context": {
-    "prefix": "bioetl-context",
-    "description": "Bind pipeline context for structured logging",
+  "BioETL Config Value Object": {
+    "prefix": "bioetl-config",
+    "description": "Immutable typed config object",
     "body": [
       "from __future__ import annotations",
       "",
-      "import structlog",
+      "from dataclasses import dataclass",
       "",
-      "logger = structlog.get_logger(__name__).bind(",
-      "    pipeline_code=\"${1:pipeline_code}\",",
-      "    run_id=\"${2:run_id}\",",
-      "    provider=\"${3:provider}\",",
-      ")"
+      "",
+      "@dataclass(frozen=True, slots=True)",
+      "class ${1:ExampleConfig}:",
+      "    \"\"\"${2:Immutable configuration value object}.\"\"\"",
+      "",
+      "    ${3:enabled}: bool = True",
+      "    ${4:timeout_seconds}: float = 30.0"
+    ]
+  },
+  "BioETL Factory": {
+    "prefix": "bioetl-factory",
+    "description": "Composition-layer factory (not a second Composition Root)",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from bioetl.domain.ports.${1:module} import ${2:ExamplePort}",
+      "",
+      "",
+      "def create_${3:example}_port(",
+      "    *,",
+      "    ${4:dependency}: ${5:object},",
+      ") -> ${2:ExamplePort}:",
+      "    \"\"\"Wire a concrete ${2:ExamplePort} for composition use.\"\"\"",
+      "    from bioetl.infrastructure.${6:adapters.example} import ${2:ExamplePort}Impl",
+      "",
+      "    return ${2:ExamplePort}Impl(${4:dependency}=${4:dependency})"
+    ]
+  },
+  "BioETL Domain Error": {
+    "prefix": "bioetl-error",
+    "description": "Domain error extending BioETL base hierarchy",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from bioetl.domain.exceptions.base_exceptions import BioETLDomainError",
+      "",
+      "",
+      "class ${1:ExampleDomainError}(BioETLDomainError):",
+      "    \"\"\"${2:Domain-specific error}.\"\"\"",
+      "",
+      "    def __init__(self, message: str, *, ${3:context_key}: ${4:str} | None = None) -> None:",
+      "        super().__init__(message)",
+      "        self.${3:context_key} = ${3:context_key}"
+    ]
+  },
+  "BioETL Unit Test": {
+    "prefix": "bioetl-test-unit",
+    "description": "Pytest unit test function",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "import pytest",
+      "",
+      "from bioetl.${1:module.path} import ${2:Symbol}",
+      "",
+      "",
+      "@pytest.mark.unit",
+      "def test_${3:behavior}() -> None:",
+      "    \"\"\"${4:Expected behavior under test}.\"\"\"",
+      "    result = ${5:Symbol}(${6:args})",
+      "    assert ${7:result is not None}"
+    ]
+  },
+  "BioETL Async Unit Test": {
+    "prefix": "bioetl-test-async",
+    "description": "Async pytest unit test",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "import pytest",
+      "",
+      "from bioetl.${1:module.path} import ${2:Symbol}",
+      "",
+      "",
+      "@pytest.mark.unit",
+      "@pytest.mark.asyncio",
+      "async def test_${3:behavior}() -> None:",
+      "    \"\"\"${4:Expected async behavior under test}.\"\"\"",
+      "    result = await ${5:Symbol}(${6:args})",
+      "    assert ${7:result is not None}"
+    ]
+  },
+  "BioETL Architecture Test": {
+    "prefix": "bioetl-test-arch",
+    "description": "Architecture test scaffold",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "import pytest",
+      "",
+      "",
+      "@pytest.mark.architecture",
+      "def test_${1:layer}_${2:invariant}() -> None:",
+      "    \"\"\"${3:Architecture invariant description}.\"\"\"",
+      "    # Prefer helpers in tests/architecture and existing import-linter contracts.",
+      "    assert ${4:True}"
+    ]
+  },
+  "BioETL Extract Stage": {
+    "prefix": "bioetl-extract",
+    "description": "Pipeline extract stage scaffold",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from collections.abc import AsyncIterator",
+      "",
+      "from bioetl.domain.types import JsonDict",
+      "",
+      "",
+      "async def extract_${1:entity}(",
+      "    *,",
+      "    ${2:source}: ${3:object},",
+      ") -> AsyncIterator[JsonDict]:",
+      "    \"\"\"Extract ${1:entity} records (Bronze input only).\"\"\"",
+      "    async for record in ${4:source}:",
+      "        yield record"
+    ]
+  },
+  "BioETL Transform Stage": {
+    "prefix": "bioetl-transform",
+    "description": "Pipeline transform stage scaffold",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from bioetl.domain.types import JsonDict",
+      "",
+      "",
+      "def transform_${1:entity}(record: JsonDict) -> JsonDict:",
+      "    \"\"\"Transform a single ${1:entity} record (no I/O).\"\"\"",
+      "    working = dict(record)",
+      "    ${2:pass}",
+      "    return working"
+    ]
+  },
+  "BioETL Validate Stage": {
+    "prefix": "bioetl-validate",
+    "description": "Pipeline validate stage scaffold",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from bioetl.domain.types import JsonDict",
+      "",
+      "",
+      "def validate_${1:entity}(record: JsonDict) -> JsonDict:",
+      "    \"\"\"Validate ${1:entity} against domain/DQ contracts (no I/O).\"\"\"",
+      "    ${2:pass}",
+      "    return record"
+    ]
+  },
+  "BioETL Export Stage": {
+    "prefix": "bioetl-export",
+    "description": "Pipeline export/write stage scaffold",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from collections.abc import Sequence",
+      "",
+      "from bioetl.domain.types import JsonDict",
+      "",
+      "",
+      "async def export_${1:entity}(",
+      "    records: Sequence[JsonDict],",
+      "    *,",
+      "    ${2:writer}: ${3:object},",
+      ") -> None:",
+      "    \"\"\"Export ${1:entity} records via infrastructure writer port.\"\"\"",
+      "    await ${2:writer}.write(records)"
+    ]
+  },
+  "BioETL Structured Log": {
+    "prefix": "bioetl-log",
+    "description": "Structured log via LoggerPort (no print)",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from bioetl.domain.ports.observability import LoggerPort",
+      "",
+      "",
+      "def _log_${1:event}(logger: LoggerPort, *, ${2:key}: ${3:str}) -> None:",
+      "    logger.info(",
+      "        \"${1:event}\",",
+      "        ${2:key}=${2:key},",
+      "    )"
+    ]
+  },
+  "BioETL Domain Event": {
+    "prefix": "bioetl-event",
+    "description": "Domain event (past tense; no I/O publishers here)",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "from dataclasses import dataclass",
+      "",
+      "from bioetl.domain.aggregates.events import DomainEvent",
+      "from bioetl.domain.types import RunID",
+      "",
+      "",
+      "@dataclass(frozen=True, slots=True)",
+      "class ${1:SomethingHappened}(DomainEvent):",
+      "    \"\"\"Event: ${2:past-tense description after successful state change}.\"\"\"",
+      "",
+      "    run_id: RunID",
+      "    ${3:subject_id}: str"
+    ]
+  },
+  "BioETL Unit Test Class": {
+    "prefix": "bioetl-test",
+    "description": "Class-based unit test (compat prefix)",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "import pytest",
+      "",
+      "from bioetl.${1:module} import ${2:ClassName}",
+      "",
+      "",
+      "@pytest.mark.unit",
+      "class Test${2:ClassName}:",
+      "    \"\"\"Tests for ${2:ClassName}.\"\"\"",
+      "",
+      "    def test_${3:behavior}(self) -> None:",
+      "        \"\"\"Test that ${4:description}.\"\"\"",
+      "        result = ${5:action}",
+      "        assert ${6:assertion}"
+    ]
+  },
+  "BioETL Architecture Test Alias": {
+    "prefix": "bioetl-arch-test",
+    "description": "Architecture test alias",
+    "body": [
+      "from __future__ import annotations",
+      "",
+      "import pytest",
+      "",
+      "",
+      "@pytest.mark.architecture",
+      "def test_${1:layer}_boundaries() -> None:",
+      "    \"\"\"Test that ${2:description}.\"\"\"",
+      "    assert ${3:True}"
     ]
   },
   "BioETL Pandera Schema": {
     "prefix": "bioetl-pandera",
-    "description": "Create a Pandera DataFrameModel schema",
+    "description": "Pandera DataFrameModel schema scaffold",
     "body": [
       "from __future__ import annotations",
       "",
@@ -58,231 +316,7 @@
       "class ${1:SchemaName}(pa.DataFrameModel):",
       "    \"\"\"${2:Schema description}.\"\"\"",
       "",
-      "    ${3:column_name}: Series[${4:type}] = pa.Field(description=\"${5:description}\")",
-      "",
-      "    model_config = pa.DataFrameModel.ConfigDict(strict=True, coerce=True)"
-    ]
-  },
-  "BioETL Test Fixture": {
-    "prefix": "bioetl-test-fixture",
-    "description": "Create a BioETL test fixture",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "import pytest",
-      "",
-      "from bioetl.domain.schemas import ${1:SchemaName}",
-      "",
-      "",
-      "@pytest.fixture",
-      "def ${2:fixture_name}() -> ${1:SchemaName}:",
-      "    \"\"\"${3:Fixture description}.\"\"\"",
-      "    return ${1:SchemaName}(",
-      "        ${4:field}=${5:value},",
-      "    )"
-    ]
-  },
-  "BioETL Unit Test": {
-    "prefix": "bioetl-test",
-    "description": "Create a BioETL unit test",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "import pytest",
-      "",
-      "from bioetl.${1:module} import ${2:ClassName}",
-      "",
-      "",
-      "class Test${2:ClassName}:",
-      "    \"\"\"Tests for ${2:ClassName}.\"\"\"",
-      "",
-      "    def test_${3:behavior}(self) -> None:",
-      "        \"\"\"Test that ${4:description}.\"\"\"",
-      "        # Arrange",
-      "        ${5:setup}",
-      "",
-      "        # Act",
-      "        result = ${6:action}",
-      "",
-      "        # Assert",
-      "        assert ${7:assertion}"
-    ]
-  },
-  "BioETL Integration Test": {
-    "prefix": "bioetl-integration-test",
-    "description": "Create a BioETL integration test",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "import pytest",
-      "",
-      "from bioetl.${1:module} import ${2:ClassName}",
-      "",
-      "",
-      "@pytest.mark.integration",
-      "class Test${2:ClassName}Integration:",
-      "    \"\"\"Integration tests for ${2:ClassName}.\"\"\"",
-      "",
-      "    def test_${3:behavior}(self) -> None:",
-      "        \"\"\"Test that ${4:description}.\"\"\"",
-      "        # Arrange",
-      "        ${5:setup}",
-      "",
-      "        # Act",
-      "        result = ${6:action}",
-      "",
-      "        # Assert",
-      "        assert ${7:assertion}"
-    ]
-  },
-  "BioETL Architecture Test": {
-    "prefix": "bioetl-arch-test",
-    "description": "Create a BioETL architecture compliance test",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "import pytest",
-      "",
-      "",
-      "@pytest.mark.architecture",
-      "def test_${1:layer}_boundaries() -> None:",
-      "    \"\"\"Test that ${2:description}.\"\"\"",
-      "    assert ${3:assertion}"
-    ]
-  },
-  "BioETL Pydantic Model": {
-    "prefix": "bioetl-pydantic",
-    "description": "Create a BioETL Pydantic model",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from pydantic import BaseModel, ConfigDict, Field",
-      "",
-      "",
-      "class ${1:ModelName}(BaseModel):",
-      "    \"\"\"${2:Model description}.\"\"\"",
-      "",
-      "    model_config = ConfigDict(frozen=True)",
-      "",
-      "    ${3:field_name}: ${4:field_type} = Field(description=\"${5:description}\")"
-    ]
-  },
-  "BioETL Settings": {
-    "prefix": "bioetl-settings",
-    "description": "Create BioETL settings with Pydantic Settings",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from pydantic import Field",
-      "from pydantic_settings import BaseSettings, SettingsConfigDict",
-      "",
-      "",
-      "class ${1:SettingsName}(BaseSettings):",
-      "    \"\"\"${2:Settings description}.\"\"\"",
-      "",
-      "    model_config = SettingsConfigDict(env_prefix=\"${3:ENV_PREFIX}_\")",
-      "",
-      "    ${4:setting_name}: str = Field(description=\"${5:description}\")"
-    ]
-  },
-  "BioETL Error Handler": {
-    "prefix": "bioetl-error",
-    "description": "Create BioETL error handling with structured logging",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from typing import Any",
-      "",
-      "import structlog",
-      "",
-      "logger = structlog.get_logger(__name__)",
-      "",
-      "",
-      "def handle_${1:error_type}_error(error: Exception, context: dict[str, Any]) -> None:",
-      "    \"\"\"Handle ${2:description}.\"\"\"",
-      "    logger.error(",
-      "        \"${3:event_name}\",",
-      "        error=str(error),",
-      "        error_type=type(error).__name__,",
-      "        **context,",
-      "    )",
-      "    raise"
-    ]
-  },
-  "BioETL Pipeline Stage": {
-    "prefix": "bioetl-stage",
-    "description": "Create a BioETL pipeline stage with logging",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from typing import Any",
-      "",
-      "import structlog",
-      "",
-      "logger = structlog.get_logger(__name__)",
-      "",
-      "",
-      "def ${1:stage_name}(input_data: Any) -> Any:",
-      "    \"\"\"${2:Stage description}.\"\"\"",
-      "    logger.info(",
-      "        \"${3:event_name}\",",
-      "        stage=\"${1:stage_name}\",",
-      "        input_records=len(input_data) if hasattr(input_data, \"__len__\") else 1,",
-      "    )",
-      "    result = ${4:implementation}",
-      "    logger.info(",
-      "        \"${5:success_event}\",",
-      "        stage=\"${1:stage_name}\",",
-      "        output_records=len(result) if hasattr(result, \"__len__\") else 1,",
-      "    )",
-      "    return result"
-    ]
-  },
-  "BioETL Data Contract": {
-    "prefix": "bioetl-contract",
-    "description": "Create a BioETL data contract validation",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from typing import Any",
-      "",
-      "from bioetl.domain.contracts import ${1:ContractName}",
-      "from bioetl.domain.schemas import ${2:SchemaName}",
-      "",
-      "",
-      "def validate_${3:entity}_contract(data: Any) -> bool:",
-      "    \"\"\"Validate ${4:description}.\"\"\"",
-      "    contract = ${1:ContractName}()",
-      "    schema = ${2:SchemaName}",
-      "    validated_data = schema.validate(data)",
-      "    return contract.validate(validated_data)"
-    ]
-  },
-  "BioETL Medallion Layer": {
-    "prefix": "bioetl-medallion",
-    "description": "Create a BioETL medallion layer transformation",
-    "body": [
-      "from __future__ import annotations",
-      "",
-      "from typing import Any",
-      "",
-      "from bioetl.domain.medallion import ${1:LayerName}Layer",
-      "from bioetl.domain.schemas import ${2:InputSchema}, ${3:OutputSchema}",
-      "",
-      "",
-      "class ${4:TransformerName}:",
-      "    \"\"\"${5:Transformer description}.\"\"\"",
-      "",
-      "    def __init__(self, config: dict[str, Any]) -> None:",
-      "        self.layer = ${1:LayerName}Layer(config)",
-      "        self.input_schema = ${2:InputSchema}",
-      "        self.output_schema = ${3:OutputSchema}",
-      "",
-      "    def transform(self, data: Any) -> Any:",
-      "        \"\"\"Transform ${6:description}.\"\"\"",
-      "        validated_input = self.input_schema.validate(data)",
-      "        transformed = self.layer.apply(validated_input)",
-      "        return self.output_schema.validate(transformed)"
+      "    ${3:column_name}: Series[${4:str}] = pa.Field(description=\"${5:description}\")"
     ]
   }
 }

--- a/.zed/snippets/yaml.json
+++ b/.zed/snippets/yaml.json
@@ -1,170 +1,97 @@
 {
   "BioETL Pipeline Config": {
     "prefix": "bioetl-pipeline-config",
-    "description": "Create a BioETL pipeline configuration",
+    "description": "Entity pipeline config scaffold (configs/entities shape)",
     "body": [
-      "# BioETL Pipeline Configuration",
-      "pipeline_name: ${1:provider}.${2:entity}",
-      "version: \"1.0.0\"",
-      "idempotency_contract: merge_upsert",
-      "",
-      "provider:",
-      "  name: ${1:provider}",
-      "  base_url: ${3:https://api.example.com}",
-      "  timeout: 30",
-      "  retry:",
-      "    max_attempts: 3",
-      "    backoff_factor: 2",
-      "",
-      "entity:",
-      "  name: ${2:entity}",
-      "  schema: ${4:SchemaName}",
-      "",
-      "extraction:",
-      "  batch_size: 100",
-      "  parallel_requests: 5",
-      "",
-      "transformation:",
-      "  normalize: true",
-      "  validate: true",
-      "",
-      "quality:",
-      "  completeness_threshold: 0.95",
-      "  validity_threshold: 0.90",
-      "",
-      "output:",
-      "  storage: ${5:delta}",
-      "  compression: zstd",
-      "  layer: ${6:curated}"
+      "version: 1.0.0",
+      "provider: ${1:chembl}",
+      "entity: ${2:activity}",
+      "pipeline:",
+      "  pipeline_name: ${1:chembl}_${2:activity}",
+      "  provider: ${1:chembl}",
+      "  entity_type: ${2:activity}",
+      "  description: ${3:Extract records from provider API}",
+      "  field_policy: {}",
+      "  business_primary_keys:",
+      "  - ${4:activity_id}",
+      "  batch_size: 1000",
+      "  checkpoint_interval: 1000",
+      "  sink:",
+      "    silver:",
+      "      mode: merge",
+      "      idempotency_contract: merge_upsert",
+      "      partition_by: []",
+      "    gold:",
+      "      enabled: true"
     ]
   },
-  "BioETL Data Quality Rules": {
-    "prefix": "bioetl-dq-rules",
-    "description": "Create BioETL data quality rules configuration",
+  "BioETL DQ Rule": {
+    "prefix": "bioetl-dq-rule",
+    "description": "DQ ranges/required_fields fragment",
     "body": [
-      "# Data Quality Rules",
-      "rules:",
-      "  - name: ${1:rule_name}",
-      "    description: \"${2:Rule description}\"",
-      "    severity: error",
-      "    condition:",
-      "      field: ${3:field_name}",
-      "      operator: ${4:not_null}",
-      "      value: ${5:value}",
-      "    threshold: ${6:0.95}"
+      "ranges:",
+      "  ${1:standard_value}:",
+      "    min: ${2:0}",
+      "    include_min: false",
+      "required_fields:",
+      "- ${3:standard_type}",
+      "- ${4:standard_value}",
+      "- ${5:standard_units}"
     ]
   },
-  "BioETL Provider Config": {
-    "prefix": "bioetl-provider-config",
-    "description": "Create a BioETL provider configuration",
+  "BioETL Retry Policy": {
+    "prefix": "bioetl-retry-policy",
+    "description": "Provider retry fragment (configs/providers)",
     "body": [
-      "# Provider Configuration",
-      "provider:",
-      "  name: ${1:ProviderName}",
-      "  display_name: \"${2:Display Name}\"",
-      "  base_url: ${3:https://api.example.com}",
-      "  documentation: ${4:https://docs.example.com}",
-      "  auth:",
-      "    type: ${5:none}",
-      "    required: false",
-      "  rate_limit:",
-      "    requests_per_minute: ${6:60}",
-      "    burst_size: ${7:10}",
-      "  endpoints:",
-      "    - name: ${8:endpoint_name}",
-      "      path: ${9:/api/v1/endpoint}",
-      "      method: GET",
-      "      required_params:",
-      "        - ${10:param1}"
+      "retry:",
+      "    use_retry_after: ${1:true}"
     ]
   },
-  "BioETL Schema Mapping": {
-    "prefix": "bioetl-schema-mapping",
-    "description": "Create a BioETL schema mapping configuration",
+  "BioETL Rate Limit": {
+    "prefix": "bioetl-rate-limit",
+    "description": "Provider rate_limit fragment (configs/providers)",
     "body": [
-      "# Schema Mapping",
-      "mapping:",
-      "  source_schema: ${1:SourceSchema}",
-      "  target_schema: ${2:TargetSchema}",
-      "  field_mappings:",
-      "    - source: ${3:source_field}",
-      "      target: ${4:target_field}",
-      "      transformation: ${5:identity}",
-      "      required: true",
-      "    - source: ${6:source_field2}",
-      "      target: ${7:target_field2}",
-      "      transformation: ${8:uppercase}",
-      "      required: false"
+      "rate_limit:",
+      "    requests_per_second: ${1:0.1}",
+      "    burst: ${2:1}"
     ]
   },
-  "BioETL Medallion Config": {
-    "prefix": "bioetl-medallion-config",
-    "description": "Create a BioETL medallion architecture configuration",
+  "BioETL Composite Enricher": {
+    "prefix": "bioetl-composite-enricher",
+    "description": "Composite enricher; join_keys subset of seed.output_keys",
     "body": [
-      "# Medallion Architecture Configuration",
-      "medallion:",
-      "  raw:",
-      "    path: storage/raw/${1:provider}",
-      "    storage: object",
-      "    compression: none",
-      "    append_only: true",
-      "  curated:",
-      "    path: storage/curated/${1:provider}",
-      "    storage: delta",
-      "    compression: zstd",
+      "# ADR-026: enricher.join_keys must be a subset of seed.output_keys",
+      "enrichers:",
+      "  - pipeline: ${1:chembl_compound_record}",
+      "    join_keys:",
+      "    - ${2:molecule_id}",
+      "    required: ${3:false}",
+      "    timeout_seconds: ${4:600}",
+      "    silver_table: silver/${5:chembl}/${6:compound_record}"
+    ]
+  },
+  "BioETL Field Priority": {
+    "prefix": "bioetl-field-priority",
+    "description": "Composite merge field_priorities fragment",
+    "body": [
+      "merge:",
+      "  strategy: left_outer",
+      "  conflict_resolution: seed_priority",
+      "  field_priorities:",
+      "    ${1:canonical_name}:",
+      "    - seed",
+      "    - ${2:chembl_compound_record}"
+    ]
+  },
+  "BioETL Sink Silver Merge": {
+    "prefix": "bioetl-sink-silver",
+    "description": "Silver sink merge fragment",
+    "body": [
+      "sink:",
+      "  silver:",
+      "    mode: merge",
       "    idempotency_contract: merge_upsert",
-      "    idempotency_key: ${2:record_id}",
-      "  serving:",
-      "    path: storage/serving/${1:provider}",
-      "    storage: delta",
-      "    compression: zstd",
-      "    validation: strict"
-    ]
-  },
-  "BioETL Observability Config": {
-    "prefix": "bioetl-observability-config",
-    "description": "Create a BioETL observability configuration",
-    "body": [
-      "# Observability Configuration",
-      "observability:",
-      "  logging:",
-      "    level: INFO",
-      "    structured: true",
-      "    format: json",
-      "  metrics:",
-      "    enabled: true",
-      "    backend: prometheus",
-      "    port: 9090",
-      "  tracing:",
-      "    enabled: false",
-      "    exporter: otlp",
-      "    endpoint: http://localhost:4317"
-    ]
-  },
-  "BioETL Test Config": {
-    "prefix": "bioetl-test-config",
-    "description": "Create a BioETL test configuration",
-    "body": [
-      "# Test Configuration",
-      "tests:",
-      "  unit:",
-      "    path: tests/unit",
-      "    markers:",
-      "      - unit",
-      "      - fast",
-      "  integration:",
-      "    path: tests/integration",
-      "    markers:",
-      "      - integration",
-      "      - slow",
-      "  e2e:",
-      "    path: tests/e2e",
-      "    markers:",
-      "      - e2e",
-      "      - very_slow",
-      "  coverage:",
-      "    threshold: 85",
-      "    branches: true"
+      "    partition_by: []"
     ]
   }
 }

--- a/tests/unit/repo_backed/scripts/test_zed_workspace_config.py
+++ b/tests/unit/repo_backed/scripts/test_zed_workspace_config.py
@@ -118,6 +118,12 @@ def test_zed_language_settings_delegate_to_project_sources_of_truth() -> None:
     assert python_settings["format_on_save"] == "off"
     assert "indent_style" not in python_settings
     assert "source.fixAll.ruff" not in python_settings["code_actions_on_format"]
+    assert python_settings["language_servers"] == [
+        "basedpyright",
+        "ruff",
+        "!pylsp",
+    ]
+    assert python_settings["formatter"] == {"language_server": {"name": "ruff"}}
     assert settings["lsp"]["ruff"] == {
         "initialization_options": {
             "settings": {"configurationPreference": "filesystemFirst"}
@@ -463,6 +469,40 @@ def test_zed_snippets_follow_current_bioetl_contracts() -> None:
 
     for snippet in python_snippets.values():
         assert "from __future__ import annotations" in snippet["body"]
+        assert str(snippet["prefix"]).startswith("bioetl-")
+
+    for snippet in yaml_snippets.values():
+        assert str(snippet["prefix"]).startswith("bioetl-")
+
+    required_python = {
+        "bioetl-vo",
+        "bioetl-port",
+        "bioetl-impl",
+        "bioetl-config",
+        "bioetl-factory",
+        "bioetl-error",
+        "bioetl-test-unit",
+        "bioetl-test-async",
+        "bioetl-test-arch",
+        "bioetl-extract",
+        "bioetl-transform",
+        "bioetl-validate",
+        "bioetl-export",
+        "bioetl-log",
+        "bioetl-event",
+    }
+    required_yaml = {
+        "bioetl-pipeline-config",
+        "bioetl-dq-rule",
+        "bioetl-retry-policy",
+        "bioetl-rate-limit",
+        "bioetl-composite-enricher",
+        "bioetl-field-priority",
+    }
+    python_prefixes = {snippet["prefix"] for snippet in python_snippets.values()}
+    yaml_prefixes = {snippet["prefix"] for snippet in yaml_snippets.values()}
+    assert required_python <= python_prefixes
+    assert required_yaml <= yaml_prefixes
 
     rendered_python = "\n".join(
         line for snippet in python_snippets.values() for line in snippet["body"]
@@ -475,11 +515,18 @@ def test_zed_snippets_follow_current_bioetl_contracts() -> None:
     assert "bioetl.pipelines" not in rendered_python
     assert "Optional[" not in rendered_python
     assert "class Config:" not in rendered_python
+    assert "print(" not in rendered_python
+    assert "structlog.get_logger" not in rendered_python
+    assert "LoggerPort" in rendered_python
+    assert "BioETLDomainError" in rendered_python
     assert "data/silver" not in rendered_yaml
     assert "data/gold" not in rendered_yaml
     assert "format: parquet" not in rendered_yaml
     assert "pipeline_name:" in rendered_yaml
     assert "idempotency_contract: merge_upsert" in rendered_yaml
+    assert "seed.output_keys" in rendered_yaml
+    assert "requests_per_second:" in rendered_yaml
+    assert "use_retry_after:" in rendered_yaml
 
 
 def test_zed_env_doctor_healthy_and_missing_module(


### PR DESCRIPTION
## Summary

Canonicalize developer tooling for Zed without touching BioETL runtime:

- **Python LSP:** `basedpyright` (semantic/types) + `ruff` (lint/format); `pylsp` remains disabled
- **CI type gate:** still **mypy** (unchanged)
- **Snippets:** required `bioetl-*` prefixes for domain/ports/impl/config/factory/errors/tests/stages/logging/events + YAML grounded in `configs/entities` / `configs/providers` / ADR-026 composites
- **Tests:** stronger `test_zed_workspace_config.py` contracts

## Verification
```
pytest tests/unit/repo_backed/scripts/test_zed_workspace_config.py -q  # green
```

## Architecture
- No changes under `src/bioetl`
- No tech-debt budget / exemption growth