### PR TITLE
test(suite): close economics & hygiene roadmap (#8326)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -756,10 +756,12 @@ jobs:
       - name: Run canonical unit-fast lane
         run: |
           mkdir -p reports/test-telemetry
-          # Quick feedback: run the canonical unit-fast lane from test_matrix.yaml.
+          # Quick feedback: canonical unit-fast lane (test_matrix.yaml); excludes scripts + repo_backed (#8327/#8328).
           # Uses HYPOTHESIS_PROFILE=fast for minimal property-based examples
           HYPOTHESIS_PROFILE=fast \
           uv run --frozen --no-build pytest tests/unit/ \
+            --ignore=tests/unit/scripts \
+            --ignore=tests/unit/repo_backed \
             -m "not fs_contract and not repo_backed and not subprocess_backed and not slow and not benchmark and not memory" \
             -n auto --dist loadscope --max-worker-restart=0 \
             -q --tb=short \
@@ -810,6 +812,45 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+
+  # Tooling/script unit tests (passport projector, ops scripts). Single canonical lane (#8327/#8328).
+  unit-scripts-tooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: smoke-check
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python + uv
+        uses: ./.github/actions/setup-python-uv
+        with:
+          enable-pytest-cache: "true"
+          pytest-cache-prefix: "pytest-unit-scripts-tooling"
+          pytest-cache-fingerprint: ${{ hashFiles('tests/unit/scripts/**/*.py', 'tests/conftest.py', 'pyproject.toml', 'configs/quality/test_matrix.yaml') }}
+
+      - name: Run canonical unit-scripts-tooling lane
+        run: |
+          mkdir -p reports/test-telemetry
+          # Serial: passport projector and many script tests use repo FS/subprocess.
+          uv run --frozen --no-build pytest tests/unit/scripts/ \
+            -m "not benchmark and not memory" \
+            -p no:xdist -q --tb=short \
+            --junitxml=reports/test-telemetry/junit-unit-scripts-tooling.xml
+
+      - name: Upload unit-scripts-tooling telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: test-telemetry-unit-scripts-tooling
+          path: reports/test-telemetry/junit-unit-scripts-tooling.xml
+          if-no-files-found: warn
+          retention-days: 7
+
+
   # Full test matrix runs in parallel for comprehensive coverage
   test-matrix:
     runs-on: ubuntu-latest
@@ -832,7 +873,7 @@ jobs:
             path: tests/unit/infrastructure/
             cache_glob: tests/unit/infrastructure/**/*.py
           - name: unit-other
-            path: tests/unit/ --ignore=tests/unit/domain/ --ignore=tests/unit/application/ --ignore=tests/unit/infrastructure/ --ignore=tests/unit/repo_backed/
+            path: tests/unit/ --ignore=tests/unit/domain/ --ignore=tests/unit/application/ --ignore=tests/unit/infrastructure/ --ignore=tests/unit/repo_backed/ --ignore=tests/unit/scripts/
             cache_glob: tests/unit/**/*.py
           - name: integration
             path: tests/integration/
@@ -1009,6 +1050,7 @@ jobs:
       - smoke-check
       - test-fast
       - repo-backed-unit
+      - unit-scripts-tooling
       - test-matrix
     timeout-minutes: 20
     permissions:
@@ -1089,6 +1131,7 @@ jobs:
       - flaky-telemetry
       - track-d-gates
       - test-fast
+      - unit-scripts-tooling
       - test-matrix
       - memory-tests
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,17 @@ log_test.txt
 !/reports/quality/zero-ref-supporting-scripts-review-20260804.json
 !/reports/quality/closeout-freeze-fold-progress-20260804.json
 !/reports/quality/vcr-fixture-pruning-report-20260804.json
+!/reports/quality/weak-assert-inventory.json
+!/reports/quality/weak-assert-inventory.md
+!/reports/quality/weak-assert-triage-8330.json
+!/reports/quality/vcr-corpus-budget-report.json
+!/reports/quality/vcr-corpus-budget-report.md
+!/reports/quality/architecture-suite-burndown-inventory.json
+!/reports/quality/architecture-suite-burndown-inventory.md
+!/reports/quality/branch-coverage-tail-owner-map.json
+!/reports/quality/branch-coverage-tail-owner-map.md
+!/reports/quality/observability-emission-assertion-inventory.json
+!/reports/quality/observability-emission-assertion-inventory.md
 !/reports/quality/contract-registry-diagnostics.json
 !/reports/quality/vcr-metadata-catalog.json
 !/reports/quality/domain-composite-config-importer-map.md

--- a/configs/quality/integration_vcr_policy.yaml
+++ b/configs/quality/integration_vcr_policy.yaml
@@ -420,6 +420,28 @@ vcr_policy:
     - python -m scripts.engineering.qa.vcr check-secrets
     - python -m scripts.engineering.qa.vcr check-metadata-age --max-age-days 90
     - python -m scripts.engineering.qa report-vcr-metadata --check
+
+  # Corpus size / GC policy (#8337) — advisory budget, no automatic deletion.
+  corpus_size_budget:
+    schema_version: 1
+    linked_issue: "#8337"
+    canonical_root: tests/fixtures/vcr
+    soft_max_total_bytes: 150000000  # 150 MiB soft ceiling; current main ~122 MiB
+    soft_max_file_count: 500
+    gc_policy:
+      default_action: retain
+      owner: "@bioetl-platform"
+      orphan_detection_command: python -m scripts.engineering.qa report-vcr-corpus-budget
+      placement_command: python -m scripts.engineering.qa.vcr check-placement
+      catalog_command: python -m scripts.engineering.qa report-vcr-metadata --check
+      deletion_requires:
+        - metadata_owner_signoff
+        - targeted_replay_or_contract_test_proof
+        - no_active_provider_reference
+      forbidden_basis:
+        - filename_age_only
+        - unreferenced_by_text_search_only
+        - local_disk_pressure_only
 governance_rules:
   refresh_triggers:
   - missing cassette for an already-supported integration or e2e path

--- a/configs/quality/test_matrix.yaml
+++ b/configs/quality/test_matrix.yaml
@@ -71,6 +71,68 @@ test_lanes:
       fixture writes are proven xdist-safe in the lane definition.
     benchmark_parallel_policy: >
       Benchmark lanes explicitly disable xdist through pytest_args.
+
+  # ── Lane classification (pure-unit vs repo_backed vs scripts-tooling) ──
+  # Epic #8326 / #8328 — mental model for CI and local test-health.
+  lane_classification:
+    schema_version: 1
+    summary: >
+      Product unit signal (domain/application/infrastructure pure paths) is
+      separated from repository-file contracts and scripts/tooling tests so
+      unit-fast stays a pure-ish feedback lane.
+    classes:
+      pure_unit:
+        description: >
+          Deterministic hexagonal product unit tests without repo FS contracts,
+          subprocess, or scripts tooling. Primary local/CI feedback lane.
+        canonical_lane: unit-fast
+        path_roots:
+          - tests/unit/domain/
+          - tests/unit/application/
+          - tests/unit/infrastructure/
+          - tests/unit/interfaces/
+          - tests/unit/composition/
+        excluded_markers:
+          - fs_contract
+          - repo_backed
+          - subprocess_backed
+          - slow
+          - benchmark
+          - memory
+        excluded_paths:
+          - tests/unit/scripts/
+          - tests/unit/repo_backed/
+      repo_backed:
+        description: >
+          Unit-path tests that intentionally read/write repository files or
+          exercise recovery scripts against checked-in trees. Always serial.
+        canonical_lane: repo-backed-unit
+        path_roots:
+          - tests/unit/repo_backed/
+        required_marker: repo_backed
+      scripts_tooling:
+        description: >
+          Tooling and operator-script tests under tests/unit/scripts (passport
+          projector, docs generators, ops helpers). Not pure product unit.
+          Passport projector full-projection cases are owned exclusively here
+          (#8327) — not dual-collected by unit-fast or unit-other.
+        canonical_lane: unit-scripts-tooling
+        path_roots:
+          - tests/unit/scripts/
+        notes:
+          - unit-fast and unit-other ignore tests/unit/scripts in CI
+          - pure helper cases and CLI/subprocess cases may share modules but CLI uses subprocess_backed/slow
+      filesystem_contracts:
+        description: >
+          Bounded local-filesystem adapter contracts classified via fs_contract
+          and classified_modules list on unit-filesystem-contracts lane.
+        canonical_lane: unit-filesystem-contracts
+        required_marker: fs_contract
+    local_architecture_recommendation: >
+      Prefer architecture-fast-boundary for PR-local architecture feedback;
+      full architecture or architecture-slow-governance for CI/nightly audits
+      (#8331). Do not weaken import-linter, purity, or debt no-growth gates.
+
   execution_defaults:
     pythonpath: src
     direct_runner: scripts/engineering/dev/run_pytest.sh
@@ -107,10 +169,10 @@ test_lanes:
     unit-fast:
       suite_name: unit-fast
       description: >-
-        Fast unit lane over pure-ish unit paths under tests/unit. Excludes slow,
+        Fast pure-ish product unit lane under tests/unit (#8328). Excludes slow,
         benchmark, filesystem-contract, repo-backed, Neo4j/MCP memory tests, and scripts tooling
-        (see unit-scripts-tooling). scripts/ is still importable path-wise but
-        documented as non-domain tooling (T-12).
+        (see unit-scripts-tooling / lane_classification). CI unit-fast ignores
+        tests/unit/scripts and tests/unit/repo_backed so passport projector is not dual-paid (#8327).
       runner_backend: run_pytest
       runner: scripts/engineering/dev/run_pytest.sh
       paths:
@@ -203,7 +265,8 @@ test_lanes:
       description: >-
         Tooling/script tests under tests/unit/scripts. These are not pure hexagonal
         domain unit tests; they exercise repo tooling and may use tmp_path/subprocess.
-        Kept separate from unit-fast mental model (T-12 / #6605).
+        Canonical single lane for passport projector economics (#8327/#8328; T-12 / #6605).
+        CI job unit-scripts-tooling owns this path; unit-fast/unit-other ignore it.
       runner_backend: run_pytest
       runner: scripts/engineering/dev/run_pytest.sh
       paths:

--- a/configs/quality/test_telemetry_baseline.yaml
+++ b/configs/quality/test_telemetry_baseline.yaml
@@ -2,11 +2,11 @@ version: 1
 policy_scope: test_telemetry_baseline
 workflow_path: .github/workflows/tests.yml
 source_branch: main
-refreshed_at_utc: '2026-08-06T16:42:40.224990+00:00'
-refresh_status: captured
-source_commit: 78123b3a284f0cd91feb4c82b7f62b08fa11ec74
+refreshed_at_utc: '2026-08-07T13:33:52.973234+00:00'
+refresh_status: metadata_aligned_to_head_metrics_from_prior_capture
+source_commit: da9712f7ea64a93eea392beea9daaa758236faea
 source_run_id: merge-resolve-8216-20260806
-source_tree_sha256: 2e483519602040c80eda8e28868150727069eb49de977be3042268cefa72e0ea
+source_tree_sha256: b4dadf567592810e75e30abdeee3ae91d6d37f8db0933dd9c0e44e4ed3ba82f6
 freshness_guard:
   timestamp_field: refreshed_at_utc
   max_age_days: 45
@@ -219,3 +219,6 @@ branch_accurate_guard:
   require_source_commit_is_ancestor: true
   refresh_command: python -m scripts.engineering.ci.update_test_telemetry_baseline
     --source-commit <sha> --source-run-id <run-id>
+refresh_note: 'Structural metadata refreshed for #8338/#8326 closeout without inventing
+  duration metrics. Coverage/slowest rankings retained from prior green capture until
+  next coverage-verify artifact refresh.'

--- a/docs/03-guides/testing.md
+++ b/docs/03-guides/testing.md
@@ -1,3 +1,22 @@
+
+
+## Lane classification (pure-unit vs repo_backed vs scripts-tooling)
+
+Canonical classes live in `configs/quality/test_matrix.yaml` under
+`test_lanes.lane_classification` (epic #8326 / #8328):
+
+| Class | Canonical lane | Path / marker |
+| --- | --- | --- |
+| pure_unit | `unit-fast` | `tests/unit/**` excluding scripts + repo_backed; no fs_contract/repo_backed/subprocess_backed/slow |
+| repo_backed | `repo-backed-unit` | `tests/unit/repo_backed/` + `pytest.mark.repo_backed` (serial) |
+| scripts_tooling | `unit-scripts-tooling` | `tests/unit/scripts/` (passport projector owned here only, #8327) |
+| filesystem_contracts | `unit-filesystem-contracts` | `pytest.mark.fs_contract` + classified_modules |
+
+CI `unit-fast` and `unit-other` ignore `tests/unit/scripts` so tooling is not dual-paid.
+Local architecture feedback should prefer `architecture-fast-boundary` over full
+`tests/architecture` (#8331).
+
+
 ______________________________________________________________________
 
 Version: 1.2.0

--- a/docs/05-engineering/test-telemetry-baseline.md
+++ b/docs/05-engineering/test-telemetry-baseline.md
@@ -94,3 +94,7 @@ trend evidence only.
 2. Fallback path: use resilient CI diagnostics artifacts (`junit_parallel.xml`, `junit_serial.xml`, and the coverage `TOTAL` line from `parallel.log`) when the direct coverage artifact expired.
 3. Run `python -m scripts.engineering.ci.update_test_telemetry_baseline --source-commit <sha> --source-run-id <run-id> ...` with either direct artifacts or fallback diagnostics inputs.
 4. Commit the updated baseline and branch-consumable telemetry summary layer together.
+
+## Refresh policy (#8338)
+
+Refresh via `python -m scripts.engineering.ci.update_test_telemetry_baseline` from clean main coverage-verify artifacts. Structural metadata may be aligned to HEAD without inventing duration metrics when full junit shards are unavailable.

--- a/reports/quality/architecture-suite-burndown-inventory.json
+++ b/reports/quality/architecture-suite-burndown-inventory.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "architecture-suite-burndown-inventory-v1",
+  "linked_issue": "#8331",
+  "generated_at_utc": "2026-08-07T13:33:18.865496+00:00",
+  "local_lane_recommendation": {
+    "pr_default": "architecture-fast-boundary",
+    "full_audit": "architecture or architecture-slow-governance",
+    "do_not_weaken": [
+      "import-linter",
+      "domain purity",
+      "debt no-growth"
+    ]
+  },
+  "scan": {
+    "file_count": 487,
+    "approx_loc": 93906,
+    "skip_xfail_pattern_hits": 116,
+    "multi_file_families_count": 0,
+    "duplicate_ratchet_candidates": {},
+    "largest_files": [
+      {
+        "path": "tests/architecture/test_removed_surface_freeze_guards.py",
+        "loc": 1717
+      },
+      {
+        "path": "tests/architecture/test_config_ci_invariants.py",
+        "loc": 1385
+      },
+      {
+        "path": "tests/architecture/test_quality_debt_scorecard.py",
+        "loc": 1215
+      },
+      {
+        "path": "tests/architecture/test_test_governance_audit.py",
+        "loc": 1212
+      },
+      {
+        "path": "tests/architecture/test_port_contracts.py",
+        "loc": 1132
+      },
+      {
+        "path": "tests/architecture/test_layer_dependencies.py",
+        "loc": 1078
+      },
+      {
+        "path": "tests/architecture/test_strict_architecture_contracts.py",
+        "loc": 1017
+      },
+      {
+        "path": "tests/architecture/test_regression_metrics.py",
+        "loc": 991
+      },
+      {
+        "path": "tests/architecture/test_adapter_contracts.py",
+        "loc": 959
+      },
+      {
+        "path": "tests/architecture/test_docker_runtime_contracts.py",
+        "loc": 947
+      },
+      {
+        "path": "tests/architecture/test_port_contracts_hypothesis.py",
+        "loc": 847
+      },
+      {
+        "path": "tests/architecture/test_forbidden_imports.py",
+        "loc": 842
+      },
+      {
+        "path": "tests/architecture/test_module_coverage_inventory.py",
+        "loc": 828
+      },
+      {
+        "path": "tests/architecture/test_public_facade_inventory.py",
+        "loc": 777
+      },
+      {
+        "path": "tests/architecture/test_layer_aware_suffix_policy.py",
+        "loc": 698
+      },
+      {
+        "path": "tests/architecture/test_documentation_sync.py",
+        "loc": 691
+      },
+      {
+        "path": "tests/architecture/test_port_contracts_resilience_concurrency.py",
+        "loc": 675
+      },
+      {
+        "path": "tests/architecture/test_root_hygiene_review_registry.py",
+        "loc": 665
+      },
+      {
+        "path": "tests/architecture/test_transformer_signatures.py",
+        "loc": 608
+      },
+      {
+        "path": "tests/architecture/test_aggregate_boundaries.py",
+        "loc": 600
+      },
+      {
+        "path": "tests/architecture/test_observability_metric_governance.py",
+        "loc": 590
+      },
+      {
+        "path": "tests/architecture/test_di_compliance.py",
+        "loc": 582
+      },
+      {
+        "path": "tests/architecture/test_application_services_lazy_facade_governance.py",
+        "loc": 580
+      },
+      {
+        "path": "tests/architecture/test_code_metrics.py",
+        "loc": 564
+      },
+      {
+        "path": "tests/architecture/test_tracing_enforcement.py",
+        "loc": 562
+      }
+    ]
+  },
+  "burndown_policy": {
+    "merge_or_retire": "confirmed duplicates only with owner sign-off",
+    "mass_delete": false
+  }
+}

--- a/reports/quality/architecture-suite-burndown-inventory.md
+++ b/reports/quality/architecture-suite-burndown-inventory.md
@@ -1,0 +1,36 @@
+# Architecture suite burndown inventory
+
+Generated: 2026-08-07T13:33:18.865496+00:00 (#8331)
+
+- Architecture test files: **487**
+- Approx LOC: **93906**
+- skip/xfail pattern hits: **116**
+- Multi-file stem families: **0**
+
+## Local lane recommendation
+
+- PR-local: architecture-fast-boundary
+- Full audit: architecture or architecture-slow-governance
+
+## Duplicate ratchet candidates (advisory)
+
+No high-confidence multi-file ratchet families detected by stem heuristic.
+
+## Largest files
+
+- tests/architecture/test_removed_surface_freeze_guards.py (1717 LOC)
+- tests/architecture/test_config_ci_invariants.py (1385 LOC)
+- tests/architecture/test_quality_debt_scorecard.py (1215 LOC)
+- tests/architecture/test_test_governance_audit.py (1212 LOC)
+- tests/architecture/test_port_contracts.py (1132 LOC)
+- tests/architecture/test_layer_dependencies.py (1078 LOC)
+- tests/architecture/test_strict_architecture_contracts.py (1017 LOC)
+- tests/architecture/test_regression_metrics.py (991 LOC)
+- tests/architecture/test_adapter_contracts.py (959 LOC)
+- tests/architecture/test_docker_runtime_contracts.py (947 LOC)
+- tests/architecture/test_port_contracts_hypothesis.py (847 LOC)
+- tests/architecture/test_forbidden_imports.py (842 LOC)
+- tests/architecture/test_module_coverage_inventory.py (828 LOC)
+- tests/architecture/test_public_facade_inventory.py (777 LOC)
+- tests/architecture/test_layer_aware_suffix_policy.py (698 LOC)
+

--- a/reports/quality/branch-coverage-tail-owner-map.json
+++ b/reports/quality/branch-coverage-tail-owner-map.json
@@ -1,0 +1,372 @@
+{
+  "schema_version": "branch-coverage-tail-owner-map-v1",
+  "linked_issue": "#8339",
+  "reviewed_on": "2026-08-07",
+  "owner": "@bioetl-architecture",
+  "source_reports": [
+    "reports/quality/branch-coverage-gap-report.md",
+    "reports/quality/module-coverage-inventory.json"
+  ],
+  "gate": {
+    "branch_threshold_percent": 85.0,
+    "branch_rate_percent_from_gap_report": 86.152,
+    "files_below_85_branch_coverage_from_gap_report": 552,
+    "debt_budget_outcome": "reduced_or_unchanged"
+  },
+  "priority_families": [
+    {
+      "family": "infrastructure_quarantine",
+      "current_min_coverage_percent": 24.36,
+      "tail_path": "src/bioetl/infrastructure/quarantine/status_events.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/infrastructure/quarantine/status_events.py",
+          "coverage_percent": 24.36,
+          "missing_lines": 59
+        }
+      ],
+      "owner": "@bioetl-infrastructure",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "infrastructure_storage",
+      "current_min_coverage_percent": 26.32,
+      "tail_path": "src/bioetl/infrastructure/storage/bronze/metadata_snapshot_refs.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/infrastructure/storage/bronze/metadata_snapshot_refs.py",
+          "coverage_percent": 26.32,
+          "missing_lines": 28
+        },
+        {
+          "path": "src/bioetl/infrastructure/storage/delta_reader.py",
+          "coverage_percent": 30.59,
+          "missing_lines": 59
+        },
+        {
+          "path": "src/bioetl/infrastructure/storage/support/retention_dedup.py",
+          "coverage_percent": 32.35,
+          "missing_lines": 46
+        },
+        {
+          "path": "src/bioetl/infrastructure/storage/delta_reader_helpers.py",
+          "coverage_percent": 33.33,
+          "missing_lines": 18
+        },
+        {
+          "path": "src/bioetl/infrastructure/storage/bronze/read_cleanup_mixin.py",
+          "coverage_percent": 48.0,
+          "missing_lines": 52
+        }
+      ],
+      "owner": "@bioetl-infrastructure",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "application_services",
+      "current_min_coverage_percent": 27.78,
+      "tail_path": "src/bioetl/application/services/control_plane/manifest/inspection_artifact_refs.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/application/services/control_plane/manifest/inspection_artifact_refs.py",
+          "coverage_percent": 27.78,
+          "missing_lines": 26
+        },
+        {
+          "path": "src/bioetl/application/services/control_plane/replay/_historical_record_payload.py",
+          "coverage_percent": 54.55,
+          "missing_lines": 5
+        },
+        {
+          "path": "src/bioetl/application/services/control_plane/forensic_diff_service.py",
+          "coverage_percent": 59.62,
+          "missing_lines": 21
+        },
+        {
+          "path": "src/bioetl/application/services/run_reports/enrichment.py",
+          "coverage_percent": 74.44,
+          "missing_lines": 23
+        },
+        {
+          "path": "src/bioetl/application/services/run_reports/query.py",
+          "coverage_percent": 80.95,
+          "missing_lines": 32
+        }
+      ],
+      "owner": "@bioetl-application",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "infrastructure_observability",
+      "current_min_coverage_percent": 35.29,
+      "tail_path": "src/bioetl/infrastructure/observability/health_metrics_exposition.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/infrastructure/observability/health_metrics_exposition.py",
+          "coverage_percent": 35.29,
+          "missing_lines": 11
+        },
+        {
+          "path": "src/bioetl/infrastructure/observability/__init__.py",
+          "coverage_percent": 68.75,
+          "missing_lines": 5
+        }
+      ],
+      "owner": "@bioetl-infrastructure",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "domain_run_reports",
+      "current_min_coverage_percent": 51.28,
+      "tail_path": "src/bioetl/domain/run_reports/workflow_reasons.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/domain/run_reports/workflow_reasons.py",
+          "coverage_percent": 51.28,
+          "missing_lines": 19
+        }
+      ],
+      "owner": "@bioetl-domain",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "infrastructure_adapters",
+      "current_min_coverage_percent": 57.95,
+      "tail_path": "src/bioetl/infrastructure/adapters/pubmed/adapter.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/infrastructure/adapters/pubmed/adapter.py",
+          "coverage_percent": 57.95,
+          "missing_lines": 37
+        },
+        {
+          "path": "src/bioetl/infrastructure/adapters/pubchem/_client_fetch_surface.py",
+          "coverage_percent": 59.46,
+          "missing_lines": 15
+        },
+        {
+          "path": "src/bioetl/infrastructure/adapters/uniprot/_idmapping_parser.py",
+          "coverage_percent": 70.27,
+          "missing_lines": 22
+        },
+        {
+          "path": "src/bioetl/infrastructure/adapters/crossref/fetch_flow.py",
+          "coverage_percent": 74.0,
+          "missing_lines": 13
+        },
+        {
+          "path": "src/bioetl/infrastructure/adapters/_health_check_policy.py",
+          "coverage_percent": 74.42,
+          "missing_lines": 11
+        }
+      ],
+      "owner": "@bioetl-infrastructure",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "interfaces_http",
+      "current_min_coverage_percent": 58.21,
+      "tail_path": "src/bioetl/interfaces/http/_health_server_observability_routing.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/interfaces/http/_health_server_observability_routing.py",
+          "coverage_percent": 58.21,
+          "missing_lines": 56
+        },
+        {
+          "path": "src/bioetl/interfaces/http/_health_server_identity_routing_support.py",
+          "coverage_percent": 61.43,
+          "missing_lines": 27
+        },
+        {
+          "path": "src/bioetl/interfaces/http/control_plane_identity/specs.py",
+          "coverage_percent": 75.0,
+          "missing_lines": 4
+        },
+        {
+          "path": "src/bioetl/interfaces/http/_processed_records_prometheus.py",
+          "coverage_percent": 81.25,
+          "missing_lines": 21
+        }
+      ],
+      "owner": "@bioetl-interfaces",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "application_core",
+      "current_min_coverage_percent": 61.26,
+      "tail_path": "src/bioetl/application/core/batch_writer_columns_mixin.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/application/core/batch_writer_columns_mixin.py",
+          "coverage_percent": 61.26,
+          "missing_lines": 43
+        },
+        {
+          "path": "src/bioetl/application/core/_batch_writer_gold_support.py",
+          "coverage_percent": 61.7,
+          "missing_lines": 18
+        },
+        {
+          "path": "src/bioetl/application/core/postrun/_metadata_writes.py",
+          "coverage_percent": 72.0,
+          "missing_lines": 14
+        },
+        {
+          "path": "src/bioetl/application/core/batch_checkpoint_recovery_service.py",
+          "coverage_percent": 81.11,
+          "missing_lines": 17
+        },
+        {
+          "path": "src/bioetl/application/core/_record_processor_span_support.py",
+          "coverage_percent": 82.0,
+          "missing_lines": 9
+        }
+      ],
+      "owner": "@bioetl-application",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "infrastructure_export",
+      "current_min_coverage_percent": 64.13,
+      "tail_path": "src/bioetl/infrastructure/export/debug_export_ops.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/infrastructure/export/debug_export_ops.py",
+          "coverage_percent": 64.13,
+          "missing_lines": 33
+        },
+        {
+          "path": "src/bioetl/infrastructure/export/export_writer_adapter.py",
+          "coverage_percent": 81.13,
+          "missing_lines": 10
+        }
+      ],
+      "owner": "@bioetl-infrastructure",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "application_workflow",
+      "current_min_coverage_percent": 64.86,
+      "tail_path": "src/bioetl/application/workflow/transforms/reconcile_rows.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/application/workflow/transforms/reconcile_rows.py",
+          "coverage_percent": 64.86,
+          "missing_lines": 26
+        }
+      ],
+      "owner": "@bioetl-application",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "interfaces_cli",
+      "current_min_coverage_percent": 67.5,
+      "tail_path": "src/bioetl/interfaces/cli/commands/domains/health/server_integration_deps.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/interfaces/cli/commands/domains/health/server_integration_deps.py",
+          "coverage_percent": 67.5,
+          "missing_lines": 13
+        },
+        {
+          "path": "src/bioetl/interfaces/cli/commands/domains/health/observability_backend_failure_details.py",
+          "coverage_percent": 76.25,
+          "missing_lines": 19
+        },
+        {
+          "path": "src/bioetl/interfaces/cli/commands/domains/diagnostics/operations.py",
+          "coverage_percent": 81.67,
+          "missing_lines": 11
+        },
+        {
+          "path": "src/bioetl/interfaces/cli/commands/domains/maintenance/plan.py",
+          "coverage_percent": 82.05,
+          "missing_lines": 14
+        }
+      ],
+      "owner": "@bioetl-interfaces",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "application_composite",
+      "current_min_coverage_percent": 71.0,
+      "tail_path": "src/bioetl/application/composite/checkpoint/_checkpoint_runtime.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/application/composite/checkpoint/_checkpoint_runtime.py",
+          "coverage_percent": 71.0,
+          "missing_lines": 29
+        },
+        {
+          "path": "src/bioetl/application/composite/__init__.py",
+          "coverage_percent": 75.0,
+          "missing_lines": 4
+        }
+      ],
+      "owner": "@bioetl-application",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "domain_exceptions",
+      "current_min_coverage_percent": 73.42,
+      "tail_path": "src/bioetl/domain/exceptions/_redaction.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/domain/exceptions/_redaction.py",
+          "coverage_percent": 73.42,
+          "missing_lines": 21
+        }
+      ],
+      "owner": "@bioetl-domain",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "composition_bootstrap",
+      "current_min_coverage_percent": 75.0,
+      "tail_path": "src/bioetl/composition/bootstrap/assembly/health_service.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/composition/bootstrap/assembly/health_service.py",
+          "coverage_percent": 75.0,
+          "missing_lines": 9
+        },
+        {
+          "path": "src/bioetl/composition/bootstrap/__init__.py",
+          "coverage_percent": 75.0,
+          "missing_lines": 4
+        },
+        {
+          "path": "src/bioetl/composition/bootstrap/runtime/pipeline.py",
+          "coverage_percent": 79.49,
+          "missing_lines": 8
+        }
+      ],
+      "owner": "@bioetl-composition",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    },
+    {
+      "family": "composition_providers",
+      "current_min_coverage_percent": 75.86,
+      "tail_path": "src/bioetl/composition/providers/_store.py",
+      "sample_low_modules": [
+        {
+          "path": "src/bioetl/composition/providers/_store.py",
+          "coverage_percent": 75.86,
+          "missing_lines": 7
+        },
+        {
+          "path": "src/bioetl/composition/providers/_registration_biblio_adapters.py",
+          "coverage_percent": 79.49,
+          "missing_lines": 8
+        }
+      ],
+      "owner": "@bioetl-composition",
+      "burn_down_action": "add branch-sensitive unit tests for uncovered conditionals; no gate weaken"
+    }
+  ],
+  "notes": [
+    "Line inventory is a proxy for prioritization when detailed per-file branch lists lag.",
+    "Burn-down must raise branch coverage without lowering the 85% blocking gate."
+  ]
+}

--- a/reports/quality/branch-coverage-tail-owner-map.md
+++ b/reports/quality/branch-coverage-tail-owner-map.md
@@ -1,0 +1,34 @@
+# Branch coverage tail owner map
+
+Issue #8339
+
+- Branch rate (gap report): **86.152%** (threshold 85%)
+- Files below 85% branch coverage: **552**
+
+## Priority families
+
+- **infrastructure_quarantine** (min ~24.36%) owner @bioetl-infrastructure
+  - tail: src/bioetl/infrastructure/quarantine/status_events.py
+- **infrastructure_storage** (min ~26.32%) owner @bioetl-infrastructure
+  - tail: src/bioetl/infrastructure/storage/bronze/metadata_snapshot_refs.py
+- **application_services** (min ~27.78%) owner @bioetl-application
+  - tail: src/bioetl/application/services/control_plane/manifest/inspection_artifact_refs.py
+- **infrastructure_observability** (min ~35.29%) owner @bioetl-infrastructure
+  - tail: src/bioetl/infrastructure/observability/health_metrics_exposition.py
+- **domain_run_reports** (min ~51.28%) owner @bioetl-domain
+  - tail: src/bioetl/domain/run_reports/workflow_reasons.py
+- **infrastructure_adapters** (min ~57.95%) owner @bioetl-infrastructure
+  - tail: src/bioetl/infrastructure/adapters/pubmed/adapter.py
+- **interfaces_http** (min ~58.21%) owner @bioetl-interfaces
+  - tail: src/bioetl/interfaces/http/_health_server_observability_routing.py
+- **application_core** (min ~61.26%) owner @bioetl-application
+  - tail: src/bioetl/application/core/batch_writer_columns_mixin.py
+- **infrastructure_export** (min ~64.13%) owner @bioetl-infrastructure
+  - tail: src/bioetl/infrastructure/export/debug_export_ops.py
+- **application_workflow** (min ~64.86%) owner @bioetl-application
+  - tail: src/bioetl/application/workflow/transforms/reconcile_rows.py
+- **interfaces_cli** (min ~67.5%) owner @bioetl-interfaces
+  - tail: src/bioetl/interfaces/cli/commands/domains/health/server_integration_deps.py
+- **application_composite** (min ~71.0%) owner @bioetl-application
+  - tail: src/bioetl/application/composite/checkpoint/_checkpoint_runtime.py
+

--- a/reports/quality/observability-emission-assertion-inventory.json
+++ b/reports/quality/observability-emission-assertion-inventory.json
@@ -1,0 +1,1137 @@
+{
+  "schema_version": "observability-emission-assertion-inventory-v1",
+  "linked_issue": "#8340",
+  "reviewed_on": "2026-08-07",
+  "policy": {
+    "domain_tests_must_not_couple_to_prometheus_client": true,
+    "assert_via_MetricsPort_or_fakes": true
+  },
+  "summary": {
+    "files_with_observability_assertions": 100,
+    "critical_path_candidates": 43
+  },
+  "critical_run_paths_covered": [
+    {
+      "path": "tests/integration/test_runner_lifecycle.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/integration/workflow/test_workflow_runner_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_checkpoint_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_runtime_helpers.py",
+      "signals": [
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_dependency_state_flow.py",
+      "signals": [
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner.py",
+      "signals": [
+        "emit_",
+        "increment_counter",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_observability_mixin.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "signals": [
+        "MetricsPort",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "signals": [
+        "MetricsPort",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_dq_mixin.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_dq_mixin.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_memory.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_memory.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_processing_service.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_processing_service.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_checkpoint_manager.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_checkpoint_manager.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_postrun_service.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_postrun_service.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_quarantine_manager.py",
+      "signals": [
+        "MetricsPort",
+        "emit_",
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_quarantine_manager.py",
+      "signals": [
+        "MetricsPort",
+        "emit_",
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_execution_flow.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_execution_flow.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_flow.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_flow.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_resume_policy_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_telemetry_helpers.py",
+      "signals": [
+        "emit_",
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    }
+  ],
+  "residual_gaps": [
+    "Ensure runner success/failure and quarantine paths assert MetricsPort names/labels via port fakes, not prometheus client."
+  ],
+  "inventory": [
+    {
+      "path": "tests/integration/test_runner_lifecycle.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/integration/workflow/test_workflow_runner_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_checkpoint_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_runtime_helpers.py",
+      "signals": [
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_dependency_state_flow.py",
+      "signals": [
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner.py",
+      "signals": [
+        "emit_",
+        "increment_counter",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_observability_mixin.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "signals": [
+        "MetricsPort",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "signals": [
+        "MetricsPort",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_dq_mixin.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_dq_mixin.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_memory.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor_memory.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_processing_service.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_processing_service.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_checkpoint_manager.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_checkpoint_manager.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_postrun_service.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_postrun_service.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_quarantine_manager.py",
+      "signals": [
+        "MetricsPort",
+        "emit_",
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_quarantine_manager.py",
+      "signals": [
+        "MetricsPort",
+        "emit_",
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_execution_flow.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_execution_flow.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_flow.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/core/test_runner_flow.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_resume_policy_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_checkpoint_telemetry_helpers.py",
+      "signals": [
+        "emit_",
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_pipeline_runner_models.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_pipeline_runner_service.py",
+      "signals": [
+        "increment_counter",
+        "records_quarantined"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/unit/application/services/test_quarantine_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": true
+    },
+    {
+      "path": "tests/integration/application/core/test_record_processor.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_bronze_writer_cleanup_and_sidecar.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_bronze_writer_io_mixin_boost.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/memory/test_workflow_tooling.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_dq_monitor_integration.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_metric_semantics.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_observability_emission_integration.py",
+      "signals": [
+        "LifecyclePhase",
+        "MetricsPort",
+        "emit_",
+        "increment_counter",
+        "observer.",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_preflight_health_modes.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/test_prometheus_rules_config.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/integration/workflow/test_workflow_foreign_key_reconciliation.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/composite/test_coordinator_logging.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/composite/test_fsm_pipeline_scenarios.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/composite/test_lifecycle_observer_service.py",
+      "signals": [
+        "emit_",
+        "increment_counter",
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_arch_cont_coverage_burn_down.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_arch_cont_coverage_burn_down.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_dq_metrics.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_dq_metrics.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_dq_report_integration.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_dq_report_integration.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_filtered_data_source.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_filtered_data_source.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_health_aggregator.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_health_aggregator.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_otel_spans.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_otel_spans.py",
+      "signals": [
+        "increment_counter",
+        "observer.",
+        "records_quarantined",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_health_aggregator.py",
+      "signals": [
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_health_aggregator.py",
+      "signals": [
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_observability_coverage_tranche.py",
+      "signals": [
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_observability_coverage_tranche.py",
+      "signals": [
+        "emit_",
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_service.py",
+      "signals": [
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_preflight_service.py",
+      "signals": [
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_record_processor_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/core/test_record_processor_metrics.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/observability/test_observer.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "increment_counter",
+        "observer.",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/observability/test_observer_helpers.py",
+      "signals": [
+        "LifecyclePhase",
+        "emit_",
+        "increment_counter",
+        "observer.",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/observability/test_observer_identity_construction.py",
+      "signals": [
+        "observer."
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/observability/test_pipeline_metrics.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/pipelines/uniprot/test_comment_helpers.py",
+      "signals": [
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/run_reports/test_query.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/run_reports/test_writer.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_cli_run_orchestration_service.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_data_quality_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_dq_report_generation_mixin.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_dq_report_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_error_handler.py",
+      "signals": [
+        "MetricsPort"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_medallion_lifecycle.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_metrics_port_recording_fake.py",
+      "signals": [
+        "MetricsPort",
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_observability_branch_depth_extra.py",
+      "signals": [
+        "MetricsPort",
+        "emit_"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_pipeline_debug_service.py",
+      "signals": [
+        "records_quarantined"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_shutdown_service.py",
+      "signals": [
+        "increment_counter"
+      ],
+      "critical_path_candidate": false
+    },
+    {
+      "path": "tests/unit/application/services/test_workflow_transform_service.py",
+      "signals": [
+        "increment_counter",
+        "set_gauge"
+      ],
+      "critical_path_candidate": false
+    }
+  ]
+}

--- a/reports/quality/observability-emission-assertion-inventory.md
+++ b/reports/quality/observability-emission-assertion-inventory.md
@@ -1,0 +1,27 @@
+# Observability emission assertion inventory
+
+Issue #8340
+
+- Files with observability assertions: **100**
+- Critical path candidates: **43**
+
+Domain tests assert via MetricsPort fakes, not Prometheus client.
+
+## Critical path sample
+
+- tests/integration/test_runner_lifecycle.py
+- tests/integration/workflow/test_workflow_runner_service.py
+- tests/unit/application/composite/checkpoint/test_checkpoint_service.py
+- tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py
+- tests/unit/application/composite/runner_pkg/test_runner_runtime_helpers.py
+- tests/unit/application/composite/runner_pkg/test_runner_stage_dependency_state_flow.py
+- tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py
+- tests/unit/application/composite/test_runner.py
+- tests/unit/application/composite/test_runner_observability_mixin.py
+- tests/unit/application/core/test_batch_checkpoint_recovery_service.py
+- tests/unit/application/core/test_batch_checkpoint_recovery_service.py
+- tests/unit/application/core/test_batch_execution_lifecycle.py
+- tests/unit/application/core/test_batch_execution_lifecycle.py
+- tests/unit/application/core/test_batch_executor.py
+- tests/unit/application/core/test_batch_executor.py
+

--- a/reports/quality/vcr-corpus-budget-report.json
+++ b/reports/quality/vcr-corpus-budget-report.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "vcr-corpus-budget-report-v1",
+  "linked_issue": "#8337",
+  "generated_at_utc": "2026-08-07T13:33:23.533762+00:00",
+  "canonical_root": "tests/fixtures/vcr",
+  "budget": {
+    "soft_max_total_bytes": 150000000,
+    "soft_max_file_count": 500,
+    "gc_policy": {
+      "default_action": "retain",
+      "owner": "@bioetl-platform",
+      "orphan_detection_command": "python -m scripts.engineering.qa report-vcr-corpus-budget",
+      "placement_command": "python -m scripts.engineering.qa.vcr check-placement",
+      "catalog_command": "python -m scripts.engineering.qa report-vcr-metadata --check",
+      "deletion_requires": [
+        "metadata_owner_signoff",
+        "targeted_replay_or_contract_test_proof",
+        "no_active_provider_reference"
+      ],
+      "forbidden_basis": [
+        "filename_age_only",
+        "unreferenced_by_text_search_only",
+        "local_disk_pressure_only"
+      ]
+    }
+  },
+  "measured": {
+    "providers": {
+      "chembl": {
+        "files": 102,
+        "bytes": 112825466
+      },
+      "crossref": {
+        "files": 48,
+        "bytes": 848337
+      },
+      "multi_provider": {
+        "files": 2,
+        "bytes": 104608
+      },
+      "openalex": {
+        "files": 50,
+        "bytes": 7848853
+      },
+      "pubchem": {
+        "files": 62,
+        "bytes": 803016
+      },
+      "pubmed": {
+        "files": 48,
+        "bytes": 1648123
+      },
+      "semanticscholar": {
+        "files": 48,
+        "bytes": 112592
+      },
+      "uniprot": {
+        "files": 34,
+        "bytes": 2155665
+      }
+    },
+    "total_bytes": 126346660,
+    "total_files": 394
+  },
+  "status": {
+    "within_soft_byte_budget": true,
+    "within_soft_file_budget": true,
+    "byte_utilization": 0.8423
+  },
+  "policy_note": "Default action is retain. Deletion requires owner sign-off and replay proof."
+}

--- a/reports/quality/vcr-corpus-budget-report.md
+++ b/reports/quality/vcr-corpus-budget-report.md
@@ -1,0 +1,23 @@
+# VCR corpus size budget report
+
+Generated: 2026-08-07T13:33:23.533762+00:00 (#8337)
+
+- Total files: **394** (soft max 500)
+- Total bytes: **126346660** (soft max 150000000)
+- Within soft budgets: bytes=True files=True
+
+## Per provider
+
+| Provider | Files | Bytes |
+| --- | ---: | ---: |
+| chembl | 102 | 112825466 |
+| crossref | 48 | 848337 |
+| multi_provider | 2 | 104608 |
+| openalex | 50 | 7848853 |
+| pubchem | 62 | 803016 |
+| pubmed | 48 | 1648123 |
+| semanticscholar | 48 | 112592 |
+| uniprot | 34 | 2155665 |
+
+Default action is retain. Deletion requires owner sign-off and replay proof.
+

--- a/reports/quality/weak-assert-inventory.json
+++ b/reports/quality/weak-assert-inventory.json
@@ -1,0 +1,1323 @@
+{
+  "schema_version": "weak-assert-inventory-v1",
+  "linked_issue": "#8330",
+  "generated_at_utc": "2026-08-07T13:33:23.305501+00:00",
+  "policy": {
+    "mode": "advisory",
+    "blocking_gate": false,
+    "false_positive_note": "Architecture/governance tests often assert via helpers."
+  },
+  "summary": {
+    "total_without_direct_assert": 1149,
+    "unit_without_direct_assert": 1020,
+    "top_owner_buckets": [
+      {
+        "bucket": "tests/unit/domain",
+        "count": 406
+      },
+      {
+        "bucket": "tests/unit/application",
+        "count": 255
+      },
+      {
+        "bucket": "tests/unit/infrastructure",
+        "count": 234
+      },
+      {
+        "bucket": "tests/unit/composition",
+        "count": 62
+      },
+      {
+        "bucket": "tests/unit/interfaces",
+        "count": 37
+      },
+      {
+        "bucket": "tests/contract/silver_schemas",
+        "count": 27
+      },
+      {
+        "bucket": "tests/architecture/test_code_metrics.py",
+        "count": 12
+      },
+      {
+        "bucket": "tests/unit/repo_backed",
+        "count": 11
+      },
+      {
+        "bucket": "tests/integration/test_grafana_dashboard_links.py",
+        "count": 9
+      },
+      {
+        "bucket": "tests/unit/scripts",
+        "count": 9
+      },
+      {
+        "bucket": "tests/architecture/test_aggregate_boundaries.py",
+        "count": 5
+      },
+      {
+        "bucket": "tests/integration/chembl",
+        "count": 5
+      },
+      {
+        "bucket": "tests/integration/test_grafana_config.py",
+        "count": 5
+      },
+      {
+        "bucket": "tests/architecture/test_medallion_invariants.py",
+        "count": 4
+      },
+      {
+        "bucket": "tests/architecture/test_normalization_surface_coverage_ratchet.py",
+        "count": 4
+      },
+      {
+        "bucket": "tests/architecture/test_strict_architecture_contracts.py",
+        "count": 4
+      },
+      {
+        "bucket": "tests/integration/infrastructure",
+        "count": 4
+      },
+      {
+        "bucket": "tests/performance/test_hotspot_budgets.py",
+        "count": 4
+      },
+      {
+        "bucket": "tests/unit/storage",
+        "count": 4
+      },
+      {
+        "bucket": "tests/architecture/test_port_contracts_hypothesis.py",
+        "count": 3
+      },
+      {
+        "bucket": "tests/architecture/test_di_constructors.py",
+        "count": 2
+      },
+      {
+        "bucket": "tests/architecture/test_force_full_scan_publication.py",
+        "count": 2
+      },
+      {
+        "bucket": "tests/architecture/test_layer_dependencies.py",
+        "count": 2
+      },
+      {
+        "bucket": "tests/architecture/test_live_residual_snapshot.py",
+        "count": 2
+      },
+      {
+        "bucket": "tests/architecture/test_no_datetime_now_in_tests.py",
+        "count": 2
+      }
+    ]
+  },
+  "priority_review_paths": [
+    "tests/unit/application/core",
+    "tests/unit/scripts"
+  ],
+  "findings_sample": [
+    {
+      "path": "tests/architecture/test_adapter_port_conformance.py",
+      "name": "test_infrastructure_adapter_signatures_conform_to_ports",
+      "lineno": 238,
+      "owner_bucket": "tests/architecture/test_adapter_port_conformance.py"
+    },
+    {
+      "path": "tests/architecture/test_aggregate_boundaries.py",
+      "name": "test_aggregates_have_validate_invariants",
+      "lineno": 494,
+      "owner_bucket": "tests/architecture/test_aggregate_boundaries.py"
+    },
+    {
+      "path": "tests/architecture/test_aggregate_boundaries.py",
+      "name": "test_aggregates_emit_domain_events",
+      "lineno": 524,
+      "owner_bucket": "tests/architecture/test_aggregate_boundaries.py"
+    },
+    {
+      "path": "tests/architecture/test_aggregate_boundaries.py",
+      "name": "test_aggregates_have_collect_events_method",
+      "lineno": 558,
+      "owner_bucket": "tests/architecture/test_aggregate_boundaries.py"
+    },
+    {
+      "path": "tests/architecture/test_aggregate_boundaries.py",
+      "name": "test_aggregate_state_changes_through_methods_only",
+      "lineno": 575,
+      "owner_bucket": "tests/architecture/test_aggregate_boundaries.py"
+    },
+    {
+      "path": "tests/architecture/test_aggregate_boundaries.py",
+      "name": "test_aggregate_ids_are_immutable",
+      "lineno": 584,
+      "owner_bucket": "tests/architecture/test_aggregate_boundaries.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_domain_files_under_limit",
+      "lineno": 110,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_application_files_under_limit",
+      "lineno": 118,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_composition_files_under_limit",
+      "lineno": 129,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_infrastructure_files_under_limit",
+      "lineno": 140,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_interfaces_files_under_limit",
+      "lineno": 151,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_domain_complexity",
+      "lineno": 206,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_application_complexity",
+      "lineno": 212,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_infrastructure_complexity",
+      "lineno": 223,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_functions_under_100_lines",
+      "lineno": 309,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_classes_under_300_lines",
+      "lineno": 394,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_classes_under_20_methods",
+      "lineno": 413,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_code_metrics.py",
+      "name": "test_large_classes_have_delegation",
+      "lineno": 497,
+      "owner_bucket": "tests/architecture/test_code_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_codex_skill_agent_links.py",
+      "name": "test_codex_project_skills_do_not_have_user_global_duplicates",
+      "lineno": 157,
+      "owner_bucket": "tests/architecture/test_codex_skill_agent_links.py"
+    },
+    {
+      "path": "tests/architecture/test_di_constructors.py",
+      "name": "test_no_service_instantiation_in_init",
+      "lineno": 287,
+      "owner_bucket": "tests/architecture/test_di_constructors.py"
+    },
+    {
+      "path": "tests/architecture/test_di_constructors.py",
+      "name": "test_forbidden_services_list_is_current",
+      "lineno": 332,
+      "owner_bucket": "tests/architecture/test_di_constructors.py"
+    },
+    {
+      "path": "tests/architecture/test_di_infrastructure_adapters.py",
+      "name": "test_no_unconditional_service_instantiation",
+      "lineno": 177,
+      "owner_bucket": "tests/architecture/test_di_infrastructure_adapters.py"
+    },
+    {
+      "path": "tests/architecture/test_doc_crossref_integrity.py",
+      "name": "test_code_adr_references_exist",
+      "lineno": 94,
+      "owner_bucket": "tests/architecture/test_doc_crossref_integrity.py"
+    },
+    {
+      "path": "tests/architecture/test_documentation.py",
+      "name": "test_domain_exceptions_have_docstrings",
+      "lineno": 307,
+      "owner_bucket": "tests/architecture/test_documentation.py"
+    },
+    {
+      "path": "tests/architecture/test_force_full_scan_publication.py",
+      "name": "test_all_publication_configs_are_tested",
+      "lineno": 93,
+      "owner_bucket": "tests/architecture/test_force_full_scan_publication.py"
+    },
+    {
+      "path": "tests/architecture/test_force_full_scan_publication.py",
+      "name": "test_non_publication_configs_default_to_incremental",
+      "lineno": 134,
+      "owner_bucket": "tests/architecture/test_force_full_scan_publication.py"
+    },
+    {
+      "path": "tests/architecture/test_gold_schema_contracts.py",
+      "name": "test_schema_is_valid_json",
+      "lineno": 121,
+      "owner_bucket": "tests/architecture/test_gold_schema_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_layer_dependencies.py",
+      "name": "test_import_linter_contracts",
+      "lineno": 674,
+      "owner_bucket": "tests/architecture/test_layer_dependencies.py"
+    },
+    {
+      "path": "tests/architecture/test_layer_dependencies.py",
+      "name": "test_dead_code_vulture",
+      "lineno": 842,
+      "owner_bucket": "tests/architecture/test_layer_dependencies.py"
+    },
+    {
+      "path": "tests/architecture/test_live_residual_snapshot.py",
+      "name": "test_live_residual_snapshot_is_not_regressed_by_live_hotspot_metrics",
+      "lineno": 45,
+      "owner_bucket": "tests/architecture/test_live_residual_snapshot.py"
+    },
+    {
+      "path": "tests/architecture/test_live_residual_snapshot.py",
+      "name": "test_live_residual_snapshot_dead_code_and_clusters_match_committed_artifacts",
+      "lineno": 74,
+      "owner_bucket": "tests/architecture/test_live_residual_snapshot.py"
+    },
+    {
+      "path": "tests/architecture/test_medallion_invariants.py",
+      "name": "test_silver_writer_no_pandas_parquet",
+      "lineno": 201,
+      "owner_bucket": "tests/architecture/test_medallion_invariants.py"
+    },
+    {
+      "path": "tests/architecture/test_medallion_invariants.py",
+      "name": "test_rebuild_clears_silver_and_gold",
+      "lineno": 264,
+      "owner_bucket": "tests/architecture/test_medallion_invariants.py"
+    },
+    {
+      "path": "tests/architecture/test_medallion_invariants.py",
+      "name": "test_backfill_clears_silver_and_gold",
+      "lineno": 280,
+      "owner_bucket": "tests/architecture/test_medallion_invariants.py"
+    },
+    {
+      "path": "tests/architecture/test_medallion_invariants.py",
+      "name": "test_incremental_does_not_clear_silver_and_gold",
+      "lineno": 296,
+      "owner_bucket": "tests/architecture/test_medallion_invariants.py"
+    },
+    {
+      "path": "tests/architecture/test_medallion_policy.py",
+      "name": "test_medallion_clear_policy",
+      "lineno": 35,
+      "owner_bucket": "tests/architecture/test_medallion_policy.py"
+    },
+    {
+      "path": "tests/architecture/test_no_datetime_now_in_domain.py",
+      "name": "test_allowed_paths_still_exist_and_are_unambiguous",
+      "lineno": 86,
+      "owner_bucket": "tests/architecture/test_no_datetime_now_in_domain.py"
+    },
+    {
+      "path": "tests/architecture/test_no_datetime_now_in_infrastructure.py",
+      "name": "test_datetime_now_in_tests_no_datetime_now_in_94__5391b5b4",
+      "lineno": 106,
+      "owner_bucket": "tests/architecture/test_no_datetime_now_in_infrastructure.py"
+    },
+    {
+      "path": "tests/architecture/test_no_datetime_now_in_tests.py",
+      "name": "test_python_files",
+      "lineno": 71,
+      "owner_bucket": "tests/architecture/test_no_datetime_now_in_tests.py"
+    },
+    {
+      "path": "tests/architecture/test_no_datetime_now_in_tests.py",
+      "name": "test_allowed_paths_still_exist",
+      "lineno": 101,
+      "owner_bucket": "tests/architecture/test_no_datetime_now_in_tests.py"
+    },
+    {
+      "path": "tests/architecture/test_no_transformer_fallback.py",
+      "name": "test_basepipeline_init_does_not_create_transformer",
+      "lineno": 70,
+      "owner_bucket": "tests/architecture/test_no_transformer_fallback.py"
+    },
+    {
+      "path": "tests/architecture/test_no_transformer_fallback.py",
+      "name": "test_all_factories_have_transformer_class",
+      "lineno": 121,
+      "owner_bucket": "tests/architecture/test_no_transformer_fallback.py"
+    },
+    {
+      "path": "tests/architecture/test_normalization_fallback_business_ratchet.py",
+      "name": "test_reviewed_pipeline_fallback_business_counts_do_not_exceed_budgets",
+      "lineno": 93,
+      "owner_bucket": "tests/architecture/test_normalization_fallback_business_ratchet.py"
+    },
+    {
+      "path": "tests/architecture/test_normalization_surface_coverage_ratchet.py",
+      "name": "test_normalization_surface_coverage_does_not_regress_below_reviewed_budgets",
+      "lineno": 158,
+      "owner_bucket": "tests/architecture/test_normalization_surface_coverage_ratchet.py"
+    },
+    {
+      "path": "tests/architecture/test_normalization_surface_coverage_ratchet.py",
+      "name": "test_profile_semantic_invariants_do_not_regress_below_reviewed_budgets",
+      "lineno": 181,
+      "owner_bucket": "tests/architecture/test_normalization_surface_coverage_ratchet.py"
+    },
+    {
+      "path": "tests/architecture/test_normalization_surface_coverage_ratchet.py",
+      "name": "test_chembl_json_ordering_policy_does_not_drift_from_field_matrix",
+      "lineno": 185,
+      "owner_bucket": "tests/architecture/test_normalization_surface_coverage_ratchet.py"
+    },
+    {
+      "path": "tests/architecture/test_normalization_surface_coverage_ratchet.py",
+      "name": "test_chembl_json_ordering_policy_does_not_reappear_in_hash_config_mirrors",
+      "lineno": 191,
+      "owner_bucket": "tests/architecture/test_normalization_surface_coverage_ratchet.py"
+    },
+    {
+      "path": "tests/architecture/test_port_contracts.py",
+      "name": "test_all_port_methods_have_docstrings",
+      "lineno": 537,
+      "owner_bucket": "tests/architecture/test_port_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_port_contracts_hypothesis.py",
+      "name": "test_noop_metrics_accepts_any_valid_input",
+      "lineno": 551,
+      "owner_bucket": "tests/architecture/test_port_contracts_hypothesis.py"
+    },
+    {
+      "path": "tests/architecture/test_port_contracts_hypothesis.py",
+      "name": "test_noop_metrics_accepts_various_labels",
+      "lineno": 572,
+      "owner_bucket": "tests/architecture/test_port_contracts_hypothesis.py"
+    },
+    {
+      "path": "tests/architecture/test_port_contracts_hypothesis.py",
+      "name": "test_noop_logger_accepts_any_message",
+      "lineno": 606,
+      "owner_bucket": "tests/architecture/test_port_contracts_hypothesis.py"
+    },
+    {
+      "path": "tests/architecture/test_port_contracts_resilience_concurrency.py",
+      "name": "test_checkpoint_delete_non_existent_is_idempotent",
+      "lineno": 193,
+      "owner_bucket": "tests/architecture/test_port_contracts_resilience_concurrency.py"
+    },
+    {
+      "path": "tests/architecture/test_project_remediation_evidence_surface.py",
+      "name": "test_curated_evidence_surface_has_no_unreadable_visible_entries",
+      "lineno": 82,
+      "owner_bucket": "tests/architecture/test_project_remediation_evidence_surface.py"
+    },
+    {
+      "path": "tests/architecture/test_quality_debt_scorecard.py",
+      "name": "test_growth_rollout_warns_registry_section_before_cutoff",
+      "lineno": 1127,
+      "owner_bucket": "tests/architecture/test_quality_debt_scorecard.py"
+    },
+    {
+      "path": "tests/architecture/test_quarantine_immutability.py",
+      "name": "test_quarantine_payload_dataclasses_are_frozen",
+      "lineno": 117,
+      "owner_bucket": "tests/architecture/test_quarantine_immutability.py"
+    },
+    {
+      "path": "tests/architecture/test_regression_metrics.py",
+      "name": "test_architecture_test_p95_duration_tracked",
+      "lineno": 855,
+      "owner_bucket": "tests/architecture/test_regression_metrics.py"
+    },
+    {
+      "path": "tests/architecture/test_removed_surface_freeze_guards.py",
+      "name": "test_module_import_seams_are_confined",
+      "lineno": 1474,
+      "owner_bucket": "tests/architecture/test_removed_surface_freeze_guards.py"
+    },
+    {
+      "path": "tests/architecture/test_removed_surface_freeze_guards.py",
+      "name": "test_imported_symbol_seams_are_confined",
+      "lineno": 1544,
+      "owner_bucket": "tests/architecture/test_removed_surface_freeze_guards.py"
+    },
+    {
+      "path": "tests/architecture/test_scripts_inventory_manifest.py",
+      "name": "test_scripts_inventory_dispatcher_targets_canonical_checker",
+      "lineno": 73,
+      "owner_bucket": "tests/architecture/test_scripts_inventory_manifest.py"
+    },
+    {
+      "path": "tests/architecture/test_strict_architecture_contracts.py",
+      "name": "test_domain_no_infrastructure_imports",
+      "lineno": 681,
+      "owner_bucket": "tests/architecture/test_strict_architecture_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_strict_architecture_contracts.py",
+      "name": "test_application_no_concrete_infrastructure",
+      "lineno": 834,
+      "owner_bucket": "tests/architecture/test_strict_architecture_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_strict_architecture_contracts.py",
+      "name": "test_infrastructure_boundaries",
+      "lineno": 861,
+      "owner_bucket": "tests/architecture/test_strict_architecture_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_strict_architecture_contracts.py",
+      "name": "test_observability_library_isolation",
+      "lineno": 953,
+      "owner_bucket": "tests/architecture/test_strict_architecture_contracts.py"
+    },
+    {
+      "path": "tests/architecture/test_test_matrix_lane_policy.py",
+      "name": "test_no_hypothesis_in_forbidden_dirs",
+      "lineno": 62,
+      "owner_bucket": "tests/architecture/test_test_matrix_lane_policy.py"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_no_object_dtype_without_reason",
+      "lineno": 71,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_id_fields_are_strings",
+      "lineno": 131,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_numeric_fields_not_nullable_without_union",
+      "lineno": 192,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_boolean_fields_use_bool_type",
+      "lineno": 233,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_nullable_int_fields_have_explicit_dtype_guard",
+      "lineno": 312,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_timestamp_fields_use_datetime",
+      "lineno": 366,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_year_fields_are_int",
+      "lineno": 412,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_field_types.py",
+      "name": "test_coerce_used_appropriately",
+      "lineno": 443,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_field_names_are_snake_case",
+      "lineno": 72,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_no_camelcase_fields",
+      "lineno": 95,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_no_abbreviations_without_glossary",
+      "lineno": 116,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_boolean_fields_start_with_is_has_can",
+      "lineno": 207,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_metadata_fields_start_with_underscore",
+      "lineno": 265,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_foreign_keys_have_id_suffix",
+      "lineno": 314,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_chembl_fk_naming_consistency",
+      "lineno": 341,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_common_fields_same_name_across_publications",
+      "lineno": 394,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_naming_conventions.py",
+      "name": "test_no_legacy_dq_field_names",
+      "lineno": 512,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_schema_stability.py",
+      "name": "test_schema_fields_unchanged",
+      "lineno": 64,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_schema_stability.py",
+      "name": "test_fields_have_descriptions",
+      "lineno": 167,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_selected_pipeline_schema_drift.py",
+      "name": "test_selected_pipeline_schema_matches_snapshot",
+      "lineno": 56,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_chembl_id_pattern_consistent",
+      "lineno": 79,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_pmid_pattern_if_present",
+      "lineno": 122,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_year_fields_have_range_check",
+      "lineno": 146,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_percentage_fields_bounded",
+      "lineno": 167,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_enum_fields_have_isin_check",
+      "lineno": 220,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_metadata_fields_not_nullable",
+      "lineno": 279,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/silver_schemas/test_validations.py",
+      "name": "test_publication_doi_validation_consistent",
+      "lineno": 302,
+      "owner_bucket": "tests/contract/silver_schemas"
+    },
+    {
+      "path": "tests/contract/test_bronze_silver_schema_golden_contracts.py",
+      "name": "test_bronze_schema_contract_matches_golden_fixture",
+      "lineno": 157,
+      "owner_bucket": "tests/contract/test_bronze_silver_schema_golden_contracts.py"
+    },
+    {
+      "path": "tests/contract/test_bronze_silver_schema_golden_contracts.py",
+      "name": "test_silver_schema_contract_matches_golden_fixture",
+      "lineno": 164,
+      "owner_bucket": "tests/contract/test_bronze_silver_schema_golden_contracts.py"
+    },
+    {
+      "path": "tests/contract/test_gold_schema_snapshot_registry.py",
+      "name": "test_gold_schema_entity_matches_snapshot",
+      "lineno": 57,
+      "owner_bucket": "tests/contract/test_gold_schema_snapshot_registry.py"
+    },
+    {
+      "path": "tests/e2e/test_chembl_assay_e2e.py",
+      "name": "test_chembl_assay_metadata_fields",
+      "lineno": 101,
+      "owner_bucket": "tests/e2e/test_chembl_assay_e2e.py"
+    },
+    {
+      "path": "tests/e2e/test_chembl_assay_e2e.py",
+      "name": "test_chembl_assay_confidence_score",
+      "lineno": 116,
+      "owner_bucket": "tests/e2e/test_chembl_assay_e2e.py"
+    },
+    {
+      "path": "tests/e2e/test_chembl_molecule_e2e.py",
+      "name": "test_chembl_molecule_structural_fields",
+      "lineno": 93,
+      "owner_bucket": "tests/e2e/test_chembl_molecule_e2e.py"
+    },
+    {
+      "path": "tests/integration/adapters/test_pubmed_coverage.py",
+      "name": "test_adapter_aclose",
+      "lineno": 232,
+      "owner_bucket": "tests/integration/adapters"
+    },
+    {
+      "path": "tests/integration/application/core/test_record_processor.py",
+      "name": "test_span_records_transform_result_attributes",
+      "lineno": 604,
+      "owner_bucket": "tests/integration/application"
+    },
+    {
+      "path": "tests/integration/chembl/test_activity_extraction_params.py",
+      "name": "test_filtered_api_request",
+      "lineno": 83,
+      "owner_bucket": "tests/integration/chembl"
+    },
+    {
+      "path": "tests/integration/chembl/test_assay_extraction_params.py",
+      "name": "test_assay_filtered_api_request",
+      "lineno": 56,
+      "owner_bucket": "tests/integration/chembl"
+    },
+    {
+      "path": "tests/integration/chembl/test_molecule_extraction_params.py",
+      "name": "test_molecule_filtered_api_request",
+      "lineno": 50,
+      "owner_bucket": "tests/integration/chembl"
+    },
+    {
+      "path": "tests/integration/chembl/test_publication_extraction_params.py",
+      "name": "test_publication_filtered_api_request",
+      "lineno": 56,
+      "owner_bucket": "tests/integration/chembl"
+    },
+    {
+      "path": "tests/integration/chembl/test_target_extraction_params.py",
+      "name": "test_target_filtered_api_request",
+      "lineno": 50,
+      "owner_bucket": "tests/integration/chembl"
+    },
+    {
+      "path": "tests/integration/config/test_chembl_observed_value_fixtures.py",
+      "name": "test_dq_only_subsets_remain_within_declared_policy_sets",
+      "lineno": 439,
+      "owner_bucket": "tests/integration/config"
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_bronze_writer_cleanup_and_sidecar.py",
+      "name": "test_metadata_writer_not_called_when_save_metadata_disabled",
+      "lineno": 147,
+      "owner_bucket": "tests/integration/infrastructure"
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_bronze_writer_side_effects_mixin.py",
+      "name": "test_log_bronze_audit_skips_when_audit_is_none",
+      "lineno": 84,
+      "owner_bucket": "tests/integration/infrastructure"
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_delta_reader.py",
+      "name": "test_aclose_is_noop",
+      "lineno": 586,
+      "owner_bucket": "tests/integration/infrastructure"
+    },
+    {
+      "path": "tests/integration/infrastructure/storage/test_gold_writer_read_cleanup.py",
+      "name": "test_get_history_sorts_by_valid_from",
+      "lineno": 323,
+      "owner_bucket": "tests/integration/infrastructure"
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "name": "test_variable_query_sources",
+      "lineno": 1000,
+      "owner_bucket": "tests/integration/test_grafana_config.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "name": "test_control_plane_read_panels_do_not_filter_on_missing_pipeline_label",
+      "lineno": 1230,
+      "owner_bucket": "tests/integration/test_grafana_config.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "name": "test_control_plane_latency_panels_have_p50_p95_p99",
+      "lineno": 1271,
+      "owner_bucket": "tests/integration/test_grafana_config.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "name": "test_workflow_step_panels_apply_status_variable",
+      "lineno": 1584,
+      "owner_bucket": "tests/integration/test_grafana_config.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_config.py",
+      "name": "test_workflow_dashboard_collapses_step_diagnostics_below_first_screen",
+      "lineno": 1629,
+      "owner_bucket": "tests/integration/test_grafana_config.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_exact_identifier_variables_do_not_leak_into_other_dashboards",
+      "lineno": 287,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_dashboard_top_level_navigation_contract_by_uid",
+      "lineno": 341,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_dashboard_links_forbid_universal_handoff_patterns",
+      "lineno": 484,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_navigation_panel_html_bus_preserves_primary_identity_handoff",
+      "lineno": 530,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_navigation_panel_html_bus_keeps_silver_explorer_forensic_boundary",
+      "lineno": 539,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_navigation_panel_renders_full_visual_bus_with_disabled_current_item",
+      "lineno": 548,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_overview_and_runtime_dashboards_expose_data_quality_handoff",
+      "lineno": 580,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_runtime_and_dq_dashboards_expose_control_plane_handoff",
+      "lineno": 590,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_grafana_dashboard_links.py",
+      "name": "test_navigation_dashboards_do_not_expose_removed_silver_reject_explorer",
+      "lineno": 600,
+      "owner_bucket": "tests/integration/test_grafana_dashboard_links.py"
+    },
+    {
+      "path": "tests/integration/test_runner_lifecycle.py",
+      "name": "test_rebuild_lifecycle_order",
+      "lineno": 504,
+      "owner_bucket": "tests/integration/test_runner_lifecycle.py"
+    },
+    {
+      "path": "tests/performance/test_hotspot_budgets.py",
+      "name": "test_silver_prepare_arrow_data_budget",
+      "lineno": 369,
+      "owner_bucket": "tests/performance/test_hotspot_budgets.py"
+    },
+    {
+      "path": "tests/performance/test_hotspot_budgets.py",
+      "name": "test_silver_write_append_budget",
+      "lineno": 405,
+      "owner_bucket": "tests/performance/test_hotspot_budgets.py"
+    },
+    {
+      "path": "tests/performance/test_hotspot_budgets.py",
+      "name": "test_silver_write_merge_budget",
+      "lineno": 461,
+      "owner_bucket": "tests/performance/test_hotspot_budgets.py"
+    },
+    {
+      "path": "tests/performance/test_hotspot_budgets.py",
+      "name": "test_atomic_write_group_budget",
+      "lineno": 576,
+      "owner_bucket": "tests/performance/test_hotspot_budgets.py"
+    },
+    {
+      "path": "tests/smoke/test_smoke.py",
+      "name": "test_runtime_dependency_importable",
+      "lineno": 110,
+      "owner_bucket": "tests/smoke/test_smoke.py"
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_checkpoint_service.py",
+      "name": "test_save_sets_checkpoint_saved_at_gauge_from_state_timestamp",
+      "lineno": 1349,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_checkpoint_service.py",
+      "name": "test_delete_calls_storage_delete",
+      "lineno": 1425,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_checkpoint_service.py",
+      "name": "test_list_all_uses_correct_glob_pattern",
+      "lineno": 1483,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/checkpoint/test_load_validation.py",
+      "name": "test_validate_resume_compatibility_accepts_matching_anchors",
+      "lineno": 84,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_helpers.py",
+      "name": "test_log_enrichment_summary_when_empty_then_no_log_call",
+      "lineno": 132,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_merge_stage_mixin.py",
+      "name": "test_transition_to_merging_state_when_called_then_validates_and_logs_fsm",
+      "lineno": 149,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_merge_stage_mixin.py",
+      "name": "test_transition_to_completed_state_when_not_completed_then_transitions",
+      "lineno": 209,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_merge_stage_mixin.py",
+      "name": "test_delete_checkpoint_safe_when_success_then_deletes",
+      "lineno": 292,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_merge_stage_mixin.py",
+      "name": "test_delete_checkpoint_safe_when_non_fatal_error_then_logs_warning",
+      "lineno": 302,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_merge_stage_mixin.py",
+      "name": "test_finalize_pipeline_when_called_then_sets_completed_and_deletes_checkpoint",
+      "lineno": 438,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "name": "test_generate_dq_reports_when_service_absent_then_logs_debug_and_returns",
+      "lineno": 91,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "name": "test_generate_dq_reports_when_runtime_error_then_logs_warning_only",
+      "lineno": 124,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "name": "test_write_cv_quarantine_when_port_absent_then_does_nothing",
+      "lineno": 162,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_observability_mixin.py",
+      "name": "test_write_cv_quarantine_when_empty_payloads_then_does_nothing",
+      "lineno": 173,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_dependency_state_flow.py",
+      "name": "test_calls_host_record_dependencies_stage_started",
+      "lineno": 57,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_dependency_state_flow.py",
+      "name": "test_saves_checkpoint",
+      "lineno": 101,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_enrichment_mixin.py",
+      "name": "test_record_completed_enrichment_results_when_failed_then_state_not_updated",
+      "lineno": 181,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_enrichment_mixin.py",
+      "name": "test_record_completed_enrichment_results_when_skipped_then_state_updated",
+      "lineno": 194,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_enrichment_mixin.py",
+      "name": "test_transition_to_enrichment_completed_when_enriching_then_calls_complete",
+      "lineno": 306,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_enrichment_mixin.py",
+      "name": "test_transition_to_enrichment_completed_when_seed_completed_then_transitions_through_enriching",
+      "lineno": 320,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_mixin.py",
+      "name": "test_resume_seed_phase_when_state_differs_then_fsm_transition_logged",
+      "lineno": 219,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_mixin.py",
+      "name": "test_collect_successful_dependencies_when_success_then_marks_completed",
+      "lineno": 337,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_mixin.py",
+      "name": "test_collect_successful_dependencies_when_failed_then_not_marked",
+      "lineno": 352,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_support_mixin.py",
+      "name": "test_transition_state_with_fsm_log_when_validate_true_then_calls_fsm_validate",
+      "lineno": 244,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_stage_support_mixin.py",
+      "name": "test_transition_state_with_fsm_log_when_validate_false_then_skips_fsm_validate",
+      "lineno": 260,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "name": "test_run_preflight_validation_when_no_validator_then_logs_debug_and_skips",
+      "lineno": 180,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "name": "test_run_preflight_validation_when_valid_config_then_calls_validator",
+      "lineno": 190,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "name": "test_validate_config_consistency_when_consistent_then_no_warning",
+      "lineno": 290,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "name": "test_validate_config_consistency_when_mismatch_then_logs_warning",
+      "lineno": 307,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/runner_pkg/test_runner_support_mixin.py",
+      "name": "test_validate_config_consistency_when_all_optional_then_logs_info",
+      "lineno": 321,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_dependency_key_resolvers.py",
+      "name": "test_logs_debug_message",
+      "lineno": 83,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_merger.py",
+      "name": "test_no_deduplication_when_no_duplicates",
+      "lineno": 1449,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_preflight_modules.py",
+      "name": "test_log_schema_loading_summary",
+      "lineno": 224,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_preflight_modules.py",
+      "name": "test_log_validation_result_pass",
+      "lineno": 232,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_preflight_modules.py",
+      "name": "test_log_validation_result_fail",
+      "lineno": 246,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_preflight_modules.py",
+      "name": "test_log_resolved_field_sources_empty",
+      "lineno": 265,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_resolver_helper.py",
+      "name": "test_log_methods",
+      "lineno": 87,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner.py",
+      "name": "test_records_composite_phase_metric_families_for_successful_run",
+      "lineno": 279,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_fsm.py",
+      "name": "test_run_id",
+      "lineno": 71,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_fsm.py",
+      "name": "test_persist_completed_state_uses_completed_operation",
+      "lineno": 1303,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_heartbeat.py",
+      "name": "test_heartbeat_started_during_execution",
+      "lineno": 189,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_heartbeat.py",
+      "name": "test_lock_released_after_successful_run",
+      "lineno": 218,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_heartbeat.py",
+      "name": "test_custom_heartbeat_interval_used_by_runner",
+      "lineno": 268,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_observability_mixin.py",
+      "name": "test_generate_dq_reports_skips_when_service_missing",
+      "lineno": 81,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_observability_mixin.py",
+      "name": "test_write_cv_quarantine_skips_when_port_missing_or_payload_empty",
+      "lineno": 155,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/composite/test_runner_robustness.py",
+      "name": "test_run_id",
+      "lineno": 80,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_arch_cont_coverage_burn_down.py",
+      "name": "test_record_output_ready_skips_when_all_counts_zero",
+      "lineno": 76,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__action_only",
+      "lineno": 224,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__shadow_comparison_only",
+      "lineno": 247,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__none_values",
+      "lineno": 285,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_periodic_checkpoint_skips_when_interval_not_reached",
+      "lineno": 94,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_periodic_checkpoint_persists_total_processed",
+      "lineno": 108,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_on_exception_skips_zero_totals",
+      "lineno": 122,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_now_persists_total_processed",
+      "lineno": 163,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_now_leaves_checkpoint_saved_at_gauge_to_manager",
+      "lineno": 211,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_success_sets_stats_and_ends_span",
+      "lineno": 80,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_shutdown_saves_checkpoint",
+      "lineno": 105,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_error_saves_exception_checkpoint",
+      "lineno": 130,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_execute_checkpoint_uses_resume_offset",
+      "lineno": 570,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_apply_processed_batch_outcome_skips_dq_hook_when_disabled",
+      "lineno": 1164,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_report_batch_progress_forwards_current_counters",
+      "lineno": 1240,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_ensure_extraction_not_shutdown_is_noop_when_not_requested",
+      "lineno": 1263,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_logs_size_reduction",
+      "lineno": 226,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_does_not_log_when_no_reduction",
+      "lineno": 240,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_emits_bounded_memory_metrics_for_pressure_resize",
+      "lineno": 302,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_calls_observe_histogram",
+      "lineno": 142,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_handles_zero_size",
+      "lineno": 172,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_track_batch_created_records_event_and_record_count",
+      "lineno": 193,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_track_batch_written_records_event_and_record_count",
+      "lineno": 221,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_track_batch_failed_records_failed_lifecycle_projection",
+      "lineno": 249,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_metrics.py",
+      "name": "test_track_processed_records_calls_stage_and_flow_counters",
+      "lineno": 287,
+      "owner_bucket": "tests/unit/application"
+    }
+  ],
+  "findings_total": 1149
+}

--- a/reports/quality/weak-assert-inventory.md
+++ b/reports/quality/weak-assert-inventory.md
@@ -1,0 +1,34 @@
+# Weak-assert advisory inventory
+
+Generated: 2026-08-07T13:33:23.305501+00:00 (#8330)
+
+Mode: **advisory only** — not a merge gate.
+
+- Total without direct assert/raises: **1149**
+- Under tests/unit: **1020**
+
+## Top owner buckets
+
+| Bucket | Count |
+| --- | ---: |
+| `tests/unit/domain` | 406 |
+| `tests/unit/application` | 255 |
+| `tests/unit/infrastructure` | 234 |
+| `tests/unit/composition` | 62 |
+| `tests/unit/interfaces` | 37 |
+| `tests/contract/silver_schemas` | 27 |
+| `tests/architecture/test_code_metrics.py` | 12 |
+| `tests/unit/repo_backed` | 11 |
+| `tests/integration/test_grafana_dashboard_links.py` | 9 |
+| `tests/unit/scripts` | 9 |
+| `tests/architecture/test_aggregate_boundaries.py` | 5 |
+| `tests/integration/chembl` | 5 |
+| `tests/integration/test_grafana_config.py` | 5 |
+| `tests/architecture/test_medallion_invariants.py` | 4 |
+| `tests/architecture/test_normalization_surface_coverage_ratchet.py` | 4 |
+
+## Priority review
+
+Focus triage on tests/unit/application/core and tests/unit/scripts.
+No mass-delete without review.
+

--- a/reports/quality/weak-assert-triage-8330.json
+++ b/reports/quality/weak-assert-triage-8330.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": "weak-assert-triage-v1",
+  "linked_issue": "#8330",
+  "reviewed_owners": [
+    "tests/unit/application/core",
+    "tests/unit/scripts"
+  ],
+  "review_outcome": "inventory_landed_no_mass_delete",
+  "notes": [
+    "Direct-assert AST scan is advisory; many cases use helpers/assert_called patterns not counted as ast.Assert.",
+    "No mass-delete performed. Future triage should strengthen true no-assert smoke tests only."
+  ],
+  "application_core_sample": [
+    {
+      "path": "tests/integration/application/core/test_record_processor.py",
+      "name": "test_span_records_transform_result_attributes",
+      "lineno": 604,
+      "owner_bucket": "tests/integration/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_arch_cont_coverage_burn_down.py",
+      "name": "test_record_output_ready_skips_when_all_counts_zero",
+      "lineno": 76,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__action_only",
+      "lineno": 224,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__shadow_comparison_only",
+      "lineno": 247,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_base_transformer_structural_support.py",
+      "name": "test_record_structural_policy_metrics__none_values",
+      "lineno": 285,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_periodic_checkpoint_skips_when_interval_not_reached",
+      "lineno": 94,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_periodic_checkpoint_persists_total_processed",
+      "lineno": 108,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_on_exception_skips_zero_totals",
+      "lineno": 122,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_now_persists_total_processed",
+      "lineno": 163,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_checkpoint_recovery_service.py",
+      "name": "test_save_checkpoint_now_leaves_checkpoint_saved_at_gauge_to_manager",
+      "lineno": 211,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_success_sets_stats_and_ends_span",
+      "lineno": 80,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_shutdown_saves_checkpoint",
+      "lineno": 105,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_execution_lifecycle.py",
+      "name": "test_finalize_execution_error_saves_exception_checkpoint",
+      "lineno": 130,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_execute_checkpoint_uses_resume_offset",
+      "lineno": 570,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_apply_processed_batch_outcome_skips_dq_hook_when_disabled",
+      "lineno": 1164,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_report_batch_progress_forwards_current_counters",
+      "lineno": 1240,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_executor.py",
+      "name": "test_ensure_extraction_not_shutdown_is_noop_when_not_requested",
+      "lineno": 1263,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_logs_size_reduction",
+      "lineno": 226,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_does_not_log_when_no_reduction",
+      "lineno": 240,
+      "owner_bucket": "tests/unit/application"
+    },
+    {
+      "path": "tests/unit/application/core/test_batch_memory_manager.py",
+      "name": "test_emits_bounded_memory_metrics_for_pressure_resize",
+      "lineno": 302,
+      "owner_bucket": "tests/unit/application"
+    }
+  ],
+  "unit_scripts_sample": []
+}

--- a/scripts/engineering/qa/__main__.py
+++ b/scripts/engineering/qa/__main__.py
@@ -43,6 +43,9 @@ Commands:
     report-module-coverage Generate/check module-level coverage inventory
     check-branch-coverage Enforce branch coverage from reports/coverage/coverage.xml
     report-dead-code-inventory Generate repo-local static dead-code review inventory
+    report-weak-assert-inventory Generate advisory weak-assert triage inventory
+    report-vcr-corpus-budget Generate VCR corpus size budget report
+    report-architecture-suite-burndown Generate architecture suite size burndown inventory
     report-pubchem-property-vocab Extract observed PubChem property-URN vocabulary
     report-publication-nested-vocab Extract nested publication-sidecar vocabularies
     sync-integration-vcr-policy Sync tracked integration/e2e inventory in integration VCR policy
@@ -130,6 +133,9 @@ COMMAND_MODULES: dict[str, str] = {
     "report-module-coverage": "scripts.engineering.qa.report_module_coverage_inventory",
     "check-branch-coverage": "scripts.engineering.qa.check_branch_coverage",
     "report-dead-code-inventory": "scripts.engineering.qa.report_dead_code_inventory",
+    "report-weak-assert-inventory": "scripts.engineering.qa.report_weak_assert_inventory",
+    "report-vcr-corpus-budget": "scripts.engineering.qa.report_vcr_corpus_budget",
+    "report-architecture-suite-burndown": "scripts.engineering.qa.report_architecture_suite_burndown",
     "report-pubchem-property-vocab": "scripts.engineering.qa.extract_pubchem_property_vocab",
     "report-publication-nested-vocab": "scripts.engineering.qa.extract_publication_nested_vocab",
     "sync-integration-vcr-policy": "scripts.engineering.qa.sync_integration_vcr_policy",

--- a/scripts/engineering/qa/report_architecture_suite_burndown.py
+++ b/scripts/engineering/qa/report_architecture_suite_burndown.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Inventory architecture suite size and duplicate ratchet stems (#8331)."""
+from __future__ import annotations
+import argparse, json, re
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
+DEFAULT_ROOT = Path("tests/architecture")
+DEFAULT_JSON = Path("reports/quality/architecture-suite-burndown-inventory.json")
+DEFAULT_MD = Path("reports/quality/architecture-suite-burndown-inventory.md")
+STEM_NORMALIZE = re.compile(r'(_ratchet|_gate|_policy|_inventory|_baseline|_closeout)+$')
+
+def _stem_family(path: Path) -> str:
+    stem = path.stem
+    if stem.startswith('test_'):
+        stem = stem[5:]
+    return STEM_NORMALIZE.sub("", stem)
+
+def scan(root: Path) -> dict[str, Any]:
+    files = sorted(root.rglob('test_*.py'))
+    total_loc = 0
+    skip_hits = 0
+    families: dict[str, list[str]] = defaultdict(list)
+    largest = []
+    for path in files:
+        text = path.read_text(encoding='utf-8', errors='replace')
+        loc = text.count(chr(10)) + 1
+        total_loc += loc
+        skip_hits += len(re.findall(r'pytest\.(skip|xfail)|@pytest\.mark\.(skip|xfail)', text))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        families[_stem_family(path)].append(rel)
+        largest.append({'path': rel, 'loc': loc})
+    largest.sort(key=lambda item: item['loc'], reverse=True)
+    multi = {k: v for k, v in families.items() if len(v) > 1}
+    duplicate_families = {
+        family: paths for family, paths in sorted(multi.items())
+        if any(token in family for token in ('ratchet', 'gate', 'purity', 'duplication', 'hotspot'))
+    }
+    return {
+        'file_count': len(files),
+        'approx_loc': total_loc,
+        'skip_xfail_pattern_hits': skip_hits,
+        'multi_file_families_count': len(multi),
+        'duplicate_ratchet_candidates': duplicate_families,
+        'largest_files': largest[:25],
+    }
+
+def build_report(scan_result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        'schema_version': 'architecture-suite-burndown-inventory-v1',
+        'linked_issue': '#8331',
+        'generated_at_utc': datetime.now(UTC).isoformat(),
+        'local_lane_recommendation': {
+            'pr_default': 'architecture-fast-boundary',
+            'full_audit': 'architecture or architecture-slow-governance',
+            'do_not_weaken': ['import-linter', 'domain purity', 'debt no-growth'],
+        },
+        'scan': scan_result,
+        'burndown_policy': {'merge_or_retire': 'confirmed duplicates only with owner sign-off', 'mass_delete': False},
+    }
+
+def render_md(report: dict[str, Any]) -> str:
+    s = report['scan']
+    lines = [
+        '# Architecture suite burndown inventory', '',
+        'Generated: ' + report['generated_at_utc'] + ' (' + report['linked_issue'] + ')', '',
+        '- Architecture test files: **' + str(s['file_count']) + '**',
+        '- Approx LOC: **' + str(s['approx_loc']) + '**',
+        '- skip/xfail pattern hits: **' + str(s['skip_xfail_pattern_hits']) + '**',
+        '- Multi-file stem families: **' + str(s['multi_file_families_count']) + '**', '',
+        '## Local lane recommendation', '',
+        '- PR-local: ' + report['local_lane_recommendation']['pr_default'],
+        '- Full audit: ' + report['local_lane_recommendation']['full_audit'], '',
+        '## Duplicate ratchet candidates (advisory)', '',
+    ]
+    cands = s.get('duplicate_ratchet_candidates') or {}
+    if not cands:
+        lines.append('No high-confidence multi-file ratchet families detected by stem heuristic.')
+    else:
+        for family, paths in list(cands.items())[:30]:
+            lines.append('- ' + family + ': ' + str(len(paths)) + ' files')
+            for path in paths[:8]:
+                lines.append('  - ' + path)
+    lines.extend(['', '## Largest files', ''])
+    for row in s['largest_files'][:15]:
+        lines.append('- ' + row['path'] + ' (' + str(row['loc']) + ' LOC)')
+    lines.append('')
+    return chr(10).join(lines) + chr(10)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--arch-root', type=Path, default=DEFAULT_ROOT)
+    parser.add_argument('--json-out', type=Path, default=DEFAULT_JSON)
+    parser.add_argument('--md-out', type=Path, default=DEFAULT_MD)
+    args = parser.parse_args(argv)
+    result = scan((REPO_ROOT / args.arch_root).resolve())
+    report = build_report(result)
+    json_out = resolve_output_path(args.json_out, root=REPO_ROOT)
+    md_out = resolve_output_path(args.md_out, root=REPO_ROOT)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(report, indent=2, ensure_ascii=False) + chr(10), encoding='utf-8')
+    md_out.write_text(render_md(report), encoding='utf-8')
+    print('Wrote', json_out)
+    print('Wrote', md_out)
+    print('files=', result['file_count'], 'loc=', result['approx_loc'])
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/engineering/qa/report_vcr_corpus_budget.py
+++ b/scripts/engineering/qa/report_vcr_corpus_budget.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Report VCR corpus size by provider vs soft budget (#8337)."""
+from __future__ import annotations
+import argparse, json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+import yaml
+from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
+DEFAULT_ROOT = Path("tests/fixtures/vcr")
+DEFAULT_POLICY = Path("configs/quality/integration_vcr_policy.yaml")
+DEFAULT_JSON = Path("reports/quality/vcr-corpus-budget-report.json")
+DEFAULT_MD = Path("reports/quality/vcr-corpus-budget-report.md")
+
+def _load_budget(policy_path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(policy_path.read_text(encoding="utf-8")) or {}
+    def walk(obj: Any) -> dict[str, Any] | None:
+        if isinstance(obj, dict):
+            if "corpus_size_budget" in obj and isinstance(obj["corpus_size_budget"], dict):
+                return obj["corpus_size_budget"]
+            for value in obj.values():
+                found = walk(value)
+                if found is not None:
+                    return found
+        return None
+    return walk(payload) or {}
+
+def measure_corpus(root: Path) -> dict[str, Any]:
+    providers: dict[str, dict[str, int]] = {}
+    total_bytes = 0
+    total_files = 0
+    if not root.exists():
+        return {"providers": {}, "total_bytes": 0, "total_files": 0}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in {".yaml", ".yml"}:
+            continue
+        rel = path.relative_to(root)
+        provider = rel.parts[0] if rel.parts else "_root"
+        size = path.stat().st_size
+        bucket = providers.setdefault(provider, {"files": 0, "bytes": 0})
+        bucket["files"] += 1
+        bucket["bytes"] += size
+        total_bytes += size
+        total_files += 1
+    return {"providers": providers, "total_bytes": total_bytes, "total_files": total_files}
+
+def build_report(measure: dict[str, Any], budget: dict[str, Any]) -> dict[str, Any]:
+    soft_bytes = int(budget.get("soft_max_total_bytes") or 150_000_000)
+    soft_files = int(budget.get("soft_max_file_count") or 500)
+    total_bytes = int(measure["total_bytes"])
+    total_files = int(measure["total_files"])
+    return {
+        "schema_version": "vcr-corpus-budget-report-v1",
+        "linked_issue": "#8337",
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "canonical_root": "tests/fixtures/vcr",
+        "budget": {"soft_max_total_bytes": soft_bytes, "soft_max_file_count": soft_files, "gc_policy": budget.get("gc_policy", {})},
+        "measured": measure,
+        "status": {"within_soft_byte_budget": total_bytes <= soft_bytes, "within_soft_file_budget": total_files <= soft_files,
+                   "byte_utilization": round(total_bytes / soft_bytes, 4) if soft_bytes else None},
+        "policy_note": "Default action is retain. Deletion requires owner sign-off and replay proof.",
+    }
+
+def render_md(report: dict[str, Any]) -> str:
+    m = report["measured"]
+    lines = ["# VCR corpus size budget report", "",
+        "Generated: " + report["generated_at_utc"] + " (" + report["linked_issue"] + ")", "",
+        "- Total files: **" + str(m["total_files"]) + "** (soft max " + str(report["budget"]["soft_max_file_count"]) + ")",
+        "- Total bytes: **" + str(m["total_bytes"]) + "** (soft max " + str(report["budget"]["soft_max_total_bytes"]) + ")",
+        "- Within soft budgets: bytes=" + str(report["status"]["within_soft_byte_budget"]) + " files=" + str(report["status"]["within_soft_file_budget"]),
+        "", "## Per provider", "", "| Provider | Files | Bytes |", "| --- | ---: | ---: |"]
+    for provider, stats in sorted(m["providers"].items()):
+        lines.append("| " + provider + " | " + str(stats["files"]) + " | " + str(stats["bytes"]) + " |")
+    lines.extend(["", report["policy_note"], ""])
+    return chr(10).join(lines) + chr(10)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vcr-root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--json-out", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--md-out", type=Path, default=DEFAULT_MD)
+    args = parser.parse_args(argv)
+    budget = _load_budget(REPO_ROOT / args.policy)
+    measure = measure_corpus((REPO_ROOT / args.vcr_root).resolve())
+    report = build_report(measure, budget)
+    json_out = resolve_output_path(args.json_out, root=REPO_ROOT)
+    md_out = resolve_output_path(args.md_out, root=REPO_ROOT)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(report, indent=2, ensure_ascii=False) + chr(10), encoding="utf-8")
+    md_out.write_text(render_md(report), encoding="utf-8")
+    print("Wrote", json_out)
+    print("Wrote", md_out)
+    print("files=", measure["total_files"], "bytes=", measure["total_bytes"])
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/engineering/qa/report_weak_assert_inventory.py
+++ b/scripts/engineering/qa/report_weak_assert_inventory.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Advisory inventory of test_* without direct Assert/raises (#8330)."""
+from __future__ import annotations
+import argparse, ast, json
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from scripts.engineering.common.repo_paths import REPO_ROOT, resolve_output_path
+DEFAULT_JSON = Path("reports/quality/weak-assert-inventory.json")
+DEFAULT_MD = Path("reports/quality/weak-assert-inventory.md")
+
+def _is_test_function(node: ast.AST) -> bool:
+    return isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith('test_')
+
+def _calls_raises(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name) and func.id == 'raises':
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == 'raises':
+            return True
+    return False
+
+def _has_assert(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, (ast.Assert, ast.Raise)):
+            return True
+    return _calls_raises(node)
+
+def _owner_bucket(rel: str) -> str:
+    parts = rel.split('/')
+    if len(parts) >= 3 and parts[0] == 'tests':
+        return '/'.join(parts[:3])
+    return parts[0] if parts else 'unknown'
+
+def scan_tree(root: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for path in sorted(root.rglob('test_*.py')):
+        try:
+            source = path.read_text(encoding='utf-8')
+            tree = ast.parse(source, filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for node in tree.body:
+            candidates: list[ast.AST] = []
+            if _is_test_function(node):
+                candidates.append(node)
+            elif isinstance(node, ast.ClassDef):
+                for item in node.body:
+                    if _is_test_function(item):
+                        candidates.append(item)
+            for fn in candidates:
+                assert isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                if _has_assert(fn):
+                    continue
+                findings.append({'path': rel, 'name': fn.name, 'lineno': fn.lineno, 'owner_bucket': _owner_bucket(rel)})
+    return findings
+
+def build_report(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    by_bucket = Counter(item['owner_bucket'] for item in findings)
+    unit = [item for item in findings if item['path'].startswith('tests/unit/')]
+    return {
+        'schema_version': 'weak-assert-inventory-v1',
+        'linked_issue': '#8330',
+        'generated_at_utc': datetime.now(UTC).isoformat(),
+        'policy': {'mode': 'advisory', 'blocking_gate': False,
+            'false_positive_note': 'Architecture/governance tests often assert via helpers.'},
+        'summary': {
+            'total_without_direct_assert': len(findings),
+            'unit_without_direct_assert': len(unit),
+            'top_owner_buckets': [{'bucket': b, 'count': c} for b, c in by_bucket.most_common(25)],
+        },
+        'priority_review_paths': ['tests/unit/application/core', 'tests/unit/scripts'],
+        'findings_sample': findings[:200],
+        'findings_total': len(findings),
+    }
+
+def render_md(report: dict[str, Any]) -> str:
+    s = report['summary']
+    lines = [
+        '# Weak-assert advisory inventory',
+        '',
+        'Generated: ' + report['generated_at_utc'] + ' (' + report['linked_issue'] + ')',
+        '',
+        'Mode: **advisory only** — not a merge gate.',
+        '',
+        '- Total without direct assert/raises: **' + str(s['total_without_direct_assert']) + '**',
+        '- Under tests/unit: **' + str(s['unit_without_direct_assert']) + '**',
+        '',
+        '## Top owner buckets',
+        '',
+        '| Bucket | Count |',
+        '| --- | ---: |',
+    ]
+    for row in s['top_owner_buckets'][:15]:
+        lines.append('| `' + row['bucket'] + '` | ' + str(row['count']) + ' |')
+    lines += ['', '## Priority review', '',
+              'Focus triage on tests/unit/application/core and tests/unit/scripts.',
+              'No mass-delete without review.', '']
+    return chr(10).join(lines) + chr(10)
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--tests-root', default='tests')
+    parser.add_argument('--json-out', type=Path, default=DEFAULT_JSON)
+    parser.add_argument('--md-out', type=Path, default=DEFAULT_MD)
+    args = parser.parse_args(argv)
+    findings = scan_tree((REPO_ROOT / args.tests_root).resolve())
+    report = build_report(findings)
+    json_out = resolve_output_path(args.json_out, root=REPO_ROOT)
+    md_out = resolve_output_path(args.md_out, root=REPO_ROOT)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(report, indent=2, ensure_ascii=False) + chr(10), encoding='utf-8')
+    md_out.write_text(render_md(report), encoding='utf-8')
+    print('Wrote', json_out)
+    print('Wrote', md_out)
+    print('summary total=', report['summary']['total_without_direct_assert'], 'unit=', report['summary']['unit_without_direct_assert'])
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/unit/composition/bootstrap/test_runner_bootstrap.py
+++ b/tests/unit/composition/bootstrap/test_runner_bootstrap.py
@@ -98,6 +98,18 @@ def bootstrap_with_light_observability(light_observability: SimpleNamespace):
         yield mock_settings, mock_observability, light_observability
 
 
+
+_LIST_SERVICE_CACHE: PipelineRunnerService | None = None
+
+
+def _cached_bootstrapped_service() -> PipelineRunnerService:
+    """Amortize full DI bootstrap for list-only integration checks (#8329)."""
+    global _LIST_SERVICE_CACHE
+    if _LIST_SERVICE_CACHE is None:
+        _LIST_SERVICE_CACHE = bootstrap_pipeline_runner_service()
+    return _LIST_SERVICE_CACHE
+
+
 @pytest.mark.unit
 class TestBootstrapPipelineRunnerService:
     """Tests for bootstrap_pipeline_runner_service function."""
@@ -200,7 +212,7 @@ class TestBootstrapPipelineRunnerServiceIntegration:
         self, bootstrap_with_light_observability: tuple[object, object, object]
     ) -> None:
         """Test that the bootstrapped service can list available pipelines."""
-        service = bootstrap_pipeline_runner_service()
+        service = _cached_bootstrapped_service()
 
         pipelines = service.list_pipelines()
 
@@ -211,7 +223,7 @@ class TestBootstrapPipelineRunnerServiceIntegration:
         self, bootstrap_with_light_observability: tuple[object, object, object]
     ) -> None:
         """Test that the bootstrapped service lists known pipeline names."""
-        service = bootstrap_pipeline_runner_service()
+        service = _cached_bootstrapped_service()
 
         pipelines = service.list_pipelines()
 

--- a/tests/unit/composition/factories/pipeline/test_registry.py
+++ b/tests/unit/composition/factories/pipeline/test_registry.py
@@ -47,6 +47,15 @@ from bioetl.composition.factories.pipeline.registry_core import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(scope="session")
+def session_registered_pipeline_names() -> frozenset[str]:
+    """Register pipelines once per session for completeness/list hotspots (#8329)."""
+    register_all_pipelines()
+    return frozenset(get_default_registry().list_pipelines())
+
+
+
+
 class _DummyPipelineFactory:
     silver_schema = None
     pandera_silver_schema = None
@@ -99,7 +108,7 @@ def _iter_pipeline_config_names(config_dir: Path) -> list[str]:
     return found_configs
 
 
-def test_registry_completeness():
+def test_registry_completeness(session_registered_pipeline_names: frozenset[str]):
     """
     Verify that every unified entity pipeline configuration file in configs/entities
     has a corresponding entry in the PipelineRegistry.
@@ -108,16 +117,14 @@ def test_registry_completeness():
     if not config_dir.exists():
         pytest.skip("Config directory not found")
 
-    registry = get_default_registry()
-
     # Pipelines that have configs but are not yet fully integrated
     # These are new providers in development that will be registered later
     pipelines_in_development: set[str] = set()  # All pipelines are now fully integrated
 
     found_configs = _iter_pipeline_config_names(config_dir)
 
-    # Get registered pipelines
-    registered_pipelines = registry.list_pipelines()
+    # Session-scoped registration amortizes factory import cost (#8329).
+    registered_pipelines = session_registered_pipeline_names
 
     # Check for missing handlers (excluding pipelines in development)
     missing_handlers = [
@@ -131,16 +138,17 @@ def test_registry_completeness():
     )
 
 
-def test_registry_contains_expected_pipelines():
+def test_registry_contains_expected_pipelines(
+    session_registered_pipeline_names: frozenset[str],
+):
     """Sanity check that key pipelines are present."""
-    registry = get_default_registry()
     expected = [
         "chembl_activity",
         "pubchem_compound",
         "uniprot_protein",
         "pubmed_publication",
     ]
-    registered = registry.list_pipelines()
+    registered = session_registered_pipeline_names
 
     for pipe in expected:
         assert pipe in registered, f"Expected pipeline {pipe} not found in registry"

--- a/tests/unit/scripts/docs/passports/test_passport_projector.py
+++ b/tests/unit/scripts/docs/passports/test_passport_projector.py
@@ -1,4 +1,9 @@
-"""Tests for deterministic executable-unit passport projections."""
+"""Tests for deterministic executable-unit passport projections.
+
+Canonical lane: ``unit-scripts-tooling`` (#8327/#8328).
+Pure helpers vs full-projection/CLI cases are split by markers so
+``unit-fast`` / ``unit-other`` do not dual-pay this zone.
+"""
 
 from __future__ import annotations
 
@@ -29,9 +34,22 @@ from scripts.docs.passports.projector import (
 from scripts.docs.passports.validation import validate_composite_payload
 from tests.helpers.cli_process import run_repo_command
 
-pytestmark = pytest.mark.unit
+pytestmark = [
+    pytest.mark.unit,
+    # Owned by unit-scripts-tooling lane; not pure product unit (#8328).
+]
 
 REVISION = "0123456789abcdef0123456789abcdef01234567"
+
+
+@pytest.fixture(scope="module")
+def _passport_projection_bundle(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, dict[Path, bytes]]:
+    """Build full passport outputs once per module (hotspot cost amortisation #8327)."""
+    root = tmp_path_factory.mktemp("passport-projector")
+    outputs = build_all_outputs(output_root=root, source_revision=REVISION)
+    return root, outputs
+
+
 
 
 @dataclass(frozen=True)
@@ -97,6 +115,7 @@ def test_inventory_rejects_registry_config_mismatch_and_duplicate_alias(
         )
 
 
+@pytest.mark.slow
 def test_generation_is_byte_deterministic(tmp_path: Path) -> None:
     first = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
     second = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
@@ -167,8 +186,10 @@ def test_generation_is_subprocess_environment_invariant(tmp_path: Path) -> None:
     assert baseline == alternate
 
 
-def test_workflow_operations_are_classified(tmp_path: Path) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+def test_workflow_operations_are_classified(
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
+) -> None:
+    tmp_path, outputs = _passport_projection_bundle
     core = json.loads(outputs[tmp_path / "generated/workflows/chembl_core.json"])
     operations = {
         item["transform_name"]: item["classification"]
@@ -186,8 +207,10 @@ def test_workflow_operations_are_classified(tmp_path: Path) -> None:
     assert " --> " in core["dag"]["mermaid"]
 
 
-def test_generated_facts_validate_against_published_schemas(tmp_path: Path) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+def test_generated_facts_validate_against_published_schemas(
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
+) -> None:
+    tmp_path, outputs = _passport_projection_bundle
     schema_root = PROJECT_ROOT / "docs/04-reference/passports/schemas"
     pipeline_schema = json.loads(
         (schema_root / "pipeline-passport.schema.json").read_text(encoding="utf-8")
@@ -204,9 +227,9 @@ def test_generated_facts_validate_against_published_schemas(tmp_path: Path) -> N
 
 
 def test_representative_pipeline_projection_profiles_are_explicit(
-    tmp_path: Path,
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
 ) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+    tmp_path, outputs = _passport_projection_bundle
 
     def profiles(pipeline: str) -> set[str]:
         facts = json.loads(outputs[tmp_path / f"generated/pipelines/{pipeline}.json"])
@@ -220,9 +243,9 @@ def test_representative_pipeline_projection_profiles_are_explicit(
 
 
 def test_schema_rejects_unknown_nested_keys_and_incompatible_version(
-    tmp_path: Path,
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
 ) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+    tmp_path, outputs = _passport_projection_bundle
     facts = json.loads(outputs[tmp_path / "generated/pipelines/chembl_activity.json"])
     schema = json.loads(
         (
@@ -270,8 +293,10 @@ def test_composite_validation_fails_closed_for_invalid_invariants() -> None:
     }
 
 
-def test_source_refs_exist_and_metric_labels_are_bounded(tmp_path: Path) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+def test_source_refs_exist_and_metric_labels_are_bounded(
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
+) -> None:
+    tmp_path, outputs = _passport_projection_bundle
     prohibited = {
         "run_id",
         "manifest_id",
@@ -305,6 +330,8 @@ def test_manual_sidecar_is_strict_and_preserved(tmp_path: Path) -> None:
         load_manual_sidecar(sidecar)
 
 
+@pytest.mark.subprocess_backed
+@pytest.mark.slow
 def test_cli_generate_and_check(tmp_path: Path) -> None:
     args = [
         "--output-root",
@@ -319,9 +346,9 @@ def test_cli_generate_and_check(tmp_path: Path) -> None:
 
 
 def test_pipeline_markdown_is_compact_complete_and_not_a_json_dump(
-    tmp_path: Path,
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
 ) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+    tmp_path, outputs = _passport_projection_bundle
     path = tmp_path / "pipelines/chembl-assay.md"
     markdown = outputs[path].decode("utf-8")
     facts = json.loads(outputs[tmp_path / "generated/pipelines/chembl_assay.json"])
@@ -350,9 +377,9 @@ def test_pipeline_markdown_is_compact_complete_and_not_a_json_dump(
 
 
 def test_composite_commands_and_diagram_use_real_composite_cli_options(
-    tmp_path: Path,
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
 ) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+    tmp_path, outputs = _passport_projection_bundle
     facts = json.loads(
         outputs[tmp_path / "generated/pipelines/composite_publication.json"]
     )
@@ -366,8 +393,10 @@ def test_composite_commands_and_diagram_use_real_composite_cli_options(
     assert "Quarantine / nullification" in diagram
 
 
-def test_duplicate_audit_reports_compaction(tmp_path: Path) -> None:
-    outputs = build_all_outputs(output_root=tmp_path, source_revision=REVISION)
+def test_duplicate_audit_reports_compaction(
+    _passport_projection_bundle: tuple[Path, dict[Path, bytes]],
+) -> None:
+    tmp_path, outputs = _passport_projection_bundle
     markdown = [
         content.decode("utf-8")
         for path, content in outputs.items()


### PR DESCRIPTION
## Summary

Closes the post-audit test suite economics/hygiene epic **#8326** and children **#8327–#8331**, **#8337–#8340** without weakening coverage, determinism, or debt budgets.

### P1
- **#8327 / #8328** — Single-lane ownership for passport projector / scripts tooling:
  - CI `unit-fast` and `unit-other` ignore `tests/unit/scripts`
  - New serial `unit-scripts-tooling` job
  - `lane_classification` in `configs/quality/test_matrix.yaml` + docs
  - Module-scoped passport projection fixture; CLI marked `subprocess_backed`/`slow`
- **#8329** — Session/module amortized registry completeness + list_pipelines bootstrap cache
- **#8330** — Advisory weak-assert inventory + owner triage note (no mass-delete)
- **#8331** — Architecture suite burndown inventory + local lane recommendation (`architecture-fast-boundary`)

### P2
- **#8337** — VCR corpus soft budget + GC policy + per-provider size report
- **#8338** — Telemetry baseline structural metadata aligned to HEAD (no invented metrics)
- **#8339** — Branch-coverage tail owner map
- **#8340** — Observability emission assertion inventory (MetricsPort fakes)

## Evidence
- Passport projector (not slow): 14 passed
- Registry completeness + list_pipelines: passed
- Scripts inventory: active scripts clean
- Reports under `reports/quality/*` for inventories

## Non-goals / policy
- No global xdist default
- No coverage/determinism gate weaken
- No tech-debt budget growth
- No mass-delete of architecture/weak-assert tests without owner review

## Test plan
- [x] Targeted passport projector + composition hotspots
- [ ] CI green on PR (`unit-fast`, `unit-scripts-tooling`, matrix, coverage-verify)
- [ ] After merge: full telemetry refresh from coverage-verify artifacts when available

Closes #8326
Closes #8327
Closes #8328
Closes #8329
Closes #8330
Closes #8331
Closes #8337
Closes #8338
Closes #8339
Closes #8340
