### PR TITLE
fix(audit): remediate cycle 3 findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -619,3 +619,6 @@ _fail_*.txt
 # Claude Code local/unofficial runtime (not an approved tracked root)
 .claude/
 2026-08-06_20-00-44.gif
+
+# Local agent workspace (untracked)
+.agents/

--- a/reports/quality/module-coverage-inventory.json
+++ b/reports/quality/module-coverage-inventory.json
@@ -16223,7 +16223,7 @@
       "missing_lines": 3,
       "module": "bioetl.infrastructure.adapters.base_metrics",
       "path": "src/bioetl/infrastructure/adapters/base_metrics.py",
-      "source_lines": 217
+      "source_lines": 207
     },
     {
       "coverage_percent": 97.87,
@@ -40035,7 +40035,7 @@
       "missing_lines": 3,
       "module": "bioetl.infrastructure.adapters.base_metrics",
       "path": "src/bioetl/infrastructure/adapters/base_metrics.py",
-      "source_lines": 217
+      "source_lines": 207
     },
     {
       "coverage_percent": 97.87,
@@ -47630,7 +47630,7 @@
   ],
   "schema_version": 1,
   "snapshot_date": "2026-08-07",
-  "source_tree_sha256": "d46f8b0ba0c97e303abb999cb9b3ab8604cdba1878d0d85703f584198bc88bf4",
+  "source_tree_sha256": "bae8d2cbafd23b25df2588c088382cbe95b35a0f5e9a70f1e6b4e4981383aee4",
   "summary": {
     "coverage_xml_present": true,
     "hotspot_family_coverage": {


### PR DESCRIPTION
## Summary
Cycle 3: refresh module-coverage inventory hash; clear local empty `.agents/` registry mismatch.

## Issues
Fixes #8373
Fixes #8374

## Verification
- check-root-review-registry → OK (after removing empty local `.agents/`)
- pytest inventory freshness → pass

## Architecture / debt
No budget increases.