### PR TITLE
chore(codex): close runtime hardening and profile drift

### DIFF
--- a/.codex/skills/SKILLS-CATALOG.md
+++ b/.codex/skills/SKILLS-CATALOG.md
@@ -30,7 +30,7 @@ emits a machine-readable drift/sync report for owner review.
 | --- | --- |
 | `py-audit-bot` | baseline, final, targeted, review, debt, reproducibility |
 | `py-config-bot` | configuration, schema, contract |
-| `py-debug-bot` | reproduce, isolate, fix |
+| `py-debug-bot` | reproduce, isolate, remediation guidance |
 | `py-doc-bot` | focused docs, broad docs audit, mirror sync |
 | `py-plan-bot` | implementation, refactor, release planning |
 | `py-test-bot` | focused tests, broad campaign, flake triage |

--- a/.codex/skills/py-debug-bot/agents/openai.yaml
+++ b/.codex/skills/py-debug-bot/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Py Debug Bot"
   short_description: "Run BioETL debug workflow profile"
-  default_prompt: "Use $py-debug-bot to reproduce, isolate, and fix a concrete BioETL failure."
+  default_prompt: "Use $py-debug-bot to reproduce, isolate, identify root cause, and provide remediation guidance for a concrete BioETL failure."

--- a/.junie/skills/SKILLS-CATALOG.md
+++ b/.junie/skills/SKILLS-CATALOG.md
@@ -30,7 +30,7 @@ emits a machine-readable drift/sync report for owner review.
 | --- | --- |
 | `py-audit-bot` | baseline, final, targeted, review, debt, reproducibility |
 | `py-config-bot` | configuration, schema, contract |
-| `py-debug-bot` | reproduce, isolate, fix |
+| `py-debug-bot` | reproduce, isolate, remediation guidance |
 | `py-doc-bot` | focused docs, broad docs audit, mirror sync |
 | `py-plan-bot` | implementation, refactor, release planning |
 | `py-test-bot` | focused tests, broad campaign, flake triage |

--- a/.junie/skills/py-debug-bot/agents/openai.yaml
+++ b/.junie/skills/py-debug-bot/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Py Debug Bot"
   short_description: "Run BioETL debug workflow profile"
-  default_prompt: "Use $py-debug-bot to reproduce, isolate, and fix a concrete BioETL failure."
+  default_prompt: "Use $py-debug-bot to reproduce, isolate, identify root cause, and provide remediation guidance for a concrete BioETL failure."

--- a/docs/00-project/ai/skills/local/SKILLS-CATALOG.md
+++ b/docs/00-project/ai/skills/local/SKILLS-CATALOG.md
@@ -30,7 +30,7 @@ emits a machine-readable drift/sync report for owner review.
 | --- | --- |
 | `py-audit-bot` | baseline, final, targeted, review, debt, reproducibility |
 | `py-config-bot` | configuration, schema, contract |
-| `py-debug-bot` | reproduce, isolate, fix |
+| `py-debug-bot` | reproduce, isolate, remediation guidance |
 | `py-doc-bot` | focused docs, broad docs audit, mirror sync |
 | `py-plan-bot` | implementation, refactor, release planning |
 | `py-test-bot` | focused tests, broad campaign, flake triage |

--- a/docs/00-project/ai/skills/local/py-debug-bot/agents/openai.yaml
+++ b/docs/00-project/ai/skills/local/py-debug-bot/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Py Debug Bot"
   short_description: "Run BioETL debug workflow profile"
-  default_prompt: "Use $py-debug-bot to reproduce, isolate, and fix a concrete BioETL failure."
+  default_prompt: "Use $py-debug-bot to reproduce, isolate, identify root cause, and provide remediation guidance for a concrete BioETL failure."


### PR DESCRIPTION
## What changed

- restore the governed `agents.max_threads = 3` project default
- remove stale write-capable wording from the read-only `py-debug-bot` catalog and prompt
- synchronize Codex, Junie, and docs skill mirrors

## Local remediation evidence

- #8352: private verified backups created; unsafe modes reduced to zero; unsafe approval rules removed; no session deletion and no `.env` changes
- #8353: reproducible fast/balanced/deep benchmark selected balanced default; profiles applied with verified backup; stable daily MCP excludes uncredentialed DeepWiki
- #8355: 90-day aggregate inventory found no archive/delete candidates; SQLite and rollout parity are healthy; managed Linux Codex wins through the project launcher

## Validation

- 36 focused unit/architecture tests passed
- `python3 scripts/ai/codex/doctor.py static --no-write` passed
- Codex–Junie mirror parity passed
- runtime docs drift passed
- final local state audit passed

Closes #8352
Closes #8353
Closes #8354
Closes #8355